### PR TITLE
feat(log): use log entry to improve grouping

### DIFF
--- a/samples/Sentry.Samples.ME.Logging/Program.cs
+++ b/samples/Sentry.Samples.ME.Logging/Program.cs
@@ -36,7 +36,13 @@ internal class Program
 
             logger.LogInformation("2 - Information messages are stored as Breadcrumb, sent with the next event.");
 
-            logger.LogError("3 - This generates an event, captured by sentry and includes breadcrumbs (2) tracked in this transaction.");
+            // Log messages with variables are grouped together.
+            // This way a log message like: 'User {userId} logged in' doesn't generate 1 issue in Sentry for each user you have.
+            // When visualizing this issue in Sentry, you can press Next and Back to see the individual log entries:
+            logger.LogError("3 - This generates an event {id}, captured by sentry and includes breadcrumbs (2) tracked in this transaction.",
+                100);
+            logger.LogError("3 - This generates an event {id}, captured by sentry and includes breadcrumbs (2) tracked in this transaction.",
+                999);
 
             using (logger.BeginScope(new Dictionary<string, string>
                 {

--- a/test/Sentry.AspNetCore.Tests/IntegrationMockedBackgroundWorker.cs
+++ b/test/Sentry.AspNetCore.Tests/IntegrationMockedBackgroundWorker.cs
@@ -75,7 +75,22 @@ namespace Else.AspNetCore.Tests
             var logger = ServiceProvider.GetRequiredService<ILogger<IntegrationMockedBackgroundWorker>>();
             logger.LogError(expectedMessage);
 
-            Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p => p.Message == expectedMessage));
+            Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p => p.LogEntry.Formatted == expectedMessage));
+        }
+
+        [Fact]
+        public void LogError_WithFormat_EventCaptured()
+        {
+            const string expectedMessage = "Test {structured} log";
+            const int param = 10;
+
+            Build();
+            var logger = ServiceProvider.GetRequiredService<ILogger<IntegrationMockedBackgroundWorker>>();
+            logger.LogError(expectedMessage, param);
+
+            Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p =>
+                p.LogEntry.Formatted == $"Test {param} log"
+                && p.LogEntry.Message == expectedMessage));
         }
 
         [Fact]


### PR DESCRIPTION
MEL integration will use sentry's logEntry interface and send both the template and the generated message.
This way Sentry can run the grouping logic over the template while displaying the final message to the user.

Resolves #120 