### PR TITLE
fix: Remove ContextLine without source code available

### DIFF
--- a/src/Sentry/Extensibility/SentryStackTraceFactory.cs
+++ b/src/Sentry/Extensibility/SentryStackTraceFactory.cs
@@ -105,7 +105,6 @@ namespace Sentry.Extensibility
                 frame.Module = method.DeclaringType?.FullName ?? unknownRequiredField;
                 frame.Package = method.DeclaringType?.Assembly.FullName;
                 frame.Function = method.Name;
-                frame.ContextLine = method.ToString();
             }
 
             frame.InApp = !IsSystemModuleName(frame.Module);


### PR DESCRIPTION
`ContextLine` is expected to be used when source is available (e.g within the PDB or `SourceLink`).

It's specially less than useful with `async` code:

<img width="913" alt="image" src="https://user-images.githubusercontent.com/1633368/58827290-f5202980-8642-11e9-9f2d-3574dea56199.png">

The function name and module are correctly extracted but `ContextLine` is generated code.