### PR TITLE
fix: don't skip events from SentryAnything namespace

### DIFF
--- a/src/Sentry.Extensions.Logging/SentryLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryLogger.cs
@@ -122,8 +122,10 @@ namespace Sentry.Extensions.Logging
                    && logLevel >= _options.MinimumEventLevel
                    // No events from Sentry code using ILogger
                    // A type from the main SDK could be used to resolve a logger
-                   //(hence 'Sentry' and not 'Sentry.'
-                   && !CategoryName.StartsWith("Sentry")
+                   // hence 'Sentry' and also 'Sentry.', won't block SentrySomething
+                   // often used by users experimenting with Sentry
+                   && !CategoryName.StartsWith("Sentry.")
+                   && !string.Equals(CategoryName, "Sentry", StringComparison.Ordinal)
                    && (_options.Filters == null
                         || _options.Filters.All(
                            f => !f.Filter(

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
@@ -160,6 +160,33 @@ namespace Sentry.Extensions.Logging.Tests
         }
 
         [Fact]
+        public void Log_SentryRootCategory_DoesNotSendEvent()
+        {
+            var expectedException = new Exception("expected message");
+            _fixture.CategoryName = "Sentry";
+            var sut = _fixture.GetSut();
+
+            sut.Log<object>(LogLevel.Critical, default, null, expectedException, null);
+
+            _fixture.Hub.DidNotReceive()
+                .CaptureEvent(Arg.Any<SentryEvent>());
+        }
+
+        // https://github.com/getsentry/sentry-dotnet/issues/132
+        [Fact]
+        public void Log_SentrySomethingCategory_SendEvent()
+        {
+            var expectedException = new Exception("expected message");
+            _fixture.CategoryName = "SentrySomething";
+            var sut = _fixture.GetSut();
+
+            sut.Log<object>(LogLevel.Critical, default, null, expectedException, null);
+
+            _fixture.Hub.Received(1)
+                .CaptureEvent(Arg.Any<SentryEvent>());
+        }
+
+        [Fact]
         public void LogCritical_SentryCategory_RecordsBreadcrumbs()
         {
             _fixture.CategoryName = "Sentry.Some.Class";


### PR DESCRIPTION
Resolves #132