### PR TITLE
Set the logger via the log event info in SentryTarget.Write

### DIFF
--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -248,6 +248,7 @@ namespace Sentry.NLog
                         Formatted = formatted,
                         Message = template
                     },
+                    Logger = logEvent.LoggerName,
                     Level = logEvent.Level.ToSentryLevel(),
                     Release = Options.Release,
                     Environment = Options.Environment,


### PR DESCRIPTION
This pull request assigns the `Logger` property of the captured `SentryEvent` as the `LoggerName` of the `NLog` `LogEventInfo`. So the `SentryTarget` just tells sentry the name of the logger via NLog. I found myself writing `BeforeSend` callbacks all over to accomplish this, when it really should have been done from the get-go.