### PR TITLE
Set up SentryOptions to allow for skipping module registration

### DIFF
--- a/src/Sentry/Internal/MainSentryEventProcessor.cs
+++ b/src/Sentry/Internal/MainSentryEventProcessor.cs
@@ -112,15 +112,18 @@ namespace Sentry.Internal
                 }
             }
 
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            if (_options.ReportAssemblies)
             {
-                if (assembly.IsDynamic)
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
                 {
-                    continue;
-                }
+                    if (assembly.IsDynamic)
+                    {
+                        continue;
+                    }
 
-                var asmName = assembly.GetName();
-                @event.Modules[asmName.Name] = asmName.Version.ToString();
+                    var asmName = assembly.GetName();
+                    @event.Modules[asmName.Name] = asmName.Version.ToString();
+                }
             }
             return @event;
         }

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -323,7 +323,7 @@ namespace Sentry
         /// <summary>
         /// Whether or not to include referenced assemblies in each event sent to sentry. Defaults to <see langword="true"/>.
         /// </summary>
-        public virtual bool ReportAssemblies { get; set; } = true;
+        public bool ReportAssemblies { get; set; } = true;
 
 #if SYSTEM_WEB
         /// <summary>

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -320,6 +320,11 @@ namespace Sentry
             }
         }
 
+        /// <summary>
+        /// Whether or not to include referenced assemblies in each event sent to sentry. Defaults to <see langword="true"/>.
+        /// </summary>
+        public virtual bool ReportAssemblies { get; set; } = true;
+
 #if SYSTEM_WEB
         /// <summary>
         /// Max request body to be captured when a Web request exists on a ASP.NET Application.

--- a/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
@@ -203,6 +203,17 @@ namespace Sentry.Tests.Internals
         }
 
         [Fact]
+        public void Process_Modules_IsEmpty_WhenSpecified()
+        {
+            _fixture.SentryOptions.ReportAssemblies = false;
+            var sut = _fixture.GetSut();
+            var evt = new SentryEvent();
+            sut.Process(evt);
+
+            Assert.Empty(evt.Modules);
+        }
+
+        [Fact]
         public void Process_SdkNameAndVersion_ToDefault()
         {
             var sut = _fixture.GetSut();


### PR DESCRIPTION
In reference to #152, this pull request adds ability to skip module registration on event processing.