### PR TITLE
NLog SentryTarget with less overhead for breadcrumb

### DIFF
--- a/src/Sentry.NLog/Sentry.NLog.csproj
+++ b/src/Sentry.NLog/Sentry.NLog.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.6.0" />
+    <PackageReference Include="NLog" Version="4.5.11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/Sentry/Sentry.csproj" />


### PR DESCRIPTION
When IncludeEventDataOnBreadcrumbs = false (Default)