### PR TITLE
Register when an exception was handled or not

### DIFF
--- a/src/Sentry.Protocol/Exceptions/Mechanism.cs
+++ b/src/Sentry.Protocol/Exceptions/Mechanism.cs
@@ -16,6 +16,12 @@ namespace Sentry.Protocol
     [DataContract]
     public class Mechanism
     {
+        /// <summary>
+        /// Keys found inside of the Exception Dictionary to inform if the exception was handled and which mechanism tracked it
+        /// </summary>
+        public static readonly string HandledKey = "Sentry:Handled";
+        public static readonly string MechanismKey = "Sentry:Mechanism";
+
         [DataMember(Name = "data", EmitDefaultValue = false)]
         internal Dictionary<string, object> InternalData { get; private set; }
 

--- a/src/Sentry.Protocol/Exceptions/Mechanism.cs
+++ b/src/Sentry.Protocol/Exceptions/Mechanism.cs
@@ -20,6 +20,10 @@ namespace Sentry.Protocol
         /// Keys found inside of the Exception Dictionary to inform if the exception was handled and which mechanism tracked it
         /// </summary>
         public static readonly string HandledKey = "Sentry:Handled";
+
+        /// <summary>
+        /// Key found inside of the Exception.Data to inform if the exception which mechanism tracked it
+        /// </summary>
         public static readonly string MechanismKey = "Sentry:Mechanism";
 
         [DataMember(Name = "data", EmitDefaultValue = false)]

--- a/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
@@ -33,6 +33,8 @@ namespace Sentry.Integrations
         {
             if (e.ExceptionObject is Exception ex)
             {
+                ex.Data["Sentry:Handled"] =  false;
+                ex.Data["Sentry:Mechanism"] = "AppDomain.UnhandledException";
                 _hub?.CaptureException(ex);
             }
 

--- a/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using Sentry.Internal;
 using System.Runtime.ExceptionServices;
 using System.Security;
+using Sentry.Protocol;
 
 namespace Sentry.Integrations
 {
@@ -33,8 +34,8 @@ namespace Sentry.Integrations
         {
             if (e.ExceptionObject is Exception ex)
             {
-                ex.Data["Sentry:Handled"] =  false;
-                ex.Data["Sentry:Mechanism"] = "AppDomain.UnhandledException";
+                ex.Data[Mechanism.HandledKey] = false;
+                ex.Data[Mechanism.MechanismKey] = "AppDomain.UnhandledException";
                 _hub?.CaptureException(ex);
             }
 

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -110,24 +110,21 @@ namespace Sentry.Internal
         {
             Debug.Assert(exception != null);
 
-            Mechanism mechanism = new Mechanism()
-            {
-                Handled = true
-            };
+            var mechanism = new Mechanism();
 
             if (exception.HelpLink != null)
             {
                 mechanism.HelpLink = exception.HelpLink;
             }
-            if (exception.Data?.Contains("Sentry:Handled") == true)
+            if (exception.Data[Mechanism.HandledKey] is bool handled)
             {
-                mechanism.Handled = (exception.Data["Sentry:Handled"] as bool?).Value;
-                exception.Data.Remove("Sentry:Handled");
+                mechanism.Handled = handled;
+                exception.Data.Remove(Mechanism.HandledKey);
             }
-            if (exception.Data?.Contains("Sentry:Mechanism") == true)
+            if (exception.Data[Mechanism.MechanismKey] is string mechanismName )
             {
-                mechanism.Type = exception.Data["Sentry:Mechanism"] as string;
-                exception.Data.Remove("Sentry:Mechanism");
+                mechanism.Type = mechanismName;
+                exception.Data.Remove(Mechanism.MechanismKey);
             }
 
             return mechanism;

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -110,14 +110,24 @@ namespace Sentry.Internal
         {
             Debug.Assert(exception != null);
 
-            Mechanism mechanism = null;
+            Mechanism mechanism = new Mechanism()
+            {
+                Handled = true
+            };
 
             if (exception.HelpLink != null)
             {
-                mechanism = new Mechanism
-                {
-                    HelpLink = exception.HelpLink
-                };
+                mechanism.HelpLink = exception.HelpLink;
+            }
+            if (exception.Data?.Contains("Sentry:Handled") == true)
+            {
+                mechanism.Handled = (exception.Data["Sentry:Handled"] as bool?).Value;
+                exception.Data.Remove("Sentry:Handled");
+            }
+            if (exception.Data?.Contains("Sentry:Mechanism") == true)
+            {
+                mechanism.Type = exception.Data["Sentry:Mechanism"] as string;
+                exception.Data.Remove("Sentry:Mechanism");
             }
 
             return mechanism;

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -121,7 +121,7 @@ namespace Sentry.Internal
                 mechanism.Handled = handled;
                 exception.Data.Remove(Mechanism.HandledKey);
             }
-            if (exception.Data[Mechanism.MechanismKey] is string mechanismName )
+            if (exception.Data[Mechanism.MechanismKey] is string mechanismName)
             {
                 mechanism.Type = mechanismName;
                 exception.Data.Remove(Mechanism.MechanismKey);

--- a/test/Sentry.Tests/AppDomainUnhandledExceptionIntegrationTests.cs
+++ b/test/Sentry.Tests/AppDomainUnhandledExceptionIntegrationTests.cs
@@ -67,7 +67,6 @@ namespace Sentry.Tests
 
             var exception = new Exception();
             sut.Handle(this, new UnhandledExceptionEventArgs(exception, true));
-            Assert.True(exception.Data?.Contains("Sentry:Handled"));
             Assert.Equal(exception.Data["Sentry:Handled"] as bool?, (bool?)false);
             Assert.True(exception.Data?.Contains("Sentry:Mechanism"));
 

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using NSubstitute;
 using Sentry.Extensibility;
 using Sentry.Internal;
+using Sentry.Protocol;
 using Xunit;
 
 namespace Sentry.Tests.Internals
@@ -123,6 +124,33 @@ namespace Sentry.Tests.Internals
             Assert.Equal(2, evt.Extra.Count);
             Assert.Contains(evt.Extra, e => e.Key == "Exception[0][first]" && e.Value == firstValue);
             Assert.Contains(evt.Extra, e => e.Key == "Exception[1][second]" && e.Value == secondValue);
+        }
+
+        [Fact]
+        public void Process_ExceptionWithout_Handled()
+        {
+            var sut = _fixture.GetSut();
+            var evt = new SentryEvent();
+            var exp = new Exception();
+
+            sut.Process(exp, evt);
+
+            Assert.NotNull(evt.SentryExceptions.ToList().Single(p => p.Mechanism.Handled == null));
+        }
+
+        [Fact]
+        public void Process_ExceptionWith_HandledTrue()
+        {
+            var sut = _fixture.GetSut();
+            var evt = new SentryEvent();
+            var exp = new Exception();
+
+            exp.Data.Add(Mechanism.HandledKey, true);
+            exp.Data.Add(Mechanism.MechanismKey, "Process_ExceptionWith_HandledTrue");
+
+            sut.Process(exp, evt);
+
+            Assert.NotNull(evt.SentryExceptions.ToList().Single(p => p.Mechanism.Handled == true));
         }
 
         [Fact]

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
@@ -134,8 +134,9 @@ namespace Sentry.Tests.Internals
             var exp = new Exception();
 
             sut.Process(exp, evt);
+            var x= evt.SentryExceptions.ToList();
 
-            Assert.NotNull(evt.SentryExceptions.ToList().Single(p => p.Mechanism.Handled == null));
+            Assert.Single(evt.SentryExceptions.Where(p => p.Mechanism.Handled == null));
         }
 
         [Fact]
@@ -150,7 +151,7 @@ namespace Sentry.Tests.Internals
 
             sut.Process(exp, evt);
 
-            Assert.NotNull(evt.SentryExceptions.ToList().Single(p => p.Mechanism.Handled == true));
+            Assert.Single(evt.SentryExceptions.Where(p => p.Mechanism.Handled == true));
         }
 
         [Fact]


### PR DESCRIPTION

With this Pr, Sentry.io is going to register if an exception was handled by setting the handled flag in the Mechanism class.

It will not fix the "event handled" internal flag because I'm unsure which parameters I need to inform for that to work.