### PR TITLE
Set DateFormatHandling.IsoDateFormat for serializer. Fixes #351

### DIFF
--- a/src/Sentry/Internal/JsonSerializer.cs
+++ b/src/Sentry/Internal/JsonSerializer.cs
@@ -12,7 +12,8 @@ namespace Sentry.Internal
             NullValueHandling = NullValueHandling.Ignore,
             ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
             Formatting = Formatting.None,
-            Converters = new[] { StringEnumConverter }
+            Converters = new[] { StringEnumConverter },
+            DateFormatHandling = DateFormatHandling.IsoDateFormat
         };
 
         public static string SerializeObject<T>(T @object) => JsonConvert.SerializeObject(@object, Settings);


### PR DESCRIPTION
Related #351 

According to [the documentation](https://www.newtonsoft.com/json/help/html/P_Newtonsoft_Json_JsonConvert_DefaultSettings.htm), the default settings are used by [JsonConvert](https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_JsonConvert.htm) method.

So, we have two options:

- Override the default settings (this is done in the PR)
- Create a new serializer with [Create](https://www.newtonsoft.com/json/help/html/M_Newtonsoft_Json_JsonSerializer_Create.htm) method

I believe that the second approach is preferable since we have more control over the serializing settings (I can update the PR).

@bruno-garcia Please let me know what do you think.