### PR TITLE
ref: Ignore return parameters that are never.

### DIFF
--- a/src/Sentry.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/ApplicationBuilderExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Builder
                 var stackTraceFactory = app.ApplicationServices.GetService<ISentryStackTraceFactory>();
                 if (stackTraceFactory != null)
                 {
-                    o.UseStackTraceFactory(stackTraceFactory);
+                    _ = o.UseStackTraceFactory(stackTraceFactory);
                 }
 
                 if (app.ApplicationServices.GetService<IEnumerable<ISentryEventProcessor>>().Any())
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Builder
             }
 
             var lifetime = app.ApplicationServices.GetService<IHostApplicationLifetime>();
-            lifetime?.ApplicationStopped.Register(SentrySdk.Close);
+            _ = lifetime?.ApplicationStopped.Register(SentrySdk.Close);
 
             return app.UseMiddleware<SentryMiddleware>();
         }

--- a/src/Sentry.AspNetCore/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
@@ -20,15 +20,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns></returns>
         public static IServiceCollection AddSentry(this IServiceCollection services)
         {
-            services.AddSingleton<ISentryEventProcessor, AspNetCoreEventProcessor>();
+            _ = services.AddSingleton<ISentryEventProcessor, AspNetCoreEventProcessor>();
             services.TryAddSingleton<IUserFactory, DefaultUserFactory>();
 
-            services
-                .AddSingleton<IRequestPayloadExtractor, FormRequestPayloadExtractor>()
-                // Last
-                .AddSingleton<IRequestPayloadExtractor, DefaultRequestPayloadExtractor>();
+            _ = services
+                    .AddSingleton<IRequestPayloadExtractor, FormRequestPayloadExtractor>()
+                    // Last
+                    .AddSingleton<IRequestPayloadExtractor, DefaultRequestPayloadExtractor>();
 
-            services.AddSentry<SentryAspNetCoreOptions>();
+            _ = services.AddSentry<SentryAspNetCoreOptions>();
 
             return services;
         }

--- a/src/Sentry.AspNetCore/SentryStartupFilter.cs
+++ b/src/Sentry.AspNetCore/SentryStartupFilter.cs
@@ -10,7 +10,7 @@ namespace Sentry.AspNetCore
         public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
             => e =>
             {
-                e.UseSentry();
+                _ = e.UseSentry();
 
                 next(e);
             };

--- a/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
@@ -56,34 +56,34 @@ namespace Microsoft.AspNetCore.Hosting
             // The earliest we can hook the SDK initialization code with the framework
             // Initialization happens at a later time depending if the default MEL backend is enabled or not.
             // In case the logging backend was replaced, init happens later, at the StartupFilter
-            builder.ConfigureLogging((context, logging) =>
+            _ = builder.ConfigureLogging((context, logging) =>
             {
                 logging.AddConfiguration();
 
                 var section = context.Configuration.GetSection("Sentry");
-                logging.Services.Configure<SentryAspNetCoreOptions>(section);
+                _ = logging.Services.Configure<SentryAspNetCoreOptions>(section);
 
                 if (configureOptions != null)
                 {
-                    logging.Services.Configure<SentryAspNetCoreOptions>(options =>
+                    _ = logging.Services.Configure<SentryAspNetCoreOptions>(options =>
                     {
                         configureOptions(context, options);
                     });
                 }
 
-                logging.Services.AddSingleton<IConfigureOptions<SentryAspNetCoreOptions>, SentryAspNetCoreOptionsSetup>();
-                logging.Services.AddSingleton<ILoggerProvider, SentryAspNetCoreLoggerProvider>();
+                _ = logging.Services.AddSingleton<IConfigureOptions<SentryAspNetCoreOptions>, SentryAspNetCoreOptionsSetup>();
+                _ = logging.Services.AddSingleton<ILoggerProvider, SentryAspNetCoreLoggerProvider>();
 
-                logging.AddFilter<SentryAspNetCoreLoggerProvider>(
+                _ = logging.AddFilter<SentryAspNetCoreLoggerProvider>(
                     "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware",
                     LogLevel.None);
 
-                logging.Services.AddSentry();
+                _ = logging.Services.AddSentry();
             });
 
-            builder.ConfigureServices(c =>
+            _ = builder.ConfigureServices(c =>
             {
-                c.AddTransient<IStartupFilter, SentryStartupFilter>();
+                _ = c.AddTransient<IStartupFilter, SentryStartupFilter>();
             });
 
             return builder;

--- a/src/Sentry.Extensions.Logging/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Sentry.Extensions.Logging/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
@@ -37,7 +37,7 @@ namespace Sentry.Extensions.Logging.Extensions.DependencyInjection
                 if (options.InitializeSdk)
                 {
                     var hub = c.GetRequiredService<OptionalHub>();
-                    SentrySdk.UseHub(hub);
+                    _ = SentrySdk.UseHub(hub);
                 }
 
                 return () => HubAdapter.Instance;

--- a/src/Sentry.Extensions.Logging/LoggingBuilderExtensions.cs
+++ b/src/Sentry.Extensions.Logging/LoggingBuilderExtensions.cs
@@ -47,14 +47,14 @@ namespace Microsoft.Extensions.Logging
 
             if (optionsConfiguration != null)
             {
-                builder.Services.Configure(optionsConfiguration);
+                _ = builder.Services.Configure(optionsConfiguration);
             }
 
-            builder.Services.AddSingleton<IConfigureOptions<SentryLoggingOptions>, SentryLoggingOptionsSetup>();
+            _ = builder.Services.AddSingleton<IConfigureOptions<SentryLoggingOptions>, SentryLoggingOptionsSetup>();
 
-            builder.Services.AddSingleton<ILoggerProvider, SentryLoggerProvider>();
+            _ = builder.Services.AddSingleton<ILoggerProvider, SentryLoggerProvider>();
 
-            builder.Services.AddSentry<SentryLoggingOptions>();
+            _ = builder.Services.AddSentry<SentryLoggingOptions>();
             return builder;
         }
     }

--- a/src/Sentry.Extensions.Logging/SentryLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryLogger.cs
@@ -92,7 +92,7 @@ namespace Sentry.Extensions.Logging
                     @event.SetTag(tuple.Value.name, tuple.Value.value);
                 }
 
-                _hub.CaptureEvent(@event);
+                _ = _hub.CaptureEvent(@event);
             }
 
             // Even if it was sent as event, add breadcrumb so next event includes it

--- a/src/Sentry.Extensions.Logging/SentryLoggerFactoryExtensions.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggerFactoryExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Extensions.Logging
                 {
                     options.DiagnosticLogger?.LogDebug("Initializing from {0} and swapping current Hub.", nameof(SentryLoggerFactoryExtensions));
                     hub = new OptionalHub(options);
-                    SentrySdk.UseHub(hub);
+                    _ = SentrySdk.UseHub(hub);
                 }
             }
             else

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -118,7 +118,7 @@ namespace Sentry.Log4Net
                 evt.Environment = Environment;
             }
 
-            Hub.CaptureEvent(evt);
+            _ = Hub.CaptureEvent(evt);
         }
 
         private static IEnumerable<KeyValuePair<string, object>> GetLoggingEventProperties(LoggingEvent loggingEvent)

--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -306,9 +306,9 @@ namespace Sentry.NLog
         /// <inheritdoc />
         protected override void FlushAsync(AsyncContinuation asyncContinuation)
         {
-            _hubAccessor()
-                .FlushAsync(Options.FlushTimeout)
-                .ContinueWith(t => asyncContinuation(t.Exception));
+            _ = _hubAccessor()
+                    .FlushAsync(Options.FlushTimeout)
+                    .ContinueWith(t => asyncContinuation(t.Exception));
         }
 
         /// <summary>
@@ -395,7 +395,7 @@ namespace Sentry.NLog
                     }
                 }
 
-                hub.CaptureEvent(evt);
+                _ = hub.CaptureEvent(evt);
             }
 
             // Whether or not it was sent as event, add breadcrumb so the next event includes it

--- a/src/Sentry.Protocol/BaseScopeExtensions.cs
+++ b/src/Sentry.Protocol/BaseScopeExtensions.cs
@@ -148,7 +148,7 @@ namespace Sentry
                                                 ?? Constants.DefaultMaxBreadcrumbs) + 1;
             if (overflow > 0)
             {
-                breadcrumbs.TryDequeue(out _);
+                _ = breadcrumbs.TryDequeue(out _);
             }
 
             breadcrumbs.Enqueue(breadcrumb);
@@ -181,7 +181,7 @@ namespace Sentry
             var extra = (ConcurrentDictionary<string, object>)scope.Extra;
             foreach (var keyValuePair in values)
             {
-                extra.AddOrUpdate(keyValuePair.Key, keyValuePair.Value, (s, o) => keyValuePair.Value);
+                _ = extra.AddOrUpdate(keyValuePair.Key, keyValuePair.Value, (s, o) => keyValuePair.Value);
             }
         }
 
@@ -204,7 +204,7 @@ namespace Sentry
             var internalTags = (ConcurrentDictionary<string, string>)scope.Tags;
             foreach (var keyValuePair in tags)
             {
-                internalTags.AddOrUpdate(keyValuePair.Key, keyValuePair.Value, (s, o) => keyValuePair.Value);
+                _ = internalTags.AddOrUpdate(keyValuePair.Key, keyValuePair.Value, (s, o) => keyValuePair.Value);
             }
         }
 
@@ -245,14 +245,14 @@ namespace Sentry
 
             if (from.InternalBreadcrumbs != null)
             {
-                ((ConcurrentQueue<Breadcrumb>)to.Breadcrumbs).EnqueueAll(from.InternalBreadcrumbs);
+                _ = ((ConcurrentQueue<Breadcrumb>)to.Breadcrumbs).EnqueueAll(from.InternalBreadcrumbs);
             }
 
             if (from.InternalExtra != null)
             {
                 foreach (var extra in from.Extra)
                 {
-                    ((ConcurrentDictionary<string, object>)to.Extra).TryAdd(extra.Key, extra.Value);
+                    _ = ((ConcurrentDictionary<string, object>)to.Extra).TryAdd(extra.Key, extra.Value);
                 }
             }
 
@@ -260,7 +260,7 @@ namespace Sentry
             {
                 foreach (var tag in from.Tags)
                 {
-                    ((ConcurrentDictionary<string, string>)to.Tags).TryAdd(tag.Key, tag.Value);
+                    _ = ((ConcurrentDictionary<string, string>)to.Tags).TryAdd(tag.Key, tag.Value);
                 }
             }
 

--- a/src/Sentry.Serilog/SentrySink.cs
+++ b/src/Sentry.Serilog/SentrySink.cs
@@ -109,7 +109,7 @@ namespace Sentry.Serilog
                 evt.Sdk.AddPackage(ProtocolPackageName, NameAndVersion.Version);
                 evt.SetExtras(GetLoggingEventProperties(logEvent));
 
-                hub.CaptureEvent(evt);
+                _ = hub.CaptureEvent(evt);
             }
 
             // Even if it was sent as event, add breadcrumb so next event includes it

--- a/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
@@ -36,7 +36,7 @@ namespace Sentry.Integrations
             {
                 ex.Data[Mechanism.HandledKey] = false;
                 ex.Data[Mechanism.MechanismKey] = "AppDomain.UnhandledException";
-                _hub?.CaptureException(ex);
+                _ = (_hub?.CaptureException(ex));
             }
 
             if (e.IsTerminating)

--- a/src/Sentry/Internal/BackgroundWorker.cs
+++ b/src/Sentry/Internal/BackgroundWorker.cs
@@ -71,12 +71,12 @@ namespace Sentry.Internal
 
             if (Interlocked.Increment(ref _currentItems) > _maxItems)
             {
-                Interlocked.Decrement(ref _currentItems);
+                _ = Interlocked.Decrement(ref _currentItems);
                 return false;
             }
 
             _queue.Enqueue(@event);
-            _queuedEventSemaphore.Release();
+            _ = _queuedEventSemaphore.Release();
             return true;
         }
 
@@ -146,8 +146,8 @@ namespace Sentry.Internal
                         }
                         finally
                         {
-                            queue.TryDequeue(out _);
-                            Interlocked.Decrement(ref _currentItems);
+                            _ = queue.TryDequeue(out _);
+                            _ = Interlocked.Decrement(ref _currentItems);
                             OnFlushObjectReceived?.Invoke(@event, EventArgs.Empty);
                         }
                     }
@@ -225,7 +225,7 @@ namespace Sentry.Internal
                     return;
                 }
 
-                Interlocked.Exchange(ref depth, trackedDepth);
+                _ = Interlocked.Exchange(ref depth, trackedDepth);
                 _options.DiagnosticLogger?.LogDebug("Tracking depth: {0}.", trackedDepth);
 
                 if (counter >= depth) // When the worker finished flushing before we set the depth
@@ -272,7 +272,7 @@ namespace Sentry.Internal
 
                 // If there's anything in the queue, it'll keep running until 'shutdownTimeout' is reached
                 // If the queue is empty it will quit immediately
-                WorkerTask.Wait(_options.ShutdownTimeout);
+                _ = WorkerTask.Wait(_options.ShutdownTimeout);
             }
             catch (OperationCanceledException)
             {

--- a/src/Sentry/Internal/Http/GzipBufferedRequestBodyHandler.cs
+++ b/src/Sentry/Internal/Http/GzipBufferedRequestBodyHandler.cs
@@ -79,7 +79,7 @@ namespace Sentry.Internal.Http
 
                 foreach (var header in headers)
                 {
-                    Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    _ = Headers.TryAddWithoutValidation(header.Key, header.Value);
                 }
 
                 Headers.ContentEncoding.Add(Gzip);

--- a/src/Sentry/Internal/Http/GzipRequestBodyHandler.cs
+++ b/src/Sentry/Internal/Http/GzipRequestBodyHandler.cs
@@ -68,7 +68,7 @@ namespace Sentry.Internal.Http
 
                 foreach (var header in content.Headers)
                 {
-                    Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    _ = Headers.TryAddWithoutValidation(header.Key, header.Value);
                 }
 
                 Headers.ContentEncoding.Add(Gzip);

--- a/src/Sentry/Internal/Http/RetryAfterHandler.cs
+++ b/src/Sentry/Internal/Http/RetryAfterHandler.cs
@@ -58,7 +58,7 @@ namespace Sentry.Internal.Http
                     return _tooManyRequestsResponse;
                 }
 
-                Interlocked.Exchange(ref _retryAfterUtcTicks, 0);
+                _ = Interlocked.Exchange(ref _retryAfterUtcTicks, 0);
             }
 
             var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
@@ -70,11 +70,11 @@ namespace Sentry.Internal.Http
                     if (response.Headers.RetryAfter.Delta != null)
                     {
                         var retryAfterUtc = _clock.GetUtcNow() + response.Headers.RetryAfter.Delta.Value;
-                        Interlocked.Exchange(ref _retryAfterUtcTicks, retryAfterUtc.UtcTicks);
+                        _ = Interlocked.Exchange(ref _retryAfterUtcTicks, retryAfterUtc.UtcTicks);
                     }
                     else if (response.Headers.RetryAfter.Date != null)
                     {
-                        Interlocked.Exchange(ref _retryAfterUtcTicks, response.Headers.RetryAfter.Date.Value.UtcTicks);
+                        _ = Interlocked.Exchange(ref _retryAfterUtcTicks, response.Headers.RetryAfter.Date.Value.UtcTicks);
                     }
                 }
                 // Sentry was sending floating point numbers which are not handled by RetryConditionHeaderValue
@@ -83,7 +83,7 @@ namespace Sentry.Internal.Http
                          && double.TryParse(values?.FirstOrDefault(), out var retryAfterSeconds))
                 {
                     var retryAfterSpan = TimeSpan.FromSeconds(retryAfterSeconds);
-                    Interlocked.Exchange(ref _retryAfterUtcTicks, _clock.GetUtcNow().AddTicks(retryAfterSpan.Ticks).UtcTicks);
+                    _ = Interlocked.Exchange(ref _retryAfterUtcTicks, _clock.GetUtcNow().AddTicks(retryAfterSpan.Ticks).UtcTicks);
                 }
             }
 

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -126,7 +126,7 @@ namespace Sentry
 
             public void Dispose()
             {
-                Interlocked.CompareExchange(ref _hub, DisabledHub.Instance, _localHub);
+                _ = Interlocked.CompareExchange(ref _hub, DisabledHub.Instance, _localHub);
                 (_localHub as IDisposable)?.Dispose();
                 _localHub = null;
             }

--- a/test/Sentry.AspNetCore.Tests/ApplicationBuilderExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/ApplicationBuilderExtensionsTests.cs
@@ -21,32 +21,32 @@ namespace Sentry.AspNetCore.Tests
             {
                 var provider = Substitute.For<IServiceProvider>();
                 var options = Substitute.For<IOptions<SentryAspNetCoreOptions>>();
-                options.Value.Returns(SentryAspNetCoreOptions);
-                provider.GetService(typeof(IOptions<SentryAspNetCoreOptions>)).Returns(options);
+                _ = options.Value.Returns(SentryAspNetCoreOptions);
+                _ = provider.GetService(typeof(IOptions<SentryAspNetCoreOptions>)).Returns(options);
 
                 if (SentryEventProcessor != null)
                 {
-                    provider.GetService(typeof(ISentryEventProcessor)).Returns(SentryEventProcessor);
+                    _ = provider.GetService(typeof(ISentryEventProcessor)).Returns(SentryEventProcessor);
                 }
 
                 if (SentryEventExceptionProcessor != null)
                 {
-                    provider.GetService(typeof(ISentryEventExceptionProcessor)).Returns(SentryEventExceptionProcessor);
+                    _ = provider.GetService(typeof(ISentryEventExceptionProcessor)).Returns(SentryEventExceptionProcessor);
                 }
 
-                provider.GetService(typeof(IEnumerable<ISentryEventProcessor>))
-                    .Returns(SentryEventProcessor != null
-                        ? new[] { SentryEventProcessor }
-                        : Enumerable.Empty<ISentryEventProcessor>());
+                _ = provider.GetService(typeof(IEnumerable<ISentryEventProcessor>))
+                        .Returns(SentryEventProcessor != null
+                            ? new[] { SentryEventProcessor }
+                            : Enumerable.Empty<ISentryEventProcessor>());
 
-                provider.GetService(typeof(IEnumerable<ISentryEventExceptionProcessor>))
-                    .Returns(SentryEventExceptionProcessor != null
-                        ? new[] { SentryEventExceptionProcessor }
-                        : Enumerable.Empty<ISentryEventExceptionProcessor>());
+                _ = provider.GetService(typeof(IEnumerable<ISentryEventExceptionProcessor>))
+                        .Returns(SentryEventExceptionProcessor != null
+                            ? new[] { SentryEventExceptionProcessor }
+                            : Enumerable.Empty<ISentryEventExceptionProcessor>());
 
 
                 var sut = Substitute.For<IApplicationBuilder>();
-                sut.ApplicationServices.Returns(provider);
+                _ = sut.ApplicationServices.Returns(provider);
                 return sut;
             }
         }
@@ -60,7 +60,7 @@ namespace Sentry.AspNetCore.Tests
             _fixture.SentryAspNetCoreOptions.DiagnosticLogger = diagnosticLogger;
             _fixture.SentryAspNetCoreOptions.Debug = true;
             var sut = _fixture.GetSut();
-            sut.UseSentry();
+            _ = sut.UseSentry();
 
             Assert.Same(diagnosticLogger, _fixture.SentryAspNetCoreOptions.DiagnosticLogger);
         }
@@ -70,7 +70,7 @@ namespace Sentry.AspNetCore.Tests
         {
             var sut = _fixture.GetSut();
 
-            sut.UseSentry();
+            _ = sut.UseSentry();
 
             Assert.Contains(_fixture.SentryAspNetCoreOptions.GetAllEventProcessors(),
                 actual => actual == _fixture.SentryEventProcessor);
@@ -83,7 +83,7 @@ namespace Sentry.AspNetCore.Tests
 
             var sut = _fixture.GetSut();
 
-            sut.UseSentry();
+            _ = sut.UseSentry();
 
             var missing = originalProviders.Except(_fixture.SentryAspNetCoreOptions.EventProcessorsProviders);
             Assert.Empty(missing);
@@ -94,7 +94,7 @@ namespace Sentry.AspNetCore.Tests
         {
             var sut = _fixture.GetSut();
 
-            sut.UseSentry();
+            _ = sut.UseSentry();
 
             Assert.Contains(_fixture.SentryAspNetCoreOptions.GetAllExceptionProcessors(),
                 actual => actual == _fixture.SentryEventExceptionProcessor);
@@ -107,7 +107,7 @@ namespace Sentry.AspNetCore.Tests
 
             var sut = _fixture.GetSut();
 
-            sut.UseSentry();
+            _ = sut.UseSentry();
 
             var missing = originalProviders.Except(_fixture.SentryAspNetCoreOptions.ExceptionProcessorsProviders);
             Assert.Empty(missing);
@@ -121,7 +121,7 @@ namespace Sentry.AspNetCore.Tests
 
             var sut = _fixture.GetSut();
 
-            sut.UseSentry();
+            _ = sut.UseSentry();
 
             Assert.Same(originalProviders, _fixture.SentryAspNetCoreOptions.EventProcessorsProviders);
         }
@@ -134,7 +134,7 @@ namespace Sentry.AspNetCore.Tests
 
             var sut = _fixture.GetSut();
 
-            sut.UseSentry();
+            _ = sut.UseSentry();
 
             Assert.Same(originalProviders, _fixture.SentryAspNetCoreOptions.ExceptionProcessorsProviders);
         }

--- a/test/Sentry.AspNetCore.Tests/AspNetCoreEventProcessorTests.cs
+++ b/test/Sentry.AspNetCore.Tests/AspNetCoreEventProcessorTests.cs
@@ -22,7 +22,7 @@ namespace Sentry.AspNetCore.Tests
             var target = new SentryEvent();
             var expected = target.Contexts.Runtime;
 
