### PR TITLE
Add support for environment in log4net appender

### DIFF
--- a/docs/manual/log4net.md
+++ b/docs/manual/log4net.md
@@ -23,6 +23,7 @@ This can be done, for example, via the `app.config` or `web.config` in case of A
       <Dsn value="dsn"/>
       <!--Sends the log event Identity value as the user-->
       <SendIdentity value="true" />
+      <Environment value="dev" />
       <threshold value="INFO" />
     </appender>
 ```

--- a/samples/Sentry.Samples.Log4Net/app.config
+++ b/samples/Sentry.Samples.Log4Net/app.config
@@ -17,6 +17,7 @@
       <Dsn value="https://5fd7a6cda8444965bade9ccfd3df9882@sentry.io/1188141" />
       <!--Sends the log event Identity value as the user-->
       <SendIdentity value="true" />
+      <Environment value="dev" />
       <threshold value="INFO" />
     </appender>
     <root>

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -25,6 +25,7 @@ namespace Sentry.Log4Net
 
         public string Dsn { get; set; }
         public bool SendIdentity { get; set; }
+        public string Environment { get; set; }
 
         public SentryAppender() : this(SentrySdk.Init, HubAdapter.Instance)
         { }
@@ -91,6 +92,11 @@ namespace Sentry.Log4Net
                 {
                     Id = loggingEvent.Identity
                 };
+            }
+
+            if (!string.IsNullOrWhiteSpace(Environment))
+            {
+                evt.Environment = Environment;
             }
 
             Hub.CaptureEvent(evt);

--- a/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
+++ b/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
@@ -276,6 +276,32 @@ namespace Sentry.Log4Net.Tests
         }
 
         [Fact]
+        public void Append_ByDefault_DoesNotSetEnvironment()
+        {
+            var sut = _fixture.GetSut();
+            var evt = new LoggingEvent(new LoggingEventData());
+
+            sut.DoAppend(evt);
+
+            _fixture.Hub.Received(1)
+                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Environment == null));
+        }
+
+        [Fact]
+        public void Append_ConfiguredEnvironment()
+        {
+            const string expected = "dev";
+            var sut = _fixture.GetSut();
+            sut.Environment = expected;
+            var evt = new LoggingEvent(new LoggingEventData());
+
+            sut.DoAppend(evt);
+
+            _fixture.Hub.Received(1)
+                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Environment == expected));
+        }
+
+        [Fact]
         public void Close_DisposesSdk()
         {
             const string expectedDsn = "dsn";


### PR DESCRIPTION
I think this feature could be useful to be able to define the environment without coding it in the application. For people (like me) who are deploying applications for a specific client, this could allow them to know in an instant if the exception has happened in acceptance, production, other