### PR TITLE
feat: Flush events

### DIFF
--- a/benchmarks/Sentry.Benchmarks/BackgroundWorkerFlushBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/BackgroundWorkerFlushBenchmarks.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Sentry.Extensibility;
+using Sentry.Internal;
+
+namespace Sentry.Benchmarks
+{
+    public class BackgroundWorkerFlushBenchmarks
+    {
+        private class FakeTransport : ITransport
+        {
+            public Task CaptureEventAsync(
+                SentryEvent @event,
+                CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+        }
+
+        private IBackgroundWorker _backgroundWorker;
+        private SentryEvent _event;
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            _backgroundWorker = new BackgroundWorker(new FakeTransport(), new SentryOptions { MaxQueueItems = 100 });
+            _event = new SentryEvent();
+            // Make sure worker spins once.
+            _backgroundWorker.EnqueueEvent(_event);
+            _backgroundWorker.FlushAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
+        }
+
+        [Params(1, 10, 100)]
+        public int Items;
+
+        [Benchmark(Description = "Enqueue event and FlushAsync")]
+        public async Task FlushAsync_QueueDepthAsync()
+        {
+            for (var i = 0; i < Items; i++)
+            {
+                _backgroundWorker.EnqueueEvent(_event);
+            }
+            await _backgroundWorker.FlushAsync(TimeSpan.FromSeconds(10));
+        }
+    }
+}

--- a/benchmarks/Sentry.Benchmarks/BenchmarkDotNet.Artifacts/results/Sentry.Benchmarks.BackgroundWorkerFlushBenchmarks-report-github.md
+++ b/benchmarks/Sentry.Benchmarks/BenchmarkDotNet.Artifacts/results/Sentry.Benchmarks.BackgroundWorkerFlushBenchmarks-report-github.md
@@ -1,0 +1,17 @@
+``` ini
+
+BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17134.765 (1803/April2018Update/Redstone4)
+Intel Core i7-7920HQ CPU 3.10GHz (Kaby Lake), 1 CPU, 6 logical and 6 physical cores
+.NET Core SDK=2.1.403
+  [Host] : .NET Core 2.1.5 (CoreCLR 4.6.26919.02, CoreFX 4.6.26919.02), 64bit RyuJIT
+  Core   : .NET Core 2.1.5 (CoreCLR 4.6.26919.02, CoreFX 4.6.26919.02), 64bit RyuJIT
+
+Job=Core  Runtime=Core  InvocationCount=1  
+UnrollFactor=1  
+
+```
+|                         Method | Items |     Mean |    Error |   StdDev | Allocated |
+|------------------------------- |------ |---------:|---------:|---------:|----------:|
+| **&#39;Enqueue event and FlushAsync&#39;** |     **1** | **128.3 us** | **7.478 us** | **21.58 us** |   **1.77 KB** |
+| **&#39;Enqueue event and FlushAsync&#39;** |    **10** | **128.8 us** | **7.144 us** | **20.38 us** |   **1.77 KB** |
+| **&#39;Enqueue event and FlushAsync&#39;** |   **100** | **167.8 us** | **9.121 us** | **26.17 us** |   **4.87 KB** |

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -24,6 +24,8 @@ namespace Sentry.Extensibility
 
         public SentryId CaptureEvent(SentryEvent evt, Scope scope = null) => SentryId.Empty;
 
+        public Task FlushAsync(TimeSpan timeout) => Task.CompletedTask;
+
         public void Dispose() { }
 
         public SentryId LastEventId => SentryId.Empty;

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -92,5 +92,10 @@ namespace Sentry.Extensibility
         [EditorBrowsable(EditorBrowsableState.Never)]
         public SentryId CaptureEvent(SentryEvent evt, Scope scope)
             => SentrySdk.CaptureEvent(evt, scope);
+
+        [DebuggerStepThrough]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Task FlushAsync(TimeSpan timeout)
+            => SentrySdk.FlushAsync(timeout);
     }
 }

--- a/src/Sentry/Extensibility/IBackgroundWorker.cs
+++ b/src/Sentry/Extensibility/IBackgroundWorker.cs
@@ -1,8 +1,28 @@
+using System;
+using System.Threading.Tasks;
+
 namespace Sentry.Extensibility
 {
+    /// <summary>
+    /// A worker that queues event synchronously and flushes async.
+    /// </summary>
     public interface IBackgroundWorker
     {
+        /// <summary>
+        /// Attempts to queue the event with the worker.
+        /// </summary>
+        /// <param name="event"></param>
+        /// <returns>True of queueing was successful. Otherwise, false.</returns>
         bool EnqueueEvent(SentryEvent @event);
+        /// <summary>
+        /// Flushes events asynchronously.
+        /// </summary>
+        /// <param name="timeout">How long to wait for flush to finish.</param>
+        /// <returns>A task to await for the flush operation.</returns>
+        Task FlushAsync(TimeSpan timeout);
+        /// <summary>
+        /// Current count of items queued up.
+        /// </summary>
         int QueuedItems { get; }
     }
 }