-            _sut.Process(target);
+            _ = _sut.Process(target);
 
             Assert.Same(expected, target.Contexts["server-runtime"]);
         }
@@ -30,9 +30,9 @@ namespace Sentry.AspNetCore.Tests
         public void Process_WithoutRuntime_NoServerRuntime()
         {
             var target = new SentryEvent();
-            target.Contexts.TryRemove(Runtime.Type, out _);
+            _ = target.Contexts.TryRemove(Runtime.Type, out _);
 
-            _sut.Process(target);
+            _ = _sut.Process(target);
 
             Assert.False(target.Contexts.ContainsKey("server-runtime"));
         }
@@ -43,7 +43,7 @@ namespace Sentry.AspNetCore.Tests
             var target = new SentryEvent();
             var expected = target.Contexts.OperatingSystem;
 
-            _sut.Process(target);
+            _ = _sut.Process(target);
 
             Assert.Same(expected, target.Contexts["server-os"]);
         }
@@ -52,9 +52,9 @@ namespace Sentry.AspNetCore.Tests
         public void Process_WithoutOperatingSystem_NoServerOperatingSystem()
         {
             var target = new SentryEvent();
-            target.Contexts.TryRemove(OperatingSystem.Type, out _);
+            _ = target.Contexts.TryRemove(OperatingSystem.Type, out _);
 
-            _sut.Process(target);
+            _ = _sut.Process(target);
 
             Assert.False(target.Contexts.ContainsKey("server-os"));
         }
@@ -66,7 +66,7 @@ namespace Sentry.AspNetCore.Tests
             const string expectedServerName = "original";
             target.ServerName = expectedServerName;
 
-            _sut.Process(target);
+            _ = _sut.Process(target);
 
             Assert.Equal(expectedServerName, target.ServerName);
         }
@@ -76,7 +76,7 @@ namespace Sentry.AspNetCore.Tests
         {
             var target = new SentryEvent();
 
-            _sut.Process(target);
+            _ = _sut.Process(target);
 
             Assert.Equal(Environment.MachineName, target.ServerName);
         }
@@ -89,7 +89,7 @@ namespace Sentry.AspNetCore.Tests
             var target = new SentryEvent();
             _options.DefaultTags[key] = expected;
 
-            _sut.Process(target);
+            _ = _sut.Process(target);
 
             Assert.Equal(expected, target.Tags[key]);
         }

--- a/test/Sentry.AspNetCore.Tests/AspNetCoreSentryWebHostBuilder.IntegrationTests.cs
+++ b/test/Sentry.AspNetCore.Tests/AspNetCoreSentryWebHostBuilder.IntegrationTests.cs
@@ -13,8 +13,8 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void UseSentry_ValidDsnString_EnablesSdk()
         {
-            _webHostBuilder.UseSentry(DsnSamples.ValidDsnWithoutSecret)
-                .Build();
+            _ = _webHostBuilder.UseSentry(DsnSamples.ValidDsnWithoutSecret)
+                    .Build();
 
             try
             {
@@ -29,7 +29,7 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void UseSentry_NoDsnProvided_DisabledSdk()
         {
-            _webHostBuilder.UseSentry().Build();
+            _ = _webHostBuilder.UseSentry().Build();
 
             Assert.False(SentrySdk.IsEnabled);
         }
@@ -37,8 +37,8 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void UseSentry_DisableDsnString_DisabledSdk()
         {
-            _webHostBuilder.UseSentry(Protocol.Constants.DisableSdkDsnValue)
-                .Build();
+            _ = _webHostBuilder.UseSentry(Protocol.Constants.DisableSdkDsnValue)
+                    .Build();
 
             Assert.False(SentrySdk.IsEnabled);
         }
@@ -46,8 +46,8 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void UseSentry_OptionsNotInitializeSdk_DisabledSdk()
         {
-            _webHostBuilder.UseSentry(o => o.InitializeSdk = false)
-                .Build();
+            _ = _webHostBuilder.UseSentry(o => o.InitializeSdk = false)
+                    .Build();
 
             Assert.False(SentrySdk.IsEnabled);
         }

--- a/test/Sentry.AspNetCore.Tests/AspNetSentrySdkTestFixture.cs
+++ b/test/Sentry.AspNetCore.Tests/AspNetSentrySdkTestFixture.cs
@@ -15,7 +15,7 @@ namespace Sentry.AspNetCore.Tests
         {
             var sentry = FakeSentryServer.CreateServer();
             var sentryHttpClient = sentry.CreateClient();
-            builder.UseSentry(options =>
+            _ = builder.UseSentry(options =>
             {
                 options.Dsn = DsnSamples.ValidDsnWithSecret;
                 options.SentryHttpClientFactory = new DelegateHttpClientFactory((d, o)

--- a/test/Sentry.AspNetCore.Tests/BaseRequestPayloadExtractorTests.cs
+++ b/test/Sentry.AspNetCore.Tests/BaseRequestPayloadExtractorTests.cs
@@ -17,14 +17,14 @@ namespace Sentry.AspNetCore.Tests
 
             public Fixture()
             {
-                Stream.CanSeek.Returns(true);
-                Stream.CanRead.Returns(true);
+                _ = Stream.CanSeek.Returns(true);
+                _ = Stream.CanRead.Returns(true);
                 HttpRequest = new HttpRequestAdapter(HttpRequestCore);
             }
 
             public TExtractor GetSut()
             {
-                HttpRequest.Body.Returns(Stream);
+                _ = HttpRequest.Body.Returns(Stream);
                 return new TExtractor();
             }
         }
@@ -35,11 +35,11 @@ namespace Sentry.AspNetCore.Tests
         public void ExtractPayload_OriginalStreamPosition_Reset()
         {
             const int originalPosition = 100;
-            TestFixture.Stream.Position.Returns(originalPosition);
+            _ = TestFixture.Stream.Position.Returns(originalPosition);
 
             var sut = TestFixture.GetSut();
 
-            sut.ExtractPayload(TestFixture.HttpRequest);
+            _ = sut.ExtractPayload(TestFixture.HttpRequest);
 
             TestFixture.Stream.Received().Position = originalPosition;
         }
@@ -49,7 +49,7 @@ namespace Sentry.AspNetCore.Tests
         {
             var sut = TestFixture.GetSut();
 
-            sut.ExtractPayload(TestFixture.HttpRequest);
+            _ = sut.ExtractPayload(TestFixture.HttpRequest);
 
             TestFixture.Stream.DidNotReceive().Close();
         }
@@ -57,7 +57,7 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void ExtractPayload_CantSeekStream_DoesNotChangePosition()
         {
-            TestFixture.Stream.CanSeek.Returns(false);
+            _ = TestFixture.Stream.CanSeek.Returns(false);
 
             var sut = TestFixture.GetSut();
 
@@ -69,7 +69,7 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void ExtractPayload_CantReadStream_DoesNotChangePosition()
         {
-            TestFixture.Stream.CanRead.Returns(false);
+            _ = TestFixture.Stream.CanRead.Returns(false);
 
             var sut = TestFixture.GetSut();
 

--- a/test/Sentry.AspNetCore.Tests/DefaultUserFactoryTests.cs
+++ b/test/Sentry.AspNetCore.Tests/DefaultUserFactoryTests.cs
@@ -21,7 +21,7 @@ namespace Sentry.AspNetCore.Tests
         public DefaultUserFactoryTests()
         {
             const string username = "test-user";
-            Identity.Name.Returns(username); // by default reads: ClaimTypes.Name
+            _ = Identity.Name.Returns(username); // by default reads: ClaimTypes.Name
             Claims = new List<Claim>
             {
                 new Claim(ClaimTypes.Email, username +"@sentry.io"),
@@ -29,12 +29,12 @@ namespace Sentry.AspNetCore.Tests
                 new Claim(ClaimTypes.NameIdentifier, "927391237"),
             };
 
-            ConnectionInfo.RemoteIpAddress.Returns(IPAddress.IPv6Loopback);
+            _ = ConnectionInfo.RemoteIpAddress.Returns(IPAddress.IPv6Loopback);
 
-            User.Identity.Returns(Identity);
-            HttpContext.User.Returns(User);
-            HttpContext.User.Claims.Returns(Claims);
-            HttpContext.Connection.Returns(ConnectionInfo);
+            _ = User.Identity.Returns(Identity);
+            _ = HttpContext.User.Returns(User);
+            _ = HttpContext.User.Claims.Returns(Claims);
+            _ = HttpContext.Connection.Returns(ConnectionInfo);
         }
 
         private readonly DefaultUserFactory _sut = new DefaultUserFactory();
@@ -55,31 +55,31 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void Create_NoUser_Null()
         {
-            HttpContext.User.ReturnsNull();
+            _ = HttpContext.User.ReturnsNull();
             Assert.Null(_sut.Create(HttpContext));
         }
 
         [Fact]
         public void Create_NoClaimsNoIdentityNoIpAddress_Null()
         {
-            HttpContext.User.Identity.ReturnsNull();
-            HttpContext.User.Claims.Returns(Enumerable.Empty<Claim>());
-            HttpContext.Connection.ReturnsNull();
+            _ = HttpContext.User.Identity.ReturnsNull();
+            _ = HttpContext.User.Claims.Returns(Enumerable.Empty<Claim>());
+            _ = HttpContext.Connection.ReturnsNull();
             Assert.Null(_sut.Create(HttpContext));
         }
 
         [Fact]
         public void Create_NoClaimsNoIdentity_Null()
         {
-            HttpContext.User.Identity.ReturnsNull();
-            HttpContext.User.Claims.Returns(Enumerable.Empty<Claim>());
+            _ = HttpContext.User.Identity.ReturnsNull();
+            _ = HttpContext.User.Claims.Returns(Enumerable.Empty<Claim>());
             Assert.Null(_sut.Create(HttpContext));
         }
 
         [Fact]
         public void Create_NoClaims_UsernameFromIdentity()
         {
-            HttpContext.User.Claims.Returns(Enumerable.Empty<Claim>());
+            _ = HttpContext.User.Claims.Returns(Enumerable.Empty<Claim>());
             var actual = _sut.Create(HttpContext);
             Assert.Equal(Identity.Name, actual.Username);
         }
@@ -87,7 +87,7 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void Create_NoClaims_IpAddress()
         {
-            HttpContext.User.Claims.Returns(Enumerable.Empty<Claim>());
+            _ = HttpContext.User.Claims.Returns(Enumerable.Empty<Claim>());
             var actual = _sut.Create(HttpContext);
             Assert.Equal(IPAddress.IPv6Loopback.ToString(), actual.IpAddress);
         }
@@ -96,7 +96,7 @@ namespace Sentry.AspNetCore.Tests
         public void Create_ClaimNameAndIdentityDontMatch_UsernameFromIdentity()
         {
             const string expected = "App configured to read it from a different claim";
-            User.Identity.Name.Returns(expected);
+            _ = User.Identity.Name.Returns(expected);
             var actual = _sut.Create(HttpContext);
 
             Assert.Equal(expected, actual.Username);
@@ -105,7 +105,7 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void Create_Id_FromClaims()
         {
-            Claims.RemoveAll(p => p.Type != ClaimTypes.NameIdentifier);
+            _ = Claims.RemoveAll(p => p.Type != ClaimTypes.NameIdentifier);
             var actual = _sut.Create(HttpContext);
             Assert.Equal(Claims.NameIdentifier(), actual.Id);
         }
@@ -113,7 +113,7 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void Create_Username_FromClaims()
         {
-            Claims.RemoveAll(p => p.Type != ClaimTypes.Name);
+            _ = Claims.RemoveAll(p => p.Type != ClaimTypes.Name);
             var actual = _sut.Create(HttpContext);
             Assert.Equal(Claims.Name(), actual.Username);
         }
@@ -121,7 +121,7 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void Create_Username_FromIdentity()
         {
-            Claims.RemoveAll(p => p.Type != ClaimTypes.Name);
+            _ = Claims.RemoveAll(p => p.Type != ClaimTypes.Name);
             var actual = _sut.Create(HttpContext);
             Assert.Equal(Identity.Name, actual.Username);
         }
@@ -129,7 +129,7 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void Create_Email_FromClaims()
         {
-            Claims.RemoveAll(p => p.Type != ClaimTypes.Email);
+            _ = Claims.RemoveAll(p => p.Type != ClaimTypes.Email);
             var actual = _sut.Create(HttpContext);
             Assert.Equal(Claims.Email(), actual.Email);
         }
@@ -137,7 +137,7 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void Create_NoRemoteIpAddress_NoIpAvailable()
         {
-            ConnectionInfo.RemoteIpAddress.Returns(null as IPAddress);
+            _ = ConnectionInfo.RemoteIpAddress.Returns(null as IPAddress);
             var actual = _sut.Create(HttpContext);
             Assert.Null(actual.IpAddress);
         }

--- a/test/Sentry.AspNetCore.Tests/FormRequestPayloadExtractorTests.cs
+++ b/test/Sentry.AspNetCore.Tests/FormRequestPayloadExtractorTests.cs
@@ -12,7 +12,7 @@ namespace Sentry.AspNetCore.Tests
         public FormRequestPayloadExtractorTests()
         {
             TestFixture = new Fixture();
-            TestFixture.HttpRequest.ContentType.Returns("application/x-www-form-urlencoded");
+            _ = TestFixture.HttpRequest.ContentType.Returns("application/x-www-form-urlencoded");
         }
 
         [Fact]
@@ -20,7 +20,7 @@ namespace Sentry.AspNetCore.Tests
         {
             var expected = new Dictionary<string, StringValues> { { "key", new StringValues("val") } };
             var f = new FormCollection(expected);
-            TestFixture.HttpRequestCore.Form.Returns(f);
+            _ = TestFixture.HttpRequestCore.Form.Returns(f);
 
             var sut = TestFixture.GetSut();
 
@@ -36,7 +36,7 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void ExtractPayload_UnsupportedContentType_DoesNotReadStream()
         {
-            TestFixture.HttpRequest.ContentType.Returns("application/json");
+            _ = TestFixture.HttpRequest.ContentType.Returns("application/json");
 
             var sut = TestFixture.GetSut();
 

--- a/test/Sentry.AspNetCore.Tests/IntegrationMockedBackgroundWorker.cs
+++ b/test/Sentry.AspNetCore.Tests/IntegrationMockedBackgroundWorker.cs
@@ -31,7 +31,7 @@ namespace Else.AspNetCore.Tests
         {
             ConfigureWehHost = builder =>
             {
-                builder.UseSentry(options =>
+                _ = builder.UseSentry(options =>
                 {
                     options.Dsn = DsnSamples.ValidDsnWithSecret;
                     options.BackgroundWorker = Worker;
@@ -47,9 +47,9 @@ namespace Else.AspNetCore.Tests
             Configure = o => o.InitializeSdk = false;
 
             Build();
-            await HttpClient.GetAsync("/throw");
+            _ = await HttpClient.GetAsync("/throw");
 
-            Worker.DidNotReceive().EnqueueEvent(Arg.Any<SentryEvent>());
+            _ = Worker.DidNotReceive().EnqueueEvent(Arg.Any<SentryEvent>());
             Assert.False(ServiceProvider.GetRequiredService<IHub>().IsEnabled);
         }
 
@@ -62,7 +62,7 @@ namespace Else.AspNetCore.Tests
             var logger = ServiceProvider.GetRequiredService<ILogger<IntegrationMockedBackgroundWorker>>();
             logger.LogCritical("test");
 
-            Worker.DidNotReceive().EnqueueEvent(Arg.Any<SentryEvent>());
+            _ = Worker.DidNotReceive().EnqueueEvent(Arg.Any<SentryEvent>());
             Assert.False(ServiceProvider.GetRequiredService<IHub>().IsEnabled);
         }
 
@@ -75,7 +75,7 @@ namespace Else.AspNetCore.Tests
             var logger = ServiceProvider.GetRequiredService<ILogger<IntegrationMockedBackgroundWorker>>();
             logger.LogError(expectedMessage);
 
-            Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p => p.LogEntry.Formatted == expectedMessage));
+            _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p => p.LogEntry.Formatted == expectedMessage));
         }
 
         [Fact]
@@ -88,9 +88,9 @@ namespace Else.AspNetCore.Tests
             var logger = ServiceProvider.GetRequiredService<ILogger<IntegrationMockedBackgroundWorker>>();
             logger.LogError(expectedMessage, param);
 
-            Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p =>
-                p.LogEntry.Formatted == $"Test {param} log"
-                && p.LogEntry.Message == expectedMessage));
+            _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p =>
+                    p.LogEntry.Formatted == $"Test {param} log"
+                    && p.LogEntry.Message == expectedMessage));
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace Else.AspNetCore.Tests
             Configure = o => o.Debug = true;
             Build();
             var options = ServiceProvider.GetRequiredService<IOptions<SentryAspNetCoreOptions>>();
-            Assert.IsType<MelDiagnosticLogger>(options.Value.DiagnosticLogger);
+            _ = Assert.IsType<MelDiagnosticLogger>(options.Value.DiagnosticLogger);
         }
 
         [Fact]
@@ -117,9 +117,9 @@ namespace Else.AspNetCore.Tests
 
             Build();
             var client = ServiceProvider.GetRequiredService<ISentryClient>();
-            client.CaptureMessage(expectedMessage);
+            _ = client.CaptureMessage(expectedMessage);
 
-            Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p => p.Message == expectedMessage));
+            _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p => p.Message == expectedMessage));
         }
 
         [Fact]
@@ -129,9 +129,9 @@ namespace Else.AspNetCore.Tests
 
             Build();
             var client = ServiceProvider.GetRequiredService<IHub>();
-            client.CaptureMessage(expectedMessage);
+            _ = client.CaptureMessage(expectedMessage);
 
-            Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p => p.Message == expectedMessage));
+            _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p => p.Message == expectedMessage));
         }
 
         [Fact]
@@ -140,9 +140,9 @@ namespace Else.AspNetCore.Tests
             Configure = o => o.SendDefaultPii = false;
 
             Build();
-            await HttpClient.GetAsync("/throw");
+            _ = await HttpClient.GetAsync("/throw");
 
-            Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(e => e.User.Username == null));
+            _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(e => e.User.Username == null));
         }
 
         [Fact]
@@ -151,9 +151,9 @@ namespace Else.AspNetCore.Tests
             Configure = o => o.SendDefaultPii = true; // Sentry package will set to Environment.UserName
 
             Build();
-            await HttpClient.GetAsync("/throw");
+            _ = await HttpClient.GetAsync("/throw");
 
-            Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(e => e.User.Username == null));
+            _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(e => e.User.Username == null));
         }
 
         [Fact]
@@ -163,16 +163,16 @@ namespace Else.AspNetCore.Tests
             Configure = o => o.SendDefaultPii = true; // Sentry package will set to Environment.UserName
             ConfigureApp = app =>
             {
-                app.Use(async (context, next) =>
+                _ = app.Use(async (context, next) =>
                 {
                     context.User = new GenericPrincipal(new GenericIdentity(expectedName), Array.Empty<string>());
                     await next();
                 });
             };
             Build();
-            await HttpClient.GetAsync("/throw");
+            _ = await HttpClient.GetAsync("/throw");
 
-            Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(e => e.User.Username == expectedName));
+            _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(e => e.User.Username == expectedName));
         }
 
         [Fact]
@@ -180,12 +180,12 @@ namespace Else.AspNetCore.Tests
         {
             ConfigureWehHost = b =>
             {
-                b.ConfigureAppConfiguration(c =>
+                _ = b.ConfigureAppConfiguration(c =>
                 {
-                    c.SetBasePath(Directory.GetCurrentDirectory()); // fails on net462 without this
-                    c.AddJsonFile("allsettings.json", optional: false);
+                    _ = c.SetBasePath(Directory.GetCurrentDirectory()); // fails on net462 without this
+                    _ = c.AddJsonFile("allsettings.json", optional: false);
                 });
-                b.UseSentry(o => o.BackgroundWorker = Worker);
+                _ = b.UseSentry(o => o.BackgroundWorker = Worker);
             };
 
             Build();
@@ -216,9 +216,9 @@ namespace Else.AspNetCore.Tests
             Configure = o => o.Environment = expected;
 
             Build();
-            await HttpClient.GetAsync("/throw");
+            _ = await HttpClient.GetAsync("/throw");
 
-            Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(e => e.Environment == expected));
+            _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(e => e.Environment == expected));
         }
 
         [Fact]
@@ -231,9 +231,9 @@ namespace Else.AspNetCore.Tests
                 () =>
                 {
                     Build();
-                    HttpClient.GetAsync("/throw").GetAwaiter().GetResult();
+                    _ = HttpClient.GetAsync("/throw").GetAwaiter().GetResult();
 
-                    Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(e => e.Environment == expected));
+                    _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(e => e.Environment == expected));
                 });
         }
 
@@ -250,9 +250,9 @@ namespace Else.AspNetCore.Tests
                 () =>
                 {
                     Build();
-                    HttpClient.GetAsync("/throw").GetAwaiter().GetResult();
+                    _ = HttpClient.GetAsync("/throw").GetAwaiter().GetResult();
 
-                    Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(e => e.Environment == expected));
+                    _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(e => e.Environment == expected));
                 });
         }
     }

--- a/test/Sentry.AspNetCore.Tests/IntegrationsTests.EventProcessor.cs
+++ b/test/Sentry.AspNetCore.Tests/IntegrationsTests.EventProcessor.cs
@@ -22,14 +22,14 @@ namespace Sentry.AspNetCore.Tests
             });
 
             Build();
-            await HttpClient.GetAsync("/throw");
-            await HttpClient.GetAsync("/throw");
+            _ = await HttpClient.GetAsync("/throw");
+            _ = await HttpClient.GetAsync("/throw");
 
             // First resolve only to decided if worth patching SentryOptions
             Assert.Equal(3, processorsResolved.Count);
