### PR TITLE
feat: Don't dedupe from inner exception

### DIFF
--- a/src/Sentry/Internal/DuplicateEventDetectionEventProcessor.cs
+++ b/src/Sentry/Internal/DuplicateEventDetectionEventProcessor.cs
@@ -2,36 +2,66 @@ using System;
 using System.Runtime.CompilerServices;
 using Sentry.Extensibility;
 
+namespace Sentry
+{
+    /// <summary>
+    /// Possible modes of dropping events that are detected to be duplicates.
+    /// </summary>
+    [Flags]
+    public enum DeduplicateMode
+    {
+        /// <summary>
+        /// Same event instance. Assumes no object reuse/pooling.
+        /// </summary>
+        SameEvent = 1,
+        /// <summary>
+        /// An exception that was captured twice.
+        /// </summary>
+        SameExceptionInstance = 2,
+        /// <summary>
+        /// An exception already captured exists as an inner exception.
+        /// </summary>
+        InnerException = 4,
+        /// <summary>
+        /// An exception already captured is part of the aggregate exception.
+        /// </summary>
+        AggregateException = 8,
+        /// <summary>
+        /// All modes combined.
+        /// </summary>
+        All = int.MaxValue
+    }
+}
+
 namespace Sentry.Internal
 {
     internal class DuplicateEventDetectionEventProcessor : ISentryEventProcessor
     {
         private readonly SentryOptions _options;
-        private readonly ConditionalWeakTable<object, object> _capturedEvent = new ConditionalWeakTable<object, object>();
+        private readonly ConditionalWeakTable<object, object> _capturedObjects = new ConditionalWeakTable<object, object>();
 
         public DuplicateEventDetectionEventProcessor(SentryOptions options) => _options = options;
 
         public SentryEvent Process(SentryEvent @event)
         {
-            if (_capturedEvent.TryGetValue(@event, out _))
+            if (_options.DeduplicateMode.HasFlag(DeduplicateMode.SameEvent))
             {
-                _options.DiagnosticLogger?.LogDebug("Same event instance detected and discarded. EventId: {0}", @event.EventId);
-                return null;
+                if (_capturedObjects.TryGetValue(@event, out _))
+                {
+                    _options.DiagnosticLogger?.LogDebug("Same event instance detected and discarded. EventId: {0}", @event.EventId);
+                    return null;
+                }
+                _capturedObjects.Add(@event, null);
             }
-            _capturedEvent.Add(@event, null);
 
-            if (@event.Exception == null)
+            if (@event.Exception == null
+                || !IsDuplicate(@event.Exception))
             {
                 return @event;
             }
 
-            if (IsDuplicate(@event.Exception))
-            {
-                _options.DiagnosticLogger?.LogDebug("Duplicate Exception detected. Event {0} will be discarded.", @event.EventId);
-                return null;
-            }
-
-            return @event;
+            _options.DiagnosticLogger?.LogDebug("Duplicate Exception detected. Event {0} will be discarded.", @event.EventId);
+            return null;
         }
 
         private bool IsDuplicate(Exception ex)
@@ -41,35 +71,37 @@ namespace Sentry.Internal
                 return false;
             }
 
-            while (true)
+            if (_options.DeduplicateMode.HasFlag(DeduplicateMode.SameExceptionInstance))
             {
-                if (_capturedEvent.TryGetValue(ex, out _))
+                if (_capturedObjects.TryGetValue(ex, out _))
                 {
                     return true;
                 }
 
-                _capturedEvent.Add(ex, null);
+                _capturedObjects.Add(ex, null);
+            }
 
-                if (ex is AggregateException aex)
+            if (_options.DeduplicateMode.HasFlag(DeduplicateMode.AggregateException)
+                && ex is AggregateException aex)
+            {
+                foreach (var aexInnerException in aex.InnerExceptions)
                 {
-                    foreach (var aexInnerException in aex.InnerExceptions)
-                    {
-                        if (IsDuplicate(aexInnerException))
-                        {
-                            return true;
-                        }
-                    }
-                }
-                else if (ex.InnerException != null)
-                {
-                    if (IsDuplicate(ex.InnerException))
+                    if (IsDuplicate(aexInnerException))
                     {
                         return true;
                     }
                 }
-
-                return false;
             }
+            else if (_options.DeduplicateMode.HasFlag(DeduplicateMode.InnerException)
+                     && ex.InnerException != null)
+            {
+                if (IsDuplicate(ex.InnerException))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -349,6 +349,14 @@ namespace Sentry
         /// </summary>
         public bool ReportAssemblies { get; set; } = true;
 
+        /// <summary>
+        /// What modes to use for event automatic deduplication
+        /// </summary>
+        /// <remarks>
+        /// By default will not drop an event solely for including an inner exception that was already captured.
+        /// </remarks>
+        public DeduplicateMode DeduplicateMode { get; set; } = DeduplicateMode.All ^ DeduplicateMode.InnerException;
+
 #if SYSTEM_WEB
         /// <summary>
         /// Max request body to be captured when a Web request exists on a ASP.NET Application.


### PR DESCRIPTION
Adds modes to de-duplication of events.
Removes the dedupe for inner exceptions.

The mains driver is EF Core that logs an exception like this:

```
An exception occurred while iterating over the results of a query for context type '"NuGetTrends.Data.NuGetTrendsContext"'."
""System.InvalidCastException: Column is null
   at Npgsql.NpgsqlDataReader.GetFieldValue[T](Int32 ordinal)
   at lambda_method(Closure , QueryContext , DbDataReader , ResultContext , Int32[] , ResultCoordinator )
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryingEnumerable`1.AsyncEnumerator.MoveNextAsync()"
```

And rethrows. When Sentry wants to log it, it's dropped by the dedupe.

The stack trace from the EF Core entry is useless to the app developer, oesn't lead to the code that started the query.

Deduping InnerExceptions can be opt-in again via:

```
SentryOptions.DeduplicateMode |= DeduplicateMode.InnerException; 
```