### PR TITLE
Add environment option to Serilog sink, fixes #290

### DIFF
--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -17,6 +17,7 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="dsn">The Sentry DSN.</param>
+        /// <param name="environment">The application environment.</param>
         /// <param name="minimumBreadcrumbLevel">Minimum log level to record a breadcrumb.</param>
         /// <param name="minimumEventLevel">Minimum log level to send an event.</param>
         /// <param name="formatProvider">The Serilog format provider.</param>
@@ -24,6 +25,7 @@ namespace Serilog
         public static LoggerConfiguration Sentry(
             this LoggerSinkConfiguration loggerConfiguration,
             string dsn = null,
+            string environment = null,
             LogEventLevel minimumBreadcrumbLevel = LogEventLevel.Information,
             LogEventLevel minimumEventLevel = LogEventLevel.Error,
             IFormatProvider formatProvider = null)
@@ -33,6 +35,7 @@ namespace Serilog
                     {
                         o.Dsn = new Dsn(dsn);
                     }
+                    o.Environment = environment;
                     o.MinimumBreadcrumbLevel = minimumBreadcrumbLevel;
                     o.MinimumEventLevel = minimumEventLevel;
                     o.FormatProvider = formatProvider;


### PR DESCRIPTION
This adds `Environment` to the list of allowed configuration options for the Serilog sink. This fixes #290, making the following Serilog configuration in `appsettings.json` possible:

```json
      {
        "Name": "Sentry",
        "Args": {
          "Dsn": "<replaced>",
          "Environment": "QA",
          "MinimumBreadcrumbLevel": "Debug",
          "MinimumEventLevel": "Error"
        }
      }
```

This is my first PR to this repository, so please let me know if I've missed anything 😊 (I think I may need to update `PublicAPI.Unshipped.txt` - not sure on that.) Thanks.