-            processorsResolved[0].DidNotReceive().Process(Arg.Any<SentryEvent>());
-            processorsResolved[1].Received(1).Process(Arg.Any<SentryEvent>());
-            processorsResolved[2].Received(1).Process(Arg.Any<SentryEvent>());
+            _ = processorsResolved[0].DidNotReceive().Process(Arg.Any<SentryEvent>());
+            _ = processorsResolved[1].Received(1).Process(Arg.Any<SentryEvent>());
+            _ = processorsResolved[2].Received(1).Process(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -44,8 +44,8 @@ namespace Sentry.AspNetCore.Tests
             });
 
             Build();
-            await HttpClient.GetAsync("/throw");
-            await HttpClient.GetAsync("/throw");
+            _ = await HttpClient.GetAsync("/throw");
+            _ = await HttpClient.GetAsync("/throw");
 
             // First resolve only to decided if worth patching SentryOptions
             Assert.Equal(3, exceptionProcessorsResolved.Count);

--- a/test/Sentry.AspNetCore.Tests/IntegrationsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/IntegrationsTests.cs
@@ -23,7 +23,7 @@ namespace Sentry.AspNetCore.Tests
 
             Handlers = new[] { handler };
             Build();
-            await HttpClient.GetAsync(handler.Path);
+            _ = await HttpClient.GetAsync(handler.Path);
 
             Assert.Same(expectedException, LastExceptionFilter.LastException);
         }
@@ -33,7 +33,7 @@ namespace Sentry.AspNetCore.Tests
         {
             var logger = Substitute.For<ILogger>();
             var factory = Substitute.For<ILoggerFactory>();
-            factory.CreateLogger(Arg.Any<string>()).Returns(logger);
+            _ = factory.CreateLogger(Arg.Any<string>()).Returns(logger);
 
             AfterConfigureBuilder = builder =>
             {
@@ -42,14 +42,14 @@ namespace Sentry.AspNetCore.Tests
                 // When logging integrations behave like this, the SDK should work normally
                 // simply without the MEL integration to event/breadcrumb
                 // Note that it runs After UseSentry
-                builder.ConfigureServices(collection =>
-                    collection.AddSingleton(factory));
+                _ = builder.ConfigureServices(collection =>
+                        collection.AddSingleton(factory));
             };
 
             Build();
 
             // Make sure custom factory was used instead of default one
-            factory.Received().CreateLogger(Arg.Any<string>());
+            _ = factory.Received().CreateLogger(Arg.Any<string>());
 
             Assert.True(SentrySdk.IsEnabled);
 

--- a/test/Sentry.AspNetCore.Tests/LastExceptionFilter.cs
+++ b/test/Sentry.AspNetCore.Tests/LastExceptionFilter.cs
@@ -12,7 +12,7 @@ namespace Sentry.AspNetCore.Tests
             =>
                 e =>
                 {
-                    e.Use(async (_, n) =>
+                    _ = e.Use(async (_, n) =>
                     {
                         try
                         {

--- a/test/Sentry.AspNetCore.Tests/MiddlewareLoggerIntegration.cs
+++ b/test/Sentry.AspNetCore.Tests/MiddlewareLoggerIntegration.cs
@@ -52,7 +52,7 @@ namespace Sentry.AspNetCore.Tests
                 var provider = new SentryLoggerProvider(hub, Clock, loggingOptions);
                 _disposable = provider;
                 SentryLogger = provider.CreateLogger(nameof(SentryLogger));
-                HttpContext.Features.Returns(FeatureCollection);
+                _ = HttpContext.Features.Returns(FeatureCollection);
             }
 
             public SentryMiddleware GetSut()
@@ -79,11 +79,11 @@ namespace Sentry.AspNetCore.Tests
             };
             var sut = _fixture.GetSut();
 
-            await Assert.ThrowsAsync<Exception>(async () => await sut.InvokeAsync(_fixture.HttpContext));
+            _ = await Assert.ThrowsAsync<Exception>(async () => await sut.InvokeAsync(_fixture.HttpContext));
 
-            _fixture.Client.Received(1).CaptureEvent(
-                Arg.Any<SentryEvent>(),
-                Arg.Is<Scope>(e => e.Breadcrumbs.Any(b => b.Message == expectedCrumb)));
+            _ = _fixture.Client.Received(1).CaptureEvent(
+                    Arg.Any<SentryEvent>(),
+                    Arg.Is<Scope>(e => e.Breadcrumbs.Any(b => b.Message == expectedCrumb)));
         }
 
         [Fact]
@@ -100,11 +100,11 @@ namespace Sentry.AspNetCore.Tests
             };
             var sut = _fixture.GetSut();
 
-            await Assert.ThrowsAsync<Exception>(async () => await sut.InvokeAsync(_fixture.HttpContext));
+            _ = await Assert.ThrowsAsync<Exception>(async () => await sut.InvokeAsync(_fixture.HttpContext));
 
-            _fixture.Client.Received(1).CaptureEvent(
-                Arg.Any<SentryEvent>(),
-                Arg.Is<Scope>(e => e.Breadcrumbs.Any(b => b.Message == expectedCrumb)));
+            _ = _fixture.Client.Received(1).CaptureEvent(
+                    Arg.Any<SentryEvent>(),
+                    Arg.Is<Scope>(e => e.Breadcrumbs.Any(b => b.Message == expectedCrumb)));
         }
 
         [Fact]
@@ -115,11 +115,11 @@ namespace Sentry.AspNetCore.Tests
             _fixture.RequestDelegate = context => throw new Exception();
             var sut = _fixture.GetSut();
 
-            await Assert.ThrowsAsync<Exception>(async () => await sut.InvokeAsync(_fixture.HttpContext));
+            _ = await Assert.ThrowsAsync<Exception>(async () => await sut.InvokeAsync(_fixture.HttpContext));
 
-            _fixture.Client.Received(1).CaptureEvent(
-                Arg.Any<SentryEvent>(),
-                Arg.Is<Scope>(e => e.Level == expected));
+            _ = _fixture.Client.Received(1).CaptureEvent(
+                    Arg.Any<SentryEvent>(),
+                    Arg.Is<Scope>(e => e.Level == expected));
         }
 
         public void Dispose() => _fixture.Dispose();

