### PR TITLE
feat: Use stacktrace from calling thread

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,6 @@
    <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="2.9.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="2.9.2" PrivateAsets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="2.9.2" />
   </ItemGroup>
 </Project>

--- a/src/Sentry/Internal/MainSentryEventProcessor.cs
+++ b/src/Sentry/Internal/MainSentryEventProcessor.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Sentry.Extensibility;
 using Sentry.PlatformAbstractions;
 using Sentry.Protocol;
@@ -108,7 +111,18 @@ namespace Sentry.Internal
                 var stackTrace = SentryStackTraceFactoryAccessor().Create(@event.Exception);
                 if (stackTrace != null)
                 {
-                    @event.Stacktrace = stackTrace;
+                    var thread = new SentryThread
+                    {
+                        Crashed = false,
+                        Current = true,
+                        Name = Thread.CurrentThread.Name,
+                        Id = Thread.CurrentThread.ManagedThreadId,
+                        Stacktrace = stackTrace
+                    };
+
+                    @event.SentryThreads = @event.SentryThreads.Any()
+                        ? new List<SentryThread>(@event.SentryThreads) { thread }
+                        : new[] { thread } as IEnumerable<SentryThread>;
                 }
             }
 

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Sentry.PlatformAbstractions" Version="1.0.0" />
-    <PackageReference Include="Sentry.Protocol" Version="1.0.6" />
+    <PackageReference Include="Sentry.Protocol" Version="2.0.0-beta" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 

--- a/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using NSubstitute;
 using Sentry.Extensibility;
 using Sentry.Internal;
@@ -257,6 +260,23 @@ namespace Sentry.Tests.Internals
             sut.Process(evt);
 
             _fixture.SentryStackTraceFactory.Received(1).Create();
+        }
+
+        [Fact]
+        public void Process_AttachStacktraceTrueAndExistentThreadInEvent_AddsNewThread()
+        {
+            var expected = new SentryStackTrace();
+            _fixture.SentryStackTraceFactory.Create(Arg.Any<Exception>()).Returns(expected);
+            _fixture.SentryOptions.AttachStacktrace = true;
+            var sut = _fixture.GetSut();
+
+            Thread.CurrentThread.Name = "second";
+            var evt = new SentryEvent { SentryThreads = new []{ new SentryThread { Name = "first" }}};
+            sut.Process(evt);
+
+            Assert.Equal(2, evt.SentryThreads.Count());
+            Assert.Equal("first", evt.SentryThreads.First().Name);
+            Assert.Equal("second", evt.SentryThreads.Last().Name);
         }
 
         [Fact]


### PR DESCRIPTION
Relies on [Sentry.Protocol version 2.0.0](https://github.com/getsentry/sentry-dotnet-protocol/releases/tag/2.0.0-beta) which no longer has Stacktrace directly on SentryEvent.

Resolves #113