### PR TITLE
WIP: fix: Allow hook to avoid EnableRewind per request

### DIFF
--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Net.Http;
+using Microsoft.AspNetCore.Http;
 using Sentry.Extensibility;
 using Sentry.Extensions.Logging;
 
@@ -42,6 +44,18 @@ namespace Sentry.AspNetCore
         /// If the request body is larger than the accepted size, nothing is sent.
         /// </remarks>
         public RequestSize MaxRequestBodySize { get; set; }
+
+        /// <summary>
+        /// A callback invoked when request body extraction is opted in.
+        /// </summary>
+        /// <remarks>
+        /// When request body extraction is enabled by setting <see cref="MaxRequestBodySize"/> to a value other than
+        /// <see cref="RequestSize.None"/> the SDK needs to enabled buffering of the request body. It does so by
+        /// invoking an extension method of <see cref="HttpRequest"/> called EnableRewind.
+        /// This callback can be used to decided whether to invoke EnableRewind or not by inspecting a specific request.
+        /// </remarks>'
+
+        public Func<HttpContext, bool> InvokeRequestEnableRewind { get; set; }
 
         /// <summary>
         /// Creates a new instance of <see cref="SentryAspNetCoreOptions"/>.

--- a/src/Sentry.AspNetCore/SentryMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryMiddleware.cs
@@ -82,7 +82,11 @@ namespace Sentry.AspNetCore
             {
                 if (_options != null && _options.MaxRequestBodySize != RequestSize.None)
                 {
-                    context.Request.EnableRewind();
+                    var rewind = _options.InvokeRequestEnableRewind;
+                    if (rewind == null || rewind.Invoke(context))
+                    {
+                        context.Request.EnableRewind();
+                    }
                 }
 
                 hub.ConfigureScope(scope =>


### PR DESCRIPTION
Resolves: #175

* Not decided if it should be added or user should opt-out altogether to body extraction instead or else (see #175 for details)
* Needs tests