--- a/test/Sentry.AspNetCore.Tests/ScopeExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/ScopeExtensionsTests.cs
@@ -28,15 +28,15 @@ namespace Sentry.AspNetCore.Tests
 
         public ScopeExtensionsTests()
         {
-            _httpContext.RequestServices.Returns(_provider);
-            _httpContext.Request.Returns(_httpRequest);
+            _ = _httpContext.RequestServices.Returns(_provider);
+            _ = _httpContext.Request.Returns(_httpRequest);
         }
 
         [Fact]
         public void Populate_Request_Method_SetToScope()
         {
             const string expected = "method";
-            _httpContext.Request.Method.Returns(expected);
+            _ = _httpContext.Request.Method.Returns(expected);
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
@@ -47,7 +47,7 @@ namespace Sentry.AspNetCore.Tests
         public void Populate_Request_QueryString_SetToScope()
         {
             const string expected = "?query=bla&something=ble";
-            _httpContext.Request.QueryString.Returns(new QueryString(expected));
+            _ = _httpContext.Request.QueryString.Returns(new QueryString(expected));
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
@@ -58,13 +58,13 @@ namespace Sentry.AspNetCore.Tests
         public void Populate_Request_Url_SetToScope()
         {
             const string expectedPath = "/request/path";
-            _httpContext.Request.Path.Returns(new PathString(expectedPath));
+            _ = _httpContext.Request.Path.Returns(new PathString(expectedPath));
 
             const string expectedHost = "host.com";
-            _httpContext.Request.Host.Returns(new HostString(expectedHost));
+            _ = _httpContext.Request.Host.Returns(new HostString(expectedHost));
 
             const string expectedScheme = "http";
-            _httpContext.Request.Scheme.Returns(expectedScheme);
+            _ = _httpContext.Request.Scheme.Returns(expectedScheme);
 
             const string expected = "http://host.com/request/path";
 
@@ -78,7 +78,7 @@ namespace Sentry.AspNetCore.Tests
         {
             const string expected = "/request/path";
             _sut.SetTag("RequestPath", expected);
-            _httpContext.Request.Path.Returns(new PathString(expected));
+            _ = _httpContext.Request.Path.Returns(new PathString(expected));
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
@@ -89,13 +89,13 @@ namespace Sentry.AspNetCore.Tests
         public void Populate_Request_Url_IncludesPortWhenOnContext()
         {
             const string expectedPath = "/request/path";
-            _httpContext.Request.Path.Returns(new PathString(expectedPath));
+            _ = _httpContext.Request.Path.Returns(new PathString(expectedPath));
 
             const string expectedHost = "host.com:9000";
-            _httpContext.Request.Host.Returns(new HostString(expectedHost));
+            _ = _httpContext.Request.Host.Returns(new HostString(expectedHost));
 
             const string expectedScheme = "http";
-            _httpContext.Request.Scheme.Returns(expectedScheme);
+            _ = _httpContext.Request.Scheme.Returns(expectedScheme);
 
             const string expected = "http://host.com:9000/request/path";
 
@@ -115,7 +115,7 @@ namespace Sentry.AspNetCore.Tests
                 { secondKey, new StringValues(new [] { "gzip", "deflate", "br" }) }
             };
 
-            _httpRequest.Headers.Returns(headers);
+            _ = _httpRequest.Headers.Returns(headers);
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
@@ -132,7 +132,7 @@ namespace Sentry.AspNetCore.Tests
                 { firstKey, new StringValues("Cookies data") }
             };
 
-            _httpRequest.Headers.Returns(headers);
+            _ = _httpRequest.Headers.Returns(headers);
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
@@ -148,7 +148,7 @@ namespace Sentry.AspNetCore.Tests
                 { firstKey, new StringValues("Cookies data") }
             };
 
-            _httpRequest.Headers.Returns(headers);
+            _ = _httpRequest.Headers.Returns(headers);
 
             SentryAspNetCoreOptions.SendDefaultPii = true;
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
@@ -160,8 +160,8 @@ namespace Sentry.AspNetCore.Tests
         public void Populate_RemoteIp_ByDefault_NotSetToEnv()
         {
             var connection = Substitute.For<ConnectionInfo>();
-            connection.RemoteIpAddress.Returns(IPAddress.IPv6Loopback);
-            _httpContext.Connection.Returns(connection);
+            _ = connection.RemoteIpAddress.Returns(IPAddress.IPv6Loopback);
+            _ = _httpContext.Connection.Returns(connection);
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
@@ -173,8 +173,8 @@ namespace Sentry.AspNetCore.Tests
         {
             const string expected = "::1";
             var connection = Substitute.For<ConnectionInfo>();
-            connection.RemoteIpAddress.Returns(IPAddress.IPv6Loopback);
-            _httpContext.Connection.Returns(connection);
+            _ = connection.RemoteIpAddress.Returns(IPAddress.IPv6Loopback);
+            _ = _httpContext.Connection.Returns(connection);
 
             SentryAspNetCoreOptions.SendDefaultPii = true;
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
@@ -187,8 +187,8 @@ namespace Sentry.AspNetCore.Tests
         {
             const int expected = 1337;
             var connection = Substitute.For<ConnectionInfo>();
-            connection.LocalPort.Returns(expected);
-            _httpContext.Connection.Returns(connection);
+            _ = connection.LocalPort.Returns(expected);
+            _ = _httpContext.Connection.Returns(connection);
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
@@ -202,8 +202,8 @@ namespace Sentry.AspNetCore.Tests
             var response = Substitute.For<HttpResponse>();
             var header = new HeaderDictionary { { "Server", expected } };
 
-            response.Headers.Returns(header);
-            _httpContext.Response.Returns(response);
+            _ = response.Headers.Returns(header);
+            _ = _httpContext.Response.Returns(response);
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
@@ -223,9 +223,9 @@ namespace Sentry.AspNetCore.Tests
         {
             _sut.Populate(_httpContext, null);
 
-            _httpContext.RequestServices
-                .DidNotReceive()
-                .GetService(typeof(IEnumerable<IRequestPayloadExtractor>));
+            _ = _httpContext.RequestServices
+                    .DidNotReceive()
+                    .GetService(typeof(IEnumerable<IRequestPayloadExtractor>));
         }
 
         [Fact]
@@ -233,22 +233,22 @@ namespace Sentry.AspNetCore.Tests
         {
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
-            _httpContext.RequestServices
-                .Received(1)
-                .GetService(typeof(IEnumerable<IRequestPayloadExtractor>));
+            _ = _httpContext.RequestServices
+                    .Received(1)
+                    .GetService(typeof(IEnumerable<IRequestPayloadExtractor>));
         }
 
         [Fact]
         public void Populate_AspNetCoreOptionsSetTrue_PayloadExtractors_NoBodyRead()
         {
             var extractor = Substitute.For<IRequestPayloadExtractor>();
-            _httpContext.RequestServices
-                .GetService(typeof(IEnumerable<IRequestPayloadExtractor>))
-                .Returns(new[] { extractor });
+            _ = _httpContext.RequestServices
+                    .GetService(typeof(IEnumerable<IRequestPayloadExtractor>))
+                    .Returns(new[] { extractor });
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
-            extractor.Received(1).ExtractPayload(Arg.Any<IHttpRequest>());
+            _ = extractor.Received(1).ExtractPayload(Arg.Any<IHttpRequest>());
         }
 
         [Theory]
@@ -256,14 +256,14 @@ namespace Sentry.AspNetCore.Tests
         public void Populate_PayloadExtractors_DoesNotConsiderInvalidResponse(object expected)
         {
             var first = Substitute.For<IRequestPayloadExtractor>();
-            first.ExtractPayload(Arg.Any<IHttpRequest>()).Returns(expected);
-            _httpContext.RequestServices
-                .GetService(typeof(IEnumerable<IRequestPayloadExtractor>))
-                .Returns(new[] { first });
+            _ = first.ExtractPayload(Arg.Any<IHttpRequest>()).Returns(expected);
+            _ = _httpContext.RequestServices
+                    .GetService(typeof(IEnumerable<IRequestPayloadExtractor>))
+                    .Returns(new[] { first });
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
-            first.Received(1).ExtractPayload(Arg.Any<IHttpRequest>());
+            _ = first.Received(1).ExtractPayload(Arg.Any<IHttpRequest>());
 
             Assert.Null(_sut.Request.Data);
         }
@@ -279,7 +279,7 @@ namespace Sentry.AspNetCore.Tests
             };
             var features = new FeatureCollection();
             features.Set<IRoutingFeature>(routeFeature);
-            _httpContext.Features.Returns(features);
+            _ = _httpContext.Features.Returns(features);
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
@@ -297,15 +297,15 @@ namespace Sentry.AspNetCore.Tests
         public void Populate_PayloadExtractors_StopsOnFirstDictionary(object expected)
         {
             var first = Substitute.For<IRequestPayloadExtractor>();
-            first.ExtractPayload(Arg.Any<IHttpRequest>()).Returns(expected);
+            _ = first.ExtractPayload(Arg.Any<IHttpRequest>()).Returns(expected);
             var second = Substitute.For<IRequestPayloadExtractor>();
-            _httpContext.RequestServices
-                .GetService(typeof(IEnumerable<IRequestPayloadExtractor>))
-                .Returns(new[] { first, second });
+            _ = _httpContext.RequestServices
+                    .GetService(typeof(IEnumerable<IRequestPayloadExtractor>))
+                    .Returns(new[] { first, second });
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
-            second.DidNotReceive().ExtractPayload(Arg.Any<IHttpRequest>());
+            _ = second.DidNotReceive().ExtractPayload(Arg.Any<IHttpRequest>());
 
             Assert.Same(expected, _sut.Request.Data);
         }
@@ -322,21 +322,21 @@ namespace Sentry.AspNetCore.Tests
         {
             var first = Substitute.For<IRequestPayloadExtractor>();
             var second = Substitute.For<IRequestPayloadExtractor>();
-            _httpContext.RequestServices
-                .GetService(typeof(IEnumerable<IRequestPayloadExtractor>))
-                .Returns(new[] { first, second });
+            _ = _httpContext.RequestServices
+                    .GetService(typeof(IEnumerable<IRequestPayloadExtractor>))
+                    .Returns(new[] { first, second });
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
-            first.Received(1).ExtractPayload(Arg.Any<IHttpRequest>());
-            second.Received(1).ExtractPayload(Arg.Any<IHttpRequest>());
+            _ = first.Received(1).ExtractPayload(Arg.Any<IHttpRequest>());
+            _ = second.Received(1).ExtractPayload(Arg.Any<IHttpRequest>());
         }
 
         [Fact]
         public void Populate_TraceIdentifier_SetAsTag()
         {
             const string expected = "identifier";
-            _httpContext.TraceIdentifier.Returns(expected);
+            _ = _httpContext.TraceIdentifier.Returns(expected);
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
@@ -348,7 +348,7 @@ namespace Sentry.AspNetCore.Tests
         {
             const string expected = "identifier";
             _sut.SetTag("RequestId", expected);
-            _httpContext.TraceIdentifier.Returns(expected);
+            _ = _httpContext.TraceIdentifier.Returns(expected);
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 
@@ -360,7 +360,7 @@ namespace Sentry.AspNetCore.Tests
         {
             const string expected = "identifier";
             _sut.SetTag("RequestId", "different identifier");
-            _httpContext.TraceIdentifier.Returns(expected);
+            _ = _httpContext.TraceIdentifier.Returns(expected);
 
             _sut.Populate(_httpContext, SentryAspNetCoreOptions);
 

--- a/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
@@ -34,8 +34,8 @@ namespace Sentry.AspNetCore.Tests
             public Fixture()
             {
                 HubAccessor = () => Hub;
-                Hub.IsEnabled.Returns(true);
-                HttpContext.Features.Returns(FeatureCollection);
+                _ = Hub.IsEnabled.Returns(true);
+                _ = HttpContext.Features.Returns(FeatureCollection);
             }
 
             public SentryMiddleware GetSut()
@@ -52,7 +52,7 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public async Task InvokeAsync_DisabledSdk_InvokesNextHandlers()
         {
-            _fixture.Hub.IsEnabled.Returns(false);
+            _ = _fixture.Hub.IsEnabled.Returns(false);
             _fixture.RequestDelegate = Substitute.For<RequestDelegate>();
 
             var sut = _fixture.GetSut();
@@ -64,12 +64,12 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public async Task InvokeAsync_DisabledSdk_NoScopePushed()
         {
-            _fixture.Hub.IsEnabled.Returns(false);
+            _ = _fixture.Hub.IsEnabled.Returns(false);
 
             var sut = _fixture.GetSut();
 
             await sut.InvokeAsync(_fixture.HttpContext);
-            _fixture.Hub.DidNotReceive().PushScope();
+            _ = _fixture.Hub.DidNotReceive().PushScope();
         }
 
         [Fact]
@@ -111,10 +111,10 @@ namespace Sentry.AspNetCore.Tests
 
             var sut = _fixture.GetSut();
 
-            await Assert.ThrowsAsync<Exception>(
-                async () => await sut.InvokeAsync(_fixture.HttpContext));
+            _ = await Assert.ThrowsAsync<Exception>(
+                    async () => await sut.InvokeAsync(_fixture.HttpContext));
 
-            _fixture.Hub.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -125,28 +125,28 @@ namespace Sentry.AspNetCore.Tests
             _fixture.Logger = null;
             var expected = new Exception("test");
             var feature = Substitute.For<IExceptionHandlerFeature>();
-            feature.Error.Returns(expected);
-            _fixture.HttpContext.Features.Get<IExceptionHandlerFeature>().Returns(feature);
+            _ = feature.Error.Returns(expected);
+            _ = _fixture.HttpContext.Features.Get<IExceptionHandlerFeature>().Returns(feature);
 
             var sut = _fixture.GetSut();
 
             await sut.InvokeAsync(_fixture.HttpContext);
 
-            _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(e => e.Exception == expected));
+            _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(e => e.Exception == expected));
         }
 
         [Fact]
         public async Task InvokeAsync_FeatureFoundWithNoError_DoesNotCapturesEvent()
         {
             var feature = Substitute.For<IExceptionHandlerFeature>();
-            feature.Error.ReturnsNull();
-            _fixture.HttpContext.Features.Get<IExceptionHandlerFeature>().Returns(feature);
+            _ = feature.Error.ReturnsNull();
+            _ = _fixture.HttpContext.Features.Get<IExceptionHandlerFeature>().Returns(feature);
 
             var sut = _fixture.GetSut();
 
             await sut.InvokeAsync(_fixture.HttpContext);
 
-            _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -190,7 +190,7 @@ namespace Sentry.AspNetCore.Tests
         public async Task InvokeAsync_OnEvaluating_HttpContextDataSet()
         {
             const string expectedTraceIdentifier = "trace id";
-            _fixture.HttpContext.TraceIdentifier.Returns(expectedTraceIdentifier);
+            _ = _fixture.HttpContext.TraceIdentifier.Returns(expectedTraceIdentifier);
             var scope = new Scope();
             _fixture.Hub.When(h => h.ConfigureScope(Arg.Any<Action<Scope>>()))
                 .Do(c => c.Arg<Action<Scope>>()(scope));
@@ -208,13 +208,13 @@ namespace Sentry.AspNetCore.Tests
         public async Task InvokeAsync_ScopePushedAndPopped_OnHappyPath()
         {
             var disposable = Substitute.For<IDisposable>();
-            _fixture.Hub.PushScope().Returns(disposable);
+            _ = _fixture.Hub.PushScope().Returns(disposable);
 
             var sut = _fixture.GetSut();
 
             await sut.InvokeAsync(_fixture.HttpContext);
 
-            _fixture.Hub.Received(1).PushScope();
+            _ = _fixture.Hub.Received(1).PushScope();
             disposable.Received(1).Dispose();
         }
 
@@ -224,14 +224,14 @@ namespace Sentry.AspNetCore.Tests
             var expected = new Exception("test");
             _fixture.RequestDelegate = _ => throw expected;
             var disposable = Substitute.For<IDisposable>();
-            _fixture.Hub.PushScope().Returns(disposable);
+            _ = _fixture.Hub.PushScope().Returns(disposable);
 
             var sut = _fixture.GetSut();
 
-            await Assert.ThrowsAsync<Exception>(
-                async () => await sut.InvokeAsync(_fixture.HttpContext));
+            _ = await Assert.ThrowsAsync<Exception>(
+                    async () => await sut.InvokeAsync(_fixture.HttpContext));
 
-            _fixture.Hub.Received(1).PushScope();
+            _ = _fixture.Hub.Received(1).PushScope();
             disposable.Received(1).Dispose();
         }
 
@@ -263,7 +263,7 @@ namespace Sentry.AspNetCore.Tests
         public void PopulateScope_WithHostingEnvironment_WebRootSet()
         {
             const string expectedWebRoot = "root";
-            _fixture.HostingEnvironment.WebRootPath.Returns(expectedWebRoot);
+            _ = _fixture.HostingEnvironment.WebRootPath.Returns(expectedWebRoot);
             var scope = new Scope();
 
             var sut = _fixture.GetSut();
@@ -278,8 +278,8 @@ namespace Sentry.AspNetCore.Tests
         {
             _fixture.Options = null;
             var activity = new Activity("test");
-            activity.Start();
-            activity.AddTag("k", "v");
+            _ = activity.Start();
+            _ = activity.AddTag("k", "v");
 
             var scope = new Scope();
 
@@ -294,8 +294,8 @@ namespace Sentry.AspNetCore.Tests
         {
             _fixture.Options.IncludeActivityData = false;
             var activity = new Activity("test");
-            activity.Start();
-            activity.AddTag("k", "v");
+            _ = activity.Start();
+            _ = activity.AddTag("k", "v");
 
             var scope = new Scope();
 
@@ -310,8 +310,8 @@ namespace Sentry.AspNetCore.Tests
         {
             _fixture.Options.IncludeActivityData = true;
             var activity = new Activity("test");
-            activity.Start();
-            activity.AddTag("k", "v");
+            _ = activity.Start();
+            _ = activity.AddTag("k", "v");
 
             var scope = new Scope();
 
@@ -326,8 +326,8 @@ namespace Sentry.AspNetCore.Tests
         {
             _fixture.Options.IncludeActivityData = true;
             var activity = new Activity("test");
-            activity.Start();
-            activity.AddTag("k", "v");
+            _ = activity.Start();
+            _ = activity.AddTag("k", "v");
             activity.Stop();
 
             var scope = new Scope();
@@ -363,11 +363,11 @@ namespace Sentry.AspNetCore.Tests
             var sut = _fixture.GetSut();
             var request = Substitute.For<HttpRequest>();
             var stream = Substitute.For<Stream>();
-            request.Body.Returns(stream);
+            _ = request.Body.Returns(stream);
             var response = Substitute.For<HttpResponse>();
-            _fixture.HttpContext.Response.Returns(response);
-            _fixture.HttpContext.Request.Returns(request);
-            request.HttpContext.Returns(_fixture.HttpContext);
+            _ = _fixture.HttpContext.Response.Returns(response);
+            _ = _fixture.HttpContext.Request.Returns(request);
+            _ = request.HttpContext.Returns(_fixture.HttpContext);
 
             var invoked = false;
             request.When(w => w.Body = Arg.Any<Stream>())
@@ -389,11 +389,11 @@ namespace Sentry.AspNetCore.Tests
             var sut = _fixture.GetSut();
             var request = Substitute.For<HttpRequest>();
             var stream = Substitute.For<Stream>();
-            request.Body.Returns(stream);
+            _ = request.Body.Returns(stream);
             var response = Substitute.For<HttpResponse>();
-            _fixture.HttpContext.Response.Returns(response);
-            _fixture.HttpContext.Request.Returns(request);
-            request.HttpContext.Returns(_fixture.HttpContext);
+            _ = _fixture.HttpContext.Response.Returns(response);
+            _ = _fixture.HttpContext.Request.Returns(request);
+            _ = request.HttpContext.Returns(_fixture.HttpContext);
 
             var invoked = false;
             request.When(w => w.Body = Arg.Any<Stream>())
@@ -415,11 +415,11 @@ namespace Sentry.AspNetCore.Tests
             var sut = _fixture.GetSut();
             var request = Substitute.For<HttpRequest>();
             var stream = Substitute.For<Stream>();
-            request.Body.Returns(stream);
+            _ = request.Body.Returns(stream);
             var response = Substitute.For<HttpResponse>();
-            _fixture.HttpContext.Response.Returns(response);
-            _fixture.HttpContext.Request.Returns(request);
-            request.HttpContext.Returns(_fixture.HttpContext);
+            _ = _fixture.HttpContext.Response.Returns(response);
+            _ = _fixture.HttpContext.Request.Returns(request);
+            _ = request.HttpContext.Returns(_fixture.HttpContext);
 
             var invoked = false;
             request.When(w => w.Body = Arg.Any<Stream>())
@@ -441,9 +441,9 @@ namespace Sentry.AspNetCore.Tests
             var sut = _fixture.GetSut();
             var request = Substitute.For<HttpRequest>();
             var stream = Substitute.For<Stream>();
-            request.Body.Returns(stream);
-            _fixture.HttpContext.Request.Returns(request);
-            request.HttpContext.Returns(_fixture.HttpContext);
+            _ = request.Body.Returns(stream);
+            _ = _fixture.HttpContext.Request.Returns(request);
+            _ = request.HttpContext.Returns(_fixture.HttpContext);
 
             await sut.InvokeAsync(_fixture.HttpContext);
 
@@ -457,9 +457,9 @@ namespace Sentry.AspNetCore.Tests
             var sut = _fixture.GetSut();
             var request = Substitute.For<HttpRequest>();
             var stream = Substitute.For<Stream>();
-            request.Body.Returns(stream);
-            _fixture.HttpContext.Request.Returns(request);
-            request.HttpContext.Returns(_fixture.HttpContext);
+            _ = request.Body.Returns(stream);
+            _ = _fixture.HttpContext.Request.Returns(request);
+            _ = request.HttpContext.Returns(_fixture.HttpContext);
 
             await sut.InvokeAsync(_fixture.HttpContext);
 
@@ -489,8 +489,8 @@ namespace Sentry.AspNetCore.Tests
         {
             var sut = _fixture.GetSut();
             var response = Substitute.For<HttpResponse>();
-            _fixture.HttpContext.Response.Returns(response);
-            response.HttpContext.Returns(_fixture.HttpContext);
+            _ = _fixture.HttpContext.Response.Returns(response);
+            _ = response.HttpContext.Returns(_fixture.HttpContext);
             response.When(r => r.OnCompleted(Arg.Any<Func<Task>>())).Do(info => info.Arg<Func<Task>>()());
 
             await sut.InvokeAsync(_fixture.HttpContext);
@@ -504,8 +504,8 @@ namespace Sentry.AspNetCore.Tests
             var sut = _fixture.GetSut();
             _fixture.Options.FlushOnCompletedRequest = false;
             var response = Substitute.For<HttpResponse>();
-            _fixture.HttpContext.Response.Returns(response);
-            response.HttpContext.Returns(_fixture.HttpContext);
+            _ = _fixture.HttpContext.Response.Returns(response);
+            _ = response.HttpContext.Returns(_fixture.HttpContext);
             response.When(r => r.OnCompleted(Arg.Any<Func<Task>>())).Do(info => info.Arg<Func<Task>>()());
 
             await sut.InvokeAsync(_fixture.HttpContext);
@@ -518,10 +518,10 @@ namespace Sentry.AspNetCore.Tests
         {
             var sut = _fixture.GetSut();
             _fixture.Options.FlushOnCompletedRequest = true;
-            _fixture.Hub.IsEnabled.Returns(false);
+            _ = _fixture.Hub.IsEnabled.Returns(false);
             var response = Substitute.For<HttpResponse>();
-            _fixture.HttpContext.Response.Returns(response);
-            response.HttpContext.Returns(_fixture.HttpContext);
+            _ = _fixture.HttpContext.Response.Returns(response);
+            _ = response.HttpContext.Returns(_fixture.HttpContext);
             response.When(r => r.OnCompleted(Arg.Any<Func<Task>>())).Do(info => info.Arg<Func<Task>>()());
 
             await sut.InvokeAsync(_fixture.HttpContext);
@@ -537,8 +537,8 @@ namespace Sentry.AspNetCore.Tests
             _fixture.Options.FlushOnCompletedRequest = true;
             _fixture.Options.FlushTimeout = timeout;
             var response = Substitute.For<HttpResponse>();
-            _fixture.HttpContext.Response.Returns(response);
-            response.HttpContext.Returns(_fixture.HttpContext);
+            _ = _fixture.HttpContext.Response.Returns(response);
+            _ = response.HttpContext.Returns(_fixture.HttpContext);
             response.When(r => r.OnCompleted(Arg.Any<Func<Task>>())).Do(info => info.Arg<Func<Task>>()());
 
             await sut.InvokeAsync(_fixture.HttpContext);

--- a/test/Sentry.AspNetCore.Tests/SentryWebHostBuilderExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryWebHostBuilderExtensionsTests.cs
@@ -40,28 +40,28 @@ namespace Sentry.AspNetCore.Tests
         [Theory, MemberData(nameof(ExpectedServices))]
         public void UseSentry_ValidDsnString_ServicesRegistered(Action<IServiceCollection> assert)
         {
-            WebHostBuilder.UseSentry(DsnSamples.ValidDsnWithoutSecret);
+            _ = WebHostBuilder.UseSentry(DsnSamples.ValidDsnWithoutSecret);
             assert(Services);
         }
 
         [Theory, MemberData(nameof(ExpectedServices))]
         public void UseSentry_Parameterless_ServicesRegistered(Action<IServiceCollection> assert)
         {
-            WebHostBuilder.UseSentry();
+            _ = WebHostBuilder.UseSentry();
             assert(Services);
         }
 
         [Theory, MemberData(nameof(ExpectedServices))]
         public void UseSentry_DisableDsnString_ServicesRegistered(Action<IServiceCollection> assert)
         {
-            WebHostBuilder.UseSentry(Protocol.Constants.DisableSdkDsnValue);
+            _ = WebHostBuilder.UseSentry(Protocol.Constants.DisableSdkDsnValue);
             assert(Services);
         }
 
         [Theory, MemberData(nameof(ExpectedServices))]
         public void UseSentry_Callback_ServicesRegistered(Action<IServiceCollection> assert)
         {
-            WebHostBuilder.UseSentry(o => o.InitializeSdk = false);
+            _ = WebHostBuilder.UseSentry(o => o.InitializeSdk = false);
             assert(Services);
         }
 

--- a/test/Sentry.AspNetCore.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/ServiceCollectionExtensionsTests.cs
@@ -13,14 +13,14 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void AddSentry_NoPreviousRegistration_RegistersHub()
         {
-            _sut.AddSentry();
+            _ = _sut.AddSentry();
             _sut.Received().Add(Arg.Is<ServiceDescriptor>(d => d.ServiceType == typeof(IHub)));
         }
 
         [Fact]
         public void AddSentry_NoPreviousRegistration_RegistersClient()
         {
-            _sut.AddSentry();
+            _ = _sut.AddSentry();
             _sut.Received().Add(Arg.Is<ServiceDescriptor>(d => d.ServiceType == typeof(ISentryClient)));
         }
 
@@ -29,9 +29,9 @@ namespace Sentry.AspNetCore.Tests
         {
             var hub = Substitute.For<IHub>();
             _sut = new ServiceCollection();
-            _sut.AddSingleton(hub);
+            _ = _sut.AddSingleton(hub);
 
-            _sut.AddSentry();
+            _ = _sut.AddSentry();
 
             Assert.Same(hub, _sut.Single(s => s.ServiceType == typeof(IHub)).ImplementationInstance);
         }
@@ -41,9 +41,9 @@ namespace Sentry.AspNetCore.Tests
         {
             var hub = Substitute.For<ISentryClient>();
             _sut = new ServiceCollection();
-            _sut.AddSingleton(hub);
+            _ = _sut.AddSingleton(hub);
 
-            _sut.AddSentry();
+            _ = _sut.AddSentry();
 
             Assert.Same(hub, _sut.Single(s => s.ServiceType == typeof(ISentryClient)).ImplementationInstance);
         }
@@ -51,7 +51,7 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void AddSentry_PayloadExtractors_Registered()
         {
-            _sut.AddSentry();
+            _ = _sut.AddSentry();
             _sut.Received().Add(Arg.Is<ServiceDescriptor>(d => d.ServiceType == typeof(IRequestPayloadExtractor)
                                                                && d.ImplementationType == typeof(FormRequestPayloadExtractor)));
 
@@ -64,9 +64,9 @@ namespace Sentry.AspNetCore.Tests
         {
             var hub = Substitute.For<ISentryClient>();
             _sut = new ServiceCollection();
-            _sut.AddSingleton(hub);
+            _ = _sut.AddSingleton(hub);
 
-            _sut.AddSentry();
+            _ = _sut.AddSentry();
 
             var last = _sut.Last(d => d.ServiceType == typeof(IRequestPayloadExtractor));
             Assert.Same(typeof(DefaultRequestPayloadExtractor), last.ImplementationType);
@@ -75,7 +75,7 @@ namespace Sentry.AspNetCore.Tests
         [Fact]
         public void AddSentry_DefaultUserFactory_Registered()
         {
-            _sut.AddSentry();
+            _ = _sut.AddSentry();
             _sut.Received().Add(Arg.Is<ServiceDescriptor>(d => d.ServiceType == typeof(IUserFactory)
                                                                && d.ImplementationType == typeof(DefaultUserFactory)));
         }

--- a/test/Sentry.Extensions.Logging.Tests/ConfigurationOptionsTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/ConfigurationOptionsTests.cs
@@ -19,14 +19,14 @@ namespace Sentry.Extensions.Logging.Tests
             public Fixture()
             {
                 Builder = new ConfigurationBuilder();
-                Builder.AddJsonFile(Path.Combine(Environment.CurrentDirectory, "appsettings.json"));
+                _ = Builder.AddJsonFile(Path.Combine(Environment.CurrentDirectory, "appsettings.json"));
             }
 
             public IServiceProvider GetSut()
             {
                 var configuration = Builder.Build();
                 var services = new ServiceCollection();
-                services.AddLogging(builder => builder.AddConfiguration(configuration).AddSentry());
+                _ = services.AddLogging(builder => builder.AddConfiguration(configuration).AddSentry());
                 return services.BuildServiceProvider();
             }
         }
@@ -52,7 +52,7 @@ namespace Sentry.Extensions.Logging.Tests
                 {"Sentry:InitializeSdk", "true"},
             };
 
-            _fixture.Builder.AddInMemoryCollection(dict);
+            _ = _fixture.Builder.AddInMemoryCollection(dict);
 
             var provider = _fixture.GetSut();
             var sentryLoggingOptions = provider.GetRequiredService<IOptions<SentryLoggingOptions>>().Value;
@@ -72,7 +72,7 @@ namespace Sentry.Extensions.Logging.Tests
                 {"Sentry:DefaultTags:" + expectedKey, expectedValue},
             };
 
-            _fixture.Builder.AddInMemoryCollection(dict);
+            _ = _fixture.Builder.AddInMemoryCollection(dict);
 
             var provider = _fixture.GetSut();
             var sentryLoggingOptions = provider.GetRequiredService<IOptions<SentryLoggingOptions>>().Value;
@@ -84,7 +84,7 @@ namespace Sentry.Extensions.Logging.Tests
         public void SentryLoggerProvider_ResolvedFromILoggerProvider()
         {
             var provider = _fixture.GetSut();
-            Assert.Single(provider.GetServices<ILoggerProvider>().OfType<SentryLoggerProvider>());
+            _ = Assert.Single(provider.GetServices<ILoggerProvider>().OfType<SentryLoggerProvider>());
         }
     }
 }

--- a/test/Sentry.Extensions.Logging.Tests/MelDiagnosticLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/MelDiagnosticLoggerTests.cs
@@ -22,7 +22,7 @@ namespace Sentry.Extensions.Logging.Tests
         public void LogLevel_ErrorLevel_IsEnabledTrue()
         {
             var sut = _fixture.GetSut();
-            _fixture.MelLogger.IsEnabled(LogLevel.Error).Returns(true);
+            _ = _fixture.MelLogger.IsEnabled(LogLevel.Error).Returns(true);
             Assert.True(sut.IsEnabled(SentryLevel.Error));
         }
 
@@ -30,14 +30,14 @@ namespace Sentry.Extensions.Logging.Tests
         public void LogLevel_InfoLevel_IsEnabledFalse()
         {
             var sut = _fixture.GetSut();
-            _fixture.MelLogger.IsEnabled(LogLevel.Information).Returns(true);
+            _ = _fixture.MelLogger.IsEnabled(LogLevel.Information).Returns(true);
             Assert.False(sut.IsEnabled(SentryLevel.Info));
         }
 
         [Fact]
         public void LogLevel_HigherLevel_IsEnabled()
         {
-            _fixture.MelLogger.IsEnabled(LogLevel.Debug).Returns(true);
+            _ = _fixture.MelLogger.IsEnabled(LogLevel.Debug).Returns(true);
             var sut = _fixture.GetSut();
             Assert.False(sut.IsEnabled(SentryLevel.Info));
         }
@@ -54,7 +54,7 @@ namespace Sentry.Extensions.Logging.Tests
 
             _fixture.Level = SentryLevel.Debug;
             var sut = _fixture.GetSut();
-            _fixture.MelLogger.IsEnabled(Arg.Any<LogLevel>()).Returns(true);
+            _ = _fixture.MelLogger.IsEnabled(Arg.Any<LogLevel>()).Returns(true);
 
             sut.Log(expectedLevel, expectedMessage, expectedException);
 

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerFactoryExtensionsTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerFactoryExtensionsTests.cs
@@ -16,13 +16,13 @@ namespace Sentry.Extensions.Logging.Tests
             const SentryLevel expected = SentryLevel.Debug;
             var sut = Substitute.For<ILoggerFactory>();
             var hub = Substitute.For<IHub>();
-            hub.IsEnabled.Returns(true);
+            _ = hub.IsEnabled.Returns(true);
             var scope = new Scope(new SentryOptions());
             hub.When(w => w.ConfigureScope(Arg.Any<Action<Scope>>()))
                 .Do(info => info.Arg<Action<Scope>>()(scope));
-            SentrySdk.UseHub(hub);
+            _ = SentrySdk.UseHub(hub);
 
-            sut.AddSentry(o =>
+            _ = sut.AddSentry(o =>
             {
                 o.InitializeSdk = false; // use the mock above
                 o.ConfigureScope(s => s.Level = expected);
@@ -37,13 +37,13 @@ namespace Sentry.Extensions.Logging.Tests
             const SentryLevel expected = SentryLevel.Debug;
             var sut = Substitute.For<ILoggerFactory>();
             var hub = Substitute.For<IHub>();
-            hub.IsEnabled.Returns(false);
+            _ = hub.IsEnabled.Returns(false);
             var scope = new Scope(new SentryOptions());
             hub.When(w => w.ConfigureScope(Arg.Any<Action<Scope>>()))
                 .Do(info => info.Arg<Action<Scope>>()(scope));
-            SentrySdk.UseHub(hub);
+            _ = SentrySdk.UseHub(hub);
 
-            sut.AddSentry(o =>
+            _ = sut.AddSentry(o =>
             {
                 o.InitializeSdk = false; // use the mock above
                 o.ConfigureScope(s => s.Level = expected);
@@ -57,7 +57,7 @@ namespace Sentry.Extensions.Logging.Tests
         {
             var sut = Substitute.For<ILoggerFactory>();
 
-            sut.AddSentry(o => o.InitializeSdk = false);
+            _ = sut.AddSentry(o => o.InitializeSdk = false);
 
             sut.Received(1)
                 .AddProvider(Arg.Is<SentryLoggerProvider>(p => p.Hub == HubAdapter.Instance));
@@ -68,7 +68,7 @@ namespace Sentry.Extensions.Logging.Tests
         {
             var sut = Substitute.For<ILoggerFactory>();
 
-            sut.AddSentry();
+            _ = sut.AddSentry();
 
             sut.Received(1)
                 .AddProvider(Arg.Is<SentryLoggerProvider>(p => p.Hub is OptionalHub));
@@ -79,13 +79,13 @@ namespace Sentry.Extensions.Logging.Tests
         {
             SentryLoggingOptions options = null;
             var sut = Substitute.For<ILoggerFactory>();
-            sut.AddSentry(o =>
+            _ = sut.AddSentry(o =>
             {
                 o.Debug = true;
                 options = o;
             });
 
-            Assert.IsType<MelDiagnosticLogger>(options.DiagnosticLogger);
+            _ = Assert.IsType<MelDiagnosticLogger>(options.DiagnosticLogger);
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace Sentry.Extensions.Logging.Tests
             SentryLoggingOptions options = null;
             var sut = Substitute.For<ILoggerFactory>();
             var diagnosticLogger = Substitute.For<IDiagnosticLogger>();
-            sut.AddSentry(o =>
+            _ = sut.AddSentry(o =>
             {
                 o.Debug = true;
                 Assert.Null(o.DiagnosticLogger);
@@ -110,7 +110,7 @@ namespace Sentry.Extensions.Logging.Tests
         {
             var callbackInvoked = false;
             var expected = Substitute.For<ILoggerFactory>();
-            expected.AddSentry(o => { callbackInvoked = true; });
+            _ = expected.AddSentry(o => { callbackInvoked = true; });
 
             Assert.True(callbackInvoked);
         }
@@ -119,7 +119,7 @@ namespace Sentry.Extensions.Logging.Tests
         public void AddSentry_NoOptionsDelegate_ProviderAdded()
         {
             var expected = Substitute.For<ILoggerFactory>();
-            expected.AddSentry();
+            _ = expected.AddSentry();
 
             expected.Received(1)
                 .AddProvider(Arg.Is<ILoggerProvider>(p => p is SentryLoggerProvider));
@@ -149,7 +149,7 @@ namespace Sentry.Extensions.Logging.Tests
             var expected = Substitute.For<ILoggerFactory>();
 
             var invoked = false;
-            expected.AddSentry(o =>
+            _ = expected.AddSentry(o =>
             {
                 Assert.NotNull(o);
                 invoked = true;

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerProviderTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerProviderTests.cs
@@ -22,7 +22,7 @@ namespace Sentry.Extensions.Logging.Tests
         {
             var sut = _fixture.GetSut();
 
-            Assert.IsType<SentryLogger>(sut.CreateLogger("category"));
+            _ = Assert.IsType<SentryLogger>(sut.CreateLogger("category"));
         }
 
         [Fact]
@@ -40,25 +40,25 @@ namespace Sentry.Extensions.Logging.Tests
         [Fact]
         public void Ctor_DisabledHub_DoesNotCreatesScope()
         {
-            _fixture.Hub.IsEnabled.Returns(false);
-            _fixture.GetSut();
-            _fixture.Hub.DidNotReceive().PushScope();
+            _ = _fixture.Hub.IsEnabled.Returns(false);
+            _ = _fixture.GetSut();
+            _ = _fixture.Hub.DidNotReceive().PushScope();
         }
 
         [Fact]
         public void Ctor_EnabledHub_CreatesScope()
         {
-            _fixture.Hub.IsEnabled.Returns(true);
-            _fixture.GetSut();
-            _fixture.Hub.Received(1).PushScope();
+            _ = _fixture.Hub.IsEnabled.Returns(true);
+            _ = _fixture.GetSut();
+            _ = _fixture.Hub.Received(1).PushScope();
         }
 
         [Fact]
         public void Dispose_DisposesNewScope()
         {
-            _fixture.Hub.IsEnabled.Returns(true);
+            _ = _fixture.Hub.IsEnabled.Returns(true);
             var disposable = Substitute.For<IDisposable>();
-            _fixture.Hub.PushScope().Returns(disposable);
+            _ = _fixture.Hub.PushScope().Returns(disposable);
 
             var sut = _fixture.GetSut();
 
@@ -76,13 +76,13 @@ namespace Sentry.Extensions.Logging.Tests
         [Fact]
         public void Ctor_ScopeSdk_ContainNameAndVersion()
         {
-            _fixture.Hub.IsEnabled.Returns(true);
+            _ = _fixture.Hub.IsEnabled.Returns(true);
             var scope = new Scope(new SentryOptions());
 
             _fixture.Hub.When(w => w.ConfigureScope(Arg.Any<Action<Scope>>()))
                 .Do(info => info.Arg<Action<Scope>>()(scope));
 
-            _fixture.GetSut();
+            _ = _fixture.GetSut();
 
             Assert.Equal(Constants.SdkName, scope.Sdk.Name);
             Assert.Equal(SentryLoggerProvider.NameAndVersion.Version, scope.Sdk.Version);

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
@@ -21,8 +21,8 @@ namespace Sentry.Extensions.Logging.Tests
 
             public Fixture()
             {
-                Hub.IsEnabled.Returns(true);
-                Clock.GetUtcNow().Returns(DateTimeOffset.MaxValue);
+                _ = Hub.IsEnabled.Returns(true);
+                _ = Clock.GetUtcNow().Returns(DateTimeOffset.MaxValue);
                 Hub.ConfigureScope(Arg.Invoke(Scope));
             }
 
@@ -69,9 +69,9 @@ namespace Sentry.Extensions.Logging.Tests
 
             sut.Log<object>(LogLevel.Critical, expectedEventId, null, null, null);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(
-                    e => e.Tags[EventIdExtensions.DataKey] == expectedEventId.ToString()));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(
+                        e => e.Tags[EventIdExtensions.DataKey] == expectedEventId.ToString()));
         }
 
         [Fact]
@@ -85,9 +85,9 @@ namespace Sentry.Extensions.Logging.Tests
 
             sut.Log<object>(LogLevel.Critical, default, props, null, null);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(
-                    e => e.Tags["foo"] == "bar"));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(
+                        e => e.Tags["foo"] == "bar"));
         }
 
         [Fact]
@@ -120,8 +120,8 @@ namespace Sentry.Extensions.Logging.Tests
 
             sut.LogCritical(expected);
 
-            _fixture.Hub.DidNotReceive()
-                .CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.DidNotReceive()
+                    .CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -151,8 +151,8 @@ namespace Sentry.Extensions.Logging.Tests
 
             sut.LogCritical(expected);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -172,7 +172,7 @@ namespace Sentry.Extensions.Logging.Tests
             _fixture.Hub.Received(1)
                 .ConfigureScope(Arg.Any<Action<Scope>>());
 
-            Assert.Single(scope.Breadcrumbs);
+            _ = Assert.Single(scope.Breadcrumbs);
         }
 
         [Fact]
@@ -183,8 +183,8 @@ namespace Sentry.Extensions.Logging.Tests
 
             sut.LogCritical(expected);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -195,8 +195,8 @@ namespace Sentry.Extensions.Logging.Tests
 
             sut.LogError(expected);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -208,8 +208,8 @@ namespace Sentry.Extensions.Logging.Tests
 
             sut.Log<object>(LogLevel.Critical, default, null, expectedException, null);
 
-            _fixture.Hub.DidNotReceive()
-                .CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.DidNotReceive()
+                    .CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -221,8 +221,8 @@ namespace Sentry.Extensions.Logging.Tests
 
             sut.Log<object>(LogLevel.Critical, default, null, expectedException, null);
 
-            _fixture.Hub.DidNotReceive()
-                .CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.DidNotReceive()
+                    .CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         // https://github.com/getsentry/sentry-dotnet/issues/132
@@ -235,8 +235,8 @@ namespace Sentry.Extensions.Logging.Tests
 
             sut.Log<object>(LogLevel.Critical, default, null, expectedException, null);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -400,7 +400,7 @@ namespace Sentry.Extensions.Logging.Tests
         [Fact]
         public void IsEnabled_DisabledSdk_ReturnsFalse()
         {
-            _fixture.Hub.IsEnabled.Returns(false);
+            _ = _fixture.Hub.IsEnabled.Returns(false);
 
             var sut = _fixture.GetSut();
 
@@ -410,7 +410,7 @@ namespace Sentry.Extensions.Logging.Tests
         [Fact]
         public void IsEnabled_EnabledSdk_ReturnsTrue()
         {
-            _fixture.Hub.IsEnabled.Returns(true);
+            _ = _fixture.Hub.IsEnabled.Returns(true);
 
             var sut = _fixture.GetSut();
 
@@ -420,7 +420,7 @@ namespace Sentry.Extensions.Logging.Tests
         [Fact]
         public void IsEnabled_EnabledSdkLogLevelNone_ReturnsFalse()
         {
-            _fixture.Hub.IsEnabled.Returns(true);
+            _ = _fixture.Hub.IsEnabled.Returns(true);
 
             var sut = _fixture.GetSut();
 
@@ -432,7 +432,7 @@ namespace Sentry.Extensions.Logging.Tests
         {
             _fixture.Options.MinimumBreadcrumbLevel = LogLevel.Critical;
             _fixture.Options.MinimumEventLevel = LogLevel.Critical;
-            _fixture.Hub.IsEnabled.Returns(true);
+            _ = _fixture.Hub.IsEnabled.Returns(true);
 
             var sut = _fixture.GetSut();
 
@@ -444,7 +444,7 @@ namespace Sentry.Extensions.Logging.Tests
         {
             _fixture.Options.MinimumBreadcrumbLevel = LogLevel.Critical;
             _fixture.Options.MinimumEventLevel = LogLevel.Trace;
-            _fixture.Hub.IsEnabled.Returns(true);
+            _ = _fixture.Hub.IsEnabled.Returns(true);
 
             var sut = _fixture.GetSut();
 
@@ -456,7 +456,7 @@ namespace Sentry.Extensions.Logging.Tests
         {
             _fixture.Options.MinimumBreadcrumbLevel = LogLevel.Trace;
             _fixture.Options.MinimumEventLevel = LogLevel.Critical;
-            _fixture.Hub.IsEnabled.Returns(true);
+            _ = _fixture.Hub.IsEnabled.Returns(true);
 
             var sut = _fixture.GetSut();
 
@@ -467,8 +467,8 @@ namespace Sentry.Extensions.Logging.Tests
         public void BeginScope_NullState_PushesScope()
         {
             var sut = _fixture.GetSut();
-            sut.BeginScope<object>(null);
-            _fixture.Hub.Received(1).PushScope<object>(null);
+            _ = sut.BeginScope<object>(null);
+            _ = _fixture.Hub.Received(1).PushScope<object>(null);
         }
 
         [Fact]
@@ -476,15 +476,15 @@ namespace Sentry.Extensions.Logging.Tests
         {
             const string expected = "state";
             var sut = _fixture.GetSut();
-            sut.BeginScope(expected);
-            _fixture.Hub.Received(1).PushScope(expected);
+            _ = sut.BeginScope(expected);
+            _ = _fixture.Hub.Received(1).PushScope(expected);
         }
 
         [Fact]
         public void BeginScope_Disposable_Scope()
         {
             var expected = Substitute.For<IDisposable>();
-            _fixture.Hub.PushScope(Arg.Any<string>()).Returns(expected);
+            _ = _fixture.Hub.PushScope(Arg.Any<string>()).Returns(expected);
 
             var sut = _fixture.GetSut();
             var actual = sut.BeginScope("state");

--- a/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
+++ b/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
@@ -53,8 +53,8 @@ namespace Sentry.Log4Net.Tests
 
             sut.DoAppend(evt);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Exception == expected));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Exception == expected));
         }
 
         [Fact]
@@ -67,9 +67,9 @@ namespace Sentry.Log4Net.Tests
             sut.DoAppend(evt);
 
             var expected = typeof(SentryAppender).Assembly.GetNameAndVersion();
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Sdk.Name == Constants.SdkName
-                                                       && e.Sdk.Version == expected.Version));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Sdk.Name == Constants.SdkName
+                                                           && e.Sdk.Version == expected.Version));
         }
 
         [Fact]
@@ -106,9 +106,9 @@ namespace Sentry.Log4Net.Tests
 
             sut.DoAppend(evt);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Logger == expectedLogger
-                                                       && e.Level == expectedLevel));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Logger == expectedLogger
+                                                           && e.Level == expectedLevel));
         }
 
         [Fact]
@@ -122,8 +122,8 @@ namespace Sentry.Log4Net.Tests
 
             sut.DoAppend(evt);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Message == expected));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Message == expected));
         }
 
         [Fact]
@@ -145,8 +145,8 @@ namespace Sentry.Log4Net.Tests
 
             sut.DoAppend(evt);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.InternalUser == null));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.InternalUser == null));
         }
 
         [Fact]
@@ -162,8 +162,8 @@ namespace Sentry.Log4Net.Tests
             sut.SendIdentity = true;
             sut.DoAppend(evt);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.User.Id == expected));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.User.Id == expected));
         }
 
         [Fact]