--- a/src/Sentry/ISentryClient.cs
+++ b/src/Sentry/ISentryClient.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading.Tasks;
 using Sentry.Protocol;
 
 namespace Sentry
@@ -19,5 +21,12 @@ namespace Sentry
         /// <param name="scope">An optional scope to be applied to the event.</param>
         /// <returns>The Id of the event</returns>
         SentryId CaptureEvent(SentryEvent evt, Scope scope = null);
+
+        /// <summary>
+        /// Flushes events queued up.
+        /// </summary>
+        /// <param name="timeout">How long to wait for flush to finish.</param>
+        /// <returns>A task to await for the flush operation.</returns>
+        Task FlushAsync(TimeSpan timeout);
     }
 }

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -115,6 +115,19 @@ namespace Sentry.Internal
             }
         }
 
+        public async Task FlushAsync(TimeSpan timeout)
+        {
+            try
+            {
+                var (_, client) = ScopeManager.GetCurrent();
+                await client.FlushAsync(timeout).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                _options.DiagnosticLogger?.LogError("Failure to Flush events", e);
+            }
+        }
+
         public void Dispose()
         {
             _options.DiagnosticLogger?.LogInfo("Disposing the Hub.");

--- a/src/Sentry/Internal/OptionalHub.cs
+++ b/src/Sentry/Internal/OptionalHub.cs
@@ -35,6 +35,8 @@ namespace Sentry.Internal
 
         public SentryId CaptureEvent(SentryEvent evt, Scope scope = null) => _hub.CaptureEvent(evt, scope);
 
+        public Task FlushAsync(TimeSpan timeout) => _hub.FlushAsync(timeout);
+
         public void ConfigureScope(Action<Scope> configureScope) => _hub.ConfigureScope(configureScope);
 
         public Task ConfigureScopeAsync(Func<Scope, Task> configureScope) => _hub.ConfigureScopeAsync(configureScope);

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Sentry.Extensibility;
 using Sentry.Internal;
 using Sentry.Protocol;
@@ -92,6 +93,8 @@ namespace Sentry
                 return SentryId.Empty;
             }
         }
+
+        public Task FlushAsync(TimeSpan timeout) => Worker.FlushAsync(timeout);
 
         private SentryId DoSendEvent(SentryEvent @event, Scope scope)
         {

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -99,6 +99,12 @@ namespace Sentry
         }
 
         /// <summary>
+        /// Flushes events queued up.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Task FlushAsync(TimeSpan timeout) => _hub.FlushAsync(timeout);
+
+        /// <summary>
         /// Close the SDK
         /// </summary>
         /// <remarks>

--- a/test/Sentry.Tests/Internals/BackgroundWorkerTests.cs
+++ b/test/Sentry.Tests/Internals/BackgroundWorkerTests.cs
@@ -6,6 +6,7 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Sentry.Extensibility;
 using Sentry.Internal;
+using Sentry.Protocol;
 using Xunit;
 
 namespace Sentry.Tests.Internals
