### PR TITLE
SentryScopeManager - Convert System.Tuple allocation into ValueTuple

### DIFF
--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -316,14 +316,14 @@ namespace Sentry.NLog
             }
 
             var exception = logEvent.Exception;
-            var formatted = RenderLogEvent(Layout, logEvent);
-            var template = logEvent.Message;
-
             var shouldOnlyLogExceptions = exception == null && IgnoreEventsWithNoException;
             var shouldIncludeProperties = ContextProperties?.Count > 0 || ShouldIncludeProperties(logEvent);
 
             if (logEvent.Level >= Options.MinimumEventLevel && !shouldOnlyLogExceptions)
             {
+                var formatted = RenderLogEvent(Layout, logEvent);
+                var template = logEvent.Message;
+
                 var evt = new SentryEvent(exception)
                 {
                     Sdk =
@@ -346,7 +346,7 @@ namespace Sentry.NLog
 
                 evt.Sdk.AddPackage(ProtocolPackageName, NameAndVersion.Version);
 
-                if (Tags.Count > 0 || IncludeEventPropertiesAsTags)
+                if (Tags.Count > 0 || (IncludeEventPropertiesAsTags && logEvent.HasProperties))
                 {
                     evt.SetTags(GetTagsFromLogEvent(logEvent));
                 }

--- a/src/Sentry/Internal/IInternalScopeManager.cs
+++ b/src/Sentry/Internal/IInternalScopeManager.cs
@@ -4,6 +4,6 @@ namespace Sentry.Internal
 {
     internal interface IInternalScopeManager : ISentryScopeManager
     {
-        Tuple<Scope, ISentryClient> GetCurrent();
+        ValueTuple<Scope, ISentryClient> GetCurrent();
     }
 }


### PR DESCRIPTION
Remove additional allocation of System.Tuple-objects.