@@ -181,7 +181,7 @@ namespace Sentry.Log4Net.Tests
         [Fact]
         public void Append_WithEnabledHub_InitNotCalled()
         {
-            _fixture.Hub.IsEnabled.Returns(true);
+            _ = _fixture.Hub.IsEnabled.Returns(true);
             var sut = _fixture.GetSut();
 
             var evt = new LoggingEvent(new LoggingEventData());
@@ -212,21 +212,21 @@ namespace Sentry.Log4Net.Tests
             sut.DoAppend(evt);
 
             Assert.False(_fixture.InitInvoked);
-            _fixture.Hub.DidNotReceiveWithAnyArgs().CaptureEvent(null);
+            _ = _fixture.Hub.DidNotReceiveWithAnyArgs().CaptureEvent(null);
         }
 
         [Fact]
         public void Append_NoDsnAndDisabledHub_HubNotCalled()
         {
             _fixture.Dsn = null;
-            _fixture.Hub.IsEnabled.Returns(false);
+            _ = _fixture.Hub.IsEnabled.Returns(false);
             var sut = _fixture.GetSut();
 
             var evt = new LoggingEvent(new LoggingEventData());
             sut.DoAppend(evt);
 
             Assert.False(_fixture.InitInvoked);
-            _fixture.Hub.DidNotReceiveWithAnyArgs().CaptureEvent(null);
+            _ = _fixture.Hub.DidNotReceiveWithAnyArgs().CaptureEvent(null);
         }
 
         [Fact]
@@ -250,12 +250,12 @@ namespace Sentry.Log4Net.Tests
 
             sut.DoAppend(evt);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e =>
-                    e.Extra["ClassName"].ToString() == expectedClass
-                    && e.Extra["FileName"].ToString() == expectedFileName
-                    && e.Extra["MethodName"].ToString() == expectedMethod
-                    && (int)e.Extra["LineNumber"] == expectedLineNumber));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e =>
+                        e.Extra["ClassName"].ToString() == expectedClass
+                        && e.Extra["FileName"].ToString() == expectedFileName
+                        && e.Extra["MethodName"].ToString() == expectedMethod
+                        && (int)e.Extra["LineNumber"] == expectedLineNumber));
         }
 
         [Fact]
@@ -271,8 +271,8 @@ namespace Sentry.Log4Net.Tests
             var evt = new LoggingEvent(new LoggingEventData());
             sut.DoAppend(evt);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Extra[id] == expected));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Extra[id] == expected));
         }
 
         [Fact]
@@ -283,8 +283,8 @@ namespace Sentry.Log4Net.Tests
 
             sut.DoAppend(evt);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Environment == null));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Environment == null));
         }
 
         [Fact]
@@ -297,8 +297,8 @@ namespace Sentry.Log4Net.Tests
 
             sut.DoAppend(evt);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Environment == expected));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Environment == expected));
         }
 
         [Fact]

--- a/test/Sentry.NLog.Tests/SentryTargetTests.cs
+++ b/test/Sentry.NLog.Tests/SentryTargetTests.cs
@@ -40,7 +40,7 @@ namespace Sentry.NLog.Tests
 
             public Fixture()
             {
-                Hub.IsEnabled.Returns(true);
+                _ = Hub.IsEnabled.Returns(true);
                 HubAccessor = () => Hub;
                 Scope = new Scope(new SentryOptions());
                 Hub.ConfigureScope(Arg.Invoke(Scope));
@@ -187,8 +187,8 @@ namespace Sentry.NLog.Tests
 
             logger.Error(expected, DefaultMessage);
 
-            _fixture.Hub.Received(1)
-                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Exception == expected));
+            _ = _fixture.Hub.Received(1)
+                        .CaptureEvent(Arg.Is<SentryEvent>(e => e.Exception == expected));
         }
 
         [Fact]
@@ -224,8 +224,8 @@ namespace Sentry.NLog.Tests
             var expected = typeof(SentryTarget).Assembly.GetNameAndVersion();
             logger.Info(DefaultMessage);
 
-            _fixture.Hub.Received(1)
-                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Sdk.Name == Constants.SdkName
+            _ = _fixture.Hub.Received(1)
+                        .CaptureEvent(Arg.Is<SentryEvent>(e => e.Sdk.Name == Constants.SdkName
                                                            && e.Sdk.Version == expected.Version));
         }
 
@@ -267,8 +267,8 @@ namespace Sentry.NLog.Tests
 
             logger.Log(evt);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Level == sentryLevel));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Level == sentryLevel));
         }
 
         [Fact]
@@ -286,8 +286,8 @@ namespace Sentry.NLog.Tests
 
             manager.GetLogger("sentry").Log(evt);
 
-            _fixture.Hub.Received(1)
-                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.LogEntry.Formatted == expected));
+            _ = _fixture.Hub.Received(1)
+                        .CaptureEvent(Arg.Is<SentryEvent>(e => e.LogEntry.Formatted == expected));
         }
 
         [Fact]
@@ -301,23 +301,23 @@ namespace Sentry.NLog.Tests
         [Fact]
         public void Log_DisabledHub_CaptureNotCalled()
         {
-            _fixture.Hub.IsEnabled.Returns(false);
+            _ = _fixture.Hub.IsEnabled.Returns(false);
             var sut = _fixture.GetLogger();
 
             sut.Error(DefaultMessage);
 
-            _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
         public void Log_EnabledHub_CaptureCalled()
         {
-            _fixture.Hub.IsEnabled.Returns(true);
+            _ = _fixture.Hub.IsEnabled.Returns(true);
             var sut = _fixture.GetLogger();
 
             sut.Error(DefaultMessage);
 
-            _fixture.Hub.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -329,7 +329,7 @@ namespace Sentry.NLog.Tests
             // ReSharper disable once AssignNullToNotNullAttribute
             sut.Error(message);
 
-            _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -341,8 +341,8 @@ namespace Sentry.NLog.Tests
 
             sut.Error("Something happened: {IPAddress}", expectedIp);
 
-            _fixture.Hub.Received(1)
-                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Extra["IPAddress"].ToString() == expectedIp));
+            _ = _fixture.Hub.Received(1)
+                        .CaptureEvent(Arg.Is<SentryEvent>(e => e.Extra["IPAddress"].ToString() == expectedIp));
         }
 
         [Fact]
@@ -384,9 +384,9 @@ namespace Sentry.NLog.Tests
 
             sut.Error(expectedMessage, param);
 
-            _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(p =>
-                p.LogEntry.Formatted == $"Test {param} log"
-                && p.LogEntry.Message == expectedMessage));
+            _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(p =>
+                    p.LogEntry.Formatted == $"Test {param} log"
+                    && p.LogEntry.Message == expectedMessage));
         }
 
         [Fact]
@@ -734,8 +734,8 @@ namespace Sentry.NLog.Tests
             var logger = factory.GetLogger("sentry");
             logger.Fatal(DefaultMessage);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Tags["Logger"] == "sentry"));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Tags["Logger"] == "sentry"));
         }
 
         [Fact]
@@ -748,8 +748,8 @@ namespace Sentry.NLog.Tests
             var logger = factory.GetLogger("sentry");
             logger.Fatal("{a}", "b");
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Tags["a"] == "b"));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Tags["a"] == "b"));
         }
 
         [Fact]
@@ -763,11 +763,11 @@ namespace Sentry.NLog.Tests
             var logger = factory.GetLogger("sentry");
             logger.Fatal("{a}", (string)null);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Tags["a"] == null));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Tags["a"] == null));
 
             var b = _fixture.Scope.Breadcrumbs.First();
-            Assert.Single(b.Data);
+            _ = Assert.Single(b.Data);
             Assert.Null(b.Data["a"]);
         }
 
@@ -785,8 +785,8 @@ namespace Sentry.NLog.Tests
             var logger = factory.GetLogger("sentry");
             logger.Fatal(DefaultMessage);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.User.Username == "sentry" && e.User.Other["mood"] == "joyous"));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.User.Username == "sentry" && e.User.Other["mood"] == "joyous"));
         }
 
         internal class LogLevelData : IEnumerable<object[]>

--- a/test/Sentry.Protocol.Tests/BaseScopeExtensionsTests.cs
+++ b/test/Sentry.Protocol.Tests/BaseScopeExtensionsTests.cs
@@ -15,7 +15,7 @@ namespace Sentry.Protocol.Tests
 
             public Fixture()
             {
-                ScopeOptions.BeforeBreadcrumb.Returns(null as Func<Breadcrumb, Breadcrumb>);
+                _ = ScopeOptions.BeforeBreadcrumb.Returns(null as Func<Breadcrumb, Breadcrumb>);
             }
             public BaseScope GetSut() => new BaseScope(ScopeOptions);
         }
