### PR TITLE
feat: Global Hub support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.1.5</Version>
+    <Version>2.1.6</Version>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../.assets/Sentry.snk</AssemblyOriginatorKeyFile>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.1.5-beta</Version>
+    <Version>2.1.5</Version>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../.assets/Sentry.snk</AssemblyOriginatorKeyFile>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.1.3</Version>
+    <Version>2.1.4</Version>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../.assets/Sentry.snk</AssemblyOriginatorKeyFile>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.1.4</Version>
+    <Version>2.1.5-beta</Version>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../.assets/Sentry.snk</AssemblyOriginatorKeyFile>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This SDK provides integrations which can hook into your app and automatically ca
 You can still use the SDK directly to send events to Sentry.
 The integrations are just wrappers around the main SDK `Sentry`.
 
-There's a [basic sample](https://github.com/getsentry/sentry-dotnet/blob/main/samples/Sentry.Samples.Console.Basic/Program.cs) and a one demonstrating [more customization](https://github.com/getsentry/sentry-dotnet/blob/main/main/Sentry.Samples.Console.Customized/Program.cs).
+There's a [basic sample](https://github.com/getsentry/sentry-dotnet/blob/main/samples/Sentry.Samples.Console.Basic/Program.cs) and a one demonstrating [more customization](https://github.com/getsentry/sentry-dotnet/blob/main/samples/Sentry.Samples.Console.Customized/Program.cs).
 
 Install the main SDK:
 ```shell

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The SDK is configurable, many of the settings are demonstrated through the sampl
 
 * HTTP Proxy
 * Event sampling
+* Filter exception by type
 * Enable request body extraction
 * Send PII data (Personal Identifiable Information, requires opt-in)
 * Read [diagnostics activity data]("https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md)

--- a/benchmarks/Sentry.Benchmarks/CaptureExceptionDuplicateDetectionBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/CaptureExceptionDuplicateDetectionBenchmarks.cs
@@ -16,22 +16,22 @@ namespace Sentry.Benchmarks
             o.SentryHttpClientFactory = new FakeHttpClientFactory();
         });
 
-        [GlobalSetup(Target = nameof(CaptureException_WithDupliacteDetection))]
+        [GlobalSetup(Target = nameof(CaptureException_WithDuplicateDetection))]
         public void EnabledWithDuplicateDetectionSdk() => _sdk = SentrySdk.Init(o =>
         {
             o.DisableDuplicateEventDetection();
             SharedConfig(o);
         });
 
-        [GlobalSetup(Target = nameof(CaptureException_WithoutDupliacteDetection))]
+        [GlobalSetup(Target = nameof(CaptureException_WithoutDuplicateDetection))]
         public void EnabledWithoutDuplicateDetectionSdk() => _sdk = SentrySdk.Init(SharedConfig);
 
-        [GlobalCleanup(Target = nameof(CaptureException_WithoutDupliacteDetection) + "," +
-                                nameof(CaptureException_WithDupliacteDetection))]
+        [GlobalCleanup(Target = nameof(CaptureException_WithoutDuplicateDetection) + "," +
+                                nameof(CaptureException_WithDuplicateDetection))]
         public void DisableDsk() => _sdk.Dispose();
 
         [Benchmark(Description = "CaptureException with duplicate detection")]
-        public void CaptureException_WithoutDupliacteDetection()
+        public void CaptureException_WithoutDuplicateDetection()
         {
             for (var i = 0; i < EventCount; i++)
             {
@@ -40,7 +40,7 @@ namespace Sentry.Benchmarks
         }
 
         [Benchmark(Description = "CaptureException without duplicate detection")]
-        public void CaptureException_WithDupliacteDetection()
+        public void CaptureException_WithDuplicateDetection()
         {
             for (var i = 0; i < EventCount; i++)
             {

--- a/benchmarks/Sentry.Benchmarks/Properties/GlobalSuppressions.cs
+++ b/benchmarks/Sentry.Benchmarks/Properties/GlobalSuppressions.cs
@@ -4,6 +4,6 @@
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "benchamarks", Scope = "member", Target = "~M:Sentry.Benchmarks.RetryAfterHandlerOverhead.With_RetryAfterHandler_429Response~System.Threading.Tasks.Task")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "benchamarks", Scope = "member", Target = "~M:Sentry.Benchmarks.RetryAfterHandlerOverhead.Without_RetryAfterHandler~System.Threading.Tasks.Task")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "benchamarks", Scope = "member", Target = "~M:Sentry.Benchmarks.RetryAfterHandlerOverhead.With_RetryAfterHandler_OkResponse~System.Threading.Tasks.Task")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "benchmarks", Scope = "member", Target = "~M:Sentry.Benchmarks.RetryAfterHandlerOverhead.With_RetryAfterHandler_429Response~System.Threading.Tasks.Task")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "benchmarks", Scope = "member", Target = "~M:Sentry.Benchmarks.RetryAfterHandlerOverhead.Without_RetryAfterHandler~System.Threading.Tasks.Task")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "benchmarks", Scope = "member", Target = "~M:Sentry.Benchmarks.RetryAfterHandlerOverhead.With_RetryAfterHandler_OkResponse~System.Threading.Tasks.Task")]

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ dotnet test -c Release \
     /p:UseSourceLink=true
 
 # Docs
-pushd docs
-./build.sh
-popd
+# Docs building is broken on travis: ImportError: No module named dateutil
+#pushd docs
+#./build.sh
+#popd

--- a/samples/Sentry.Samples.AspNetCore.Mvc/ExampleEventProcessor.cs
+++ b/samples/Sentry.Samples.AspNetCore.Mvc/ExampleEventProcessor.cs
@@ -14,7 +14,7 @@ namespace Samples.AspNetCore.Mvc
         {
             // Here I can modify the event, while taking dependencies via DI
 
-            @event.SetExtra("Response:HasStarted", _httpContext.HttpContext.Response.HasStarted);
+            @event.SetExtra("Response:HasStarted", _httpContext.HttpContext?.Response.HasStarted);
             return @event;
         }
     }

--- a/samples/Sentry.Samples.AspNetCore.Mvc/Program.cs
+++ b/samples/Sentry.Samples.AspNetCore.Mvc/Program.cs
@@ -28,7 +28,7 @@ namespace Samples.AspNetCore.Mvc
                     // Tracks the release which sent the event and enables more features: https://docs.sentry.io/learn/releases/
                     // If not explicitly set here, the SDK attempts to read it from: AssemblyInformationalVersionAttribute and AssemblyVersion
                     // TeamCity: %build.vcs.number%, VSTS: BUILD_SOURCEVERSION, Travis-CI: TRAVIS_COMMIT, AppVeyor: APPVEYOR_REPO_COMMIT, CircleCI: CIRCLE_SHA1
-                    options.Release = "e386dfd"; // Could be also the be like: 2.0 or however your version your app
+                    options.Release = "e386dfd"; // Could also be any format, such as: 2.0, or however version of your app is
 
                     options.MaxBreadcrumbs = 200;
 

--- a/samples/Sentry.Samples.AspNetCore.Serilog/Sentry.Samples.AspNetCore.Serilog.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Serilog/Sentry.Samples.AspNetCore.Serilog.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.Console.Customized/Program.cs
+++ b/samples/Sentry.Samples.Console.Customized/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Xml.Xsl;
 using Sentry;
 using Sentry.Extensibility;
 using Sentry.Protocol;
@@ -77,6 +78,9 @@ internal static class Program
                 return crumb;
             };
 
+            // Ignore exception by its type:
+            o.AddExceptionFilterForType<XsltCompileException>();
+
             // Configure the background worker which sends events to sentry:
             // Wait up to 5 seconds before shutdown while there are events to send.
             o.ShutdownTimeout = TimeSpan.FromSeconds(5);
@@ -105,6 +109,9 @@ internal static class Program
             };
         }))
         {
+            // Ignored by its type due to the setting above
+            SentrySdk.CaptureException(new XsltCompileException());
+
             SentrySdk.AddBreadcrumb(
                 "A 'bad breadcrumb' that will be rejected because of 'BeforeBreadcrumb callback above.'");
 

--- a/samples/Sentry.Samples.Console.Customized/Program.cs
+++ b/samples/Sentry.Samples.Console.Customized/Program.cs
@@ -9,7 +9,7 @@ using Sentry.Protocol;
 
 // One of the ways to set your DSN is via an attribute:
 // It could be set via AssemblyInfo.cs and patched via CI.
-// Other ways are via environment variable, configuration files and explictly via parameter to Init
+// Other ways are via environment variable, configuration files and explicitly via parameter to Init
 [assembly: Dsn(Program.DefaultDsn)]
 // Tracks the release which sent the event and enables more features: https://docs.sentry.io/learn/releases/
 // Much like the DSN above, this is only one of the ways to define the release.
@@ -42,7 +42,7 @@ internal static class Program
             o.AttachStacktrace = true;
 
             // Sentry won't consider code from namespace LibraryX.* as part of the app code and will hide it from the stacktrace by default
-            // To see the lines from non `AppCode`, select `Full`. That'll include non App code like System.*, Microsoft.* and LibraryX.*
+            // To see the lines from non `AppCode`, select `Full`. Will include non App code like System.*, Microsoft.* and LibraryX.*
             o.AddInAppExclude("LibraryX.");
 
             // Before excluding all prefixed 'LibraryX.', any stack trace from a type namespaced 'LibraryX.Core' will be considered InApp.

--- a/samples/Sentry.Samples.GenericHost/Sentry.Samples.GenericHost.csproj
+++ b/samples/Sentry.Samples.GenericHost/Sentry.Samples.GenericHost.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.6" />
   </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.GenericHost/Sentry.Samples.GenericHost.csproj
+++ b/samples/Sentry.Samples.GenericHost/Sentry.Samples.GenericHost.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.4" />
   </ItemGroup>

--- a/src/Sentry.AspNetCore/ScopeExtensions.cs
+++ b/src/Sentry.AspNetCore/ScopeExtensions.cs
@@ -75,7 +75,7 @@ namespace Sentry.AspNetCore
             catch(Exception e)
             {
                 // Suppress the error here; we expect an ArgumentNullException if httpContext.Request.RouteValues is null from GetRouteData()
-                // TODO: Consider adding a bool to the Sentry options to make routedata extraction optional in case they don't use a routing middleware?
+                // TODO: Consider adding a bool to the Sentry options to make route data extraction optional in case they don't use a routing middleware?
                 options?.DiagnosticLogger?.LogDebug("Failed to extract route data.", e);
             }
 

--- a/src/Sentry.Extensions.Logging/SentryLoggerFactoryExtensions.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggerFactoryExtensions.cs
@@ -43,8 +43,17 @@ namespace Microsoft.Extensions.Logging
             IHub hub;
             if (options.InitializeSdk)
             {
-                hub = new OptionalHub(options);
-                SentrySdk.UseHub(hub);
+                if (SentrySdk.IsEnabled && options.Dsn is null)
+                {
+                    options.DiagnosticLogger?.LogWarning("Not calling Init from {0} because SDK is already enabled and no DSN was provided to the integration", nameof(SentryLoggerFactoryExtensions));
+                    hub = HubAdapter.Instance;
+                }
+                else
+                {
+                    options.DiagnosticLogger?.LogDebug("Initializing from {0} and swapping current Hub.", nameof(SentryLoggerFactoryExtensions));
+                    hub = new OptionalHub(options);
+                    SentrySdk.UseHub(hub);
+                }
             }
             else
             {

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -118,7 +118,7 @@ namespace Sentry.Log4Net
                 evt.Environment = Environment;
             }
 
-            Hub.CaptureEvent(evt);
+            _ = Hub.CaptureEvent(evt);
         }
 
         private static IEnumerable<KeyValuePair<string, object>> GetLoggingEventProperties(LoggingEvent loggingEvent)

--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -255,6 +255,12 @@ namespace Sentry.NLog
         /// <inheritdoc />
         protected override void InitializeTarget()
         {
+            // If a layout has been configured on the options, replace the default logger.
+            if (Options.Layout != null)
+            {
+                Layout = Options.Layout;
+            }
+
             base.InitializeTarget();
 
             if (InternalLogger.IsDebugEnabled || InternalLogger.IsInfoEnabled || InternalLogger.IsWarnEnabled || InternalLogger.IsErrorEnabled || InternalLogger.IsFatalEnabled)
@@ -285,16 +291,15 @@ namespace Sentry.NLog
                 Options.Environment = customEnvironment;
             }
 
-            // If a layout has been configured on the options, replace the default logger.
-            if (Options.Layout != null)
-            {
-                Layout = Options.Layout;
-            }
-
             // If the sdk is not there, set it on up.
             if (InitializeSdk && _sdkDisposable == null)
             {
                 _sdkDisposable = SentrySdk.Init(Options);
+            }
+
+            if (_hubAccessor()?.IsEnabled != true)
+            {
+                InternalLogger.Info("Sentry(Name={0}): Hub not enabled", Name);
             }
         }
 

--- a/src/Sentry.Protocol/Context/Browser.cs
+++ b/src/Sentry.Protocol/Context/Browser.cs
@@ -5,7 +5,7 @@ namespace Sentry.Protocol
 {
     /// <summary>
     /// Carries information about the browser or user agent for web-related errors.
-    /// This can either be the browser this event ocurred in, or the user agent of a
+    /// This can either be the browser this event occurred in, or the user agent of a
     /// web request that triggered the event.
     /// </summary>
     /// <seealso href="https://docs.sentry.io/clientdev/interfaces/contexts/"/>

--- a/src/Sentry.Protocol/Context/Device.cs
+++ b/src/Sentry.Protocol/Context/Device.cs
@@ -14,6 +14,9 @@ namespace Sentry.Protocol
         [DataMember(Name = "timezone", EmitDefaultValue = false)]
         private string TimezoneSerializable => Timezone?.Id;
 
+        [DataMember(Name = "timezone_display_name", EmitDefaultValue = false)]
+        private string TimezoneName => Timezone?.DisplayName;
+
         /// <summary>
         /// Tells Sentry which type of context this is.
         /// </summary>

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -71,6 +71,8 @@ namespace Sentry.Extensibility
         /// </summary>
         public void Dispose() { }
 
+        public IHub Clone() => Instance;
+
         /// <summary>
         /// No-Op.
         /// </summary>

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -12,7 +12,7 @@ namespace Sentry.Extensibility
         /// <summary>
         /// The singleton instance.
         /// </summary>
-        public static DisabledHub Instance = new DisabledHub();
+        public static readonly DisabledHub Instance = new DisabledHub();
 
         /// <summary>
         /// Always disabled.
@@ -71,6 +71,10 @@ namespace Sentry.Extensibility
         /// </summary>
         public void Dispose() { }
 
+        /// <summary>
+        /// Returns the same disabled instance.
+        /// </summary>
+        /// <returns></returns>
         public IHub Clone() => Instance;
 
         /// <summary>

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -139,5 +139,9 @@ namespace Sentry.Extensibility
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Task FlushAsync(TimeSpan timeout)
             => SentrySdk.FlushAsync(timeout);
+
+        [DebuggerStepThrough]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IHub Clone() => SentrySdk.GetCurrentHub().Clone();
     }
 }

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -140,6 +140,10 @@ namespace Sentry.Extensibility
         public Task FlushAsync(TimeSpan timeout)
             => SentrySdk.FlushAsync(timeout);
 
+        /// <summary>
+        /// Clones the current Hub bound to the <see cref="SentrySdk"/>.
+        /// </summary>
+        /// <returns></returns>
         [DebuggerStepThrough]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public IHub Clone() => SentrySdk.GetCurrentHub().Clone();

--- a/src/Sentry/Extensibility/IExceptionFilter.cs
+++ b/src/Sentry/Extensibility/IExceptionFilter.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Sentry.Extensibility
+{
+    /// <summary>
+    /// A filter to be applied to an exception instance.
+    /// </summary>
+    public interface IExceptionFilter
+    {
+        /// <summary>
+        /// Whether to filter out or not the exception.
+        /// </summary>
+        /// <param name="ex">The exception about to be captured.</param>
+        /// <returns><c>true</c> if [the event should be filtered out]; otherwise, <c>false</c></returns>.
+        bool Filter(Exception ex);
+    }
+}

--- a/src/Sentry/IHub.cs
+++ b/src/Sentry/IHub.cs
@@ -20,5 +20,10 @@ namespace Sentry
         /// Last event id recorded in the current scope
         /// </summary>
         SentryId LastEventId { get; }
+
+        /// <summary>
+        /// Clones the Hub.
+        /// </summary>
+        IHub Clone();
     }
 }

--- a/src/Sentry/Integrations/TaskUnobservedTaskExceptionIntegration.cs
+++ b/src/Sentry/Integrations/TaskUnobservedTaskExceptionIntegration.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Diagnostics;
+using Sentry.Internal;
+using System.Runtime.ExceptionServices;
+using System.Security;
+using Sentry.Protocol;
+using System.Threading.Tasks;
+
+namespace Sentry.Integrations
+{
+    internal class TaskUnobservedTaskExceptionIntegration : IInternalSdkIntegration
+    {
+        private readonly IAppDomain _appDomain;
+        private IHub _hub;
+
+        internal TaskUnobservedTaskExceptionIntegration(IAppDomain appDomain = null)
+            => _appDomain = appDomain ?? AppDomainAdapter.Instance;
+
+        public void Register(IHub hub, SentryOptions _)
+        {
+            Debug.Assert(hub != null);
+            _hub = hub;
+            _appDomain.UnobservedTaskException += Handle;
+        }
+
+        public void Unregister(IHub hub)
+        {
+            _appDomain.UnobservedTaskException -= Handle;
+            _hub = null;
+        }
+
+        // Internal for testability
+        [HandleProcessCorruptedStateExceptions, SecurityCritical]
+        internal void Handle(object sender, UnobservedTaskExceptionEventArgs e)
+        {
+            if (e.Exception != null)
+            {
+                e.Exception.Data[Mechanism.MechanismKey] = "UnobservedTaskException";
+                _ = _hub?.CaptureException(e.Exception);
+                (_hub as IDisposable)?.Dispose();
+            }
+        }
+    }
+}

--- a/src/Sentry/Internal/AppDomainAdapter.cs
+++ b/src/Sentry/Internal/AppDomainAdapter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.ExceptionServices;
 using System.Security;
+using System.Threading.Tasks;
 
 namespace Sentry.Internal
 {
@@ -9,6 +10,8 @@ namespace Sentry.Internal
         event UnhandledExceptionEventHandler UnhandledException;
 
         event EventHandler ProcessExit;
+
+        event EventHandler<UnobservedTaskExceptionEventArgs> UnobservedTaskException;
     }
 
     internal sealed class AppDomainAdapter : IAppDomain
@@ -19,15 +22,21 @@ namespace Sentry.Internal
         {
             AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
             AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+            TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
         }
 
         public event UnhandledExceptionEventHandler UnhandledException;
 
         public event EventHandler ProcessExit;
 
+        public event EventHandler<UnobservedTaskExceptionEventArgs> UnobservedTaskException;
+
         private void OnProcessExit(object sender, EventArgs e) => ProcessExit?.Invoke(sender, e);
 
         [HandleProcessCorruptedStateExceptions, SecurityCritical]
         private void OnUnhandledException(object sender, UnhandledExceptionEventArgs e) => UnhandledException?.Invoke(this, e);
+
+        [HandleProcessCorruptedStateExceptions, SecurityCritical]
+        private void OnUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e) => UnobservedTaskException?.Invoke(this, e);
     }
 }

--- a/src/Sentry/Internal/ExceptionTypeFilter.cs
+++ b/src/Sentry/Internal/ExceptionTypeFilter.cs
@@ -1,0 +1,11 @@
+using System;
+using Sentry.Extensibility;
+
+namespace Sentry.Internal
+{
+    internal class ExceptionTypeFilter<TException> : IExceptionFilter where TException : Exception
+    {
+        private readonly Type _filteredType = typeof(TException);
+        public bool Filter(Exception ex) => _filteredType.IsInstanceOfType(ex);
+    }
+}

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -56,6 +56,21 @@ namespace Sentry.Internal
             _rootScope = PushScope();
         }
 
+        public IHub Clone()
+        {
+            _options.DiagnosticLogger?.LogDebug("Cloning Hub.");
+
+            var clone = new Hub(_options);
+            foreach (var scopeClient in ScopeManager.ScopeAndClientStack)
+            {
+                var clonedScope = scopeClient.Key.Clone();
+                var cloneItem = new KeyValuePair<Scope, ISentryClient>(clonedScope, scopeClient.Value);
+
+                _ = clone.PushScope(cloneItem);
+            }
+            return clone;
+        }
+
         public void ConfigureScope(Action<Scope> configureScope)
         {
             try

--- a/src/Sentry/Internal/OptionalHub.cs
+++ b/src/Sentry/Internal/OptionalHub.cs
@@ -52,5 +52,7 @@ namespace Sentry.Internal
         public SentryId LastEventId => _hub.LastEventId;
 
         public void Dispose() => (_hub as IDisposable)?.Dispose();
+
+        public IHub Clone() => _hub.Clone();
     }
 }

--- a/src/Sentry/Internal/SentryScopeManager.cs
+++ b/src/Sentry/Internal/SentryScopeManager.cs
@@ -67,7 +67,7 @@ namespace Sentry.Internal
 
             if (state != null)
             {
-                if(state is KeyValuePair<Scope, ISentryClient> newScope)
+                if (state is KeyValuePair<Scope, ISentryClient> newScope)
                 {
                     clonedScope = newScope.Key;
                     client = newScope.Value;

--- a/src/Sentry/Internal/Web/SystemWebRequestEventProcessor.cs
+++ b/src/Sentry/Internal/Web/SystemWebRequestEventProcessor.cs
@@ -41,7 +41,7 @@ namespace Sentry.Internal.Web
             }
 
             @event.Request.Method = context.Request.HttpMethod;
-            @event.Request.Url = context.Request.Path;
+            @event.Request.Url = context.Request.RawUrl;
 
             try
             {

--- a/src/Sentry/Internal/Web/SystemWebRequestEventProcessor.cs
+++ b/src/Sentry/Internal/Web/SystemWebRequestEventProcessor.cs
@@ -41,7 +41,7 @@ namespace Sentry.Internal.Web
             }
 
             @event.Request.Method = context.Request.HttpMethod;
-            @event.Request.Url = context.Request.RawUrl;
+            @event.Request.Url = context.Request.Url.AbsoluteUri;
 
             try
             {

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sentry.PlatformAbstractions" Version="1.1.0" />
+    <PackageReference Include="Sentry.PlatformAbstractions" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Sentry.Protocol\Sentry.Protocol.csproj" />

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -90,7 +90,7 @@ namespace Sentry
             }
             catch (Exception e)
             {
-                _options.DiagnosticLogger?.LogError("An error occured when capturing the event {0}.", e, @event.EventId);
+                _options.DiagnosticLogger?.LogError("An error occurred when capturing the event {0}.", e, @event.EventId);
                 return SentryId.Empty;
             }
         }

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Sentry.Extensibility;
@@ -108,6 +109,16 @@ namespace Sentry
                 if (Random.NextDouble() > sample)
                 {
                     _options.DiagnosticLogger?.LogDebug("Event sampled.");
+                    return SentryId.Empty;
+                }
+            }
+            if (@event.Exception is Exception ex
+                && _options.ExceptionFilters is IExceptionFilter[] filters && filters.Length > 0)
+            {
+                if (filters.Any(f => f.Filter(ex)))
+                {
+                    _options.DiagnosticLogger?.LogInfo(
+                        "Event with exception of type '{0}' was dropped by an exception filter.", ex.GetType());
                     return SentryId.Empty;
                 }
             }

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -341,7 +341,15 @@ namespace Sentry
             get => Debug ? _diagnosticLogger : null;
             set
             {
-                _diagnosticLogger?.LogInfo("Replacing current logger with: '{0}'.", value?.GetType().Name);
+                if (value is null)
+                {
+                    _diagnosticLogger?.LogDebug("Sentry will not emit SDK debug messages because debug mode has been turned off.");
+                }
+                else
+                {
+                    _diagnosticLogger?.LogInfo("Replacing current logger with: '{0}'.", value.GetType().Name);
+                }
+
                 _diagnosticLogger = value;
             }
         }

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -367,6 +367,11 @@ namespace Sentry
         /// </remarks>
         public DeduplicateMode DeduplicateMode { get; set; } = DeduplicateMode.All ^ DeduplicateMode.InnerException;
 
+        /// <summary>
+        /// whether to use a single (global) Hub as opposed to one per thread.
+        /// </summary>
+        public bool GlobalHudMode { get; set; } = SentrySdk.GlobalHudDefaultMode;
+
 #if SYSTEM_WEB
         /// <summary>
         /// Max request body to be captured when a Web request exists on a ASP.NET Application.

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -52,7 +52,9 @@ namespace Sentry
         /// <summary>
         /// A list of integrations to be added when the SDK is initialized
         /// </summary>
-        internal ISdkIntegration[] Integrations { get; set; } 
+        internal ISdkIntegration[] Integrations { get; set; }
+
+        internal IExceptionFilter[] ExceptionFilters { get; set; } = Array.Empty<IExceptionFilter>();
 
         internal IBackgroundWorker BackgroundWorker { get; set; }
 

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -370,7 +370,7 @@ namespace Sentry
         /// <summary>
         /// whether to use a single (global) Hub as opposed to one per thread.
         /// </summary>
-        public bool GlobalHudMode { get; set; } = SentrySdk.GlobalHudDefaultMode;
+        public bool GlobalHubMode { get; set; } = SentrySdk.GlobalHubDefaultMode;
 
 #if SYSTEM_WEB
         /// <summary>

--- a/src/Sentry/SentryOptionsExtensions.cs
+++ b/src/Sentry/SentryOptionsExtensions.cs
@@ -57,6 +57,23 @@ namespace Sentry
             => options.Integrations = options.Integrations.Where(p => p.GetType() != typeof(TIntegration)).ToArray();
 
         /// <summary>
+        /// Add an exception filter.
+        /// </summary>
+        /// <param name="options">The SentryOptions to hold the processor.</param>
+        /// <param name="exceptionFilter">The exception filter to add.</param>
+        public static void AddExceptionFilter(this SentryOptions options, IExceptionFilter exceptionFilter)
+            => options.ExceptionFilters = options.ExceptionFilters.Concat(new[] { exceptionFilter }).ToArray();
+
+        /// <summary>
+        /// Ignore exception of type <typeparamref name="TException"/> or derived.
+        /// </summary>
+        /// <typeparam name="TException">The type of the exception to ignore.</typeparam>
+        /// <param name="options">The SentryOptions to store the exceptions type ignore.</param>
+        /// <returns></returns>
+        public static void AddExceptionFilterForType<TException>(this SentryOptions options) where TException : Exception
+            => options.AddExceptionFilter(new ExceptionTypeFilter<TException>());
+
+        /// <summary>
         /// Add prefix to exclude from 'InApp' stack trace list
         /// </summary>
         /// <param name="options"></param>

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -15,7 +15,7 @@ namespace Sentry
     /// Sentry SDK entrypoint
     /// </summary>
     /// <remarks>
-    /// This is a façade to the SDK instance.
+    /// This is a facade to the SDK instance.
     /// It allows safe static access to a client and scope management.
     /// When the SDK is uninitialized, calls to this class result in no-op so no callbacks are invoked.
     /// </remarks>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.1" />
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Sentry.AspNetCore.Tests/BaseRequestPayloadExtractorTests.cs
+++ b/test/Sentry.AspNetCore.Tests/BaseRequestPayloadExtractorTests.cs
@@ -55,7 +55,7 @@ namespace Sentry.AspNetCore.Tests
         }
 
         [Fact]
-        public void ExtractPayload_CantSeakStream_DoesNotChangePosition()
+        public void ExtractPayload_CantSeekStream_DoesNotChangePosition()
         {
             TestFixture.Stream.CanSeek.Returns(false);
 

--- a/test/Sentry.AspNetCore.Tests/ScopeExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/ScopeExtensionsTests.cs
@@ -46,7 +46,7 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void Populate_Request_QueryString_SetToScope()
         {
-            const string expected = "?query=bla&somethign=ble";
+            const string expected = "?query=bla&something=ble";
             _httpContext.Request.QueryString.Returns(new QueryString(expected));
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
@@ -108,7 +108,7 @@ namespace Sentry.AspNetCore.Tests
         public void Populate_Request_Headers_SetToScope()
         {
             const string firstKey = "User-Agent";
-            const string secondKey = "Accept-Encodingt";
+            const string secondKey = "Accept-Encoding";
             var headers = new HeaderDictionary
             {
                 { firstKey, new StringValues("Mozilla/5.0") },

--- a/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
@@ -205,7 +205,7 @@ namespace Sentry.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task InvokeAsync_ScopePushedAndPoped_OnHappyPath()
+        public async Task InvokeAsync_ScopePushedAndPopped_OnHappyPath()
         {
             var disposable = Substitute.For<IDisposable>();
             _fixture.Hub.PushScope().Returns(disposable);
@@ -219,7 +219,7 @@ namespace Sentry.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task InvokeAsync_ScopePushedAndPoped_OnError()
+        public async Task InvokeAsync_ScopePushedAndPopped_OnError()
         {
             var expected = new Exception("test");
             _fixture.RequestDelegate = _ => throw expected;
@@ -514,7 +514,7 @@ namespace Sentry.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task InvokeAsync_DisabledHub_DoesNotCallFlushAync()
+        public async Task InvokeAsync_DisabledHub_DoesNotCallFlushAsync()
         {
             var sut = _fixture.GetSut();
             _fixture.Options.FlushOnCompletedRequest = true;

--- a/test/Sentry.Extensions.Logging.Tests/Sentry.Extensions.Logging.Tests.csproj
+++ b/test/Sentry.Extensions.Logging.Tests/Sentry.Extensions.Logging.Tests.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
   </ItemGroup>
 

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
@@ -368,7 +368,7 @@ namespace Sentry.Extensions.Logging.Tests
         {
             var sut = _fixture.GetSut();
 
-            sut.LogDebug("antyhing");
+            sut.LogDebug("anything");
 
             _fixture.Hub.DidNotReceive()
                 .AddBreadcrumb(
@@ -385,7 +385,7 @@ namespace Sentry.Extensions.Logging.Tests
         {
             var sut = _fixture.GetSut();
 
-            sut.LogTrace("antyhing");
+            sut.LogTrace("anything");
 
             _fixture.Hub.DidNotReceive()
                 .AddBreadcrumb(

--- a/test/Sentry.NLog.Tests/SentryTargetTests.cs
+++ b/test/Sentry.NLog.Tests/SentryTargetTests.cs
@@ -129,7 +129,7 @@ namespace Sentry.NLog.Tests
                         <target type='Sentry' name='sentry' dsn='{ValidDsnWithoutSecret}'>
                             <user username=""myUser"">
                                 <other name='mood' layout='joyous'/>
-                            </user>   
+                            </user>
                         </target>
                     </targets>
                 </nlog>";
@@ -354,22 +354,22 @@ namespace Sentry.NLog.Tests
                 "{{ default }}",
                 expectedGroupingKey
             };
-            
+
             var logger = _fixture.GetLogger();
 
             var evt = LogEventInfo.Create(LogLevel.Error, logger.Name, DefaultMessage);
-            
+
             evt.Properties[SentryTarget.AdditionalGroupingKeyProperty] = expectedGroupingKey;
-            
+
             var actualSentryEvent = default(SentryEvent);
             _fixture.Hub.When(h => h.CaptureEvent(Arg.Is<SentryEvent>(
                     e => e.Extra[SentryTarget.AdditionalGroupingKeyProperty].ToString() == expectedGroupingKey)))
                 .Do(c => actualSentryEvent = c.Arg<SentryEvent>());
-    
-            
+
+
             logger.Log(evt);
-           
-            
+
+
             Assert.NotNull(actualSentryEvent);
             Assert.Equal(expectedFingerprint, actualSentryEvent.Fingerprint);
         }
@@ -491,17 +491,17 @@ namespace Sentry.NLog.Tests
             _fixture.SdkDisposeHandle = null;
             _fixture.Options.InitializeSdk = true;
 
-            var logwriter = new System.IO.StringWriter();
+            var logWriter = new System.IO.StringWriter();
 
             try
             {
-                InternalLogger.LogWriter = logwriter;
+                InternalLogger.LogWriter = logWriter;
                 InternalLogger.LogLevel = LogLevel.Debug;
 
                 _ = _fixture.GetLoggerFactory();
 
-                var logoutput = logwriter.ToString();
-                Assert.Contains("Init was called but no DSN was provided nor located. Sentry SDK will be disabled.", logoutput);
+                var logOutput = logWriter.ToString();
+                Assert.Contains("Init was called but no DSN was provided nor located. Sentry SDK will be disabled.", logOutput);
             }
             finally
             {

--- a/test/Sentry.Protocol.Tests/Context/DeviceTests.cs
+++ b/test/Sentry.Protocol.Tests/Context/DeviceTests.cs
@@ -52,6 +52,7 @@ namespace Sentry.Protocol.Tests.Context
 
             Assert.Equal("{\"type\":\"device\","+
                          $"\"timezone\":\"{TimeZoneInfo.Local.Id}\"," +
+                         $"\"timezone_display_name\":\"{TimeZoneInfo.Local.DisplayName}\"," +
                          "\"name\":\"testing.sentry.io\"," +
                          "\"manufacturer\":\"Manufacturer\"," +
                          "\"brand\":\"Brand\"," +
@@ -175,7 +176,7 @@ namespace Sentry.Protocol.Tests.Context
             yield return new object[] { (new Device { ScreenDensity = 1 }, "{\"type\":\"device\",\"screen_density\":1.0}") };
             yield return new object[] { (new Device { ScreenDpi = 1 }, "{\"type\":\"device\",\"screen_dpi\":1}") };
             yield return new object[] { (new Device { BootTime = DateTimeOffset.MaxValue }, "{\"type\":\"device\",\"boot_time\":\"9999-12-31T23:59:59.9999999+00:00\"}") };
-            yield return new object[] { (new Device { Timezone = TimeZoneInfo.Utc }, "{\"type\":\"device\",\"timezone\":\"UTC\"}") };
+            yield return new object[] { (new Device { Timezone = TimeZoneInfo.Utc }, $"{{\"type\":\"device\",\"timezone\":\"UTC\",\"timezone_display_name\":\"{TimeZoneInfo.Utc.DisplayName}\"}}") };
         }
     }
 }

--- a/test/Sentry.Testing/EnvironmentVariableGuard.cs
+++ b/test/Sentry.Testing/EnvironmentVariableGuard.cs
@@ -4,7 +4,7 @@ namespace Sentry.Testing
 {
     public static class EnvironmentVariableGuard
     {
-        // To allow different xunit colletions use of this
+        // To allow different xunit collections use of this
         private static readonly object Lock = new object();
 
         public static void WithVariable(string key, string value, Action action)

--- a/test/Sentry.Tests/Helpers/Reflection/AssemblyCreationHelper.cs
+++ b/test/Sentry.Tests/Helpers/Reflection/AssemblyCreationHelper.cs
@@ -10,8 +10,8 @@ namespace Sentry.Tests.Helpers.Reflection
         {
             var assemblyBuilder = (AssemblyBuilder)CreateAssembly();
 
-            var dsnAttrib = typeof(DsnAttribute);
-            var ctor = dsnAttrib.GetConstructor(new[] { typeof(string) });
+            var dsnAttribute = typeof(DsnAttribute);
+            var ctor = dsnAttribute.GetConstructor(new[] { typeof(string) });
             var attributeBuilder = new CustomAttributeBuilder(ctor, new object[] { dsn });
             assemblyBuilder.SetCustomAttribute(attributeBuilder);
 
@@ -33,8 +33,8 @@ namespace Sentry.Tests.Helpers.Reflection
                 asmName ?? new AssemblyName(Guid.NewGuid().ToString()),
                 AssemblyBuilderAccess.RunAndCollect);
 
-            var infoAttrib = typeof(AssemblyInformationalVersionAttribute);
-            var ctor = infoAttrib.GetConstructor(new[] { typeof(string) });
+            var infoAttribute = typeof(AssemblyInformationalVersionAttribute);
+            var ctor = infoAttribute.GetConstructor(new[] { typeof(string) });
             var attributeBuilder = new CustomAttributeBuilder(ctor, new object[] { version });
             assemblyBuilder.SetCustomAttribute(attributeBuilder);
 

--- a/test/Sentry.Tests/HubExtensionsTests.cs
+++ b/test/Sentry.Tests/HubExtensionsTests.cs
@@ -34,8 +34,8 @@ namespace Sentry.Tests
             var disposable = Substitute.For<IDisposable>();
             Sut.PushScope().Returns(disposable);
 
-            var acutal = Sut.PushAndLockScope();
-            acutal.Dispose();
+            var actual = Sut.PushAndLockScope();
+            actual.Dispose();
 
             disposable.Received(1).Dispose();
         }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NSubstitute;
 using Sentry;
@@ -106,6 +107,33 @@ namespace NotSentry.Tests
 
             Assert.NotEqual(default, actualId);
             Assert.Equal(actualId, sut.LastEventId);
+        }
+
+        [Fact]
+        public void CloneHub_Preserve_Tags_Without_Reference()
+        {
+            var tags = new Dictionary<string, string> {
+                { "A","1" },
+                { "B","2" },
+                {"C","3" }
+            };
+            var sut = _fixture.GetSut();
+
+            sut.ConfigureScope(scope => scope.SetTags(tags));
+            var clone = sut.Clone();
+
+            clone.ConfigureScope(scope => {
+                foreach(var tag in tags)
+                {
+                    Assert.True(scope.Tags.ContainsKey(tag.Key));
+                    Assert.Equal(tag.Value, scope.Tags[tag.Key]);
+                }
+            });
+
+            sut.ConfigureScope(scope => scope.SetTag("A", "0"));
+            clone.ConfigureScope(scope => Assert.Equal("1", scope.Tags["A"]));
+
+            sut.Dispose();
         }
     }
 }

--- a/test/Sentry.Tests/Internals/DefaultSentryHttpClientFactoryTests.cs
+++ b/test/Sentry.Tests/Internals/DefaultSentryHttpClientFactoryTests.cs
@@ -61,7 +61,7 @@ namespace Sentry.Tests.Internals
         [Theory]
         [InlineData(CompressionLevel.Fastest)]
         [InlineData(CompressionLevel.Optimal)]
-        public void Create_CompressionLeveEnabled_ByDefault_IncludesGzipRequestBodyHandler(CompressionLevel level)
+        public void Create_CompressionLevelEnabled_ByDefault_IncludesGzipRequestBodyHandler(CompressionLevel level)
         {
             _fixture.HttpOptions.RequestBodyCompressionLevel = level;
 
@@ -75,7 +75,7 @@ namespace Sentry.Tests.Internals
         [Theory]
         [InlineData(CompressionLevel.Fastest)]
         [InlineData(CompressionLevel.Optimal)]
-        public void Create_CompressionLeveEnabled_NonBuffered_IncludesGzipRequestBodyHandler(CompressionLevel level)
+        public void Create_CompressionLevelEnabled_NonBuffered_IncludesGzipRequestBodyHandler(CompressionLevel level)
         {
             _fixture.HttpOptions.RequestBodyCompressionLevel = level;
             _fixture.HttpOptions.RequestBodyCompressionBuffered = false;

--- a/test/Sentry.Tests/Internals/DsnLocatorTests.cs
+++ b/test/Sentry.Tests/Internals/DsnLocatorTests.cs
@@ -88,7 +88,7 @@ namespace Sentry.Tests.Internals
 
             var asm = AssemblyCreationHelper.CreateAssemblyWithDsnAttribute(expected);
 
-            // Not resposible to do validation, returns raw string
+            // Not responsible to do validation, returns raw string
             var actual = DsnLocator.FindDsn(asm);
 
             Assert.Equal(expected, actual);

--- a/test/Sentry.Tests/Internals/Http/GzipBufferedRequestBodyHandlerTests.cs
+++ b/test/Sentry.Tests/Internals/Http/GzipBufferedRequestBodyHandlerTests.cs
@@ -43,10 +43,10 @@ namespace Sentry.Tests.Internals.Http
             await sut.SendAsync(_fixture.Message, None);
 
             var gzippedContent = await _fixture.Message.Content.ReadAsByteArrayAsync();
-            var contentLegnth = ((GzipBufferedRequestBodyHandler.BufferedStreamContent)_fixture.Message.Content)
+            var contentLength = ((GzipBufferedRequestBodyHandler.BufferedStreamContent)_fixture.Message.Content)
                 .ContentLength;
 
-            Assert.Equal(gzippedContent.Length, contentLegnth);
+            Assert.Equal(gzippedContent.Length, contentLength);
         }
 
         [Fact]

--- a/test/Sentry.Tests/TaskUnobservedTaskExceptionIntegrationTests.cs
+++ b/test/Sentry.Tests/TaskUnobservedTaskExceptionIntegrationTests.cs
@@ -1,0 +1,100 @@
+using System;
+using NSubstitute;
+using Sentry.Integrations;
+using Sentry.Internal;
+using Xunit;
+using System.Linq;
+using System.Threading.Tasks;
+using Sentry.Extensibility;
+using Sentry.Protocol;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Sentry.Tests
+{
+    public class TaskUnobservedTaskExceptionIntegrationTests
+    {
+        private class Fixture
+        {
+            public IHub Hub { get; set; } = Substitute.For<IHub, IDisposable>();
+            public IAppDomain AppDomain { get; set; } = Substitute.For<IAppDomain>();
+
+            public Fixture() => Hub.IsEnabled.Returns(true);
+
+            public TaskUnobservedTaskExceptionIntegration GetSut()
+                => new TaskUnobservedTaskExceptionIntegration(AppDomain);
+        }
+
+        private readonly Fixture _fixture = new Fixture();
+        public SentryOptions SentryOptions { get; set; } = new SentryOptions();
+
+        [Fact]
+        public void Handle_WithException_CaptureEvent()
+        {
+            var sut = _fixture.GetSut();
+            sut.Register(_fixture.Hub, SentryOptions);
+
+            sut.Handle(this, new UnobservedTaskExceptionEventArgs(new AggregateException()));
+
+            _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
+        }
+
+// Only triggers in release mode.
+#if RELEASE
+        [Fact] // Integration test.
+        public void Handle_UnobservedTaskException_CaptureEvent()
+        {
+            _fixture.AppDomain = AppDomainAdapter.Instance;
+            var evt = new ManualResetEvent(false);
+            _fixture.Hub.When(x => x.CaptureEvent(Arg.Any<SentryEvent>()))
+                .Do(_ => evt.Set());
+
+            var sut = _fixture.GetSut();
+            sut.Register(_fixture.Hub, SentryOptions);
+            try
+            {
+                Task.Factory.StartNew(() => { throw new Exception("Unhandled on Task"); });
+                Thread.Sleep(2000);
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+
+                Assert.True(evt.WaitOne(TimeSpan.FromMilliseconds(1)));
+            }
+            finally
+            {
+                sut.Unregister(_fixture.Hub);
+            }
+        }
+#endif
+
+        [Fact]
+        public void Handle_NoException_NoCaptureEvent()
+        {
+            var sut = _fixture.GetSut();
+            sut.Register(_fixture.Hub, SentryOptions);
+
+            sut.Handle(this, new UnobservedTaskExceptionEventArgs(null));
+
+            _ = _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+        }
+
+        [Fact]
+        public void Register_UnhandledException_Subscribes()
+        {
+            var sut = _fixture.GetSut();
+            sut.Register(_fixture.Hub, SentryOptions);
+
+            _fixture.AppDomain.Received().UnobservedTaskException += sut.Handle;
+        }
+
+        [Fact]
+        public void Unregister_UnhandledException_Unsubscribes()
+        {
+            var sut = _fixture.GetSut();
+            sut.Register(_fixture.Hub, SentryOptions);
+            sut.Unregister(_fixture.Hub);
+
+            _fixture.AppDomain.Received(1).UnobservedTaskException -= sut.Handle;
+        }
+    }
+}


### PR DESCRIPTION
This "Feature" (more likely just adding the pattern from the new SDKs) allows you to choose how the SDK will handle Hubs.

By default, the GlobalHudMode is set to false so that it performs the same as before this PR (by that, one "Hub" per threads, Ideally used for applications where multiple users interact).

On the other hand, by setting GlobalHudMode true there'll be a unique Hub for the entire application, this flow is useful for applications where a single user interacts with the application (like an app).