@@ -15,9 +16,17 @@ namespace Sentry.Tests.Internals
         private class Fixture
         {
             public ITransport Transport { get; set; } = Substitute.For<ITransport>();
-            public IProducerConsumerCollection<SentryEvent> Queue { get; set; } = new ConcurrentQueue<SentryEvent>();
+            public IDiagnosticLogger Logger { get; set; } = Substitute.For<IDiagnosticLogger>();
+            public ConcurrentQueue<object> Queue { get; set; } = new ConcurrentQueue<object>();
             public CancellationTokenSource CancellationTokenSource { get; set; } = new CancellationTokenSource();
             public SentryOptions SentryOptions { get; set; } = new SentryOptions();
+
+            public Fixture()
+            {
+                Logger.IsEnabled(Arg.Any<SentryLevel>()).Returns(true);
+                SentryOptions.Debug = true;
+                SentryOptions.DiagnosticLogger = Logger;
+            }
 
             public BackgroundWorker GetSut()
                 => new BackgroundWorker(
@@ -202,9 +211,8 @@ namespace Sentry.Tests.Internals
                 sut.EnqueueEvent(expected);
                 transportEvent.WaitOne(); // Wait first event to be in-flight
 
+                // in-flight events are kept in queue until completed.
                 var queued = sut.EnqueueEvent(expected);
-                Assert.True(queued); // Queue to limit (1)
-                queued = sut.EnqueueEvent(expected);
                 Assert.False(queued); // Fails to queue second
 
                 eventsQueuedEvent.Set();
@@ -283,12 +291,113 @@ namespace Sentry.Tests.Internals
         [Fact]
         public void QueuedItems_ReflectsQueue()
         {
-            const int expectedCount = int.MaxValue;
-            _fixture.Queue = Substitute.For<IProducerConsumerCollection<SentryEvent>>();
-            _fixture.Queue.Count.Returns(expectedCount);
+            _fixture.Queue.Enqueue(null);
             using (var sut = _fixture.GetSut())
             {
-                Assert.Equal(expectedCount, sut.QueuedItems);
+                Assert.Equal(1, sut.QueuedItems);
+            }
+        }
+
+        [Fact]
+        public async Task FlushAsync_DisposedWorker_LogsAndReturns()
+        {
+            var sut = _fixture.GetSut();
+            sut.Dispose();
+            await sut.FlushAsync(TimeSpan.MaxValue);
+            _fixture.Logger.Received().Log(SentryLevel.Debug, "Worker disposed. Nothing to flush.");
+        }
+
+        [Fact]
+        public async Task FlushAsync_EmptyQueue_LogsAndReturns()
+        {
+            var sut = _fixture.GetSut();
+            await sut.FlushAsync(TimeSpan.MaxValue);
+            _fixture.Logger.Received().Log(SentryLevel.Debug, "No events to flush.");
+        }
+
+        [Fact]
+        public async Task FlushAsync_SingleEvent_FlushReturnsAfterEventSent()
+        {
+            // Arrange
+            var expected = new SentryEvent();
+            var transportEvent = new ManualResetEvent(false);
+            var eventsQueuedEvent = new ManualResetEvent(false);
+            _fixture.Transport
+                .When(t => t.CaptureEventAsync(expected, Arg.Any<CancellationToken>()))
+                .Do(p =>
+                {
+                    transportEvent.Set(); // Processing first event
+                    eventsQueuedEvent.WaitOne(); // Stay blocked while test queue events
+                });
+
+            using (var sut = _fixture.GetSut())
+            {
+                // Act
+                sut.EnqueueEvent(expected);
+                transportEvent.WaitOne(); // Wait first event to be in-flight
+
+                var flushTask = sut.FlushAsync(TimeSpan.FromDays(1));
+                Assert.Equal(2, _fixture.Queue.Count); // Event being processed and the flush handle
+
+                eventsQueuedEvent.Set();
+                await flushTask;
+
+                _fixture.Logger.Received().Log(SentryLevel.Debug, "Successfully flushed all events up to call to FlushAsync.");
+                Assert.Empty(_fixture.Queue); // Only the item being processed at the blocked callback
+            }
+        }
+
+        [Fact]
+        public async Task FlushAsync_ZeroTimeout_Accepted()
+        {
+            // Arrange
+            var expected = new SentryEvent();
+            var transportEvent = new ManualResetEvent(false);
+            var eventsQueuedEvent = new ManualResetEvent(false);
+            _fixture.Transport
+                .When(t => t.CaptureEventAsync(expected, Arg.Any<CancellationToken>()))
+                .Do(p =>
+                {
+                    transportEvent.Set(); // Processing first event
+                    eventsQueuedEvent.WaitOne(); // Stay blocked while test queue events
+                });
+
+            using (var sut = _fixture.GetSut())
+            {
+                // Act
+                sut.EnqueueEvent(expected);
+                transportEvent.WaitOne(); // Wait first event to be in-flight
+
+                await sut.FlushAsync(TimeSpan.Zero);
+            }
+        }
+
+        [Fact]
+        public async Task FlushAsync_FullQueue_RespectsTimeout()
+        {
+            // Arrange
+            var expected = new SentryEvent();
+            var transportEvent = new ManualResetEvent(false);
+            var eventsQueuedEvent = new ManualResetEvent(false);
+            _fixture.SentryOptions.MaxQueueItems = 1;
+            _fixture.Transport
+                .When(t => t.CaptureEventAsync(expected, Arg.Any<CancellationToken>()))
+                .Do(p =>
+                {
+                    transportEvent.Set(); // Processing first event
+                    eventsQueuedEvent.WaitOne(); // Stay blocked while test queue events
+                });
+
+            using (var sut = _fixture.GetSut())
+            {
+                // Act
+                sut.EnqueueEvent(expected);
+                transportEvent.WaitOne(); // Wait first event to be in-flight
+
+                await sut.FlushAsync(TimeSpan.FromSeconds(1));
+
+                _fixture.Logger.Received().Log(SentryLevel.Debug, "Timeout when trying to flush queue.");
+                Assert.Single(_fixture.Queue); // Only the item being processed at the blocked callback
             }
         }
     }


### PR DESCRIPTION
Adds the ability to flush events queued up to the point `FlushAsync` is called.

It's a breaking change as it adds a new method to `ISentryClient` so consumers which implement this interface by themselves would be affected (no C#8 yet, argh).

This should be released as version `2.0.0`.

Will be useful to serverless environments like Azure Functions and AWS Lambda. See #126