@@ -135,7 +135,7 @@ namespace Sentry.Protocol.Tests
         public void SetExtra_SecondExtra_AddedToDictionary()
         {
             var originalExtra = new ConcurrentDictionary<string, object>();
-            originalExtra.TryAdd("original", new object());
+            _ = originalExtra.TryAdd("original", new object());
             var sut = _fixture.GetSut();
             sut.InternalExtra = originalExtra;
 
@@ -168,7 +168,7 @@ namespace Sentry.Protocol.Tests
         public void SetExtras_SecondExtra_AddedToDictionary()
         {
             var originalExtra = new ConcurrentDictionary<string, object>();
-            originalExtra.TryAdd("original", new object());
+            _ = originalExtra.TryAdd("original", new object());
 
             var sut = _fixture.GetSut();
             sut.InternalExtra = originalExtra;
@@ -241,7 +241,7 @@ namespace Sentry.Protocol.Tests
         public void SetTag_SecondTag_AddedToDictionary()
         {
             var originalTag = new ConcurrentDictionary<string, string>();
-            originalTag.TryAdd("original", "value");
+            _ = originalTag.TryAdd("original", "value");
 
             var sut = _fixture.GetSut();
             sut.InternalTags = originalTag;
@@ -262,7 +262,7 @@ namespace Sentry.Protocol.Tests
         {
             var sut = _fixture.GetSut();
             var expectedTag = new ConcurrentDictionary<string, string>();
-            expectedTag.TryAdd("expected", "tag");
+            _ = expectedTag.TryAdd("expected", "tag");
 
             sut.InternalTags = expectedTag;
 
@@ -276,7 +276,7 @@ namespace Sentry.Protocol.Tests
         {
             var sut = _fixture.GetSut();
             var originalTag = new ConcurrentDictionary<string, string>();
-            originalTag.TryAdd("original", "value");
+            _ = originalTag.TryAdd("original", "value");
 
             sut.InternalTags = originalTag;
 
@@ -311,7 +311,7 @@ namespace Sentry.Protocol.Tests
         [Fact]
         public void AddBreadcrumb_BeforeBreadcrumbDropsCrumb_NoBreadcrumbInEvent()
         {
-            _fixture.ScopeOptions.BeforeBreadcrumb.Returns((Breadcrumb c) => null);
+            _ = _fixture.ScopeOptions.BeforeBreadcrumb.Returns((Breadcrumb c) => null);
             var sut = _fixture.GetSut();
 
             sut.AddBreadcrumb("no expected");
@@ -323,7 +323,7 @@ namespace Sentry.Protocol.Tests
         public void AddBreadcrumb_BeforeBreadcrumbNewCrumb_NewCrumbUsed()
         {
             var expected = new Breadcrumb();
-            _fixture.ScopeOptions.BeforeBreadcrumb.Returns(_ => expected);
+            _ = _fixture.ScopeOptions.BeforeBreadcrumb.Returns(_ => expected);
             var sut = _fixture.GetSut();
 
             sut.AddBreadcrumb("no expected");
@@ -335,7 +335,7 @@ namespace Sentry.Protocol.Tests
         public void AddBreadcrumb_BeforeBreadcrumbReturns_SameCrumb()
         {
             var expected = new Breadcrumb();
-            _fixture.ScopeOptions.BeforeBreadcrumb.Returns(c => c);
+            _ = _fixture.ScopeOptions.BeforeBreadcrumb.Returns(c => c);
             var sut = _fixture.GetSut();
 
             sut.AddBreadcrumb(expected);
@@ -363,7 +363,7 @@ namespace Sentry.Protocol.Tests
         [InlineData(10)]
         public void AddBreadcrumb_WithOptions_BoundOptionsLimit(int limit)
         {
-            _fixture.ScopeOptions.MaxBreadcrumbs.Returns(limit);
+            _ = _fixture.ScopeOptions.MaxBreadcrumbs.Returns(limit);
             var sut = _fixture.GetSut();
 
             for (var i = 0; i < limit + 1; i++)
@@ -379,7 +379,7 @@ namespace Sentry.Protocol.Tests
         {
             const int limit = 5;
 
-            _fixture.ScopeOptions.MaxBreadcrumbs.Returns(limit);
+            _ = _fixture.ScopeOptions.MaxBreadcrumbs.Returns(limit);
             var sut = _fixture.GetSut();
 
             for (var i = 0; i < limit + 1; i++)
@@ -585,7 +585,7 @@ namespace Sentry.Protocol.Tests
             var target = _fixture.GetSut();
             sut.Apply(target);
 
-            Assert.Single(target.InternalBreadcrumbs);
+            _ = Assert.Single(target.InternalBreadcrumbs);
         }
 
         [Fact]
@@ -637,7 +637,7 @@ namespace Sentry.Protocol.Tests
 
             sut.Apply(target);
 
-            Assert.Single(target.InternalExtra);
+            _ = Assert.Single(target.InternalExtra);
             Assert.Equal(expectedValue, target.InternalExtra[conflictingKey]);
         }
 
@@ -650,7 +650,7 @@ namespace Sentry.Protocol.Tests
             var target = _fixture.GetSut();
             sut.Apply(target);
 
-            Assert.Single(target.InternalExtra);
+            _ = Assert.Single(target.InternalExtra);
         }
 
         [Fact]
@@ -702,7 +702,7 @@ namespace Sentry.Protocol.Tests
 
             sut.Apply(target);
 
-            Assert.Single(target.InternalTags);
+            _ = Assert.Single(target.InternalTags);
             Assert.Equal(expectedValue, target.InternalTags[conflictingKey]);
         }
 
@@ -715,7 +715,7 @@ namespace Sentry.Protocol.Tests
             var target = _fixture.GetSut();
             sut.Apply(target);
 
-            Assert.Single(target.InternalTags);
+            _ = Assert.Single(target.InternalTags);
         }
 
         [Fact]
@@ -832,7 +832,7 @@ namespace Sentry.Protocol.Tests
 
             sut.Apply(target);
 
-            Assert.Single(target.Contexts);
+            _ = Assert.Single(target.Contexts);
             Assert.Equal(expectedValue, target.Contexts[conflictingKey]);
         }
 
@@ -845,7 +845,7 @@ namespace Sentry.Protocol.Tests
             var target = _fixture.GetSut();
             sut.Apply(target);
 
-            Assert.Single(target.Contexts);
+            _ = Assert.Single(target.Contexts);
         }
 
         [Fact]

--- a/test/Sentry.Protocol.Tests/DsnTests.cs
+++ b/test/Sentry.Protocol.Tests/DsnTests.cs
@@ -132,7 +132,7 @@ namespace Sentry.Protocol.Tests
         [Fact]
         public void Ctor_NullDsn_ThrowsArgumentNull()
         {
-            Assert.Throws<ArgumentNullException>(() => new Dsn(null));
+            _ = Assert.Throws<ArgumentNullException>(() => new Dsn(null));
         }
 
         [Fact]

--- a/test/Sentry.Protocol.Tests/SentryEventTests.cs
+++ b/test/Sentry.Protocol.Tests/SentryEventTests.cs
@@ -37,10 +37,10 @@ namespace Sentry.Protocol.Tests
             sut.InternalBreadcrumbs = new ConcurrentQueue<Breadcrumb>();
             sut.InternalBreadcrumbs.Enqueue(new Breadcrumb(timestamp, "crumb"));
             sut.InternalExtra = new ConcurrentDictionary<string, object>();
-            sut.InternalExtra.TryAdd("extra_key", "extra_value");
+            _ = sut.InternalExtra.TryAdd("extra_key", "extra_value");
             sut.InternalFingerprint = new[] { "fingerprint" };
             sut.InternalTags = new ConcurrentDictionary<string, string>();
-            sut.InternalTags.TryAdd("tag_key", "tag_value");
+            _ = sut.InternalTags.TryAdd("tag_key", "tag_value");
 
             var actual = JsonSerializer.SerializeObject(sut);
 

--- a/test/Sentry.Serilog.Tests/SentrySinkTests.cs
+++ b/test/Sentry.Serilog.Tests/SentrySinkTests.cs
@@ -25,7 +25,7 @@ namespace Sentry.Serilog.Tests
 
             public Fixture()
             {
-                Hub.IsEnabled.Returns(true);
+                _ = Hub.IsEnabled.Returns(true);
                 HubAccessor = () => Hub;
                 Hub.ConfigureScope(Arg.Invoke(Scope));
             }
@@ -52,8 +52,8 @@ namespace Sentry.Serilog.Tests
 
             sut.Emit(evt);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Exception == expected));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Exception == expected));
         }
 
         [Fact]
@@ -89,9 +89,9 @@ namespace Sentry.Serilog.Tests
             sut.Emit(evt);
 
             var expected = typeof(SentrySink).Assembly.GetNameAndVersion();
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Sdk.Name == Constants.SdkName
-                                                       && e.Sdk.Version == expected.Version));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Sdk.Name == Constants.SdkName
+                                                           && e.Sdk.Version == expected.Version));
         }
 
         [Fact]
@@ -145,8 +145,8 @@ namespace Sentry.Serilog.Tests
 
             sut.Emit(evt);
 
-            _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Level == sentryLevel));
+            _ = _fixture.Hub.Received(1)
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Level == sentryLevel));
         }
 
         [Fact]
@@ -161,7 +161,7 @@ namespace Sentry.Serilog.Tests
 
             sut.Emit(evt);
 
-            _fixture.Hub.Received(1)
+            _ = _fixture.Hub.Received(1)
                 .CaptureEvent(Arg.Is<SentryEvent>(e => e.LogEntry.Formatted == expected));
         }
 
@@ -179,27 +179,27 @@ namespace Sentry.Serilog.Tests
         [Fact]
         public void Emit_DisabledHub_CaptureNotCalled()
         {
-            _fixture.Hub.IsEnabled.Returns(false);
+            _ = _fixture.Hub.IsEnabled.Returns(false);
             var sut = _fixture.GetSut();
 
             var evt = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Error, null, MessageTemplate.Empty,
                 Enumerable.Empty<LogEventProperty>());
             sut.Emit(evt);
 
-            _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
         public void Emit_EnabledHub_CaptureCalled()
         {
-            _fixture.Hub.IsEnabled.Returns(true);
+            _ = _fixture.Hub.IsEnabled.Returns(true);
             var sut = _fixture.GetSut();
 
             var evt = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Error, null, MessageTemplate.Empty,
                 Enumerable.Empty<LogEventProperty>());
             sut.Emit(evt);
 
-            _fixture.Hub.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -209,7 +209,7 @@ namespace Sentry.Serilog.Tests
 
             sut.Emit(null);
 
-            _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -224,7 +224,7 @@ namespace Sentry.Serilog.Tests
 
             sut.Emit(evt);
 
-            _fixture.Hub.Received(1)
+            _ = _fixture.Hub.Received(1)
                 .CaptureEvent(Arg.Is<SentryEvent>(e => e.Extra["IPAddress"].ToString() == expectedIp));
         }
 
@@ -266,9 +266,9 @@ namespace Sentry.Serilog.Tests
 
             sut.Emit(evt);
 
-            _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(p =>
-                p.LogEntry.Formatted == $"Test {param} log"
-                && p.LogEntry.Message == expectedMessage));
+            _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(p =>
+                    p.LogEntry.Formatted == $"Test {param} log"
+                    && p.LogEntry.Message == expectedMessage));
         }
 
         [Fact]
@@ -282,7 +282,7 @@ namespace Sentry.Serilog.Tests
 
             sut.Emit(evt);
 
-            _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -296,7 +296,7 @@ namespace Sentry.Serilog.Tests
 
             sut.Emit(evt);
 
-            _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -339,7 +339,7 @@ namespace Sentry.Serilog.Tests
 
             sut.Emit(evt);
 
-            _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(p =>
+            _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(p =>
                 p.Logger == expectedLogger));
         }
 
@@ -354,8 +354,8 @@ namespace Sentry.Serilog.Tests
 
             sut.Emit(evt);
 
-            _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(p =>
-                p.Logger == null));
+            _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(p =>
+                    p.Logger == null));
         }
     }
 }

--- a/test/Sentry.Testing/FakeSentryServer.cs
+++ b/test/Sentry.Testing/FakeSentryServer.cs
@@ -14,12 +14,12 @@ namespace Sentry.Testing
             var builder = new WebHostBuilder()
                 .Configure(app =>
                 {
-                    app.Use(async (context, next) =>
-                    {
-                        var handler = handlers.FirstOrDefault(p => p.Path == context.Request.Path);
+                    _ = app.Use(async (context, next) =>
+                        {
+                            var handler = handlers.FirstOrDefault(p => p.Path == context.Request.Path);
 
-                        await (handler?.Handler(context) ?? next());
-                    });
+                            await (handler?.Handler(context) ?? next());
+                        });
                 });
 
             return new TestServer(builder);

--- a/test/Sentry.Testing/LastExceptionFilter.cs
+++ b/test/Sentry.Testing/LastExceptionFilter.cs
@@ -12,17 +12,17 @@ namespace Sentry.Testing
             =>
                 e =>
                 {
-                    e.Use(async (_, n) =>
-                    {
-                        try
+                    _ = e.Use(async (_, n) =>
                         {
-                            await n();
-                        }
-                        catch (Exception ex)
-                        {
-                            LastException = ex;
-                        }
-                    });
+                            try
+                            {
+                                await n();
+                            }
+                            catch (Exception ex)
+                            {
+                                LastException = ex;
+                            }
+                        });
 
                     next(e);
                 };

--- a/test/Sentry.Testing/SentrySdkTestFixture.cs
+++ b/test/Sentry.Testing/SentrySdkTestFixture.cs
@@ -40,18 +40,18 @@ namespace Sentry.Testing
         {
             var builder = new WebHostBuilder();
 
-            builder.ConfigureServices(s =>
+            _ = builder.ConfigureServices(s =>
             {
                 var lastException = new LastExceptionFilter();
-                s.AddSingleton<IStartupFilter>(lastException);
-                s.AddSingleton(lastException);
+                _ = s.AddSingleton<IStartupFilter>(lastException);
+                _ = s.AddSingleton(lastException);
 
                 ConfigureServices?.Invoke(s);
             });
-            builder.Configure(app =>
+            _ = builder.Configure(app =>
             {
                 ConfigureApp?.Invoke(app);
-                app.Use(async (context, next) =>
+                _ = app.Use(async (context, next) =>
                 {
                     var handler = Handlers.FirstOrDefault(p => p.Path == context.Request.Path);
 

--- a/test/Sentry.Tests/AppDomainUnhandledExceptionIntegrationTests.cs
+++ b/test/Sentry.Tests/AppDomainUnhandledExceptionIntegrationTests.cs
@@ -34,7 +34,7 @@ namespace Sentry.Tests
 
             sut.Handle(this, new UnhandledExceptionEventArgs(new Exception(), true));
 
-            _fixture.Hub.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace Sentry.Tests
 
             sut.Handle(this, new UnhandledExceptionEventArgs(new object(), true));
 
-            _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]

--- a/test/Sentry.Tests/Extensibility/HubAdapterTests.cs
+++ b/test/Sentry.Tests/Extensibility/HubAdapterTests.cs
@@ -20,15 +20,15 @@ namespace Sentry.Tests.Extensibility
         public HubAdapterTests()
         {
             Hub = Substitute.For<IHub>();
-            SentrySdk.UseHub(Hub);
+            _ = SentrySdk.UseHub(Hub);
         }
 
         [Fact]
         public void CaptureEvent_MockInvoked()
         {
             var expected = new SentryEvent();
-            HubAdapter.Instance.CaptureEvent(expected);
-            Hub.Received(1).CaptureEvent(expected);
+            _ = HubAdapter.Instance.CaptureEvent(expected);
+            _ = Hub.Received(1).CaptureEvent(expected);
         }
 
         [Fact]
@@ -36,16 +36,16 @@ namespace Sentry.Tests.Extensibility
         {
             var expectedEvent = new SentryEvent();
             var expectedScope = new Scope();
-            HubAdapter.Instance.CaptureEvent(expectedEvent, expectedScope);
-            Hub.Received(1).CaptureEvent(expectedEvent, expectedScope);
+            _ = HubAdapter.Instance.CaptureEvent(expectedEvent, expectedScope);
+            _ = Hub.Received(1).CaptureEvent(expectedEvent, expectedScope);
         }
 
         [Fact]
         public void CaptureException_MockInvoked()
         {
             var expected = new Exception();
-            HubAdapter.Instance.CaptureException(expected);
-            Hub.Received(1).CaptureException(expected);
+            _ = HubAdapter.Instance.CaptureException(expected);
+            _ = Hub.Received(1).CaptureException(expected);
         }
 
         [Fact]
@@ -68,8 +68,8 @@ namespace Sentry.Tests.Extensibility
         public void ConfigureScopeAsync_MockInvoked()
         {
             Task Expected(Scope _) => Task.CompletedTask;
-            HubAdapter.Instance.ConfigureScopeAsync(Expected);
-            Hub.Received(1).ConfigureScopeAsync(Expected);
+            _ = HubAdapter.Instance.ConfigureScopeAsync(Expected);
+            _ = Hub.Received(1).ConfigureScopeAsync(Expected);
         }
 
         [Fact]
@@ -93,16 +93,16 @@ namespace Sentry.Tests.Extensibility
         [Fact]
         public void PushScope_MockInvoked()
         {
-            HubAdapter.Instance.PushScope();
-            Hub.Received(1).PushScope();
+            _ = HubAdapter.Instance.PushScope();
+            _ = Hub.Received(1).PushScope();
         }
 
         [Fact]
         public void PushScope_State_MockInvoked()
         {
             var expected = new object();
-            HubAdapter.Instance.PushScope(expected);
-            Hub.Received(1).PushScope(expected);
+            _ = HubAdapter.Instance.PushScope(expected);
+            _ = Hub.Received(1).PushScope(expected);
         }
 
         [Fact]
@@ -123,7 +123,7 @@ namespace Sentry.Tests.Extensibility
         public void AddBreadcrumb_WithClock_BreadcrumbInstanceCreated()
         {
             var clock = Substitute.For<ISystemClock>();
-            clock.GetUtcNow().Returns(DateTimeOffset.MaxValue);
+            _ = clock.GetUtcNow().Returns(DateTimeOffset.MaxValue);
 
             TestAddBreadcrumbExtension((message, category, type, data, level)
                 => HubAdapter.Instance.AddBreadcrumb(
@@ -134,7 +134,7 @@ namespace Sentry.Tests.Extensibility
                     data,
                     level));
 
-            clock.Received(1).GetUtcNow();
+            _ = clock.Received(1).GetUtcNow();
         }
 
         private void TestAddBreadcrumbExtension(

--- a/test/Sentry.Tests/Extensibility/RequestBodyExtractionDispatcherTests.cs
+++ b/test/Sentry.Tests/Extensibility/RequestBodyExtractionDispatcherTests.cs
@@ -19,8 +19,8 @@ namespace Sentry.Tests.Extensibility
 
             public Fixture()
             {
-                HttpRequest.ContentLength.Returns(10);
-                Extractor.ExtractPayload(Arg.Any<IHttpRequest>()).Returns("Result");
+                _ = HttpRequest.ContentLength.Returns(10);
+                _ = Extractor.ExtractPayload(Arg.Any<IHttpRequest>()).Returns("Result");
                 Extractors = new[] { Extractor };
             }
 
@@ -41,7 +41,7 @@ namespace Sentry.Tests.Extensibility
         [Fact]
         public void ExtractPayload_ExtractorEmptyString_ReturnsNull()
         {
-            _fixture.Extractor.ExtractPayload(Arg.Any<IHttpRequest>()).Returns(string.Empty);
+            _ = _fixture.Extractor.ExtractPayload(Arg.Any<IHttpRequest>()).Returns(string.Empty);
             var sut = _fixture.GetSut();
 
             Assert.Null(sut.ExtractPayload(_fixture.HttpRequest));
@@ -50,7 +50,7 @@ namespace Sentry.Tests.Extensibility
         [Fact]
         public void ExtractPayload_ExtractorNull_ReturnsNull()
         {
-            _fixture.Extractor.ExtractPayload(Arg.Any<IHttpRequest>()).ReturnsNull();
+            _ = _fixture.Extractor.ExtractPayload(Arg.Any<IHttpRequest>()).ReturnsNull();
             var sut = _fixture.GetSut();
 
             Assert.Null(sut.ExtractPayload(_fixture.HttpRequest));
@@ -66,7 +66,7 @@ namespace Sentry.Tests.Extensibility
         public void ExtractPayload_RequestSizeSmall_ContentLength(RequestSize requestSize, int contentLength, bool readBody)
         {
             _fixture.RequestSize = requestSize;
-            _fixture.HttpRequest.ContentLength.Returns(contentLength);
+            _ = _fixture.HttpRequest.ContentLength.Returns(contentLength);
             var sut = _fixture.GetSut();
 
             Assert.Equal(readBody, sut.ExtractPayload(_fixture.HttpRequest) != null);
@@ -83,14 +83,14 @@ namespace Sentry.Tests.Extensibility
         public void Ctor_NullExtractors_ThrowsArgumentNullException()
         {
             _fixture.Extractors = null;
-            Assert.Throws<ArgumentNullException>(() => _fixture.GetSut());
+            _ = Assert.Throws<ArgumentNullException>(() => _fixture.GetSut());
         }
 
         [Fact]
         public void Ctor_NullOptions_ThrowsArgumentNullException()
         {
             _fixture.SentryOptions = null;
-            Assert.Throws<ArgumentNullException>(() => _fixture.GetSut());
+            _ = Assert.Throws<ArgumentNullException>(() => _fixture.GetSut());
         }
     }
 }

--- a/test/Sentry.Tests/HubExtensionsTests.cs
+++ b/test/Sentry.Tests/HubExtensionsTests.cs
@@ -23,16 +23,16 @@ namespace Sentry.Tests
         [Fact]
         public void PushAndLockScope_PushesNewScope()
         {
-            Sut.PushAndLockScope();
+            _ = Sut.PushAndLockScope();
 
-            Sut.Received(1).PushScope();
+            _ = Sut.Received(1).PushScope();
         }
 
         [Fact]
         public void PushAndLockScope_Disposed_DisposesInnerScope()
         {
             var disposable = Substitute.For<IDisposable>();
-            Sut.PushScope().Returns(disposable);
+            _ = Sut.PushScope().Returns(disposable);
 
             var actual = Sut.PushAndLockScope();
             actual.Dispose();
@@ -43,7 +43,7 @@ namespace Sentry.Tests
         [Fact]
         public void PushAndLockScope_CreatedScopeIsLocked()
         {
-            Sut.PushAndLockScope();
+            _ = Sut.PushAndLockScope();
 
             Assert.True(Scope.Locked);
         }
@@ -72,7 +72,7 @@ namespace Sentry.Tests
             const string expectedMessage = "message";
             Sut.AddBreadcrumb(expectedMessage);
 
-            Assert.Single(Scope.Breadcrumbs);
+            _ = Assert.Single(Scope.Breadcrumbs);
             var crumb = Scope.Breadcrumbs.Single();
             Assert.Equal(expectedMessage, crumb.Message);
             Assert.Null(crumb.Category);
@@ -87,7 +87,7 @@ namespace Sentry.Tests
         {
             var expectedTimestamp = DateTimeOffset.MaxValue;
             var clock = Substitute.For<ISystemClock>();
-            clock.GetUtcNow().Returns(expectedTimestamp);
+            _ = clock.GetUtcNow().Returns(expectedTimestamp);
 
             const string expectedMessage = "message";
             const string expectedType = "type";
@@ -107,7 +107,7 @@ namespace Sentry.Tests
                 expectedData,
                 expectedLevel);
 
-            Assert.Single(Scope.Breadcrumbs);
+            _ = Assert.Single(Scope.Breadcrumbs);
             var crumb = Scope.Breadcrumbs.First();
 
             Assert.Equal(expectedMessage, crumb.Message);

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -36,7 +36,7 @@ namespace NotSentry.Tests
             using (sut.PushScope())
             {
                 sut.ConfigureScope(s => s.AddBreadcrumb("test"));
-                Assert.Single(sut.ScopeManager.GetCurrent().Key.Breadcrumbs);
+                _ = Assert.Single(sut.ScopeManager.GetCurrent().Key.Breadcrumbs);
             }
 
             Assert.Empty(sut.ScopeManager.GetCurrent().Key.Breadcrumbs);
@@ -62,12 +62,12 @@ namespace NotSentry.Tests
 
             var sut = _fixture.GetSut();
 
-            sut.CaptureMessage("test");
+            _ = sut.CaptureMessage("test");
 
-            _fixture.Worker.Received(1)
-                .EnqueueEvent(Arg.Do<SentryEvent>(
-                    e => Assert.DoesNotContain(e.SentryExceptions.Single().Stacktrace.Frames,
-                        p => p.Function == nameof(CaptureMessage_AttachStacktraceTrue_IncludesStackTrace))));
+            _ = _fixture.Worker.Received(1)
+                    .EnqueueEvent(Arg.Do<SentryEvent>(
+                        e => Assert.DoesNotContain(e.SentryExceptions.Single().Stacktrace.Frames,
+                            p => p.Function == nameof(CaptureMessage_AttachStacktraceTrue_IncludesStackTrace))));
         }
 
         [Fact]
@@ -77,17 +77,17 @@ namespace NotSentry.Tests
 
             var sut = _fixture.GetSut();
 
-            sut.CaptureMessage("test");
+            _ = sut.CaptureMessage("test");
 
-            _fixture.Worker.Received(1)
-                .EnqueueEvent(Arg.Is<SentryEvent>(e => e.SentryExceptionValues == null));
+            _ = _fixture.Worker.Received(1)
+                    .EnqueueEvent(Arg.Is<SentryEvent>(e => e.SentryExceptionValues == null));
         }
 
         [Fact]
         public void CaptureMessage_FailedQueue_LastEventIdSetToEmpty()
         {
             var expectedId = Guid.Empty;
-            _fixture.Worker.EnqueueEvent(Arg.Any<SentryEvent>()).Returns(false);
+            _ = _fixture.Worker.EnqueueEvent(Arg.Any<SentryEvent>()).Returns(false);
             var sut = _fixture.GetSut();
 
             var actualId = sut.CaptureMessage("test");
@@ -99,7 +99,7 @@ namespace NotSentry.Tests
         [Fact]
         public void CaptureMessage_SuccessQueued_LastEventIdSetToReturnedId()
         {
-            _fixture.Worker.EnqueueEvent(Arg.Any<SentryEvent>()).Returns(true);
+            _ = _fixture.Worker.EnqueueEvent(Arg.Any<SentryEvent>()).Returns(true);
             var sut = _fixture.GetSut();
 
             var actualId = sut.CaptureMessage("test");

--- a/test/Sentry.Tests/Internals/DefaultSentryHttpClientFactoryTests.cs
+++ b/test/Sentry.Tests/Internals/DefaultSentryHttpClientFactoryTests.cs
@@ -109,7 +109,7 @@ namespace Sentry.Tests.Internals
             };
             var sut = _fixture.GetSut();
 
-            sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            _ = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
 
             Assert.True(configureHandlerInvoked);
         }
@@ -125,7 +125,7 @@ namespace Sentry.Tests.Internals
             };
             var sut = _fixture.GetSut();
 
-            sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            _ = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
 
             Assert.True(configureHandlerInvoked);
         }
@@ -141,7 +141,7 @@ namespace Sentry.Tests.Internals
             };
             var sut = _fixture.GetSut();
 
-            sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            _ = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
 
             Assert.True(configureHandlerInvoked);
         }
@@ -158,7 +158,7 @@ namespace Sentry.Tests.Internals
             };
             var sut = _fixture.GetSut();
 
-            sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            _ = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
 
             Assert.True(configureHandlerInvoked);
         }

--- a/test/Sentry.Tests/Internals/Http/GzipBufferedRequestBodyHandlerTests.cs
+++ b/test/Sentry.Tests/Internals/Http/GzipBufferedRequestBodyHandlerTests.cs
@@ -40,7 +40,7 @@ namespace Sentry.Tests.Internals.Http
         {
             var sut = _fixture.GetSut();
 
-            await sut.SendAsync(_fixture.Message, None);
+            _ = await sut.SendAsync(_fixture.Message, None);
 
             var gzippedContent = await _fixture.Message.Content.ReadAsByteArrayAsync();
             var contentLength = ((GzipBufferedRequestBodyHandler.BufferedStreamContent)_fixture.Message.Content)
@@ -54,7 +54,7 @@ namespace Sentry.Tests.Internals.Http
         {
             var sut = _fixture.GetSut();
 
-            await sut.SendAsync(_fixture.Message, None);
+            _ = await sut.SendAsync(_fixture.Message, None);
 
             var gzippedContent = await _fixture.Message.Content.ReadAsByteArrayAsync();
             Assert.True(gzippedContent.Length < 100);
@@ -65,9 +65,9 @@ namespace Sentry.Tests.Internals.Http
         {
             var sut = _fixture.GetSut();
 
-            await sut.SendAsync(_fixture.Message, None);
+            _ = await sut.SendAsync(_fixture.Message, None);
 
-            Assert.IsType<GzipBufferedRequestBodyHandler.BufferedStreamContent>(_fixture.Message.Content);
+            _ = Assert.IsType<GzipBufferedRequestBodyHandler.BufferedStreamContent>(_fixture.Message.Content);
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace Sentry.Tests.Internals.Http
 
             var sut = _fixture.GetSut();
 
-            await sut.SendAsync(_fixture.Message, None);
+            _ = await sut.SendAsync(_fixture.Message, None);
 
             Assert.Contains(_fixture.Message.Content.Headers,
                 p => p.Key == "test" && p.Value.Count() == 2);
@@ -88,7 +88,7 @@ namespace Sentry.Tests.Internals.Http
         {
             var sut = _fixture.GetSut();
 
-            await sut.SendAsync(_fixture.Message, None);
+            _ = await sut.SendAsync(_fixture.Message, None);
 
             Assert.Equal("gzip", _fixture.Message.Content.Headers.ContentEncoding.First());
         }
@@ -96,9 +96,9 @@ namespace Sentry.Tests.Internals.Http
         [Fact]
         public void Ctor_NoCompression_ThrowsInvalidOperationException()
         {
-            Assert.Throws<InvalidOperationException>(
-                () => new GzipRequestBodyHandler(Substitute.For<HttpMessageHandler>(),
-                    CompressionLevel.NoCompression));
+            _ = Assert.Throws<InvalidOperationException>(
+                    () => new GzipRequestBodyHandler(Substitute.For<HttpMessageHandler>(),
+                        CompressionLevel.NoCompression));
         }
     }
 }

--- a/test/Sentry.Tests/Internals/Http/GzipRequestBodyHandlerTests.cs
+++ b/test/Sentry.Tests/Internals/Http/GzipRequestBodyHandlerTests.cs
@@ -40,7 +40,7 @@ namespace Sentry.Tests.Internals.Http
         {
             var sut = _fixture.GetSut();
 
-            await sut.SendAsync(_fixture.Message, None);
+            _ = await sut.SendAsync(_fixture.Message, None);
 
             var gzippedContent = await _fixture.Message.Content.ReadAsByteArrayAsync();
             Assert.True(gzippedContent.Length < 100);
@@ -51,9 +51,9 @@ namespace Sentry.Tests.Internals.Http
         {
             var sut = _fixture.GetSut();
 
-            await sut.SendAsync(_fixture.Message, None);
+            _ = await sut.SendAsync(_fixture.Message, None);
 
-            Assert.IsType<GzipRequestBodyHandler.GzipContent>(_fixture.Message.Content);
+            _ = Assert.IsType<GzipRequestBodyHandler.GzipContent>(_fixture.Message.Content);
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace Sentry.Tests.Internals.Http
 
             var sut = _fixture.GetSut();
 
-            await sut.SendAsync(_fixture.Message, None);
+            _ = await sut.SendAsync(_fixture.Message, None);
 
             Assert.Contains(_fixture.Message.Content.Headers,
                 p => p.Key == "test" && p.Value.Count() == 2);
@@ -74,7 +74,7 @@ namespace Sentry.Tests.Internals.Http
         {
             var sut = _fixture.GetSut();
 
-            await sut.SendAsync(_fixture.Message, None);
+            _ = await sut.SendAsync(_fixture.Message, None);
 
             Assert.Equal("gzip", _fixture.Message.Content.Headers.ContentEncoding.First());
         }
@@ -82,9 +82,9 @@ namespace Sentry.Tests.Internals.Http
         [Fact]
         public void Ctor_NoCompression_ThrowsInvalidOperationException()
         {
-            Assert.Throws<InvalidOperationException>(
-                () => new GzipRequestBodyHandler(Substitute.For<HttpMessageHandler>(),
-                    CompressionLevel.NoCompression));
+            _ = Assert.Throws<InvalidOperationException>(
+                    () => new GzipRequestBodyHandler(Substitute.For<HttpMessageHandler>(),
+                        CompressionLevel.NoCompression));
         }
     }
 }

--- a/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
@@ -31,8 +31,8 @@ namespace Sentry.Tests.Internals.Http
 
             public Fixture()
             {
-                HttpMessageHandler.VerifyableSendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
-                    .Returns(_ => SentryResponses.GetOkResponse());
+                _ = HttpMessageHandler.VerifyableSendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
+                        .Returns(_ => SentryResponses.GetOkResponse());
 
                 HttpClient = new HttpClient(HttpMessageHandler);
             }
@@ -47,8 +47,8 @@ namespace Sentry.Tests.Internals.Http
         {
             var sut = _fixture.GetSut();
             await sut.CaptureEventAsync(null);
-            await _fixture.HttpMessageHandler.DidNotReceive()
-                .VerifyableSendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>());
+            _ = await _fixture.HttpMessageHandler.DidNotReceive()
+                    .VerifyableSendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -64,9 +64,9 @@ namespace Sentry.Tests.Internals.Http
                     id: SentryResponses.ResponseId),
                 token);
 
-            await _fixture.HttpMessageHandler
-                .Received(1)
-                .VerifyableSendAsync(Arg.Any<HttpRequestMessage>(), Arg.Is<CancellationToken>(c => c.IsCancellationRequested));
+            _ = await _fixture.HttpMessageHandler
+                    .Received(1)
+                    .VerifyableSendAsync(Arg.Any<HttpRequestMessage>(), Arg.Is<CancellationToken>(c => c.IsCancellationRequested));
         }
 
         [Fact]
