### PR TITLE
fix: set score url to fully constructed url

### DIFF
--- a/src/Sentry.AspNetCore/ScopeExtensions.cs
+++ b/src/Sentry.AspNetCore/ScopeExtensions.cs
@@ -65,7 +65,12 @@ namespace Sentry.AspNetCore
 
             // Logging integration, if enabled, sets the following tag which ends up as duplicate
             // to Request.Url. Prefer the interface value and remove tag.
-            scope.Request.Url = context.Request.Path;
+            var host = context.Request.Host.Host;
+            if (context.Request.Host.Port != null)
+            {
+                host += $":{context.Request.Host.Port}";
+            }
+            scope.Request.Url = $"{context.Request.Scheme}://{host}{context.Request.Path}";
             scope.UnsetTag("RequestPath");
 
             scope.Request.QueryString = context.Request.QueryString.ToString();

--- a/test/Sentry.AspNetCore.Tests/ScopeExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/ScopeExtensionsTests.cs
@@ -55,8 +55,16 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void Populate_Request_Url_SetToScope()
         {
-            const string expected = "/request/path";
-            _httpContext.Request.Path.Returns(new PathString(expected));
+            const string expectedPath = "/request/path";
+            _httpContext.Request.Path.Returns(new PathString(expectedPath));
+
+            const string expectedHost = "host.com";
+            _httpContext.Request.Host.Returns(new HostString(expectedHost));
+
+            const string expectedScheme = "http";
+            _httpContext.Request.Scheme.Returns(expectedScheme);
+
+            const string expected = "http://host.com/request/path";
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
@@ -73,6 +81,25 @@ namespace Sentry.AspNetCore.Tests
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
             Assert.False(_sut.Tags.ContainsKey("RequestPath"));
+        }
+
+        [Fact]
+        public void Populate_Request_Url_IncludesPortWhenOnContext()
+        {
+            const string expectedPath = "/request/path";
+            _httpContext.Request.Path.Returns(new PathString(expectedPath));
+
+            const string expectedHost = "host.com:9000";
+            _httpContext.Request.Host.Returns(new HostString(expectedHost));
+
+            const string expectedScheme = "http";
+            _httpContext.Request.Scheme.Returns(expectedScheme);
+
+            const string expected = "http://host.com:9000/request/path";
+
+            _sut.Populate(_httpContext, SentryAspNetCoreOptions);
+
+            Assert.Equal(expected, _sut.Request.Url);
         }
 
         [Fact]


### PR DESCRIPTION
Previously the Url property on scope was only set as the path from the HttpContext. This is not the fully constructed url of the request and sending only the path here breaks some functionality in the Sentry UI. 

This addresses https://github.com/getsentry/sentry-dotnet/issues/366.