### PR TITLE
Capture event when unoptimized asm

### DIFF
--- a/samples/Sentry.Samples.Console.Customized/Sentry.Samples.Console.Customized.csproj
+++ b/samples/Sentry.Samples.Console.Customized/Sentry.Samples.Console.Customized.csproj
@@ -5,6 +5,8 @@
     <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
     <!--Set explicitly to demonstrate one way of defining the Sentry Release-->
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <!-- To be able to load structuremap 4.4.0 which is unsigned-->
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +15,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="structuremap" Version="4.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Sentry/Integrations/UnoptimizedAssemblyIntegration.cs
+++ b/src/Sentry/Integrations/UnoptimizedAssemblyIntegration.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Linq;
+using Sentry.Extensibility;
+using Sentry.Protocol;
+using Sentry.Reflection;
+
+namespace Sentry.Integrations
+{
+    /// <summary>
+    /// An integration that emits events when detects assemblies compiled for debug.
+    /// </summary>
+    public class UnoptimizedAssemblyIntegration : ISdkIntegration
+    {
+        /// <summary>
+        /// Registers the integration with the hub and options.
+        /// </summary>
+        /// <param name="hub">The hub to use to send events.</param>
+        /// <param name="options">The options to configure the integration.</param>
+        public void Register(IHub hub, SentryOptions options)
+        {
+            if (options.NotifyUnoptimizedAssembly)
+            {
+                options.DiagnosticLogger?.LogDebug("Subscribing to AssemblyLoad to detect unoptimized assemblies.");
+                // TODO: .NET Core equivalent
+                AppDomain.CurrentDomain.AssemblyLoad += (sender, args) =>
+                {
+                    if (!args.LoadedAssembly.IsOptimized())
+                    {
+                        CaptureEvent(hub, options, args.LoadedAssembly.FullName);
+                        hub.FlushAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
+                    }
+                };
+
+                var unoptimizedAssemblies = AppDomain.CurrentDomain.GetAssemblies()
+                    .Where(a => !a.IsOptimized())
+                    .Select(a => a.FullName)
+                    .ToArray();
+
+                if (unoptimizedAssemblies.Any())
+                {
+                    CaptureEvent(hub, options, unoptimizedAssemblies);
+                }
+            }
+        }
+
+        private static void CaptureEvent(IHub hub, SentryOptions options, params string[] assemblies)
+        {
+            if (assemblies.Length > 0)
+            {
+                options.DiagnosticLogger?.LogInfo("Unoptimized Assembly found. Raising event for {count} assemblies", assemblies.Length);
+                using (hub.PushScope())
+                {
+                    hub.ConfigureScope(s =>
+                    {
+                        s.SetFingerprint(new[] {"UnoptimizedAssemblyIntegration"});
+                        foreach (var asm in assemblies)
+                        {
+                            options.DiagnosticLogger?.LogInfo("Unoptimized Assembly: {asm}", asm);
+                            s.SetExtra("unoptimized-assembly", asm);
+                        }
+                        s.Level = SentryLevel.Warning;
+                    });
+                    hub.CaptureMessage("Unoptimized assembly detected.");
+                }
+            }
+        }
+    }
+}

--- a/src/Sentry/Reflection/AssemblyExtensions.cs
+++ b/src/Sentry/Reflection/AssemblyExtensions.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Reflection;
 using Sentry.Protocol;
 
@@ -28,6 +29,21 @@ namespace Sentry.Reflection
                       ?? asmName.Version.ToString();
 
             return new SdkVersion { Name = name, Version = version };
+        }
+
+        /// <summary>
+        /// Whether the assembly was compiled with the optimize+ flag
+        /// </summary>
+        /// <param name="asm">The assembly to verify the optimization flag</param>
+        /// <returns>
+        /// true if no <see cref="DebuggableAttribute"/> exists or
+        /// <see cref="DebuggableAttribute.IsJITOptimizerDisabled"/> is false,
+        /// otherwise, false.
+        /// </returns>
+        public static bool IsOptimized(this Assembly asm)
+        {
+            var att = asm.GetCustomAttribute<DebuggableAttribute>();
+            return att == null || att.IsJITOptimizerDisabled == false;
         }
     }
 }

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -350,6 +350,11 @@ namespace Sentry
         public bool ReportAssemblies { get; set; } = true;
 
         /// <summary>
+        /// Whether the SDK should raise events if unoptimized assemblies are loaded.
+        /// </summary>
+        public bool NotifyUnoptimizedAssembly { get; set; }
+
+        /// <summary>
         /// What modes to use for event automatic deduplication
         /// </summary>
         /// <remarks>
@@ -411,7 +416,8 @@ namespace Sentry
             Integrations
                 = ImmutableList.Create<ISdkIntegration>(
                     new AppDomainUnhandledExceptionIntegration(),
-                    new AppDomainProcessExitIntegration());
+                    new AppDomainProcessExitIntegration(),
+                    new UnoptimizedAssemblyIntegration());
 
             InAppExclude
                 = ImmutableList.Create(


### PR DESCRIPTION
I first thought of this feature when I found out that the old Sentry SDK had debug builds published to nuget.org.
This is happening because default of `dotnet pack` is Debug. One needs to set `-c Release` to get the optmized assemblies.

Since this came [again on twitter](https://twitter.com/khellang/status/1229171900141756416), I decided to open up a draft at least to discuss.

Resolves #364