@@ -77,9 +77,9 @@ namespace Sentry.Tests.Internals.Http
             var expectedEvent = new SentryEvent();
 
             _fixture.SentryOptions.Debug = true;
-            _fixture.SentryOptions.DiagnosticLogger.IsEnabled(SentryLevel.Error).Returns(true);
-            _fixture.HttpMessageHandler.VerifyableSendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
-                .Returns(_ => SentryResponses.GetErrorResponse(expectedCode, expectedMessage));
+            _ = _fixture.SentryOptions.DiagnosticLogger.IsEnabled(SentryLevel.Error).Returns(true);
+            _ = _fixture.HttpMessageHandler.VerifyableSendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
+                    .Returns(_ => SentryResponses.GetErrorResponse(expectedCode, expectedMessage));
 
             var sut = _fixture.GetSut();
 
@@ -99,9 +99,9 @@ namespace Sentry.Tests.Internals.Http
             var expectedEvent = new SentryEvent();
 
             _fixture.SentryOptions.Debug = true;
-            _fixture.SentryOptions.DiagnosticLogger.IsEnabled(SentryLevel.Error).Returns(true);
-            _fixture.HttpMessageHandler.VerifyableSendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
-                .Returns(_ => SentryResponses.GetErrorResponse(expectedCode, null));
+            _ = _fixture.SentryOptions.DiagnosticLogger.IsEnabled(SentryLevel.Error).Returns(true);
+            _ = _fixture.HttpMessageHandler.VerifyableSendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
+                    .Returns(_ => SentryResponses.GetErrorResponse(expectedCode, null));
 
             var sut = _fixture.GetSut();
 
@@ -127,7 +127,7 @@ namespace Sentry.Tests.Internals.Http
             var sut = _fixture.GetSut();
 
             var evt = new SentryEvent();
-            sut.CreateRequest(evt);
+            _ = sut.CreateRequest(evt);
 
             Assert.True(callbackInvoked);
         }

--- a/test/Sentry.Tests/Internals/Http/RetryAfterHandlerTests.cs
+++ b/test/Sentry.Tests/Internals/Http/RetryAfterHandlerTests.cs
@@ -101,7 +101,7 @@ namespace Sentry.Tests.Internals.Http
         {
             var expected = new HttpResponseMessage(TooManyRequests);
             const double floating = 292.052427053D; // Just under 5 minutes, taken from a Sentry response
-            expected.Headers.TryAddWithoutValidation("Retry-After", new[] { floating.ToString(CultureInfo.InvariantCulture) });
+            _ = expected.Headers.TryAddWithoutValidation("Retry-After", new[] { floating.ToString(CultureInfo.InvariantCulture) });
 
             _fixture.StubHandler.SendAsyncFunc = (message, token) => expected;
 
@@ -118,14 +118,14 @@ namespace Sentry.Tests.Internals.Http
         {
             var expected = new HttpResponseMessage(TooManyRequests);
             const double floating = 4138.97064495D; // Taken from a Sentry response
-            expected.Headers.TryAddWithoutValidation("Retry-After", new[] { floating.ToString(CultureInfo.InvariantCulture) });
+            _ = expected.Headers.TryAddWithoutValidation("Retry-After", new[] { floating.ToString(CultureInfo.InvariantCulture) });
 
             _fixture.StubHandler.SendAsyncFunc = (message, token) => expected;
 
             var invoker = _fixture.GetInvoker();
 
             // First call
-            await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/"), None);
+            _ = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/"), None);
             Assert.True(_fixture.StubHandler.SendAsyncCalled);
 
             _fixture.StubHandler.SendAsyncCalled = false; // reset
@@ -148,7 +148,7 @@ namespace Sentry.Tests.Internals.Http
             var invoker = _fixture.GetInvoker();
 
             // First call
-            await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/"), None);
+            _ = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/"), None);
             Assert.True(_fixture.StubHandler.SendAsyncCalled);
 
             _fixture.StubHandler.SendAsyncCalled = false; // reset
@@ -171,7 +171,7 @@ namespace Sentry.Tests.Internals.Http
             var invoker = _fixture.GetInvoker();
 
             // First call
-            await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/"), None);
+            _ = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/"), None);
             Assert.True(_fixture.StubHandler.SendAsyncCalled);
 
             _fixture.StubHandler.SendAsyncCalled = false; // reset
@@ -194,7 +194,7 @@ namespace Sentry.Tests.Internals.Http
             var invoker = _fixture.GetInvoker();
 
             // First call: Too Many Requests, RetryAfterUtcTicks
-            await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/"), None);
+            _ = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/"), None);
             Assert.True(_fixture.StubHandler.SendAsyncCalled);
             Assert.Equal(date.UtcTicks, _fixture.Sut.RetryAfterUtcTicks);
 

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
@@ -136,7 +136,7 @@ namespace Sentry.Tests.Internals
             sut.Process(exp, evt);
             var x= evt.SentryExceptions.ToList();
 
-            Assert.Single(evt.SentryExceptions.Where(p => p.Mechanism.Handled == null));
+            _ = Assert.Single(evt.SentryExceptions.Where(p => p.Mechanism.Handled == null));
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace Sentry.Tests.Internals
 
             sut.Process(exp, evt);
 
-            Assert.Single(evt.SentryExceptions.Where(p => p.Mechanism.Handled == true));
+            _ = Assert.Single(evt.SentryExceptions.Where(p => p.Mechanism.Handled == true));
         }
 
         [Fact]

--- a/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
@@ -31,7 +31,7 @@ namespace Sentry.Tests.Internals
             var sut = _fixture.GetSut();
             var evt = new SentryEvent();
 
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Null(evt.User.Username);
         }
@@ -44,7 +44,7 @@ namespace Sentry.Tests.Internals
             _fixture.SentryOptions.SendDefaultPii = true;
             var sut = _fixture.GetSut();
 
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(Environment.UserName, evt.User.Username);
         }
@@ -58,7 +58,7 @@ namespace Sentry.Tests.Internals
             _fixture.SentryOptions.IsEnvironmentUser = true;
             var sut = _fixture.GetSut();
 
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(Environment.UserName, evt.User.Username);
         }
@@ -71,7 +71,7 @@ namespace Sentry.Tests.Internals
             _fixture.SentryOptions.IsEnvironmentUser = false;
 
             var sut = _fixture.GetSut();
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Null(evt.User.Username);
         }
@@ -82,7 +82,7 @@ namespace Sentry.Tests.Internals
             var sut = _fixture.GetSut();
             var evt = new SentryEvent();
 
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Null(evt.ServerName);
         }
@@ -94,7 +94,7 @@ namespace Sentry.Tests.Internals
             var evt = new SentryEvent();
 
             _fixture.SentryOptions.SendDefaultPii = true;
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(Environment.MachineName, evt.ServerName);
         }
@@ -107,7 +107,7 @@ namespace Sentry.Tests.Internals
             var sut = _fixture.GetSut();
             var evt = new SentryEvent { ServerName = expectedServerName };
             _fixture.SentryOptions.SendDefaultPii = true;
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(expectedServerName, evt.ServerName);
         }
@@ -121,7 +121,7 @@ namespace Sentry.Tests.Internals
             var evt = new SentryEvent();
 
             _fixture.SentryOptions.SendDefaultPii = true;
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(expectedServerName, evt.ServerName);
         }
@@ -135,7 +135,7 @@ namespace Sentry.Tests.Internals
             var evt = new SentryEvent();
 
             _fixture.SentryOptions.SendDefaultPii = false;
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(expectedServerName, evt.ServerName);
         }
@@ -148,7 +148,7 @@ namespace Sentry.Tests.Internals
             var sut = _fixture.GetSut();
             var evt = new SentryEvent();
 
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(expectedVersion, evt.Release);
         }
@@ -159,7 +159,7 @@ namespace Sentry.Tests.Internals
             var sut = _fixture.GetSut();
             var evt = new SentryEvent();
 
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(sut.Release, evt.Release);
         }
@@ -172,7 +172,7 @@ namespace Sentry.Tests.Internals
             var sut = _fixture.GetSut();
             var evt = new SentryEvent();
 
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(expected, evt.Environment);
         }
@@ -189,7 +189,7 @@ namespace Sentry.Tests.Internals
                 expected,
                 () =>
                 {
-                    sut.Process(evt);
+                    _ = sut.Process(evt);
                 });
 
             Assert.Equal(expected, evt.Environment);
@@ -204,7 +204,7 @@ namespace Sentry.Tests.Internals
                 Level = null
             };
 
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(SentryLevel.Error, evt.Level);
         }
@@ -222,7 +222,7 @@ namespace Sentry.Tests.Internals
             var sut = _fixture.GetSut();
 
             var evt = new SentryEvent();
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.False(invoked);
         }
@@ -232,7 +232,7 @@ namespace Sentry.Tests.Internals
         {
             var sut = _fixture.GetSut();
             var evt = new SentryEvent();
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(Protocol.Constants.Platform, evt.Platform);
         }
@@ -242,7 +242,7 @@ namespace Sentry.Tests.Internals
         {
             var sut = _fixture.GetSut();
             var evt = new SentryEvent();
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.NotEmpty(evt.Modules);
         }
@@ -253,7 +253,7 @@ namespace Sentry.Tests.Internals
             _fixture.SentryOptions.ReportAssemblies = false;
             var sut = _fixture.GetSut();
             var evt = new SentryEvent();
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Empty(evt.Modules);
         }
@@ -264,7 +264,7 @@ namespace Sentry.Tests.Internals
             var sut = _fixture.GetSut();
             var evt = new SentryEvent();
 
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(Constants.SdkName, evt.Sdk.Name);
             Assert.Equal(typeof(ISentryClient).Assembly.GetNameAndVersion().Version, evt.Sdk.Version);
@@ -286,7 +286,7 @@ namespace Sentry.Tests.Internals
                 }
             };
 
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(expectedName, evt.Sdk.Name);
             Assert.Equal(expectedVersion, evt.Sdk.Version);
@@ -299,22 +299,22 @@ namespace Sentry.Tests.Internals
             var sut = _fixture.GetSut();
 
             var evt = new SentryEvent();
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
-            _fixture.SentryStackTraceFactory.Received(1).Create();
+            _ = _fixture.SentryStackTraceFactory.Received(1).Create();
         }
 
         [Fact]
         public void Process_AttachStacktraceTrueAndExistentThreadInEvent_AddsNewThread()
         {
             var expected = new SentryStackTrace();
-            _fixture.SentryStackTraceFactory.Create(Arg.Any<Exception>()).Returns(expected);
+            _ = _fixture.SentryStackTraceFactory.Create(Arg.Any<Exception>()).Returns(expected);
             _fixture.SentryOptions.AttachStacktrace = true;
             var sut = _fixture.GetSut();
 
             Thread.CurrentThread.Name = "second";
             var evt = new SentryEvent { SentryThreads = new []{ new SentryThread { Name = "first" }}};
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(2, evt.SentryThreads.Count());
             Assert.Equal("first", evt.SentryThreads.First().Name);
@@ -328,9 +328,9 @@ namespace Sentry.Tests.Internals
             var sut = _fixture.GetSut();
 
             var evt = new SentryEvent(new Exception());
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
-            _fixture.SentryStackTraceFactory.DidNotReceive().Create();
+            _ = _fixture.SentryStackTraceFactory.DidNotReceive().Create();
         }
 
         [Fact]
@@ -339,7 +339,7 @@ namespace Sentry.Tests.Internals
             var sut = _fixture.GetSut();
 
             var evt = new SentryEvent();
