### PR TITLE
Renamed SendEventPropertiesAsData to IncludeEventProperties

### DIFF
--- a/samples/Sentry.Samples.NLog/NLog.config
+++ b/samples/Sentry.Samples.NLog/NLog.config
@@ -14,21 +14,28 @@
 
     <target xsi:type="Sentry" name="sentry"
             dsn="https://5fd7a6cda8444965bade9ccfd3df9882@sentry.io/1188141"
+            environment="Development"
+            includeEventProperties="True"
             layout="${message}"
             breadcrumbLayout="${message}"
             minimumBreadcrumbLevel="Debug"
+            ignoreEventsWithNoException="False"
+            includeEventDataOnBreadcrumbs="False"
+            includeEventPropertiesAsTags="True"
             minimumEventLevel="Error">
 
       <!-- Advanced options can be configured here-->
       <options
-          environment="Development"
           attachStacktrace="true"
           sendDefaultPii="true"
-          shutdownTimeoutSeconds="5"
-        >
-        <!--Advanced options can be specified as attributes or elements-->
-        <includeEventDataOnBreadcrumbs>true</includeEventDataOnBreadcrumbs>
-      </options>
+          shutdownTimeoutSeconds="5"          
+        />
+
+      <!--Optionally add any desired additional Tags that will be sent with every message -->
+      <tag name="exception" value="${exception:format=shorttype}" includeEmptyValue="false" />
+
+      <!--Optionally add any desired additional Data that will be sent with every message -->
+      <contextproperty name="threadid" value="${threadid}" includeEmptyValue="true" />
 
       <!-- Optionally specify user properties via NLog (here using MappedDiagnosticsLogicalContext as an example) -->
       <user id="${mdlc:item=id}" 
@@ -38,9 +45,6 @@
         <!-- You can also apply additional user properties here-->
         <other name="mood" layout="joyous"/>
       </user>
-
-      <!--Add any desired additional tags that will be sent with every message -->
-      <tag name="logger" layout="${logger}" />
     </target>
   </targets>
 

