### PR TITLE
Marked that dsn isn't required to be declared in the NLog config file

### DIFF
--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -70,7 +70,6 @@ namespace Sentry.NLog
         /// <summary>
         /// The Data Source Name of a given project in Sentry.
         /// </summary>
-        [RequiredParameter]
         public string Dsn
         {
             get => Options.Dsn?.ToString();


### PR DESCRIPTION
This updates the declarations on SentryTarget to specify that DSN doesn't _need_ to be declared in the config file, as it could be set up elsewhere.