### PR TITLE
tests: NLog default levels

### DIFF
--- a/test/Sentry.NLog.Tests/SentryNLogOptionsTests.cs
+++ b/test/Sentry.NLog.Tests/SentryNLogOptionsTests.cs
@@ -1,0 +1,22 @@
+using NLog;
+using Xunit;
+
+namespace Sentry.NLog.Tests
+{
+    public class SentrySerilogOptionsTests
+    {
+        [Fact]
+        public void Ctor_MinimumBreadcrumbLevel_Information()
+        {
+            var options = new SentryNLogOptions();
+            Assert.Equal(LogLevel.Info, options.MinimumBreadcrumbLevel);
+        }
+
+        [Fact]
+        public void Ctor_MinimumEventLevel_Error()
+        {
+            var options = new SentryNLogOptions();
+            Assert.Equal(LogLevel.Error, options.MinimumEventLevel);
+        }
+    }
+}


### PR DESCRIPTION
Parity with Sentry.Serilog RE: #237 for testing default NLog log level options.