### PR TITLE
Fixed Sentry.Samples.NLog so NLog.config is valid

### DIFF
--- a/samples/Sentry.Samples.NLog/NLog.config
+++ b/samples/Sentry.Samples.NLog/NLog.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      throwConfigExceptions="true"
 >
   <extensions>
     <add assembly="Sentry.NLog" />
@@ -32,10 +33,10 @@
         />
 
       <!--Optionally add any desired additional Tags that will be sent with every message -->
-      <tag name="exception" value="${exception:format=shorttype}" includeEmptyValue="false" />
+      <tag name="exception" layout="${exception:format=shorttype}" includeEmptyValue="false" />
 
       <!--Optionally add any desired additional Data that will be sent with every message -->
-      <contextproperty name="threadid" value="${threadid}" includeEmptyValue="true" />
+      <contextproperty name="threadid" layout="${threadid}" includeEmptyValue="true" />
 
       <!-- Optionally specify user properties via NLog (here using MappedDiagnosticsLogicalContext as an example) -->
       <user id="${mdlc:item=id}" 


### PR DESCRIPTION
Resolves #403 (Followup to #393 that fixed the Readme.md)