### PR TITLE
Update README.md

### DIFF
--- a/samples/Sentry.Samples.NLog/README.md
+++ b/samples/Sentry.Samples.NLog/README.md
@@ -28,8 +28,8 @@ The following options are available for the NLog Sentry Target:
     initializeSdk="True"
     flushTimeoutSeconds="15"
     >
-        <tag name="exception" value="${exception:format=shorttype}" includeEmptyValue="false" /><!-- Repeatable SentryEvent Tags -->
-        <contextproperty name="threadid" value="${threadid}" includeEmptyValue="true" />        <!-- Repeatable SentryEvent Data -->
+        <tag name="exception" layout="${exception:format=shorttype}" includeEmptyValue="false" /><!-- Repeatable SentryEvent Tags -->
+        <contextproperty name="threadid" layout="${threadid}" includeEmptyValue="true" />        <!-- Repeatable SentryEvent Data -->
         <!-- Advanced options can be configured here-->
         <options
             sendDefaultPii="False"


### PR DESCRIPTION
This change fixes the NLog error when using this configuration 
"Parameter value not supported on TargetPropertyWithContext"

The attribute should be "layout" and not "value"

Tested with NLog version : 4.7.0
Sentry NLog version : 2.1.1
