### PR TITLE
Fix #208

### DIFF
--- a/src/Sentry.Extensions.Logging/SentryLoggerFactoryExtensions.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggerFactoryExtensions.cs
@@ -50,11 +50,6 @@ namespace Microsoft.Extensions.Logging
                 hub = HubAdapter.Instance;
             }
 
-            foreach (var callback in options.ConfigureScopeCallbacks)
-            {
-                hub.ConfigureScope(callback);
-            }
-
             factory.AddProvider(new SentryLoggerProvider(hub, SystemClock.Clock, options));
             return factory;
         }

--- a/src/Sentry.Extensions.Logging/SentryLoggerProvider.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggerProvider.cs
@@ -43,6 +43,12 @@ namespace Sentry.Extensions.Logging
             _clock = clock;
             _options = options;
 
+            // Add scope configuration to hub from options
+            foreach (var callback in options.ConfigureScopeCallbacks)
+            {
+                hub.ConfigureScope(callback);
+            }
+
             if (hub.IsEnabled)
             {
                 _scope = hub.PushScope();


### PR DESCRIPTION
This will allow scope creation callbacks to be called from within SentryLoggerProvider constructor. Also removed in AddSentry for ILoggerFactory to avoid duplicate calls.