### PR TITLE
Adds ability to specify user values via NLog configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -142,6 +142,7 @@ csharp_style_deconstructed_variable_declaration = true : suggestion
 # Code style defaults
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = false
+csharp_prefer_braces = true : suggestion
 
 # Indentation
 csharp_indent_block_contents = true
@@ -182,3 +183,4 @@ csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
+

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Version>2.0.0-beta7</Version>
     <LangVersion>7.3</LangVersion>
-    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">True</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../.assets/Sentry.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <Deterministic>True</Deterministic>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Version>2.0.0-beta7</Version>
     <LangVersion>7.3</LangVersion>
-    <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">True</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../.assets/Sentry.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <Deterministic>True</Deterministic>

--- a/samples/Sentry.Samples.NLog/NLog.config
+++ b/samples/Sentry.Samples.NLog/NLog.config
@@ -30,6 +30,15 @@
         <includeEventDataOnBreadcrumbs>true</includeEventDataOnBreadcrumbs>
       </options>
 
+      <!-- Optionally specify user properties via NLog (here using NestedDiagnosticsLogicalContext as an example) -->
+      <user id="${gdc:item=id}" 
+            username="${gdc:item=username}"
+            email="${gdc:item=email}"
+            >
+        <!-- You can also apply additional user properties here-->
+        <other name="mood" layout="joyous"/>
+      </user>
+
       <!--Add any desired additional tags that will be sent with every message -->
       <tag name="logger" layout="${logger}" />
     </target>

--- a/samples/Sentry.Samples.NLog/NLog.config
+++ b/samples/Sentry.Samples.NLog/NLog.config
@@ -30,10 +30,10 @@
         <includeEventDataOnBreadcrumbs>true</includeEventDataOnBreadcrumbs>
       </options>
 
-      <!-- Optionally specify user properties via NLog (here using NestedDiagnosticsLogicalContext as an example) -->
-      <user id="${gdc:item=id}" 
-            username="${gdc:item=username}"
-            email="${gdc:item=email}"
+      <!-- Optionally specify user properties via NLog (here using MappedDiagnosticsLogicalContext as an example) -->
+      <user id="${mdlc:item=id}" 
+            username="${mdlc:item=username}"
+            email="${mdlc:item=email}"
             >
         <!-- You can also apply additional user properties here-->
         <other name="mood" layout="joyous"/>

--- a/samples/Sentry.Samples.NLog/Program.cs
+++ b/samples/Sentry.Samples.NLog/Program.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using NLog;
 using NLog.Config;
 using NLog.Targets;
+using Sentry.NLog;
 
 // ReSharper disable ConvertToConstant.Local
 namespace Sentry.Samples.NLog
@@ -83,7 +85,7 @@ namespace Sentry.Samples.NLog
         {
             // Other overloads exist, for example, configure the SDK with only the DSN or no parameters at all.
             var config = LogManager.Configuration = new LoggingConfiguration();
-            config
+            _ = config
                 .AddSentry(o =>
                 {
                     o.Layout = "${message}";
@@ -101,6 +103,18 @@ namespace Sentry.Samples.NLog
 
                     o.IncludeEventDataOnBreadcrumbs = true; // Optionally include event properties with breadcrumbs
                     o.ShutdownTimeoutSeconds = 5;
+
+                    //Optionally specify user properties via NLog (here using GlobalDiagnosticsContext as an example)
+                    o.User = new SentryNLogUser
+                    {
+                        Id = "${gdc:item=id}",
+                        Username = "${gdc:item=id}",
+                        Email= "${gdc:item=id}",
+                        Other =
+                        {
+                            new TargetPropertyWithContext("mood", "joyous")
+                        },
+                    };
 
                     o.AddTag("logger", "${logger}");  // Send the logger name as a tag
 

--- a/src/Sentry.NLog/PublicAPI.Unshipped.txt
+++ b/src/Sentry.NLog/PublicAPI.Unshipped.txt
@@ -1,1 +1,15 @@
-﻿
+﻿Sentry.NLog.SentryNLogOptions.User.get -> Sentry.NLog.SentryNLogUser
+Sentry.NLog.SentryNLogOptions.User.set -> void
+Sentry.NLog.SentryNLogUser
+Sentry.NLog.SentryNLogUser.Email.get -> NLog.Layouts.Layout
+Sentry.NLog.SentryNLogUser.Email.set -> void
+Sentry.NLog.SentryNLogUser.Id.get -> NLog.Layouts.Layout
+Sentry.NLog.SentryNLogUser.Id.set -> void
+Sentry.NLog.SentryNLogUser.IpAddress.get -> NLog.Layouts.Layout
+Sentry.NLog.SentryNLogUser.IpAddress.set -> void
+Sentry.NLog.SentryNLogUser.Other.get -> System.Collections.Generic.IList<NLog.Targets.TargetPropertyWithContext>
+Sentry.NLog.SentryNLogUser.SentryNLogUser() -> void
+Sentry.NLog.SentryNLogUser.Username.get -> NLog.Layouts.Layout
+Sentry.NLog.SentryNLogUser.Username.set -> void
+Sentry.NLog.SentryTarget.User.get -> Sentry.NLog.SentryNLogUser
+Sentry.NLog.SentryTarget.User.set -> void

--- a/src/Sentry.NLog/SentryNLogOptions.cs
+++ b/src/Sentry.NLog/SentryNLogOptions.cs
@@ -89,5 +89,11 @@ namespace Sentry.NLog
         /// This might be not ideal when using multiple integrations in case you want another one doing the Init.
         /// </remarks>
         public bool InitializeSdk { get; set; } = true;
+
+        /// <summary>
+        /// Optionally configure one or more parts of the user information to be rendered dynamically from an NLog layout
+        /// </summary>
+        [NLogConfigurationIgnoreProperty] // Configure this directly on the target in XML config.
+        public SentryNLogUser User { get; set; } = new SentryNLogUser();
     }
 }

--- a/src/Sentry.NLog/SentryNLogUser.cs
+++ b/src/Sentry.NLog/SentryNLogUser.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using System.Collections.Generic;
+using NLog.Config;
+using NLog.Layouts;
+using NLog.Targets;
+
+namespace Sentry.NLog
+{
+    /// <summary>
+    /// A helper class used to configure Sentry user properties using NLog layouts
+    /// </summary>
+    public class SentryNLogUser
+    {
+        /// <summary>
+        /// A <see cref="Layout"/> used to dynamically specify the id of a user for a sentry event.
+        /// </summary>
+        public Layout Id { get; set; }
+
+        /// <summary>
+        /// A <see cref="Layout"/> used to dynamically specify the username of a user for a sentry event.
+        /// </summary>
+        public Layout Username { get; set; }
+
+        /// <summary>
+        /// A <see cref="Layout"/> used to dynamically specify the email of a user for a sentry event.
+        /// </summary>
+        public Layout Email { get; set; }
+
+        /// <summary>
+        /// A <see cref="Layout"/> used to dynamically specify the ip address of a user for a sentry event.
+        /// </summary>
+        public Layout IpAddress { get; set; }
+
+        /// <summary>
+        /// Additional information about the user
+        /// </summary>
+        /// <summary>
+        /// Add any desired additional tags that will be sent with every message.
+        /// </summary>
+        [ArrayParameter(typeof(TargetPropertyWithContext), "other")]
+        public IList<TargetPropertyWithContext> Other { get; } = new List<TargetPropertyWithContext>();
+    }
+}

--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -194,6 +194,15 @@ namespace Sentry.NLog
             set => Options.FlushTimeout = TimeSpan.FromSeconds(value);
         }
 
