### PR TITLE
Lock scope

### DIFF
--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptionsExtensions.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptionsExtensions.cs
@@ -29,8 +29,6 @@ namespace Sentry.AspNetCore
 
             if (aspnetOptions.InitializeSdk)
             {
-                loggingOptions.PushSentryScopeOnBeginScope = false;
-
                 loggingOptions.InitializeSdk = true;
 
                 loggingOptions.Init(o =>

--- a/src/Sentry.AspNetCore/SentryMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryMiddleware.cs
@@ -55,7 +55,7 @@ namespace Sentry.AspNetCore
         /// <returns></returns>
         public async Task InvokeAsync(HttpContext context)
         {
-            using (_sentry.PushScope())
+            using (_sentry.PushAndLockScope())
             {
                 _sentry.ConfigureScope(scope =>
                 {

--- a/src/Sentry.Extensions.Logging/SentryLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryLogger.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
-using Sentry.Extensibility;
 using Sentry.Infrastructure;
 
 namespace Sentry.Extensions.Logging
@@ -31,10 +30,7 @@ namespace Sentry.Extensions.Logging
             _hub = hub;
         }
 
-        public IDisposable BeginScope<TState>(TState state)
-            => _options.PushSentryScopeOnBeginScope
-                ? _hub.PushScope(state)
-                : DisabledHub.Instance;
+        public IDisposable BeginScope<TState>(TState state) => _hub.PushScope(state);
 
         public bool IsEnabled(LogLevel logLevel)
             => _hub.IsEnabled
@@ -64,9 +60,8 @@ namespace Sentry.Extensions.Logging
                 var @event = new SentryEvent(exception)
                 {
                     Logger = CategoryName,
+                    Message = message,
                 };
-
-                @event.Message = message;
 
                 var tuple = eventId.ToTupleOrNull();
                 if (tuple.HasValue)

--- a/src/Sentry.Extensions.Logging/SentryLoggerProvider.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggerProvider.cs
@@ -11,6 +11,7 @@ namespace Sentry.Extensions.Logging
         private readonly IHub _hub;
         private readonly ISystemClock _clock;
         private readonly SentryLoggingOptions _options;
+
         private IDisposable _scope;
         private IDisposable _sdk;
 

--- a/src/Sentry.Extensions.Logging/SentryLoggingOptions.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggingOptions.cs
@@ -36,15 +36,6 @@ namespace Sentry.Extensions.Logging
         internal Action<SentryOptions> ConfigureOptions { get; private set; }
 
         /// <summary>
-        /// Whether to invoke <see cref="SentrySdk.PushScope{TState}"/> when <see cref="ILogger.BeginScope{TState}"/> is called
-        /// </summary>
-        /// <remarks>
-        /// When other integrations are also included, scopes can be created by the outer integration.
-        /// They might expect to keep all log entries in the form of breadcrumbs instead of losing them when the logger disposes scopes
-        /// </remarks>
-        public bool PushSentryScopeOnBeginScope { get; set; } = true;
-
-        /// <summary>
         /// Initializes the SDK: This action should be done only once per application lifetime.
         /// </summary>
         /// <remarks>

--- a/src/Sentry/IScopeOptions.cs
+++ b/src/Sentry/IScopeOptions.cs
@@ -3,5 +3,6 @@ namespace Sentry
     public interface IScopeOptions
     {
         int MaxBreadcrumbs { get; }
+        bool Locked { get; set; }
     }
 }

--- a/src/Sentry/Internal/SentryScopeManager.cs
+++ b/src/Sentry/Internal/SentryScopeManager.cs
@@ -49,6 +49,13 @@ namespace Sentry.Internal
         {
             var currentScopeAndClientStack = ScopeAndClientStack;
             var (scope, client) = currentScopeAndClientStack.Peek();
+
+            if (scope.Options.Locked)
+            {
+                // TODO: keep state on current scope?
+                return DisabledHub.Instance;
+            }
+
             var clonedScope = scope.Clone();
             if (state != null) clonedScope.Apply(state);
             var scopeSnapshot = new ScopeSnapshot(currentScopeAndClientStack, this);

--- a/src/Sentry/Protocol/Scope.cs
+++ b/src/Sentry/Protocol/Scope.cs
@@ -151,12 +151,15 @@ namespace Sentry.Protocol
 
         public event EventHandler OnEvaluating;
 
-        public Scope(IScopeOptions options) : this (options, true)
+        public Scope(IScopeOptions options)
+            : this(options ?? new SentryOptions(), true)
         {
         }
 
         private Scope(IScopeOptions options, bool introspect)
         {
+            Debug.Assert(options != null);
+
             Options = options;
 
             if (introspect)
@@ -174,7 +177,9 @@ namespace Sentry.Protocol
             }
         }
 
-        protected internal Scope() { } // NOTE: derived types (think Event) don't need to enforce scope semantics
+        protected internal Scope()
+            : this(null)
+        { }
 
         internal void Evaluate()
         {

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -31,6 +31,8 @@ namespace Sentry
         /// </value>
         public int MaxBreadcrumbs { get; set; } = DefaultMaxBreadcrumbs;
 
+        public bool Locked { get; set; }
+
         public Dsn Dsn { get; set; }
 
         public Func<SentryEvent, SentryEvent> BeforeSend { get; set; }

--- a/test/Sentry.AspNetCore.Tests/MiddlewareLoggerIntegration.cs
+++ b/test/Sentry.AspNetCore.Tests/MiddlewareLoggerIntegration.cs
@@ -37,7 +37,6 @@ namespace Sentry.AspNetCore.Tests
                 var loggingOptions = new SentryLoggingOptions
                 {
                     InitializeSdk = false,
-                    PushSentryScopeOnBeginScope = true
                 };
                 var aspnetOptions = new SentryAspNetCoreOptions();
                 aspnetOptions.Apply(loggingOptions);

--- a/test/Sentry.Tests/HubExtensionsTests.cs
+++ b/test/Sentry.Tests/HubExtensionsTests.cs
@@ -21,6 +21,52 @@ namespace Sentry.Tests
         }
 
         [Fact]
+        public void PushAndLockScope_PushesNewScope()
+        {
+            Sut.PushAndLockScope();
+
+            Sut.Received(1).PushScope();
+        }
+
+        [Fact]
+        public void PushAndLockScope_Disposed_DisposesInnerScope()
+        {
+            var disposable = Substitute.For<IDisposable>();
+            Sut.PushScope().Returns(disposable);
+
+            var acutal = Sut.PushAndLockScope();
+            acutal.Dispose();
+
+            disposable.Received(1).Dispose();
+        }
+
+        [Fact]
+        public void PushAndLockScope_CreatedScopeIsLocked()
+        {
+            Sut.PushAndLockScope();
+
+            Assert.True(Scope.Options.Locked);
+        }
+
+        [Fact]
+        public void LockScope_LocksScope()
+        {
+            Sut.LockScope();
+
+            Assert.True(Scope.Options.Locked);
+        }
+
+        [Fact]
+        public void UnlockScope_UnlocksScope()
+        {
+            Sut.LockScope();
+
+            Sut.UnlockScope();
+
+            Assert.False(Scope.Options.Locked);
+        }
+
+        [Fact]
         public void AddBreadcrumb_MinimalArguments_CreatesBreadcrumb()
         {
             const string expectedMessage = "message";


### PR DESCRIPTION
Allows integrations to become root of transaction while keeping previous scope data separate