--- a/samples/Sentry.Samples.NLog/README.md
+++ b/samples/Sentry.Samples.NLog/README.md
@@ -8,6 +8,70 @@ In both cases **you need to add your own DSN** so you can see the events sent in
 You can get your [Sentry DSN at sentry.io](https://sentry.io).
 Make sure to add it to both `NLog.config` and `Program.cs` in this directory.
 
+## Configuration of NLog.config
+The following options are available for the NLog Sentry Target:
+
+```xml
+<target xsi:type="Sentry" name="sentry"
+    dsn="https://123@sentry.io/456"
+    environment="${environment:cached=true:ASPNETCORE_ENVIRONMENT}"
+    release="${assembly-version:cached=true:type=File}"
+    layout="${message}"
+    includeEventProperties="True"
+    includeMdlc="False"
+    breadcrumbLayout="${message}"
+    minimumBreadcrumbLevel="Debug"
+    minimumEventLevel="Error"
+    ignoreEventsWithNoException="False"
+    includeEventDataOnBreadcrumbs="False"
+    includeEventPropertiesAsTags="True"
+    initializeSdk="True"
+    flushTimeoutSeconds="15"
+    >
+        <tag name="exception" value="${exception:format=shorttype}" includeEmptyValue="false" /><!-- Repeatable SentryEvent Tags -->
+        <contextproperty name="threadid" value="${threadid}" includeEmptyValue="true" />        <!-- Repeatable SentryEvent Data -->
+        <!-- Advanced options can be configured here-->
+        <options
+            sendDefaultPii="False"
+            isEnvironmentUser="True"
+            attachStacktrace="False"
+        />
+        <!-- Optionally specify user properties via NLog (here using MappedDiagnosticsLogicalContext as an example) -->
+        <user
+            id="${mdlc:item=id}" 
+            username="${mdlc:item=username}"
+            email="${mdlc:item=email}">
+            <other name="mood" layout="joyous"/>    <!-- You can also apply additional user properties here-->
+        </user>
+</target>
+```
+
+* **dsn** - Sentry Data Source Name Address. See also https://sentry.io
+* **initializeSdk** -  Whether the NLog target should initialize the Sentry SDK (Using Dsn). Default: _True_
+* **environment** - Application Environment sent to Sentry
+* **release** - Application Release Version sent to Sentry
+* **layout** - NLog Layout for rendering SentryEvent message. Default: _${message}_
+* **includeEventProperties** - Include LogEvent properties as Data on SentryEvent. Default: _True_
+* **includeEventPropertiesAsTags** - Include LogEvent properties as extra Tags on SentryEvent. Default: _False_
+* **includeMdlc** - Include NLog MDLC as Data on SentryEvent. Default: _False_
+* **includeEventDataOnBreadcrumbs** - Include all event Data on breadcrumbs just like for standard SentryEvent. Default: _False_
+* **breadcrumbLayout** - NLog Layout for styling the breadcrumb message. Default: Same as **layout**
+* **minimumEventLevel** - Send NLog LogEvents as SentryEvent when matching severity (or worse). Default: _Error_
+* **minimumBreadcrumbLevel** - Send NLog LogEvents as Breadcrumbs when matching severity (or worse). Default: _Info_
+* **ignoreEventsWithNoException** - Ignore NLog LogEvents without an exception. Default: _False_
+* **flushTimeoutSeconds** - Flush timeout in seconds before aborting flush to Sentry. Default: _15_
+* **user**
+   * **id** -
+   * **username** -
+   * **email** -
+* **options**
+   * **sendDefaultPii** - Whether to include default Personal Identifiable information (UserName / IP-Address). Default: _False_
+   * **isEnvironmentUser** - Lookup Environment.User if having enabled **sendDefaultPii**. Default: _True_
+   * **attachStacktrace** - Whether to send the stack trace of a event captured without an exception. Default: _False_
+
+There is filtering logic in the Sentry Target that is usually handled by NLog Logging Rules and Filters.
+Mostly because the same Sentry Target is writing both breadcrumbs and actual SentryEvents.
+
 ## Running this sample
 
 Now you're ready to run the code.

--- a/src/Sentry.NLog/PublicAPI.Shipped.txt
+++ b/src/Sentry.NLog/PublicAPI.Shipped.txt
@@ -2,6 +2,10 @@
 Sentry.NLog.SentryNLogOptions
 Sentry.NLog.SentryNLogOptions.BreadcrumbLayout.get -> NLog.Layouts.Layout
 Sentry.NLog.SentryNLogOptions.BreadcrumbLayout.set -> void
+Sentry.NLog.SentryNLogOptions.DsnLayout.get -> NLog.Layouts.Layout
+Sentry.NLog.SentryNLogOptions.DsnLayout.set -> void
+Sentry.NLog.SentryNLogOptions.EnvironmentLayout.get -> NLog.Layouts.Layout
+Sentry.NLog.SentryNLogOptions.EnvironmentLayout.set -> void
 Sentry.NLog.SentryNLogOptions.FlushTimeout.get -> System.TimeSpan
 Sentry.NLog.SentryNLogOptions.FlushTimeout.set -> void
 Sentry.NLog.SentryNLogOptions.IgnoreEventsWithNoException.get -> bool
@@ -16,10 +20,10 @@ Sentry.NLog.SentryNLogOptions.MinimumBreadcrumbLevel.get -> NLog.LogLevel
 Sentry.NLog.SentryNLogOptions.MinimumBreadcrumbLevel.set -> void
 Sentry.NLog.SentryNLogOptions.MinimumEventLevel.get -> NLog.LogLevel
 Sentry.NLog.SentryNLogOptions.MinimumEventLevel.set -> void
-Sentry.NLog.SentryNLogOptions.SendEventPropertiesAsData.get -> bool
-Sentry.NLog.SentryNLogOptions.SendEventPropertiesAsData.set -> void
-Sentry.NLog.SentryNLogOptions.SendEventPropertiesAsTags.get -> bool
-Sentry.NLog.SentryNLogOptions.SendEventPropertiesAsTags.set -> void
+Sentry.NLog.SentryNLogOptions.ReleaseLayout.get -> NLog.Layouts.Layout
+Sentry.NLog.SentryNLogOptions.ReleaseLayout.set -> void
+Sentry.NLog.SentryNLogOptions.IncludeEventPropertiesAsTags.get -> bool
+Sentry.NLog.SentryNLogOptions.IncludeEventPropertiesAsTags.set -> void
 Sentry.NLog.SentryNLogOptions.SentryNLogOptions() -> void
 Sentry.NLog.SentryNLogOptions.ShutdownTimeoutSeconds.get -> int
 Sentry.NLog.SentryNLogOptions.ShutdownTimeoutSeconds.set -> void
@@ -27,14 +31,18 @@ Sentry.NLog.SentryNLogOptions.Tags.get -> System.Collections.Generic.IList<NLog.
 Sentry.NLog.SentryTarget
 Sentry.NLog.SentryTarget.BreadcrumbLayout.get -> NLog.Layouts.Layout
 Sentry.NLog.SentryTarget.BreadcrumbLayout.set -> void
-Sentry.NLog.SentryTarget.Dsn.get -> string
+Sentry.NLog.SentryTarget.Dsn.get -> NLog.Layouts.Layout
 Sentry.NLog.SentryTarget.Dsn.set -> void
+Sentry.NLog.SentryTarget.Environment.get -> NLog.Layouts.Layout
+Sentry.NLog.SentryTarget.Environment.set -> void
 Sentry.NLog.SentryTarget.FlushTimeoutSeconds.get -> int
 Sentry.NLog.SentryTarget.FlushTimeoutSeconds.set -> void
 Sentry.NLog.SentryTarget.IgnoreEventsWithNoException.get -> bool
 Sentry.NLog.SentryTarget.IgnoreEventsWithNoException.set -> void
 Sentry.NLog.SentryTarget.IncludeEventDataOnBreadcrumbs.get -> bool
 Sentry.NLog.SentryTarget.IncludeEventDataOnBreadcrumbs.set -> void
+Sentry.NLog.SentryTarget.IncludeEventPropertiesAsTags.get -> bool
+Sentry.NLog.SentryTarget.IncludeEventPropertiesAsTags.set -> void
 Sentry.NLog.SentryTarget.InitializeSdk.get -> bool
 Sentry.NLog.SentryTarget.InitializeSdk.set -> void
 Sentry.NLog.SentryTarget.MinimumBreadcrumbLevel.get -> string
@@ -42,6 +50,8 @@ Sentry.NLog.SentryTarget.MinimumBreadcrumbLevel.set -> void
 Sentry.NLog.SentryTarget.MinimumEventLevel.get -> string
 Sentry.NLog.SentryTarget.MinimumEventLevel.set -> void
 Sentry.NLog.SentryTarget.Options.get -> Sentry.NLog.SentryNLogOptions
+Sentry.NLog.SentryTarget.Release.get -> NLog.Layouts.Layout
+Sentry.NLog.SentryTarget.Release.set -> void
 Sentry.NLog.SentryTarget.SendEventPropertiesAsData.get -> bool
 Sentry.NLog.SentryTarget.SendEventPropertiesAsData.set -> void
 Sentry.NLog.SentryTarget.SendEventPropertiesAsTags.get -> bool

--- a/src/Sentry.NLog/SentryNLogOptions.cs
+++ b/src/Sentry.NLog/SentryNLogOptions.cs
@@ -46,16 +46,9 @@ namespace Sentry.NLog
         public bool IgnoreEventsWithNoException { get; set; } = false;
 
         /// <summary>
-        /// Determines whether event-level properties will be sent to sentry as additional data. Defaults to <see langword="true" />.
-        /// </summary>
-        /// <seealso cref="SendEventPropertiesAsTags" />
-        public bool SendEventPropertiesAsData { get; set; } = true;
-
-        /// <summary>
         /// Determines whether event properties will be sent to sentry as Tags or not. Defaults to <see langword="false" />.
         /// </summary>
-        /// <seealso cref="SendEventPropertiesAsData"/>
-        public bool SendEventPropertiesAsTags { get; set; } = false;
+        public bool IncludeEventPropertiesAsTags { get; set; } = false;
 
         /// <summary>
         /// Determines whether or not to include event-level data as data in breadcrumbs for future errors.
@@ -70,10 +63,28 @@ namespace Sentry.NLog
         public Layout BreadcrumbLayout { get; set; }
 
         /// <summary>
-        /// Configured layout for the NLog logger.
+        /// Configured layout for rendering SentryEvent message
         /// </summary>
         [NLogConfigurationIgnoreProperty] // Configure this directly on the target in XML config.
         public Layout Layout { get; set; }
+
+        /// <summary>
+        /// Configured layout for Dsn-Address to Sentry
+        /// </summary>
+        [NLogConfigurationIgnoreProperty] // Configure this directly on the target in XML config.
+        public Layout DsnLayout { get; set; }
+
+        /// <summary>
+        /// Configured layout for application Release version to Sentry
+        /// </summary>
+        [NLogConfigurationIgnoreProperty] // Configure this directly on the target in XML config.
+        public Layout ReleaseLayout { get; set; }
+
+        /// <summary>
+        /// Configured layout for application Environment to Sentry
+        /// </summary>
+        [NLogConfigurationIgnoreProperty] // Configure this directly on the target in XML config.
+        public Layout EnvironmentLayout { get; set; }
 
         /// <summary>
         /// Any additional tags to apply to each logged message.

--- a/src/Sentry.NLog/SentryNLogUser.cs
+++ b/src/Sentry.NLog/SentryNLogUser.cs
@@ -9,6 +9,7 @@ namespace Sentry.NLog
     /// <summary>
     /// A helper class used to configure Sentry user properties using NLog layouts
     /// </summary>
+    [NLogConfigurationItem]
     public class SentryNLogUser
     {
         /// <summary>

--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -62,6 +62,7 @@ namespace Sentry.NLog
             // Overrides default layout. Still will be explicitly overwritten if manually configured in the
             // NLog.config file.
             Layout = "${message}";
+            IncludeEventProperties = true;
 
             Options = options;
             _hubAccessor = hubAccessor;
@@ -86,12 +87,30 @@ namespace Sentry.NLog
         public IList<TargetPropertyWithContext> Tags => Options.Tags;
 
         /// <summary>
-        /// The Data Source Name of a given project in Sentry.
+        /// Configured layout for Data Source Name of a given project in Sentry
         /// </summary>
-        public string Dsn
+        public Layout Dsn
         {
-            get => Options.Dsn?.ToString();
-            set => Options.Dsn = value == null ? null : new Dsn(value);
+            get => Options.DsnLayout;
+            set => Options.DsnLayout = value;
+        }
+
+        /// <summary>
+        /// Configured layout for application Release version to Sentry
+        /// </summary>
+        public Layout Release
+        {
+            get => Options.ReleaseLayout;
+            set => Options.ReleaseLayout = value;
+        }
+
+        /// <summary>
+        /// Configured layout for application Environment to Sentry
+        /// </summary>
+        public Layout Environment
+        {
+            get => Options.EnvironmentLayout;
+            set => Options.EnvironmentLayout = value;
         }
 
         /// <summary>
@@ -144,25 +163,36 @@ namespace Sentry.NLog
         }
 
         /// <summary>
+        /// Determines whether event properties will be sent to sentry as Tags or not.
+        /// Defaults to <see langword="false" />.
+        /// </summary>
+        public bool IncludeEventPropertiesAsTags
+        {
+            get => Options.IncludeEventPropertiesAsTags;
+            set => Options.IncludeEventPropertiesAsTags = value;
+        }
+
+        /// <summary>
         /// Determines whether event-level properties will be sent to sentry as additional data.
         /// Defaults to <see langword="true" />.
         /// </summary>
-        /// <seealso cref="SendEventPropertiesAsTags" />
-        public bool SendEventPropertiesAsData
+        /// <seealso cref="IncludeEventPropertiesAsTags" />
+        [Obsolete("Use IncludeEventProperties instead")]
+        public bool SendEventPropertiesAsData 
         {
-            get => Options.SendEventPropertiesAsData;
-            set => Options.SendEventPropertiesAsData = value;
+            get => IncludeEventProperties;
+            set => IncludeEventProperties = value;
         }
 
         /// <summary>
         /// Determines whether event properties will be sent to sentry as Tags or not.
         /// Defaults to <see langword="false" />.
         /// </summary>
-        /// <seealso cref="SendEventPropertiesAsData"/>
+        [Obsolete("Use IncludeEventPropertiesAsTags instead")]
         public bool SendEventPropertiesAsTags
         {
-            get => Options.SendEventPropertiesAsTags;
-            set => Options.SendEventPropertiesAsTags = value;
+            get => IncludeEventPropertiesAsTags;
+            set => IncludeEventPropertiesAsTags = value;
         }
 
         /// <summary>
@@ -215,7 +245,23 @@ namespace Sentry.NLog
         {
             base.InitializeTarget();
 
-            IncludeEventProperties = Options.SendEventPropertiesAsData;
+            var customDsn = Dsn?.Render(LogEventInfo.CreateNullEvent());
+            if (!string.IsNullOrEmpty(customDsn))
+            {
+                Options.Dsn = new Dsn(customDsn);
+            }
+
+            var customRelease = Release?.Render(LogEventInfo.CreateNullEvent());
+            if (!string.IsNullOrEmpty(customRelease))
+            {
+                Options.Release = customRelease;
+            }
+
+            var customEnvironment = Environment?.Render(LogEventInfo.CreateNullEvent());
+            if (!string.IsNullOrEmpty(customEnvironment))
+            {
+                Options.Environment = customEnvironment;
+            }
 
             // If a layout has been configured on the options, replace the default logger.
             if (Options.Layout != null)
@@ -298,7 +344,7 @@ namespace Sentry.NLog
 
                 evt.Sdk.AddPackage(ProtocolPackageName, NameAndVersion.Version);
 
-                if (Tags.Count > 0 || SendEventPropertiesAsTags)
+                if (Tags.Count > 0 || IncludeEventPropertiesAsTags)
                 {
                     evt.SetTags(GetTagsFromLogEvent(logEvent));
                 }
@@ -322,8 +368,7 @@ namespace Sentry.NLog
                     : breadcrumbFormatted;
 
                 IDictionary<string, string> data = null;
-
-                // If this is true, an exception is being logged with no custom message
+// If this is true, an exception is being logged with no custom message
                 if (exception != null && !message.StartsWith(exception.Message))
                 {
                     // Exception won't be used as Breadcrumb message. Avoid losing it by adding as data:
@@ -374,7 +419,7 @@ namespace Sentry.NLog
 
         private IEnumerable<KeyValuePair<string, string>> GetTagsFromLogEvent(LogEventInfo logEvent)
         {
-            if (SendEventPropertiesAsTags)
+            if (IncludeEventPropertiesAsTags)
             {
                 if (logEvent.HasProperties)
                 {

--- a/test/Sentry.NLog.Tests/ConfigurationExtensionsTest.cs
+++ b/test/Sentry.NLog.Tests/ConfigurationExtensionsTest.cs
@@ -34,7 +34,7 @@ namespace Sentry.NLog.Tests
             var actual = _sut.AddSentry(expectedDsn, o => o.FlushTimeout = expectedTimeout);
             var sentryTarget = Assert.IsType<SentryTarget>(actual.AllTargets[0]);
             Assert.Equal(expectedTimeout.TotalSeconds, sentryTarget.FlushTimeoutSeconds);
-            Assert.Equal(expectedDsn, sentryTarget.Dsn);
+            Assert.Equal(expectedDsn, sentryTarget.Options.Dsn.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
And renamed SendEventPropertiesAsTags to IncludeEventPropertiesAsTags.

This aligns the NLog Sentry Target with other NLog Targets that inherits from NLog [TargetWithContext](https://nlog-project.org/documentation/v4.5.0/html/T_NLog_Targets_TargetWithContext.htm).

Abused the [Readme.md](https://github.com/snakefoot/sentry-dotnet/tree/master/samples/Sentry.Samples.NLog) from the Sample-project to explain the available settings on the NLog Sentry Target.

Btw. weird one cannot announce inherited properties as part of the public API for SentryTarget:
- TargetWithContext.IncludeEventProperties
- TargetWithContext.IncludeMdlc

Added NLog Layout support (allow dynamic lookup in appsettings) for the following properties:
- Dsn
- Environment
- Release