-            sut.Process(evt);
+            _ = sut.Process(evt);
 
             Assert.Equal(TimeZoneInfo.Local, evt.Contexts.Device.Timezone);
         }
@@ -357,13 +357,15 @@ namespace Sentry.Tests.Internals
 
                 var evt = new SentryEvent();
                 // Act
-                sut.Process(evt);
+                _ = sut.Process(evt);
 
                 // Assert
                 dynamic ret = evt.Contexts[key];
+#pragma warning disable IDE0058 // Expression value is never used, cannot use _ = because it'll affect the test result
                 Assert.Equal(getter().Name, ret["Name"]);
                 Assert.Equal(getter().DisplayName, ret["DisplayName"]);
                 Assert.Equal(getter().Calendar.GetType().Name, ret["Calendar"]);
+#pragma warning restore IDE0058
             }
             finally
             {

--- a/test/Sentry.Tests/Internals/SentryScopeManagerTests.cs
+++ b/test/Sentry.Tests/Internals/SentryScopeManagerTests.cs
@@ -53,7 +53,7 @@ namespace Sentry.Tests.Internals
             var sut = _fixture.GetSut();
 
             var root = sut.GetCurrent();
-            sut.PushScope();
+            _ = sut.PushScope();
 
             Assert.NotEqual(root, sut.GetCurrent());
         }
@@ -126,7 +126,7 @@ namespace Sentry.Tests.Internals
         {
             var sut = _fixture.GetSut();
             var first = sut.GetCurrent();
-            sut.PushScope();
+            _ = sut.PushScope();
             var second = sut.GetCurrent();
 
             Assert.NotEqual(first, second);
@@ -137,7 +137,7 @@ namespace Sentry.Tests.Internals
         {
             var sut = _fixture.GetSut();
             var firstScope = sut.GetCurrent();
-            sut.PushScope();
+            _ = sut.PushScope();
             var secondScope = sut.GetCurrent();
 
             Assert.Same(firstScope.Value, secondScope.Value);
@@ -148,7 +148,7 @@ namespace Sentry.Tests.Internals
         {
             var sut = _fixture.GetSut();
             var firstScope = sut.GetCurrent();
-            sut.PushScope(new object());
+            _ = sut.PushScope(new object());
             var secondScope = sut.GetCurrent();
 
             Assert.Same(firstScope.Value, secondScope.Value);
@@ -159,7 +159,7 @@ namespace Sentry.Tests.Internals
         {
             var sut = _fixture.GetSut();
             var first = sut.GetCurrent();
-            sut.PushScope(new object());
+            _ = sut.PushScope(new object());
             var second = sut.GetCurrent();
 
             Assert.NotEqual(first, second);
@@ -215,10 +215,10 @@ namespace Sentry.Tests.Internals
             // Creates event second, disposes first
             var t1 = Task.Run(() =>
             {
-                t1Evt.Set(); // unblock task start
+                _ = t1Evt.Set(); // unblock task start
 
                 // Wait t2 create scope
-                t2Evt.WaitOne();
+                _ = t2Evt.WaitOne();
                 try
                 {
                     // t2 created scope, make sure this parent is still root
@@ -232,14 +232,14 @@ namespace Sentry.Tests.Internals
                 }
                 finally
                 {
-                    t1Evt.Set();
+                    _ = t1Evt.Set();
                 }
 
                 Assert.Equal(root, sut.GetCurrent());
             });
 
-            t1Evt.WaitOne(); // Wait t1 start
-            t1Evt.Reset();
+            _ = t1Evt.WaitOne(); // Wait t1 start
+            _ = t1Evt.Reset();
 
             // Creates a scope first, disposes after t2
             var t2 = Task.Run(() =>
@@ -253,11 +253,11 @@ namespace Sentry.Tests.Internals
                 }
                 finally
                 {
-                    t2Evt.Set(); // release t1
+                    _ = t2Evt.Set(); // release t1
                 }
 
                 // Wait for t1 to create and dispose its scope
-                t1Evt.WaitOne();
+                _ = t1Evt.WaitOne();
                 scope.Dispose();
 
                 Assert.Equal(root, sut.GetCurrent());

--- a/test/Sentry.Tests/Internals/Web/SystemWebRequestEventProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/Web/SystemWebRequestEventProcessorTests.cs
@@ -20,7 +20,7 @@ namespace Sentry.Tests.Internals.Web
 
             public Fixture()
             {
-                RequestPayloadExtractor.ExtractPayload(Arg.Any<IHttpRequest>()).Returns(MockBody);
+                _ = RequestPayloadExtractor.ExtractPayload(Arg.Any<IHttpRequest>()).Returns(MockBody);
                 HttpContext = new HttpContext(new HttpRequest("test", "http://test", null), new HttpResponse(new StringWriter()));
             }
 
@@ -37,7 +37,7 @@ namespace Sentry.Tests.Internals.Web
         public void Ctor_NullEvent_ThrowsArgumentNullException()
         {
             _fixture.RequestPayloadExtractor = null;
-            Assert.Throws<ArgumentNullException>(() => _fixture.GetSut());
+            _ = Assert.Throws<ArgumentNullException>(() => _fixture.GetSut());
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace Sentry.Tests.Internals.Web
         [Fact]
         public void Process_NoBodyExtracted_NoRequestData()
         {
-            _fixture.RequestPayloadExtractor.ExtractPayload(Arg.Any<IHttpRequest>()).Returns(null);
+            _ = _fixture.RequestPayloadExtractor.ExtractPayload(Arg.Any<IHttpRequest>()).Returns(null);
             var expected = new SentryEvent();
 
             var sut = _fixture.GetSut();

--- a/test/Sentry.Tests/SentryClientExtensionsTests.cs
+++ b/test/Sentry.Tests/SentryClientExtensionsTests.cs
@@ -12,74 +12,74 @@ namespace Sentry.Tests
         [Fact]
         public void CaptureException_DisabledClient_DoesNotCaptureEvent()
         {
-            _sut.IsEnabled.Returns(false);
+            _ = _sut.IsEnabled.Returns(false);
             var id = _sut.CaptureException(new Exception());
 
-            _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
             Assert.Equal(default, id);
         }
 
         [Fact]
         public void CaptureException_EnabledClient_CapturesEvent()
         {
-            _sut.IsEnabled.Returns(true);
-            _sut.CaptureException(new Exception());
-            _sut.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _sut.IsEnabled.Returns(true);
+            _ = _sut.CaptureException(new Exception());
+            _ = _sut.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
         public void CaptureMessage_DisabledClient_DoesNotCaptureEvent()
         {
-            _sut.IsEnabled.Returns(false);
+            _ = _sut.IsEnabled.Returns(false);
             var id = _sut.CaptureMessage("Message");
 
-            _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
             Assert.Equal(default, id);
         }
 
         [Fact]
         public void CaptureMessage_EnabledClient_CapturesEvent()
         {
-            _sut.IsEnabled.Returns(true);
-            _sut.CaptureMessage("Message");
-            _sut.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _sut.IsEnabled.Returns(true);
+            _ = _sut.CaptureMessage("Message");
+            _ = _sut.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
         public void CaptureMessage_Level_CapturesEventWithLevel()
         {
             const SentryLevel expectedLevel = SentryLevel.Fatal;
-            _sut.IsEnabled.Returns(true);
-            _sut.CaptureMessage("Message", expectedLevel);
-            _sut.Received(1).CaptureEvent(Arg.Is<SentryEvent>(e => e.Level == expectedLevel));
+            _ = _sut.IsEnabled.Returns(true);
+            _ = _sut.CaptureMessage("Message", expectedLevel);
+            _ = _sut.Received(1).CaptureEvent(Arg.Is<SentryEvent>(e => e.Level == expectedLevel));
         }
 
         [Fact]
         public void CaptureMessage_Message_CapturesEventWithMessage()
         {
             const string expectedMessage = "message";
-            _sut.IsEnabled.Returns(true);
-            _sut.CaptureMessage(expectedMessage);
-            _sut.Received(1).CaptureEvent(Arg.Is<SentryEvent>(e => e.Message == expectedMessage));
+            _ = _sut.IsEnabled.Returns(true);
+            _ = _sut.CaptureMessage(expectedMessage);
+            _ = _sut.Received(1).CaptureEvent(Arg.Is<SentryEvent>(e => e.Message == expectedMessage));
         }
 
         [Fact]
         public void CaptureMessage_WhitespaceMessage_DoesNotCapturesEventWithMessage()
         {
-            _sut.IsEnabled.Returns(true);
+            _ = _sut.IsEnabled.Returns(true);
             var id = _sut.CaptureMessage("   ");
 
-            _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
             Assert.Equal(default, id);
         }
 
         [Fact]
         public void CaptureMessage_NullMessage_DoesNotCapturesEventWithMessage()
         {
-            _sut.IsEnabled.Returns(true);
+            _ = _sut.IsEnabled.Returns(true);
             var id = _sut.CaptureMessage(null);
 
-            _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+            _ = _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
             Assert.Equal(default, id);
         }
     }

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -25,21 +25,21 @@ namespace Sentry.Tests
         public void CaptureEvent_ExceptionFiltered_EmptySentryId()
         {
             _fixture.SentryOptions.AddExceptionFilterForType<SystemException>();
-            _fixture.BackgroundWorker.EnqueueEvent(Arg.Any<SentryEvent>()).Returns(true);
+            _ = _fixture.BackgroundWorker.EnqueueEvent(Arg.Any<SentryEvent>()).Returns(true);
 
             var sut = _fixture.GetSut();
 
             // Filtered out for it's the exact filtered type
             Assert.Equal(default, sut.CaptureException(new SystemException()));
-            _fixture.BackgroundWorker.DidNotReceive().EnqueueEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.BackgroundWorker.DidNotReceive().EnqueueEvent(Arg.Any<SentryEvent>());
 
             // Filtered for it's a derived type
             Assert.Equal(default, sut.CaptureException(new ArithmeticException()));
-            _fixture.BackgroundWorker.DidNotReceive().EnqueueEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.BackgroundWorker.DidNotReceive().EnqueueEvent(Arg.Any<SentryEvent>());
 
             // Not filtered since it's not in the inheritance chain
             Assert.NotEqual(default, sut.CaptureException(new Exception()));
-            _fixture.BackgroundWorker.Received(1).EnqueueEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.BackgroundWorker.Received(1).EnqueueEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace Sentry.Tests
 
             var evt = new SentryEvent(new Exception());
 
-            sut.CaptureEvent(evt);
+            _ = sut.CaptureEvent(evt);
 
             exceptionProcessor.Received(1).Process(evt.Exception, evt);
         }
@@ -80,7 +80,7 @@ namespace Sentry.Tests
 
             var evt = new SentryEvent(new Exception());
 
-            sut.CaptureEvent(evt, scope);
+            _ = sut.CaptureEvent(evt, scope);
 
             exceptionProcessor.Received(1).Process(evt.Exception, evt);
         }
@@ -104,7 +104,7 @@ namespace Sentry.Tests
         {
             var expectedId = Guid.NewGuid();
             var expectedEvent = new SentryEvent(id: expectedId);
-            _fixture.BackgroundWorker.EnqueueEvent(expectedEvent).Returns(true);
+            _ = _fixture.BackgroundWorker.EnqueueEvent(expectedEvent).Returns(true);
 
             var sut = _fixture.GetSut();
 
@@ -117,7 +117,7 @@ namespace Sentry.Tests
         {
             var expectedId = Guid.NewGuid();
             var expectedEvent = new SentryEvent(id: expectedId);
-            _fixture.BackgroundWorker.EnqueueEvent(expectedEvent).Returns(true);
+            _ = _fixture.BackgroundWorker.EnqueueEvent(expectedEvent).Returns(true);
 
             var sut = _fixture.GetSut();
 
@@ -139,7 +139,7 @@ namespace Sentry.Tests
                 evaluated = true;
             };
 
-            sut.CaptureEvent(new SentryEvent(), scope);
+            _ = sut.CaptureEvent(new SentryEvent(), scope);
 
             Assert.True(evaluated);
             Assert.Same(scope, actualSender);
@@ -154,7 +154,7 @@ namespace Sentry.Tests
             var @event = new SentryEvent();
 
             var sut = _fixture.GetSut();
-            sut.CaptureEvent(@event, scope);
+            _ = sut.CaptureEvent(@event, scope);
 
             Assert.Equal(scope.InternalBreadcrumbs, @event.InternalBreadcrumbs);
         }
@@ -169,7 +169,7 @@ namespace Sentry.Tests
             var actualId = sut.CaptureEvent(expectedEvent, new Scope(_fixture.SentryOptions));
 
             Assert.Equal(default, actualId);
-            _fixture.BackgroundWorker.DidNotReceive().EnqueueEvent(Arg.Any<SentryEvent>());
+            _ = _fixture.BackgroundWorker.DidNotReceive().EnqueueEvent(Arg.Any<SentryEvent>());
         }
 
         [Fact]
@@ -181,7 +181,7 @@ namespace Sentry.Tests
             var @event = new SentryEvent();
 
             var sut = _fixture.GetSut();
-            sut.CaptureEvent(@event);
+            _ = sut.CaptureEvent(@event);
 
             Assert.Same(@event, received);
         }
@@ -200,7 +200,7 @@ namespace Sentry.Tests
             };
 
             var sut = _fixture.GetSut();
-            sut.CaptureEvent(@event, scope);
+            _ = sut.CaptureEvent(@event, scope);
 
             Assert.Equal(expected, @event.Level);
         }
@@ -229,7 +229,7 @@ namespace Sentry.Tests
 
             var sut = _fixture.GetSut();
 
-            sut.CaptureEvent(@event);
+            _ = sut.CaptureEvent(@event);
 
             Assert.Same(@event, received);
         }
@@ -245,7 +245,7 @@ namespace Sentry.Tests
 
             var sut = _fixture.GetSut();
 
-            sut.CaptureEvent(@event);
+            _ = sut.CaptureEvent(@event);
 
             Assert.Same(@event, received);
         }
@@ -259,7 +259,7 @@ namespace Sentry.Tests
             var @event = new SentryEvent();
 
             var sut = _fixture.GetSut();
-            sut.CaptureEvent(@event);
+            _ = sut.CaptureEvent(@event);
 
             var crumb = @event.Breadcrumbs.First();
             Assert.Equal("BeforeSend callback failed.", crumb.Message);
@@ -276,7 +276,7 @@ namespace Sentry.Tests
             var @event = new SentryEvent();
 
             var sut = _fixture.GetSut();
-            sut.CaptureEvent(@event);
+            _ = sut.CaptureEvent(@event);
 
             Assert.Equal(expectedRelease, @event.Release);
         }
@@ -286,7 +286,7 @@ namespace Sentry.Tests
         {
             var sut = _fixture.GetSut();
             sut.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => sut.CaptureEvent(null));
+            _ = Assert.Throws<ObjectDisposedException>(() => sut.CaptureEvent(null));
         }
 
         [Fact]
@@ -382,7 +382,7 @@ namespace Sentry.Tests
 
             using (var sut = new SentryClient(_fixture.SentryOptions))
             {
-                Assert.IsType<BackgroundWorker>(sut.Worker);
+                _ = Assert.IsType<BackgroundWorker>(sut.Worker);
             }
         }
     }

--- a/test/Sentry.Tests/SentryOptionsExtensionsTests.cs
+++ b/test/Sentry.Tests/SentryOptionsExtensionsTests.cs
@@ -114,7 +114,7 @@ namespace Sentry.Tests
             Sut.AddExceptionProcessors(new[] { Substitute.For<ISentryEventExceptionProcessor>() });
             Sut.AddExceptionProcessor(Substitute.For<ISentryEventExceptionProcessor>());
 
-            Assert.IsType<MainExceptionProcessor>(Sut.GetAllExceptionProcessors().First());
+            _ = Assert.IsType<MainExceptionProcessor>(Sut.GetAllExceptionProcessors().First());
         }
 
         [Fact]
@@ -179,20 +179,20 @@ namespace Sentry.Tests
             Sut.AddEventProcessors(new[] { Substitute.For<ISentryEventProcessor>() });
             Sut.AddEventProcessor(Substitute.For<ISentryEventProcessor>());
 
-            Assert.IsType<MainSentryEventProcessor>(Sut.GetAllEventProcessors().Skip(1).First());
+            _ = Assert.IsType<MainSentryEventProcessor>(Sut.GetAllEventProcessors().Skip(1).First());
         }
 
         [Fact]
         public void GetAllEventProcessors_NoAdding_SecondReturned_MainSentryEventProcessor()
         {
-            Assert.IsType<MainSentryEventProcessor>(Sut.GetAllEventProcessors().Skip(1).First());
+            _ = Assert.IsType<MainSentryEventProcessor>(Sut.GetAllEventProcessors().Skip(1).First());
         }
 
         [Fact]
         public void UseStackTraceFactory_ReplacesStackTraceFactory()
         {
             var expected = Substitute.For<ISentryStackTraceFactory>();
-            Sut.UseStackTraceFactory(expected);
+            _ = Sut.UseStackTraceFactory(expected);
 
             Assert.Same(expected, Sut.SentryStackTraceFactory);
         }
@@ -204,7 +204,7 @@ namespace Sentry.Tests
             var exceptionProcessor = Sut.GetAllExceptionProcessors().OfType<MainExceptionProcessor>().Single();
 
             var expected = Substitute.For<ISentryStackTraceFactory>();
-            Sut.UseStackTraceFactory(expected);
+            _ = Sut.UseStackTraceFactory(expected);
 
             Assert.Same(expected, eventProcessor.SentryStackTraceFactoryAccessor());
             Assert.Same(expected, exceptionProcessor.SentryStackTraceFactoryAccessor());
@@ -213,7 +213,7 @@ namespace Sentry.Tests
         [Fact]
         public void UseStackTraceFactory_NotNull()
         {
-            Assert.Throws<ArgumentNullException>(() => Sut.UseStackTraceFactory(null));
+            _ = Assert.Throws<ArgumentNullException>(() => Sut.UseStackTraceFactory(null));
         }
 
         [Fact]
@@ -223,13 +223,13 @@ namespace Sentry.Tests
             Sut.AddEventProcessors(new[] { Substitute.For<ISentryEventProcessor>() });
             Sut.AddEventProcessor(Substitute.For<ISentryEventProcessor>());
 
-            Assert.IsType<DuplicateEventDetectionEventProcessor>(Sut.GetAllEventProcessors().First());
+            _ = Assert.IsType<DuplicateEventDetectionEventProcessor>(Sut.GetAllEventProcessors().First());
         }
 
         [Fact]
         public void GetAllEventProcessors_NoAdding_FirstReturned_DuplicateDetectionProcessor()
         {
-            Assert.IsType<DuplicateEventDetectionEventProcessor>(Sut.GetAllEventProcessors().First());
+            _ = Assert.IsType<DuplicateEventDetectionEventProcessor>(Sut.GetAllEventProcessors().First());
         }
 
         [Fact]

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -47,7 +47,7 @@ namespace Sentry.Tests
         [Fact]
         public void Init_BrokenDsn_Throws()
         {
-            Assert.Throws<UriFormatException>(() => SentrySdk.Init("invalid stuff"));
+            _ = Assert.Throws<UriFormatException>(() => SentrySdk.Init("invalid stuff"));
         }
 
         [Fact]
@@ -149,7 +149,7 @@ namespace Sentry.Tests
         public void Init_EmptyDsn_LogsWarning()
         {
             var logger = Substitute.For<IDiagnosticLogger>();
-            logger.IsEnabled(SentryLevel.Warning).Returns(true);
+            _ = logger.IsEnabled(SentryLevel.Warning).Returns(true);
 
             var options = new SentryOptions
             {
@@ -167,7 +167,7 @@ namespace Sentry.Tests
         public void Init_EmptyDsnDisabledDiagnostics_DoesNotLogWarning()
         {
             var logger = Substitute.For<IDiagnosticLogger>();
-            logger.IsEnabled(SentryLevel.Warning).Returns(true);
+            _ = logger.IsEnabled(SentryLevel.Warning).Returns(true);
 
             var options = new SentryOptions
             {
@@ -190,7 +190,7 @@ namespace Sentry.Tests
             SentrySdk.ConfigureScope(p =>
             {
                 called = true;
-                Assert.Single(p.Breadcrumbs);
+                _ = Assert.Single(p.Breadcrumbs);
             });
             Assert.True(called);
             called = false;
@@ -227,7 +227,7 @@ namespace Sentry.Tests
             SentrySdk.ConfigureScope(p =>
             {
                 called = true;
-                Assert.Single(p.Breadcrumbs);
+                _ = Assert.Single(p.Breadcrumbs);
             });
             Assert.True(called);
             second.Dispose();
@@ -365,9 +365,9 @@ namespace Sentry.Tests
             }))
             {
                 SentrySdk.AddBreadcrumb(expected);
-                SentrySdk.CaptureMessage("message");
+                _ = SentrySdk.CaptureMessage("message");
 
-                worker.EnqueueEvent(Arg.Is<SentryEvent>(e => e.Breadcrumbs.Single().Message == expected));
+                _ = worker.EnqueueEvent(Arg.Is<SentryEvent>(e => e.Breadcrumbs.Single().Message == expected));
             }
         }
 

--- a/test/Sentry.Tests/TaskUnobservedTaskExceptionIntegrationTests.cs
+++ b/test/Sentry.Tests/TaskUnobservedTaskExceptionIntegrationTests.cs
@@ -56,7 +56,7 @@ namespace Sentry.Tests
                 var taskStartedEvent = new ManualResetEvent(false);
                 _ = Task.Run(() =>
                 {
-                    taskStartedEvent.Set();
+                    _ = taskStartedEvent.Set();
                     throw new Exception("Unhandled on Task");
                 });
                 Assert.True(taskStartedEvent.WaitOne(TimeSpan.FromSeconds(4)));


### PR DESCRIPTION
This PR will clear a lot of errors (acting more like warnings) that won't affect the flow of the code.