### PR TITLE
Utilizes Flush functionality in NLog target

### DIFF
--- a/src/Sentry.NLog/SentryNLogOptions.cs
+++ b/src/Sentry.NLog/SentryNLogOptions.cs
@@ -24,6 +24,11 @@ namespace Sentry.NLog
             get => ShutdownTimeout.Seconds;
             set => ShutdownTimeout = TimeSpan.FromSeconds(value);
         }
+        
+        /// <summary>
+        /// How long to wait for the flush to finish. Defaults to 2 seconds.
+        /// </summary>
+        public TimeSpan FlushTimeout { get; set; } = TimeSpan.FromSeconds(2);
 
         /// <summary>
         /// Minimum log level for events to trigger a send to Sentry. Defaults to <see cref="M:LogLevel.Error" />.

--- a/src/Sentry.NLog/SentryNLogOptions.cs
+++ b/src/Sentry.NLog/SentryNLogOptions.cs
@@ -26,17 +26,17 @@ namespace Sentry.NLog
         }
         
         /// <summary>
-        /// How long to wait for the flush to finish. Defaults to 2 seconds.
+        /// How long to wait for the flush to finish. Defaults to 15 seconds (same as NLog default).
         /// </summary>
-        public TimeSpan FlushTimeout { get; set; } = TimeSpan.FromSeconds(2);
+        public TimeSpan FlushTimeout { get; set; } = TimeSpan.FromSeconds(15);
 
         /// <summary>
-        /// Minimum log level for events to trigger a send to Sentry. Defaults to <see cref="M:LogLevel.Error" />.
+        /// Minimum log level for events to trigger a send to Sentry. Defaults to <see cref="LogLevel.Error" />.
         /// </summary>
         public LogLevel MinimumEventLevel { get; set; } = LogLevel.Error;
 
         /// <summary>
-        /// Minimum log level to be included in the breadcrumb. Defaults to <see cref="M:LogLevel.Info" />.
+        /// Minimum log level to be included in the breadcrumb. Defaults to <see cref="LogLevel.Info" />.
         /// </summary>
         public LogLevel MinimumBreadcrumbLevel { get; set; } = LogLevel.Info;
 

--- a/src/Sentry.NLog/SentryNLogOptions.cs
+++ b/src/Sentry.NLog/SentryNLogOptions.cs
@@ -31,12 +31,12 @@ namespace Sentry.NLog
         public TimeSpan FlushTimeout { get; set; } = TimeSpan.FromSeconds(15);
 
         /// <summary>
-        /// Minimum log level for events to trigger a send to Sentry. Defaults to <see cref="LogLevel.Error" />.
+        /// Minimum log level for events to trigger a send to Sentry. Defaults to <see cref="M:LogLevel.Error" />.
         /// </summary>
         public LogLevel MinimumEventLevel { get; set; } = LogLevel.Error;
 
         /// <summary>
-        /// Minimum log level to be included in the breadcrumb. Defaults to <see cref="LogLevel.Info" />.
+        /// Minimum log level to be included in the breadcrumb. Defaults to <see cref="M:LogLevel.Info" />.
         /// </summary>
         public LogLevel MinimumBreadcrumbLevel { get; set; } = LogLevel.Info;
 

--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -211,16 +211,9 @@ namespace Sentry.NLog
         /// <inheritdoc />
         protected override void FlushAsync(AsyncContinuation asyncContinuation)
         {
-            try
-            {
-                _hubAccessor().FlushAsync(Options.FlushTimeout);
-
-                asyncContinuation(null);
-            }
-            catch (Exception e)
-            {
-                asyncContinuation(e);
-            }
+            _hubAccessor()
+                .FlushAsync(Options.FlushTimeout)
+                .ContinueWith(t => asyncContinuation(t.Exception));
         }
 
         /// <summary>

--- a/test/Sentry.NLog.Tests/SentryTargetTests.cs
+++ b/test/Sentry.NLog.Tests/SentryTargetTests.cs
@@ -388,7 +388,7 @@ namespace Sentry.NLog.Tests
 
             factory.Flush(continuation, timeout);
 
-            await Task.Delay(TimeSpan.FromSeconds(NLogTimeout));
+            await Task.Delay(timeout);
             
             testDisposable.Received().Dispose();
             hub.Received().FlushAsync(Arg.Any<TimeSpan>()).GetAwaiter().GetResult();


### PR DESCRIPTION
Utilizes the new flush feature in `Sentry.NLog.SentryTarget`. I defaulted the timeout to the default shutdown timeout (2 seconds), but if another value would be better to use, then that can be changed.