### PR TITLE
null check contextProp.Value during IncludeEventDataOnBreadcrumbs

### DIFF
--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -332,7 +332,7 @@ namespace Sentry.NLog
                         data = data ?? new Dictionary<string, string>(contextProps.Count);
                         foreach (var contextProp in contextProps)
                         {
-                            data.Add(contextProp.Key, contextProp.Value.ToString());
+                            data.Add(contextProp.Key, contextProp.Value?.ToString());
                         }
                     }
                 }


### PR DESCRIPTION
without this, our application blows up during logs when properties pass null values (which in some cases is intentional)