### PR TITLE
feat: Send sourcelink URL in event

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <DefineConstants>SYSTEM_WEB;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
    <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="2.9.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="2.9.2" PrivateAssets="All" />

--- a/samples/Sentry.Samples.Serilog/Program.cs
+++ b/samples/Sentry.Samples.Serilog/Program.cs
@@ -15,6 +15,7 @@ internal class Program
             // Other overloads exist, for example, configure the SDK with only the DSN or no parameters at all.
             .WriteTo.Sentry(o =>
             {
+                o.Debug = true;
                 o.MinimumBreadcrumbLevel = LogEventLevel.Debug; // Debug and higher are stored as breadcrumbs (default os Information)
                 o.MinimumEventLevel = LogEventLevel.Error; // Error and higher is sent as event (default is Error)
                 // If DSN is not set, the SDK will look for an environment variable called SENTRY_DSN. If nothing is found, SDK is disabled.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,7 +29,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="2.0.0" PrivateAssets="All" Condition="'$(Configuration)' != 'Release'" />
   </ItemGroup>
 </Project>

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -21,5 +21,10 @@
     <PackageReference Include="Sentry.Protocol" Version="2.0.0-beta2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\..\..\.nuget\packages\system.reflection.metadata\1.6.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* Pending protocol change to support the source link data.
* For now adding the data to stackframe vars to see in Sentry.
* Async needs to be supported now that processing stack traces does I/O
* Cache result of exe/pdb lookup