+        /// <summary>
+        /// Optionally configure one or more parts of the user information to be rendered dynamically from an NLog layout
+        /// </summary>
+        public SentryNLogUser User
+        {
+            get => Options.User;
+            set => Options.User = value;
+        }
+
         /// <inheritdoc />
         protected override void CloseTarget()
         {
@@ -284,6 +293,7 @@ namespace Sentry.NLog
                     Level = logEvent.Level.ToSentryLevel(),
                     Release = Options.Release,
                     Environment = Options.Environment,
+                    User = GetUser(logEvent),
                 };
 
                 evt.Sdk.AddPackage(ProtocolPackageName, NameAndVersion.Version);
@@ -343,6 +353,21 @@ namespace Sentry.NLog
                     data: data,
                     level: logEvent.Level.ToBreadcrumbLevel());
             }
+        }
+
+        private User GetUser(LogEventInfo logEvent)
+        {
+            if (User == null)
+                return null;
+
+            return new User
+            {
+                Email = User.Email?.Render(logEvent),
+                Id = User.Id?.Render(logEvent),
+                IpAddress = User.IpAddress?.Render(logEvent),
+                Username = User.Username?.Render(logEvent),
+                Other = User.Other.ToDictionary(a => a.Name, b => b.Layout.Render(logEvent)),
+            };
         }
 
         private IEnumerable<KeyValuePair<string, string>> GetTagsFromLogEvent(LogEventInfo logEvent)

--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -358,7 +358,9 @@ namespace Sentry.NLog
         private User GetUser(LogEventInfo logEvent)
         {
             if (User == null)
+            {
                 return null;
+            }
 
             return new User
             {
@@ -389,7 +391,9 @@ namespace Sentry.NLog
                 {
                     var tagValue = RenderLogEvent(tag.Layout, logEvent);
                     if (!tag.IncludeEmptyValue && string.IsNullOrEmpty(tagValue))
+                    {
                         continue;
+                    }
 
                     yield return new KeyValuePair<string, string>(tag.Name, tagValue);
                 }

--- a/test/Sentry.NLog.Tests/SentryNLogOptionsTests.cs
+++ b/test/Sentry.NLog.Tests/SentryNLogOptionsTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Sentry.NLog.Tests
 {
-    public class SentrySerilogOptionsTests
+    public class SentryNLogOptionsTests
     {
         [Fact]
         public void Ctor_MinimumBreadcrumbLevel_Information()

--- a/test/Sentry.NLog.Tests/SentryTargetTests.cs
+++ b/test/Sentry.NLog.Tests/SentryTargetTests.cs
@@ -731,7 +731,6 @@ namespace Sentry.NLog.Tests
 
             _fixture.Hub.Received(1)
                 .CaptureEvent(Arg.Is<SentryEvent>(e => e.User.Username == "sentry"));
-
         }
 
         internal class LogLevelData : IEnumerable<object[]>


### PR DESCRIPTION
RE: #322 
I opted to have a user object to keep the user information logically coupled. If it would be more clear in another format I'm fine with changing it, but I also figured it would be more straightforward to do it this way especially if we want to add support for structured contexts or other things (i.e. fingerprint) for them to be logically structured like in sentry documentation.