### PR TITLE
SentryScopeManager - Fixed clone of Stack so it does not reverse order

### DIFF
--- a/src/Sentry/Internal/SentryScopeManager.cs
+++ b/src/Sentry/Internal/SentryScopeManager.cs
@@ -10,15 +10,15 @@ namespace Sentry.Internal
     internal sealed class SentryScopeManager : IInternalScopeManager, IDisposable
     {
         private readonly SentryOptions _options;
-        private readonly AsyncLocal<Stack<KeyValuePair<Scope, ISentryClient>>> _asyncLocalScope = new AsyncLocal<Stack<KeyValuePair<Scope, ISentryClient>>>();
+        private readonly AsyncLocal<KeyValuePair<Scope, ISentryClient>[]> _asyncLocalScope = new AsyncLocal<KeyValuePair<Scope, ISentryClient>[]>();
 
-        internal Stack<KeyValuePair<Scope, ISentryClient>> ScopeAndClientStack
+        internal KeyValuePair<Scope, ISentryClient>[] ScopeAndClientStack
         {
             get => _asyncLocalScope.Value ?? (_asyncLocalScope.Value = NewStack());
             set => _asyncLocalScope.Value = value;
         }
 
-        private Func<Stack<KeyValuePair<Scope, ISentryClient>>> NewStack { get; }
+        private Func<KeyValuePair<Scope, ISentryClient>[]> NewStack { get; }
 
         public SentryScopeManager(
             SentryOptions options,
@@ -26,10 +26,14 @@ namespace Sentry.Internal
         {
             Debug.Assert(rootClient != null);
             _options = options;
-            NewStack = () => new Stack<KeyValuePair<Scope, ISentryClient>>(new [] { new KeyValuePair<Scope, ISentryClient>(new Scope(options), rootClient) });
+            NewStack = () => new [] { new KeyValuePair<Scope, ISentryClient>(new Scope(options), rootClient) };
         }
 
-        public KeyValuePair<Scope, ISentryClient> GetCurrent() => ScopeAndClientStack.Peek();
+        public KeyValuePair<Scope, ISentryClient> GetCurrent()
+        {
+            var current = ScopeAndClientStack;
+            return current[current.Length - 1];
+        }
 
         public void ConfigureScope(Action<Scope> configureScope)
         {
@@ -50,7 +54,7 @@ namespace Sentry.Internal
         public IDisposable PushScope<TState>(TState state)
         {
             var currentScopeAndClientStack = ScopeAndClientStack;
-            var scope = currentScopeAndClientStack.Peek();
+            var scope = currentScopeAndClientStack[currentScopeAndClientStack.Length - 1];
 
             if (scope.Key.Locked)
             {
@@ -69,12 +73,9 @@ namespace Sentry.Internal
             var scopeSnapshot = new ScopeSnapshot(_options, currentScopeAndClientStack, this);
 
             _options?.DiagnosticLogger?.LogDebug("New scope pushed.");
-            var newScopeAndClientStack = new Stack<KeyValuePair<Scope, ISentryClient>>(currentScopeAndClientStack.Count + 1);
-            foreach (var item in currentScopeAndClientStack)
-            {
-                newScopeAndClientStack.Push(item);
-            }
-            newScopeAndClientStack.Push(new KeyValuePair<Scope, ISentryClient>(clonedScope, scope.Value));
+            var newScopeAndClientStack = new KeyValuePair<Scope, ISentryClient>[currentScopeAndClientStack.Length + 1];
+            Array.Copy(currentScopeAndClientStack, newScopeAndClientStack, currentScopeAndClientStack.Length);
+            newScopeAndClientStack[newScopeAndClientStack.Length - 1] = new KeyValuePair<Scope, ISentryClient>(clonedScope, scope.Value);
 
             ScopeAndClientStack = newScopeAndClientStack;
             return scopeSnapshot;
@@ -94,21 +95,23 @@ namespace Sentry.Internal
             _options?.DiagnosticLogger?.LogDebug("Binding a new client to the current scope.");
 
             var currentScopeAndClientStack = ScopeAndClientStack;
-            var newScopeAndClientStack = new Stack<KeyValuePair<Scope, ISentryClient>>(currentScopeAndClientStack);
-            var top = newScopeAndClientStack.Pop();
-            newScopeAndClientStack.Push(new KeyValuePair<Scope, ISentryClient>(top.Key, client ?? DisabledHub.Instance));
+            var top = currentScopeAndClientStack[currentScopeAndClientStack.Length - 1];
+
+            var newScopeAndClientStack = new KeyValuePair<Scope, ISentryClient>[currentScopeAndClientStack.Length];
+            Array.Copy(currentScopeAndClientStack, newScopeAndClientStack, currentScopeAndClientStack.Length);
+            newScopeAndClientStack[newScopeAndClientStack.Length - 1] = new KeyValuePair<Scope, ISentryClient>(top.Key, client ?? DisabledHub.Instance);
             ScopeAndClientStack = newScopeAndClientStack;
         }
 
         private sealed class ScopeSnapshot : IDisposable
         {
             private readonly SentryOptions _options;
-            private readonly Stack<KeyValuePair<Scope, ISentryClient>> _snapshot;
+            private readonly KeyValuePair<Scope, ISentryClient>[] _snapshot;
             private readonly SentryScopeManager _scopeManager;
 
             public ScopeSnapshot(
                 SentryOptions options,
-                Stack<KeyValuePair<Scope, ISentryClient>> snapshot,
+                KeyValuePair<Scope, ISentryClient>[] snapshot,
                 SentryScopeManager scopeManager)
             {
                 Debug.Assert(snapshot != null);
@@ -122,10 +125,13 @@ namespace Sentry.Internal
             {
                 _options?.DiagnosticLogger?.LogDebug("Disposing scope.");
 
+                var previousScopeKey = _snapshot[_snapshot.Length - 1].Key;
+                var currentScope = _scopeManager.ScopeAndClientStack;
+
                 // Only reset the parent if this is still the current scope
-                foreach (var scope in _scopeManager.ScopeAndClientStack)
+                for (int i = currentScope.Length - 1; i >= 0; --i)
                 {
-                    if (ReferenceEquals(scope.Key, _snapshot.Peek().Key))
+                    if (ReferenceEquals(currentScope[i].Key, previousScopeKey))
                     {
                         _scopeManager.ScopeAndClientStack = _snapshot;
                         break;

--- a/test/Sentry.Tests/Internals/SentryScopeManagerTests.cs
+++ b/test/Sentry.Tests/Internals/SentryScopeManagerTests.cs
@@ -80,6 +80,24 @@ namespace Sentry.Tests.Internals
         }
 
         [Fact]
+        public void BindClient_ScopeState_StaysTheSame()
+        {
+            var sut = _fixture.GetSut();
+            var currentScope = sut.GetCurrent();
+
+            var scope1 = sut.PushScope(1);
+            var scope2 = sut.PushScope(2);
+            Assert.Equal(2, sut.GetCurrent().Key.Extra["state"]);
+
+            sut.BindClient(Substitute.For<ISentryClient>());
+
+            Assert.Equal(2, sut.GetCurrent().Key.Extra["state"]);
+
+            scope2.Dispose();
+            Assert.Equal(1, sut.GetCurrent().Key.Extra["state"]);
+        }
+
+        [Fact]
         public void ConfigureScope_NullArgument_NoOp()
         {
             var sut = _fixture.GetSut();


### PR DESCRIPTION
Discovered I have introduced a subtle bug in #405

Where enumerating a Stack, then one actual get items in reversed order. So when cloning a stack without thinking then one gets reversed order.

The funny part is that it didn't matter much, since one didn't depend much on the stack-nature, except when validating parent on dispose. The most optimal order to scan is to check original parent first.

But when having reversed the order, then original-parent suddenly was at the bottom of the stack, because of the reverse-order on clone.

Alternative solution is to use `System.Linq.Enumerable.Reverse()`:

`var newScopeAndClientStack = new Stack<KeyValuePair<Scope, ISentryClient>>(currentScopeAndClientStack.Reverse());`