### PR TITLE
ref: Require XML doc for Release builds only

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,6 +7,9 @@
     <!--Generate xml docs for all projects under 'src'-->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
+    <!-- CS1591: Missing XML comment for publicly visible type or member -->
+    <NoWarn Condition="'$(Configuration)' == 'Debug'">$(NoWarn);CS1591</NoWarn>
+
     <Authors>Sentry Team and Contributors</Authors>
     <Company>Sentry.io</Company>
     <Product>Sentry</Product>


### PR DESCRIPTION
Let Debug builds ignore xml docs