### PR TITLE
Make sure provider gets disposed on app shutdown

### DIFF
--- a/src/Sentry.Extensions.Logging/LoggingBuilderExtensions.cs
+++ b/src/Sentry.Extensions.Logging/LoggingBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
 using Sentry.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
@@ -23,7 +24,8 @@ namespace Microsoft.Extensions.Logging
             var options = new SentryLoggingOptions();
             optionsConfiguration?.Invoke(options);
 
-            builder.AddProvider(new SentryLoggerProvider(options));
+            builder.Services.AddSingleton(options);
+            builder.Services.AddSingleton<ILoggerProvider, SentryLoggerProvider>();
             return builder;
         }
     }

--- a/test/Sentry.AspNetCore.Tests/AspNetCoreSentryWebHostBuilder.IntegrationTests.cs
+++ b/test/Sentry.AspNetCore.Tests/AspNetCoreSentryWebHostBuilder.IntegrationTests.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Xunit;
+
+namespace Sentry.AspNetCore.Tests
+{
+    [Collection(nameof(SentrySdkCollection))]
+    public class SentryWebHostBuilderExtensionsIntegrationTests : AspNetSentrySdkTestFixture
+    {
+        private readonly IWebHostBuilder _webHostBuilder = WebHost.CreateDefaultBuilder()
+            .UseStartup<Startup>();
+
+        [Fact]
+        public void UseSentry_ValidDsnString_EnablesSdk()
+        {
+            _webHostBuilder.UseSentry(DsnSamples.ValidDsnWithoutSecret)
+                .Build();
+
+            try
+            {
+                Assert.True(SentrySdk.IsEnabled);
+            }
+            finally
+            {
+                SentrySdk.Close();
+            }
+        }
+
+        [Fact]
+        public void UseSentry_NoDsnProvided_DisabledSdk()
+        {
+            _webHostBuilder.UseSentry().Build();
+
+            Assert.False(SentrySdk.IsEnabled);
+        }
+
+        [Fact]
+        public void UseSentry_DisableDsnString_DisabledSdk()
+        {
+            _webHostBuilder.UseSentry(Internal.Constants.DisableSdkDsnValue)
+                .Build();
+
+            Assert.False(SentrySdk.IsEnabled);
+        }
+
+        [Fact]
+        public void UseSentry_OptionsNotInitializeSdk_DisabledSdk()
+        {
+            _webHostBuilder.UseSentry(o => o.InitializeSdk = false)
+                .Build();
+
+            Assert.False(SentrySdk.IsEnabled);
+        }
+
+    }
+}

--- a/test/Sentry.AspNetCore.Tests/Sentry.AspNetCore.Tests.csproj
+++ b/test/Sentry.AspNetCore.Tests/Sentry.AspNetCore.Tests.csproj
@@ -10,8 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* Registering a type ensures when resolved, lifetime is owned by the container which disposes it on shutdown.
* Resolves aspnet/Hosting/issues/1466