### PR TITLE
Add nullable reference types support (Sentry, Sentry.Protocol)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Version>2.1.6</Version>
     <LangVersion>latest</LangVersion>
-    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../.assets/Sentry.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <Deterministic>True</Deterministic>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,21 +1,26 @@
 <Project>
+
   <PropertyGroup>
     <Version>2.1.6</Version>
-    <LangVersion>7.3</LangVersion>
-    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../.assets/Sentry.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <Deterministic>True</Deterministic>
     <Features>strict</Features>
   </PropertyGroup>
+
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <DefineConstants>SYSTEM_WEB;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
-   <ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="2.3.0" PrivateAssets="All" />
     <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="1.0.0-beta" PrivateAssets="All" />
     <PackageReference Include="Roslynator.Formatting.Analyzers" Version="1.0.0-rc" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.0" PrivateAssets="All" />
+    <PackageReference Include="Nullable" Version="1.2.1" PrivateAssets="All" />
   </ItemGroup>
+
 </Project>

--- a/src/Sentry.Protocol/BaseScope.cs
+++ b/src/Sentry.Protocol/BaseScope.cs
@@ -7,7 +7,7 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// The Scoped part of the protocol
+    /// The Scoped part of the protocol.
     /// </summary>
     /// <remarks>
     /// Members are included in the event but often modified as part
@@ -19,25 +19,25 @@ namespace Sentry.Protocol
     {
         // Default values are null so no serialization of empty objects or arrays
         [DataMember(Name = "user", EmitDefaultValue = false)]
-        internal User InternalUser { get; private set; }
+        internal User? InternalUser { get; private set; }
 
         [DataMember(Name = "contexts", EmitDefaultValue = false)]
-        internal Contexts InternalContexts { get; private set; }
+        internal Contexts? InternalContexts { get; private set; }
 
         [DataMember(Name = "request", EmitDefaultValue = false)]
-        internal Request InternalRequest { get; private set; }
+        internal Request? InternalRequest { get; private set; }
 
         [DataMember(Name = "fingerprint", EmitDefaultValue = false)]
-        internal IEnumerable<string> InternalFingerprint { get; set; }
+        internal IEnumerable<string>? InternalFingerprint { get; set; }
 
         [DataMember(Name = "breadcrumbs", EmitDefaultValue = false)]
-        internal ConcurrentQueue<Breadcrumb> InternalBreadcrumbs { get; set; }
+        internal ConcurrentQueue<Breadcrumb>? InternalBreadcrumbs { get; set; }
 
         [DataMember(Name = "extra", EmitDefaultValue = false)]
-        internal ConcurrentDictionary<string, object> InternalExtra { get; set; }
+        internal ConcurrentDictionary<string, object>? InternalExtra { get; set; }
 
         [DataMember(Name = "tags", EmitDefaultValue = false)]
-        internal ConcurrentDictionary<string, string> InternalTags { get; set; }
+        internal ConcurrentDictionary<string, string>? InternalTags { get; set; }
 
         /// <summary>
         /// An optional scope option
@@ -49,7 +49,7 @@ namespace Sentry.Protocol
         /// <returns>
         /// The options or null, if no options were defined.
         /// </returns>
-        public IScopeOptions ScopeOptions { get; }
+        public IScopeOptions? ScopeOptions { get; }
 
         /// <summary>
         /// Sentry level
@@ -67,7 +67,7 @@ namespace Sentry.Protocol
         /// (which have route template /user/{id}) are identified as the same transaction.
         /// </remarks>
         [DataMember(Name = "transaction", EmitDefaultValue = false)]
-        public string Transaction { get; set; }
+        public string? Transaction { get; set; }
 
         /// <summary>
         /// Gets or sets the HTTP.
@@ -77,7 +77,7 @@ namespace Sentry.Protocol
         /// </value>
         public Request Request
         {
-            get => InternalRequest ?? (InternalRequest = new Request());
+            get => InternalRequest ??= new Request();
             set => InternalRequest = value;
         }
 
@@ -89,7 +89,7 @@ namespace Sentry.Protocol
         /// </value>
         public Contexts Contexts
         {
-            get => InternalContexts ?? (InternalContexts = new Contexts());
+            get => InternalContexts ??= new Contexts();
             set => InternalContexts = value;
         }
 
@@ -101,7 +101,7 @@ namespace Sentry.Protocol
         /// </value>
         public User User
         {
-            get => InternalUser ?? (InternalUser = new User());
+            get => InternalUser ??= new User();
             set => InternalUser = value;
         }
 
@@ -110,14 +110,14 @@ namespace Sentry.Protocol
         /// </summary>
         /// <remarks>Requires Sentry 8.0 or higher</remarks>
         [DataMember(Name = "environment", EmitDefaultValue = false)]
-        public string Environment { get; set; }
+        public string? Environment { get; set; }
 
         /// <summary>
         /// SDK information
         /// </summary>
         /// <remarks>New in Sentry version: 8.4</remarks>
         [DataMember(Name = "sdk", EmitDefaultValue = false)]
-        public SdkVersion Sdk { get; internal set; } = new SdkVersion();
+        public SdkVersion? Sdk { get; internal set; } = new SdkVersion();
 
         /// <summary>
         /// A list of strings used to dictate the deduplication of this event.
@@ -135,7 +135,7 @@ namespace Sentry.Protocol
         /// A trail of events which happened prior to an issue.
         /// </summary>
         /// <seealso href="https://docs.sentry.io/learn/breadcrumbs/"/>
-        public IEnumerable<Breadcrumb> Breadcrumbs => InternalBreadcrumbs ?? (InternalBreadcrumbs = new ConcurrentQueue<Breadcrumb>());
+        public IEnumerable<Breadcrumb> Breadcrumbs => InternalBreadcrumbs ??= new ConcurrentQueue<Breadcrumb>();
 
         /// <summary>
         /// An arbitrary mapping of additional metadata to store with the event.
@@ -146,7 +146,7 @@ namespace Sentry.Protocol
 #else
             IReadOnlyDictionary<string, object>
 #endif
-            Extra => InternalExtra ?? (InternalExtra = new ConcurrentDictionary<string, object>());
+            Extra => InternalExtra ??= new ConcurrentDictionary<string, object>();
 
         /// <summary>
         /// Arbitrary key-value for this event
@@ -157,11 +157,11 @@ namespace Sentry.Protocol
 #else
             IReadOnlyDictionary<string, string>
 #endif
-            Tags => InternalTags ?? (InternalTags = new ConcurrentDictionary<string, string>());
+            Tags => InternalTags ??= new ConcurrentDictionary<string, string>();
 
         /// <summary>
         /// Creates a scope with the specified options
         /// </summary>
-        public BaseScope(IScopeOptions options) => ScopeOptions = options;
+        public BaseScope(IScopeOptions? options) => ScopeOptions = options;
     }
 }

--- a/src/Sentry.Protocol/BaseScope.cs
+++ b/src/Sentry.Protocol/BaseScope.cs
@@ -40,11 +40,11 @@ namespace Sentry.Protocol
         internal ConcurrentDictionary<string, string>? InternalTags { get; set; }
 
         /// <summary>
-        /// An optional scope option
+        /// An optional scope option.
         /// </summary>
         /// <remarks>
         /// Options are not mandatory. it allows defining callback for deciding
-        /// on adding breadcrumbs and the max breadcrumbs allowed
+        /// on adding breadcrumbs and the max breadcrumbs allowed.
         /// </remarks>
         /// <returns>
         /// The options or null, if no options were defined.
@@ -52,7 +52,7 @@ namespace Sentry.Protocol
         public IScopeOptions? ScopeOptions { get; }
 
         /// <summary>
-        /// Sentry level
+        /// Sentry level.
         /// </summary>
         [DataMember(Name = "level", EmitDefaultValue = false)]
         public SentryLevel? Level { get; set; }
@@ -61,7 +61,7 @@ namespace Sentry.Protocol
         /// The name of the transaction in which there was an event.
         /// </summary>
         /// <remarks>
-        /// A transaction should only be defined when it can be well defined
+        /// A transaction should only be defined when it can be well defined.
         /// On a Web framework, for example, a transaction is the route template
         /// rather than the actual request path. That is so GET /user/10 and /user/20
         /// (which have route template /user/{id}) are identified as the same transaction.
@@ -82,7 +82,7 @@ namespace Sentry.Protocol
         }
 
         /// <summary>
-        /// Gets the structured Sentry context
+        /// Gets the structured Sentry context.
         /// </summary>
         /// <value>
         /// The contexts.
@@ -94,7 +94,7 @@ namespace Sentry.Protocol
         }
 
         /// <summary>
-        /// Gets the user information
+        /// Gets the user information.
         /// </summary>
         /// <value>
         /// The user.
@@ -108,12 +108,12 @@ namespace Sentry.Protocol
         /// <summary>
         /// The environment name, such as 'production' or 'staging'.
         /// </summary>
-        /// <remarks>Requires Sentry 8.0 or higher</remarks>
+        /// <remarks>Requires Sentry 8.0 or higher.</remarks>
         [DataMember(Name = "environment", EmitDefaultValue = false)]
         public string? Environment { get; set; }
 
         /// <summary>
-        /// SDK information
+        /// SDK information.
         /// </summary>
         /// <remarks>New in Sentry version: 8.4</remarks>
         [DataMember(Name = "sdk", EmitDefaultValue = false)]

--- a/src/Sentry.Protocol/BaseScopeExtensions.cs
+++ b/src/Sentry.Protocol/BaseScopeExtensions.cs
@@ -138,7 +138,7 @@ namespace Sentry
                 }
             }
 
-            var breadcrumbs = (ConcurrentQueue<Breadcrumb>) scope.Breadcrumbs;
+            var breadcrumbs = (ConcurrentQueue<Breadcrumb>)scope.Breadcrumbs;
 
             var overflow = breadcrumbs.Count - (scope.ScopeOptions?.MaxBreadcrumbs
                                                 ?? Constants.DefaultMaxBreadcrumbs) + 1;
@@ -165,7 +165,7 @@ namespace Sentry
         /// <param name="key">The key.</param>
         /// <param name="value">The value.</param>
         public static void SetExtra(this BaseScope scope, string key, object value)
-            => ((ConcurrentDictionary<string, object>) scope.Extra).AddOrUpdate(key, value, (s, o) => value);
+            => ((ConcurrentDictionary<string, object>)scope.Extra).AddOrUpdate(key, value, (s, o) => value);
 
         /// <summary>
         /// Sets the extra key-value pairs to the <see cref="BaseScope"/>.
@@ -174,7 +174,7 @@ namespace Sentry
         /// <param name="values">The values.</param>
         public static void SetExtras(this BaseScope scope, IEnumerable<KeyValuePair<string, object>> values)
         {
-            var extra = (ConcurrentDictionary<string, object>) scope.Extra;
+            var extra = (ConcurrentDictionary<string, object>)scope.Extra;
             foreach (var keyValuePair in values)
             {
                 _ = extra.AddOrUpdate(keyValuePair.Key, keyValuePair.Value, (_, o) => keyValuePair.Value);
@@ -197,7 +197,7 @@ namespace Sentry
         /// <param name="tags"></param>
         public static void SetTags(this BaseScope scope, IEnumerable<KeyValuePair<string, string>> tags)
         {
-            var internalTags = (ConcurrentDictionary<string, string>) scope.Tags;
+            var internalTags = (ConcurrentDictionary<string, string>)scope.Tags;
             foreach (var keyValuePair in tags)
             {
                 _ = internalTags.AddOrUpdate(keyValuePair.Key, keyValuePair.Value, (s, o) => keyValuePair.Value);
@@ -248,7 +248,7 @@ namespace Sentry
             {
                 foreach (var extra in from.Extra)
                 {
-                    _ = ((ConcurrentDictionary<string, object>) to.Extra).TryAdd(extra.Key, extra.Value);
+                    _ = ((ConcurrentDictionary<string, object>)to.Extra).TryAdd(extra.Key, extra.Value);
                 }
             }
 
@@ -256,7 +256,7 @@ namespace Sentry
             {
                 foreach (var tag in from.Tags)
                 {
-                    _ = ((ConcurrentDictionary<string, string>) to.Tags).TryAdd(tag.Key, tag.Value);
+                    _ = ((ConcurrentDictionary<string, string>)to.Tags).TryAdd(tag.Key, tag.Value);
                 }
             }
 

--- a/src/Sentry.Protocol/BaseScopeExtensions.cs
+++ b/src/Sentry.Protocol/BaseScopeExtensions.cs
@@ -39,7 +39,7 @@ namespace Sentry
         /// <param name="level">The level.</param>
         public static void AddBreadcrumb(
             this BaseScope scope,
-            string? message,
+            string message,
             string? category,
             string? type,
             in (string, string)? dataPair = null,
@@ -83,7 +83,7 @@ namespace Sentry
         /// <param name="level">The level.</param>
         public static void AddBreadcrumb(
             this BaseScope scope,
-            string? message,
+            string message,
             string? category = null,
             string? type = null,
             Dictionary<string, string>? data = null,
@@ -122,7 +122,7 @@ namespace Sentry
         public static void AddBreadcrumb(
             this BaseScope scope,
             DateTimeOffset? timestamp,
-            string? message,
+            string message,
             string? category = null,
             string? type = null,
             IReadOnlyDictionary<string, string>? data = null,

--- a/src/Sentry.Protocol/BaseScopeExtensions.cs
+++ b/src/Sentry.Protocol/BaseScopeExtensions.cs
@@ -29,23 +29,24 @@ namespace Sentry
 
 #if HAS_VALUE_TUPLE
         /// <summary>
-        /// Adds a breadcrumb to the scope
+        /// Adds a breadcrumb to the scope.
         /// </summary>
         /// <param name="scope">The scope.</param>
         /// <param name="message">The message.</param>
-        /// <param name="type">The type.</param>
         /// <param name="category">The category.</param>
+        /// <param name="type">The type.</param>
         /// <param name="dataPair">The data key-value pair.</param>
         /// <param name="level">The level.</param>
         public static void AddBreadcrumb(
-                    this BaseScope scope,
-                    string message,
-                    string category,
-                    string type,
-                    in (string, string)? dataPair = null,
-                    BreadcrumbLevel level = default)
+            this BaseScope scope,
+            string? message,
+            string? category,
+            string? type,
+            in (string, string)? dataPair = null,
+            BreadcrumbLevel level = default)
         {
-            Dictionary<string, string> data = null;
+            Dictionary<string, string>? data = null;
+
             if (dataPair != null)
             {
                 data = new Dictionary<string, string>
@@ -55,12 +56,12 @@ namespace Sentry
             }
 
             scope.AddBreadcrumb(
-                timestamp: null,
-                message: message,
-                category: category,
-                type: type,
-                data: data,
-                level: level);
+                null,
+                message,
+                category,
+                type,
+                data,
+                level);
         }
 #endif
 
@@ -75,23 +76,23 @@ namespace Sentry
         /// <param name="level">The level.</param>
         public static void AddBreadcrumb(
             this BaseScope scope,
-            string message,
-            string category = null,
-            string type = null,
-            Dictionary<string, string> data = null,
+            string? message,
+            string? category = null,
+            string? type = null,
+            Dictionary<string, string>? data = null,
             BreadcrumbLevel level = default)
         {
             scope.AddBreadcrumb(
-                timestamp: null,
-                message: message,
-                category: category,
-                type: type,
-                data: data,
-                level: level);
+                null,
+                message,
+                category,
+                type,
+                data,
+                level);
         }
 
         /// <summary>
-        /// Adds a breadcrumb to the scope
+        /// Adds a breadcrumb to the scope.
         /// </summary>
         /// <remarks>
         /// This overload is used for testing.
@@ -107,23 +108,23 @@ namespace Sentry
         public static void AddBreadcrumb(
             this BaseScope scope,
             DateTimeOffset? timestamp,
-            string message,
-            string category = null,
-            string type = null,
-            IReadOnlyDictionary<string, string> data = null,
+            string? message,
+            string? category = null,
+            string? type = null,
+            IReadOnlyDictionary<string, string>? data = null,
             BreadcrumbLevel level = default)
             => scope.AddBreadcrumb(new Breadcrumb(
-                timestamp: timestamp,
-                message: message,
-                type: type,
-                data: data,
-                category: category,
-                level: level));
+                timestamp,
+                message,
+                type,
+                data,
+                category,
+                level));
 
         /// <summary>
-        /// Adds a breadcrumb to the <see cref="BaseScope"/>
+        /// Adds a breadcrumb to the <see cref="BaseScope"/>.
         /// </summary>
-        /// <param name="scope">Scope</param>
+        /// <param name="scope">Scope.</param>
         /// <param name="breadcrumb">The breadcrumb.</param>
         internal static void AddBreadcrumb(this BaseScope scope, Breadcrumb breadcrumb)
         {
@@ -132,9 +133,9 @@ namespace Sentry
                 return;
             }
 
-            if (scope.ScopeOptions?.BeforeBreadcrumb is Func<Breadcrumb, Breadcrumb> callback)
+            if (scope.ScopeOptions?.BeforeBreadcrumb != null)
             {
-                breadcrumb = callback(breadcrumb);
+                breadcrumb = scope.ScopeOptions.BeforeBreadcrumb(breadcrumb);
 
                 if (breadcrumb == null)
                 {
@@ -142,7 +143,7 @@ namespace Sentry
                 }
             }
 
-            var breadcrumbs = (ConcurrentQueue<Breadcrumb>)scope.Breadcrumbs;
+            var breadcrumbs = (ConcurrentQueue<Breadcrumb>) scope.Breadcrumbs;
 
             var overflow = breadcrumbs.Count - (scope.ScopeOptions?.MaxBreadcrumbs
                                                 ?? Constants.DefaultMaxBreadcrumbs) + 1;
@@ -155,7 +156,7 @@ namespace Sentry
         }
 
         /// <summary>
-        /// Sets the fingerprint to the <see cref="BaseScope"/>
+        /// Sets the fingerprint to the <see cref="BaseScope"/>.
         /// </summary>
         /// <param name="scope">The scope.</param>
         /// <param name="fingerprint">The fingerprint.</param>
@@ -163,7 +164,7 @@ namespace Sentry
             => scope.InternalFingerprint = fingerprint;
 
         /// <summary>
-        /// Sets the extra key-value to the <see cref="BaseScope"/>
+        /// Sets the extra key-value to the <see cref="BaseScope"/>.
         /// </summary>
         /// <param name="scope">The scope.</param>
         /// <param name="key">The key.</param>
@@ -172,7 +173,7 @@ namespace Sentry
             => ((ConcurrentDictionary<string, object>)scope.Extra).AddOrUpdate(key, value, (s, o) => value);
 
         /// <summary>
-        /// Sets the extra key-value pairs to the <see cref="BaseScope"/>
+        /// Sets the extra key-value pairs to the <see cref="BaseScope"/>.
         /// </summary>
         /// <param name="scope">The scope.</param>
         /// <param name="values">The values.</param>
@@ -181,12 +182,12 @@ namespace Sentry
             var extra = (ConcurrentDictionary<string, object>)scope.Extra;
             foreach (var keyValuePair in values)
             {
-                _ = extra.AddOrUpdate(keyValuePair.Key, keyValuePair.Value, (s, o) => keyValuePair.Value);
+                _ = extra.AddOrUpdate(keyValuePair.Key, keyValuePair.Value, (_, o) => keyValuePair.Value);
             }
         }
 
         /// <summary>
-        /// Sets the tag to the <see cref="BaseScope"/>
+        /// Sets the tag to the <see cref="BaseScope"/>.
         /// </summary>
         /// <param name="scope">The scope.</param>
         /// <param name="key">The key.</param>
@@ -195,7 +196,7 @@ namespace Sentry
             => ((ConcurrentDictionary<string, string>)scope.Tags).AddOrUpdate(key, value, (s, o) => value);
 
         /// <summary>
-        /// Set all items as tags
+        /// Set all items as tags.
         /// </summary>
         /// <param name="scope">The scope.</param>
         /// <param name="tags"></param>
@@ -209,7 +210,7 @@ namespace Sentry
         }
 
         /// <summary>
-        /// Removes a tag from the <see cref="BaseScope"/>
+        /// Removes a tag from the <see cref="BaseScope"/>.
         /// </summary>
         /// <param name="scope">The scope.</param>
         /// <param name="key"></param>
@@ -217,7 +218,7 @@ namespace Sentry
             => scope.InternalTags?.TryRemove(key, out _);
 
         /// <summary>
-        /// Applies the data from one scope to the other while
+        /// Applies the data from one scope to the other.
         /// </summary>
         /// <param name="from">The scope to data copy from.</param>
         /// <param name="to">The scope to copy data to.</param>
@@ -227,7 +228,7 @@ namespace Sentry
         /// Conflicting keys are not overriden
         /// This is a shallow copy.
         /// </remarks>
-        public static void Apply(this BaseScope from, BaseScope to)
+        public static void Apply(this BaseScope? from, BaseScope? to)
         {
             if (from == null || to == null)
             {
@@ -245,14 +246,14 @@ namespace Sentry
 
             if (from.InternalBreadcrumbs != null)
             {
-                _ = ((ConcurrentQueue<Breadcrumb>)to.Breadcrumbs).EnqueueAll(from.InternalBreadcrumbs);
+                _ = ((ConcurrentQueue<Breadcrumb>) to.Breadcrumbs).EnqueueAll(from.InternalBreadcrumbs);
             }
 
             if (from.InternalExtra != null)
             {
                 foreach (var extra in from.Extra)
                 {
-                    _ = ((ConcurrentDictionary<string, object>)to.Extra).TryAdd(extra.Key, extra.Value);
+                    _ = ((ConcurrentDictionary<string, object>) to.Extra).TryAdd(extra.Key, extra.Value);
                 }
             }
 
@@ -260,7 +261,7 @@ namespace Sentry
             {
                 foreach (var tag in from.Tags)
                 {
-                    _ = ((ConcurrentDictionary<string, string>)to.Tags).TryAdd(tag.Key, tag.Value);
+                    _ = ((ConcurrentDictionary<string, string>) to.Tags).TryAdd(tag.Key, tag.Value);
                 }
             }
 
@@ -268,22 +269,13 @@ namespace Sentry
             from.InternalRequest?.CopyTo(to.Request);
             from.InternalUser?.CopyTo(to.User);
 
-            if (to.Environment == null)
-            {
-                to.Environment = from.Environment;
-            }
+            to.Environment ??= from.Environment;
 
-            if (to.Transaction == null)
-            {
-                to.Transaction = from.Transaction;
-            }
+            to.Transaction ??= from.Transaction;
 
-            if (to.Level == null)
-            {
-                to.Level = from.Level;
-            }
+            to.Level ??= from.Level;
 
-            if (from.Sdk != null)
+            if (from.Sdk != null && to.Sdk != null)
             {
                 if (from.Sdk.Name != null && from.Sdk.Version != null)
                 {
@@ -302,7 +294,7 @@ namespace Sentry
         }
 
         /// <summary>
-        /// Applies the state object into the scope
+        /// Applies the state object into the scope.
         /// </summary>
         /// <param name="scope">The scope to apply the data.</param>
         /// <param name="state">The state object to apply.</param>
@@ -323,7 +315,7 @@ namespace Sentry
                         scope.SetTags(keyValStringObject
                             .Select(k => new KeyValuePair<string, string>(
                                 k.Key,
-                                k.Value?.ToString()))
+                                k.Value?.ToString()!))
                             .Where(kv => !string.IsNullOrEmpty(kv.Value)));
 
                         break;

--- a/src/Sentry.Protocol/BaseScopeExtensions.cs
+++ b/src/Sentry.Protocol/BaseScopeExtensions.cs
@@ -45,6 +45,13 @@ namespace Sentry
             in (string, string)? dataPair = null,
             BreadcrumbLevel level = default)
         {
+            // Not to throw on code that ignores nullability warnings.
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            if (scope is null)
+            {
+                return;
+            }
+
             Dictionary<string, string>? data = null;
 
             if (dataPair != null)
@@ -82,6 +89,13 @@ namespace Sentry
             Dictionary<string, string>? data = null,
             BreadcrumbLevel level = default)
         {
+            // Not to throw on code that ignores nullability warnings.
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            if (scope is null)
+            {
+                return;
+            }
+
             scope.AddBreadcrumb(
                 null,
                 message,
@@ -113,13 +127,22 @@ namespace Sentry
             string? type = null,
             IReadOnlyDictionary<string, string>? data = null,
             BreadcrumbLevel level = default)
-            => scope.AddBreadcrumb(new Breadcrumb(
+        {
+            // Not to throw on code that ignores nullability warnings.
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            if (scope is null)
+            {
+                return;
+            }
+
+            scope.AddBreadcrumb(new Breadcrumb(
                 timestamp,
                 message,
                 type,
                 data,
                 category,
                 level));
+        }
 
         /// <summary>
         /// Adds a breadcrumb to the <see cref="BaseScope"/>.
@@ -128,7 +151,7 @@ namespace Sentry
         /// <param name="breadcrumb">The breadcrumb.</param>
         internal static void AddBreadcrumb(this BaseScope scope, Breadcrumb breadcrumb)
         {
-            if (scope.ScopeOptions?.BeforeBreadcrumb is {} beforeBreadcrumb)
+            if (scope.ScopeOptions?.BeforeBreadcrumb is { } beforeBreadcrumb)
             {
                 breadcrumb = beforeBreadcrumb(breadcrumb);
 
@@ -223,9 +246,11 @@ namespace Sentry
         /// Conflicting keys are not overriden.
         /// This is a shallow copy.
         /// </remarks>
-        public static void Apply(this BaseScope from, BaseScope? to)
+        public static void Apply(this BaseScope from, BaseScope to)
         {
-            if (to == null)
+            // Not to throw on code that ignores nullability warnings.
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            if (from is null || to is null)
             {
                 return;
             }
@@ -270,7 +295,7 @@ namespace Sentry
 
             to.Level ??= from.Level;
 
-            if (from.Sdk == null || to.Sdk == null)
+            if (from.Sdk is null || to.Sdk is null)
                 return;
 
             if (from.Sdk.Name != null && from.Sdk.Version != null)

--- a/src/Sentry.Protocol/BaseScopeExtensions.cs
+++ b/src/Sentry.Protocol/BaseScopeExtensions.cs
@@ -155,7 +155,7 @@ namespace Sentry
         /// </summary>
         /// <param name="scope">The scope.</param>
         /// <param name="fingerprint">The fingerprint.</param>
-        public static void SetFingerprint(this BaseScope scope, IEnumerable<string> fingerprint)
+        public static void SetFingerprint(this BaseScope scope, IEnumerable<string>? fingerprint)
             => scope.InternalFingerprint = fingerprint;
 
         /// <summary>
@@ -223,8 +223,13 @@ namespace Sentry
         /// Conflicting keys are not overriden.
         /// This is a shallow copy.
         /// </remarks>
-        public static void Apply(this BaseScope from, BaseScope to)
+        public static void Apply(this BaseScope from, BaseScope? to)
         {
+            if (to == null)
+            {
+                return;
+            }
+
             // Fingerprint isn't combined. It's absolute.
             // One set explicitly on target (i.e: event)
             // takes precedence and is not overwritten

--- a/src/Sentry.Protocol/BaseScopeExtensions.cs
+++ b/src/Sentry.Protocol/BaseScopeExtensions.cs
@@ -128,9 +128,9 @@ namespace Sentry
         /// <param name="breadcrumb">The breadcrumb.</param>
         internal static void AddBreadcrumb(this BaseScope scope, Breadcrumb breadcrumb)
         {
-            if (scope.ScopeOptions?.BeforeBreadcrumb != null)
+            if (scope.ScopeOptions?.BeforeBreadcrumb is {} beforeBreadcrumb)
             {
-                breadcrumb = scope.ScopeOptions.BeforeBreadcrumb(breadcrumb);
+                breadcrumb = beforeBreadcrumb(breadcrumb);
 
                 if (breadcrumb == null)
                 {
@@ -177,7 +177,7 @@ namespace Sentry
             var extra = (ConcurrentDictionary<string, object>)scope.Extra;
             foreach (var keyValuePair in values)
             {
-                _ = extra.AddOrUpdate(keyValuePair.Key, keyValuePair.Value, (_, o) => keyValuePair.Value);
+                _ = extra.AddOrUpdate(keyValuePair.Key, keyValuePair.Value, (s, o) => keyValuePair.Value);
             }
         }
 
@@ -188,7 +188,7 @@ namespace Sentry
         /// <param name="key">The key.</param>
         /// <param name="value">The value.</param>
         public static void SetTag(this BaseScope scope, string key, string value)
-            => ((ConcurrentDictionary<string, string>) scope.Tags).AddOrUpdate(key, value, (s, o) => value);
+            => ((ConcurrentDictionary<string, string>)scope.Tags).AddOrUpdate(key, value, (s, o) => value);
 
         /// <summary>
         /// Set all items as tags.

--- a/src/Sentry.Protocol/BaseScopeExtensions.cs
+++ b/src/Sentry.Protocol/BaseScopeExtensions.cs
@@ -241,7 +241,7 @@ namespace Sentry
 
             if (from.InternalBreadcrumbs != null)
             {
-                _ = ((ConcurrentQueue<Breadcrumb>) to.Breadcrumbs).EnqueueAll(from.InternalBreadcrumbs);
+                _ = ((ConcurrentQueue<Breadcrumb>)to.Breadcrumbs).EnqueueAll(from.InternalBreadcrumbs);
             }
 
             if (from.InternalExtra != null)

--- a/src/Sentry.Protocol/Breadcrumb.cs
+++ b/src/Sentry.Protocol/Breadcrumb.cs
@@ -8,7 +8,7 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// Series of application events
+    /// Series of application events.
     /// </summary>
     [DataContract]
     [DebuggerDisplay("Message: {" + nameof(Message) + "}, Type: {" + nameof(Type) + "}")]
@@ -30,7 +30,7 @@ namespace Sentry.Protocol
         /// Very long text might be abbreviated in the UI.
         /// </summary>
         [DataMember(Name = "message", EmitDefaultValue = false)]
-        public string Message { get; }
+        public string? Message { get; }
 
         /// <summary>
         /// The type of breadcrumb.
@@ -40,7 +40,7 @@ namespace Sentry.Protocol
         /// Other types are currently http for HTTP requests and navigation for navigation events.
         /// </remarks>
         [DataMember(Name = "type", EmitDefaultValue = false)]
-        public string Type { get; }
+        public string? Type { get; }
 
         /// <summary>
         /// Data associated with this breadcrumb.
@@ -50,7 +50,7 @@ namespace Sentry.Protocol
         /// Additional parameters that are unsupported by the type are rendered as a key/value table.
         /// </remarks>
         [DataMember(Name = "data", EmitDefaultValue = false)]
-        public IReadOnlyDictionary<string, string> Data { get; }
+        public IReadOnlyDictionary<string, string>? Data { get; }
 
         /// <summary>
         /// Dotted strings that indicate what the crumb is or where it comes from.
@@ -60,13 +60,13 @@ namespace Sentry.Protocol
         /// For instance aspnet.mvc.filter could be used to indicate that it came from an Action Filter.
         /// </remarks>
         [DataMember(Name = "category", EmitDefaultValue = false)]
-        public string Category { get; }
+        public string? Category { get; }
 
         /// <summary>
         /// The level of the event.
         /// </summary>
         /// <remarks>
-        /// Levels are used in the UI to emphasize and deemphasize the crumb.
+        /// Levels are used in the UI to emphasize and de-emphasize the crumb.
         /// </remarks>
         [DataMember(Name = "level", EmitDefaultValue = false)]
         public BreadcrumbLevel Level { get; }
@@ -82,8 +82,8 @@ namespace Sentry.Protocol
         public Breadcrumb(
             string message,
             string type,
-            IReadOnlyDictionary<string, string> data = null,
-            string category = null,
+            IReadOnlyDictionary<string, string>? data = null,
+            string? category = null,
             BreadcrumbLevel level = default)
         : this(
             null,
@@ -107,10 +107,10 @@ namespace Sentry.Protocol
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal Breadcrumb(
             DateTimeOffset? timestamp = null,
-            string message = null,
-            string type = null,
-            IReadOnlyDictionary<string, string> data = null,
-            string category = null,
+            string? message = null,
+            string? type = null,
+            IReadOnlyDictionary<string, string>? data = null,
+            string? category = null,
             BreadcrumbLevel level = default)
         {
             Timestamp = timestamp ?? DateTimeOffset.UtcNow;

--- a/src/Sentry.Protocol/BreadcrumbLevel.cs
+++ b/src/Sentry.Protocol/BreadcrumbLevel.cs
@@ -3,35 +3,39 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// The level of the Breadcrumb
+    /// The level of the Breadcrumb.
     /// </summary>
     public enum BreadcrumbLevel
     {
         /// <summary>
-        /// Debug level
+        /// Debug level.
         /// </summary>
         [EnumMember(Value = "debug")]
         Debug = -1,
+
         /// <summary>
-        /// Information level
+        /// Information level.
         /// </summary>
         /// <remarks>
-        /// This is value 0, hence, default
+        /// This is value 0, hence, default.
         /// </remarks>
         [EnumMember(Value = "info")]
         Info = 0, // Defaults to Info
+
         /// <summary>
-        /// Warning breadcrumb level
+        /// Warning breadcrumb level.
         /// </summary>
         [EnumMember(Value = "warning")]
         Warning = 1,
+
         /// <summary>
-        /// Error breadcrumb level
+        /// Error breadcrumb level.
         /// </summary>
         [EnumMember(Value = "error")]
         Error = 2,
+
         /// <summary>
-        /// Critical breadcrumb level
+        /// Critical breadcrumb level.
         /// </summary>
         [EnumMember(Value = "critical")]
         Critical = 3,

--- a/src/Sentry.Protocol/CollectionsExtensions.cs
+++ b/src/Sentry.Protocol/CollectionsExtensions.cs
@@ -21,13 +21,9 @@ namespace Sentry.Protocol
             return target;
         }
 
-        public static void TryCopyTo<TKey, TValue>(this IDictionary<TKey, TValue>? from, IDictionary<TKey, TValue>? to)
+        public static void TryCopyTo<TKey, TValue>(this IDictionary<TKey, TValue> from, IDictionary<TKey, TValue> to)
+            where TKey : notnull
         {
-            if (from == null || to == null)
-            {
-                return;
-            }
-
             foreach (var kv in from)
             {
                 if (!to.ContainsKey(kv.Key))

--- a/src/Sentry.Protocol/CollectionsExtensions.cs
+++ b/src/Sentry.Protocol/CollectionsExtensions.cs
@@ -9,7 +9,7 @@ namespace Sentry.Protocol
             this ConcurrentDictionary<string, object> dictionary,
             string key)
             where TValue : class, new()
-            => dictionary.GetOrAdd(key, _ => new TValue()) as TValue;
+            => (TValue) dictionary.GetOrAdd(key, _ => new TValue());
 
         public static ConcurrentQueue<T> EnqueueAll<T>(this ConcurrentQueue<T> target, IEnumerable<T> values)
         {
@@ -21,7 +21,7 @@ namespace Sentry.Protocol
             return target;
         }
 
-        public static void TryCopyTo<TKey, TValue>(this IDictionary<TKey, TValue> from, IDictionary<TKey, TValue> to)
+        public static void TryCopyTo<TKey, TValue>(this IDictionary<TKey, TValue>? from, IDictionary<TKey, TValue>? to)
         {
             if (from == null || to == null)
             {

--- a/src/Sentry.Protocol/Constants.cs
+++ b/src/Sentry.Protocol/Constants.cs
@@ -10,16 +10,19 @@ namespace Sentry.Protocol
         /// </summary>
         /// <see href="https://docs.sentry.io/clientdev/overview/#usage-for-end-users"/>
         public const string DisableSdkDsnValue = "";
+
         /// <summary>
         /// Default maximum number of breadcrumbs to hold in memory.
         /// </summary>
         public const int DefaultMaxBreadcrumbs = 100;
+
         /// <summary>
         /// Protocol version.
         /// </summary>
         public const int ProtocolVersion = 7;
+
         /// <summary>
-        /// Platform key that defines an events is coming from any .NET implementation
+        /// Platform key that defines an events is coming from any .NET implementation.
         /// </summary>
         public const string Platform = "csharp";
     }

--- a/src/Sentry.Protocol/Context/App.cs
+++ b/src/Sentry.Protocol/Context/App.cs
@@ -20,46 +20,52 @@ namespace Sentry.Protocol
         /// </summary>
         [DataMember(Name = "type", EmitDefaultValue = false)]
         public const string Type = "app";
+
         /// <summary>
         /// Version-independent application identifier, often a dotted bundle ID.
         /// </summary>
         [DataMember(Name = "app_identifier", EmitDefaultValue = false)]
-        public string Identifier { get; set; }
+        public string? Identifier { get; set; }
+
         /// <summary>
         /// Formatted UTC timestamp when the application was started by the user.
         /// </summary>
         [DataMember(Name = "app_start_time", EmitDefaultValue = false)]
         public DateTimeOffset? StartTime { get; set; }
+
         /// <summary>
         /// Application specific device identifier.
         /// </summary>
         [DataMember(Name = "device_app_hash", EmitDefaultValue = false)]
-        public string Hash { get; set; }
+        public string? Hash { get; set; }
+
         /// <summary>
         /// String identifying the kind of build, e.g. testflight.
         /// </summary>
         [DataMember(Name = "build_type", EmitDefaultValue = false)]
-        public string BuildType { get; set; }
+        public string? BuildType { get; set; }
+
         /// <summary>
         /// Human readable application name, as it appears on the platform.
         /// </summary>
         [DataMember(Name = "app_name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
+
         /// <summary>
         /// Human readable application version, as it appears on the platform.
         /// </summary>
         [DataMember(Name = "app_version", EmitDefaultValue = false)]
-        public string Version { get; set; }
+        public string? Version { get; set; }
+
         /// <summary>
         /// Internal build identifier, as it appears on the platform.
         /// </summary>
         [DataMember(Name = "app_build", EmitDefaultValue = false)]
-        public string Build { get; set; }
+        public string? Build { get; set; }
 
         /// <summary>
-        /// Clones this instance
+        /// Clones this instance.
         /// </summary>
-        /// <returns></returns>
         internal App Clone()
             => new App
             {

--- a/src/Sentry.Protocol/Context/Browser.cs
+++ b/src/Sentry.Protocol/Context/Browser.cs
@@ -17,21 +17,22 @@ namespace Sentry.Protocol
         /// </summary>
         [DataMember(Name = "type", EmitDefaultValue = false)]
         public const string Type = "browser";
+
         /// <summary>
         /// Display name of the browser application.
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
+
         /// <summary>
         /// Version string of the browser.
         /// </summary>
         [DataMember(Name = "version", EmitDefaultValue = false)]
-        public string Version { get; set; }
+        public string? Version { get; set; }
 
         /// <summary>
         /// Clones this instance
         /// </summary>
-        /// <returns></returns>
         internal Browser Clone()
             => new Browser
             {

--- a/src/Sentry.Protocol/Context/Contexts.cs
+++ b/src/Sentry.Protocol/Context/Contexts.cs
@@ -59,13 +59,8 @@ namespace Sentry.Protocol
         /// <summary>
         /// Copies the items of the context while cloning the known types.
         /// </summary>
-        internal void CopyTo(Contexts? to)
+        internal void CopyTo(Contexts to)
         {
-            if (to == null)
-            {
-                return;
-            }
-
             foreach (var kv in this)
             {
                 var value = kv.Key switch

--- a/src/Sentry.Protocol/Context/Contexts.cs
+++ b/src/Sentry.Protocol/Context/Contexts.cs
@@ -5,9 +5,8 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// Represents Sentry's structured Context
+    /// Represents Sentry's structured Context.
     /// </summary>
-    /// <inheritdoc />
     /// <seealso href="https://docs.sentry.io/clientdev/interfaces/contexts/" />
     [DataContract]
     public class Contexts : ConcurrentDictionary<string, object>
@@ -16,14 +15,17 @@ namespace Sentry.Protocol
         /// Describes the application.
         /// </summary>
         public App App => this.GetOrCreate<App>(App.Type);
+
         /// <summary>
         /// Describes the browser.
         /// </summary>
         public Browser Browser => this.GetOrCreate<Browser>(Browser.Type);
+
         /// <summary>
         /// Describes the device.
         /// </summary>
         public Device Device => this.GetOrCreate<Device>(Device.Type);
+
         /// <summary>
         /// Defines the operating system.
         /// </summary>
@@ -31,19 +33,20 @@ namespace Sentry.Protocol
         /// In web contexts, this is the operating system of the browser (normally pulled from the User-Agent string).
         /// </remarks>
         public OperatingSystem OperatingSystem => this.GetOrCreate<OperatingSystem>(OperatingSystem.Type);
+
         /// <summary>
         /// This describes a runtime in more detail.
         /// </summary>
         public Runtime Runtime => this.GetOrCreate<Runtime>(Runtime.Type);
+
         /// <summary>
-        /// This describes a GPU of the device..
+        /// This describes a GPU of the device.
         /// </summary>
         public Gpu Gpu => this.GetOrCreate<Gpu>(Gpu.Type);
 
         /// <summary>
-        /// Creates a deep clone of this context
+        /// Creates a deep clone of this context.
         /// </summary>
-        /// <returns></returns>
         internal Contexts Clone()
         {
             var context = new Contexts();
@@ -54,10 +57,9 @@ namespace Sentry.Protocol
         }
 
         /// <summary>
-        /// Copies the items of the context while cloning the known types
+        /// Copies the items of the context while cloning the known types.
         /// </summary>
-        /// <param name="to">To.</param>
-        internal void CopyTo(Contexts to)
+        internal void CopyTo(Contexts? to)
         {
             if (to == null)
             {
@@ -66,32 +68,16 @@ namespace Sentry.Protocol
 
             foreach (var kv in this)
             {
-                object value;
-                switch (kv.Key)
+                var value = kv.Key switch
                 {
-                    case App.Type:
-                        value = (kv.Value as App)?.Clone();
-                        break;
-                    case Browser.Type:
-                        value = (kv.Value as Browser)?.Clone();
-                        break;
-                    case Device.Type:
-                        value = (kv.Value as Device)?.Clone();
-                        break;
-                    case OperatingSystem.Type:
-                        value = (kv.Value as OperatingSystem)?.Clone();
-                        break;
-                    case Runtime.Type:
-                        value = (kv.Value as Runtime)?.Clone();
-                        break;
-                    case Gpu.Type:
-                        value = (kv.Value as Gpu)?.Clone();
-                        break;
-
-                    default:
-                        value = kv.Value;
-                        break;
-                }
+                    App.Type when kv.Value is App app => app.Clone(),
+                    Browser.Type when kv.Value is Browser browser => browser.Clone(),
+                    Device.Type when kv.Value is Device device => device.Clone(),
+                    OperatingSystem.Type when kv.Value is OperatingSystem os => os.Clone(),
+                    Runtime.Type when kv.Value is Runtime runtime => runtime.Clone(),
+                    Gpu.Type when kv.Value is Gpu gpu => gpu.Clone(),
+                    _ => kv.Value
+                };
 
                 to.TryAdd(kv.Key, value);
             }

--- a/src/Sentry.Protocol/Context/Device.cs
+++ b/src/Sentry.Protocol/Context/Device.cs
@@ -12,31 +12,35 @@ namespace Sentry.Protocol
     public class Device
     {
         [DataMember(Name = "timezone", EmitDefaultValue = false)]
-        private string TimezoneSerializable => Timezone?.Id;
+        private string? TimezoneSerializable => Timezone?.Id;
 
         [DataMember(Name = "timezone_display_name", EmitDefaultValue = false)]
-        private string TimezoneName => Timezone?.DisplayName;
+        private string? TimezoneName => Timezone?.DisplayName;
 
         /// <summary>
         /// Tells Sentry which type of context this is.
         /// </summary>
         [DataMember(Name = "type", EmitDefaultValue = false)]
         public const string Type = "device";
+
         /// <summary>
         /// The name of the device. This is typically a hostname.
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
+
         /// <summary>
-        /// The manufacturer of the device
+        /// The manufacturer of the device.
         /// </summary>
         [DataMember(Name = "manufacturer", EmitDefaultValue = false)]
-        public string Manufacturer { get; set; }
+        public string? Manufacturer { get; set; }
+
         /// <summary>
-        /// The brand of the device
+        /// The brand of the device.
         /// </summary>
         [DataMember(Name = "brand", EmitDefaultValue = false)]
-        public string Brand { get; set; }
+        public string? Brand { get; set; }
+
         /// <summary>
         /// The family of the device.
         /// </summary>
@@ -47,7 +51,8 @@ namespace Sentry.Protocol
         /// iPhone, Samsung Galaxy
         /// </example>
         [DataMember(Name = "family", EmitDefaultValue = false)]
-        public string Family { get; set; }
+        public string? Family { get; set; }
+
         /// <summary>
         /// The model name.
         /// </summary>
@@ -55,82 +60,98 @@ namespace Sentry.Protocol
         /// Samsung Galaxy S3
         /// </example>
         [DataMember(Name = "model", EmitDefaultValue = false)]
-        public string Model { get; set; }
+        public string? Model { get; set; }
+
         /// <summary>
         /// An internal hardware revision to identify the device exactly.
         /// </summary>
         [DataMember(Name = "model_id", EmitDefaultValue = false)]
-        public string ModelId { get; set; }
+        public string? ModelId { get; set; }
+
         /// <summary>
         /// The CPU architecture.
         /// </summary>
         [DataMember(Name = "arch", EmitDefaultValue = false)]
-        public string Architecture { get; set; }
+        public string? Architecture { get; set; }
+
         /// <summary>
         /// If the device has a battery an integer defining the battery level (in the range 0-100).
         /// </summary>
         [DataMember(Name = "battery_level", EmitDefaultValue = false)]
         public short? BatteryLevel { get; set; }
+
         /// <summary>
         /// True if the device is charging.
         /// </summary>
         [DataMember(Name = "charging", EmitDefaultValue = false)]
         public bool? IsCharging { get; set; }
+
         /// <summary>
-        /// True if the device has a internet connection
+        /// True if the device has a internet connection.
         /// </summary>
         [DataMember(Name = "online", EmitDefaultValue = false)]
         public bool? IsOnline { get; set; }
+
         /// <summary>
         /// This can be a string portrait or landscape to define the orientation of a device.
         /// </summary>
         [DataMember(Name = "orientation", EmitDefaultValue = false)]
         public DeviceOrientation? Orientation { get; set; }
+
         /// <summary>
         /// A boolean defining whether this device is a simulator or an actual device.
         /// </summary>
         [DataMember(Name = "simulator", EmitDefaultValue = false)]
         public bool? Simulator { get; set; }
+
         /// <summary>
         /// Total system memory available in bytes.
         /// </summary>
         [DataMember(Name = "memory_size", EmitDefaultValue = false)]
         public long? MemorySize { get; set; }
+
         /// <summary>
         /// Free system memory in bytes.
         /// </summary>
         [DataMember(Name = "free_memory", EmitDefaultValue = false)]
         public long? FreeMemory { get; set; }
+
         /// <summary>
         /// Memory usable for the app in bytes.
         /// </summary>
         [DataMember(Name = "usable_memory", EmitDefaultValue = false)]
         public long? UsableMemory { get; set; }
+
         /// <summary>
         /// True, if the device memory is low.
         /// </summary>
         [DataMember(Name = "low_memory")]
         public bool? LowMemory { get; set; }
+
         /// <summary>
         /// Total device storage in bytes.
         /// </summary>
         [DataMember(Name = "storage_size", EmitDefaultValue = false)]
         public long? StorageSize { get; set; }
+
         /// <summary>
         /// Free device storage in bytes.
         /// </summary>
         [DataMember(Name = "free_storage", EmitDefaultValue = false)]
         public long? FreeStorage { get; set; }
+
         /// <summary>
         /// Total size of an attached external storage in bytes (e.g.: android SDK card).
         /// </summary>
         [DataMember(Name = "external_storage_size", EmitDefaultValue = false)]
         public long? ExternalStorageSize { get; set; }
+
         /// <summary>
         /// Free size of an attached external storage in bytes (e.g.: android SDK card).
         /// </summary>
         [DataMember(Name = "external_free_storage", EmitDefaultValue = false)]
         public long? ExternalFreeStorage { get; set; }
+
         /// <summary>
         /// The resolution of the screen.
         /// </summary>
@@ -138,17 +159,20 @@ namespace Sentry.Protocol
         /// 800x600
         /// </example>
         [DataMember(Name = "screen_resolution", EmitDefaultValue = false)]
-        public string ScreenResolution { get; set; }
+        public string? ScreenResolution { get; set; }
+
         /// <summary>
         /// The logical density of the display.
         /// </summary>
         [DataMember(Name = "screen_density", EmitDefaultValue = false)]
         public float? ScreenDensity { get; set; }
+
         /// <summary>
         /// The screen density as dots-per-inch.
         /// </summary>
         [DataMember(Name = "screen_dpi", EmitDefaultValue = false)]
         public int? ScreenDpi { get; set; }
+
         /// <summary>
         /// A formatted UTC timestamp when the system was booted.
         /// </summary>
@@ -157,18 +181,18 @@ namespace Sentry.Protocol
         /// </example>
         [DataMember(Name = "boot_time", EmitDefaultValue = false)]
         public DateTimeOffset? BootTime { get; set; }
+
         /// <summary>
         /// The timezone of the device.
         /// </summary>
         /// <example>
         /// Europe/Vienna
         /// </example>
-        public TimeZoneInfo Timezone { get; set; }
+        public TimeZoneInfo? Timezone { get; set; }
 
         /// <summary>
-        /// Clones this instance
+        /// Clones this instance.
         /// </summary>
-        /// <returns></returns>
         internal Device Clone()
             => new Device
             {

--- a/src/Sentry.Protocol/Context/DeviceOrientation.cs
+++ b/src/Sentry.Protocol/Context/DeviceOrientation.cs
@@ -9,12 +9,13 @@ namespace Sentry.Protocol
     public enum DeviceOrientation
     {
         /// <summary>
-        /// Portrait
+        /// Portrait.
         /// </summary>
         [EnumMember(Value = "portrait")]
         Portrait,
+
         /// <summary>
-        /// Landscape
+        /// Landscape.
         /// </summary>
         [EnumMember(Value = "landscape")]
         Landscape

--- a/src/Sentry.Protocol/Context/Gpu.cs
+++ b/src/Sentry.Protocol/Context/Gpu.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// Graphics device unit
+    /// Graphics device unit.
     /// </summary>
     /// <seealso href="https://docs.sentry.io/development/sdk-dev/interfaces/gpu/"/>
     [DataContract]
@@ -17,29 +17,29 @@ namespace Sentry.Protocol
         public const string Type = "gpu";
 
         /// <summary>
-        /// The name of the graphics device
+        /// The name of the graphics device.
         /// </summary>
         /// <example>
         /// iPod touch: Apple A8 GPU
         /// Samsung S7: Mali-T880
         /// </example>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
-        /// The PCI Id of the graphics device
+        /// The PCI Id of the graphics device.
         /// </summary>
         /// <remarks>
-        /// Combined with <see cref="VendorId"/> uniquely identifies the GPU
+        /// Combined with <see cref="VendorId"/> uniquely identifies the GPU.
         /// </remarks>
         [DataMember(Name = "id", EmitDefaultValue = false)]
         public int? Id { get; set; }
 
         /// <summary>
-        /// The PCI vendor Id of the graphics device
+        /// The PCI vendor Id of the graphics device.
         /// </summary>
         /// <remarks>
-        /// Combined with <see cref="Id"/> uniquely identifies the GPU
+        /// Combined with <see cref="Id"/> uniquely identifies the GPU.
         /// </remarks>
         /// <seealso href="https://docs.microsoft.com/en-us/windows-hardware/drivers/install/identifiers-for-pci-devices"/>
         /// <seealso href="http://pci-ids.ucw.cz/read/PC/"/>
@@ -47,13 +47,13 @@ namespace Sentry.Protocol
         public int? VendorId { get; set; }
 
         /// <summary>
-        /// The vendor name reported by the graphic device
+        /// The vendor name reported by the graphic device.
         /// </summary>
         /// <example>
         /// Apple, ARM, WebKit
         /// </example>
         [DataMember(Name = "vendor_name", EmitDefaultValue = false)]
-        public string VendorName { get; set; }
+        public string? VendorName { get; set; }
 
         /// <summary>
         /// Total GPU memory available in mega-bytes.
@@ -62,12 +62,12 @@ namespace Sentry.Protocol
         public int? MemorySize { get; set; }
 
         /// <summary>
-        /// Device type
+        /// Device type.
         /// </summary>
-        /// <remarks>The low level API used</remarks>
+        /// <remarks>The low level API used.</remarks>
         /// <example>Metal, Direct3D11, OpenGLES3, PlayStation4, XboxOne</example>
         [DataMember(Name = "api_type", EmitDefaultValue = false)]
-        public string ApiType { get; set; }
+        public string? ApiType { get; set; }
 
         /// <summary>
         /// Whether the GPU is multi-threaded rendering or not.
@@ -76,7 +76,7 @@ namespace Sentry.Protocol
         public bool? MultiThreadedRendering { get; set; }
 
         /// <summary>
-        /// The Version of the API of the graphics device
+        /// The Version of the API of the graphics device.
         /// </summary>
         /// <example>
         /// iPod touch: Metal
@@ -85,21 +85,20 @@ namespace Sentry.Protocol
         /// OpenGL 2.0, Direct3D 9.0c
         /// </example>
         [DataMember(Name = "version", EmitDefaultValue = false)]
-        public string Version { get; set; }
+        public string? Version { get; set; }
 
         /// <summary>
-        /// The Non-Power-Of-Two support level
+        /// The Non-Power-Of-Two support level.
         /// </summary>
         /// <example>
         /// Full
         /// </example>
         [DataMember(Name = "npot_support", EmitDefaultValue = false)]
-        public string NpotSupport { get; set; }
+        public string? NpotSupport { get; set; }
 
         /// <summary>
-        /// Clones this instance
+        /// Clones this instance.
         /// </summary>
-        /// <returns></returns>
         internal Gpu Clone()
             => new Gpu
             {

--- a/src/Sentry.Protocol/Context/OperatingSystem.cs
+++ b/src/Sentry.Protocol/Context/OperatingSystem.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// Represents Sentry's context for OS
+    /// Represents Sentry's context for OS.
     /// </summary>
     /// <remarks>
     /// Defines the operating system that caused the event. In web contexts, this is the operating system of the browser (normally pulled from the User-Agent string).
@@ -18,16 +18,19 @@ namespace Sentry.Protocol
         /// </summary>
         [DataMember(Name = "type", EmitDefaultValue = false)]
         public const string Type = "os";
+
         /// <summary>
         /// The name of the operating system.
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
+
         /// <summary>
         /// The version of the operating system.
         /// </summary>
         [DataMember(Name = "version", EmitDefaultValue = false)]
-        public string Version { get; set; }
+        public string? Version { get; set; }
+
         /// <summary>
         /// An optional raw description that Sentry can use in an attempt to normalize OS info.
         /// </summary>
@@ -36,20 +39,23 @@ namespace Sentry.Protocol
         /// this field can be used to provide a raw system info (e.g: uname)
         /// </remarks>
         [DataMember(Name = "raw_description", EmitDefaultValue = false)]
-        public string RawDescription { get; set; }
+        public string? RawDescription { get; set; }
+
         /// <summary>
         /// The internal build revision of the operating system.
         /// </summary>
         [DataMember(Name = "build", EmitDefaultValue = false)]
-        public string Build { get; set; }
+        public string? Build { get; set; }
+
         /// <summary>
-        ///  If known, this can be an independent kernel version string. Typically
+        /// If known, this can be an independent kernel version string. Typically
         /// this is something like the entire output of the 'uname' tool.
         /// </summary>
         [DataMember(Name = "kernel_version", EmitDefaultValue = false)]
-        public string KernelVersion { get; set; }
+        public string? KernelVersion { get; set; }
+
         /// <summary>
-        ///  An optional boolean that defines if the OS has been jailbroken or rooted.
+        /// An optional boolean that defines if the OS has been jailbroken or rooted.
         /// </summary>
         [DataMember(Name = "rooted", EmitDefaultValue = false)]
         public bool? Rooted { get; set; }
@@ -57,7 +63,6 @@ namespace Sentry.Protocol
         /// <summary>
         /// Clones this instance
         /// </summary>
-        /// <returns></returns>
         internal OperatingSystem Clone()
             => new OperatingSystem
             {

--- a/src/Sentry.Protocol/Context/Runtime.cs
+++ b/src/Sentry.Protocol/Context/Runtime.cs
@@ -18,31 +18,35 @@ namespace Sentry.Protocol
         /// </summary>
         [DataMember(Name = "type", EmitDefaultValue = false)]
         public const string Type = "runtime";
+
         /// <summary>
         /// The name of the runtime.
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
+
         /// <summary>
         /// The version identifier of the runtime.
         /// </summary>
         [DataMember(Name = "version", EmitDefaultValue = false)]
-        public string Version { get; set; }
+        public string? Version { get; set; }
+
         /// <summary>
         ///  An optional raw description that Sentry can use in an attempt to normalize Runtime info.
         /// </summary>
         /// <remarks>
         /// When the system doesn't expose a clear API for <see cref="Name"/> and <see cref="Version"/>
-        /// this field can be used to provide a raw system info (e.g: .NET Framework 4.7.1)
+        /// this field can be used to provide a raw system info (e.g: .NET Framework 4.7.1).
         /// </remarks>
         [DataMember(Name = "raw_description", EmitDefaultValue = false)]
-        public string RawDescription { get; set; }
+        public string? RawDescription { get; set; }
+
         /// <summary>
-        ///  An optional build number
+        /// An optional build number.
         /// </summary>
         /// <see href="https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed"/>
         [DataMember(Name = "build", EmitDefaultValue = false)]
-        public string Build { get; set; }
+        public string? Build { get; set; }
 
         /// <summary>
         /// Clones this instance

--- a/src/Sentry.Protocol/Dsn.cs
+++ b/src/Sentry.Protocol/Dsn.cs
@@ -86,7 +86,7 @@ namespace Sentry
         /// <param name="dsn">The string to attempt parsing.</param>
         /// <param name="finalDsn">The <see cref="Dsn"/> when successfully parsed.</param>
         /// <returns><c>true</c> if the string is a valid <see cref="Dsn"/> as was successfully parsed. Otherwise, <c>false</c>.</returns>
-        public static bool TryParse(string dsn, out Dsn? finalDsn)
+        public static bool TryParse(string dsn, [NotNullWhen(true)] out Dsn? finalDsn)
         {
             try
             {

--- a/src/Sentry.Protocol/Dsn.cs
+++ b/src/Sentry.Protocol/Dsn.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Sentry.Protocol;
 
 // ReSharper disable once CheckNamespace

--- a/src/Sentry.Protocol/Dsn.cs
+++ b/src/Sentry.Protocol/Dsn.cs
@@ -19,20 +19,24 @@ namespace Sentry
         /// The project ID which the authenticated user is bound to.
         /// </summary>
         public string ProjectId { get; }
+
         /// <summary>
-        /// An optional path of which Sentry is hosted
+        /// An optional path of which Sentry is hosted.
         /// </summary>
-        public string Path { get; }
+        public string? Path { get; }
+
         /// <summary>
         /// The optional secret key to authenticate the SDK.
         /// </summary>
-        public string SecretKey { get; }
+        public string? SecretKey { get; }
+
         /// <summary>
         /// The required public key to authenticate the SDK.
         /// </summary>
         public string PublicKey { get; }
+
         /// <summary>
-        /// The URI used to communicate with Sentry
+        /// The URI used to communicate with Sentry.
         /// </summary>
         public Uri SentryUri { get; }
 
@@ -45,7 +49,7 @@ namespace Sentry
         /// </remarks>
         public Dsn(string dsn)
         {
-            var parsed = Parse(dsn, throwOnError: true);
+            var parsed = Parse(dsn, true);
             Debug.Assert(parsed != null, "Parse should throw instead of returning null!");
 
             _dsn = parsed.Item1;
@@ -56,7 +60,7 @@ namespace Sentry
             SentryUri = parsed.Item6;
         }
 
-        private Dsn(string dsn, string projectId, string path, string secretKey, string publicKey, Uri sentryUri)
+        private Dsn(string dsn, string projectId, string? path, string? secretKey, string publicKey, Uri sentryUri)
         {
             _dsn = dsn;
             ProjectId = projectId;
@@ -77,16 +81,16 @@ namespace Sentry
             Constants.DisableSdkDsnValue.Equals(dsn, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
-        /// Tries to parse the string into a <see cref="Dsn"/>
+        /// Tries to parse the string into a <see cref="Dsn"/>.
         /// </summary>
         /// <param name="dsn">The string to attempt parsing.</param>
         /// <param name="finalDsn">The <see cref="Dsn"/> when successfully parsed.</param>
         /// <returns><c>true</c> if the string is a valid <see cref="Dsn"/> as was successfully parsed. Otherwise, <c>false</c>.</returns>
-        public static bool TryParse(string dsn, out Dsn finalDsn)
+        public static bool TryParse(string dsn, out Dsn? finalDsn)
         {
             try
             {
-                var parsed = Parse(dsn, throwOnError: false);
+                var parsed = Parse(dsn, false);
                 if (parsed == null)
                 {
                     finalDsn = null;
@@ -104,7 +108,7 @@ namespace Sentry
             }
         }
 
-        private static Tuple<string, string, string, string, string, Uri> Parse(string dsn, bool throwOnError)
+        private static Tuple<string, string, string, string?, string, Uri>? Parse(string dsn, bool throwOnError)
         {
             Uri uri;
             if (throwOnError)
@@ -141,7 +145,7 @@ namespace Sentry
                 return null;
             }
 
-            string secretKey = null;
+            string? secretKey = null;
             if (keys.Length > 1)
             {
                 secretKey = keys[1];
@@ -171,7 +175,7 @@ namespace Sentry
         }
 
         /// <summary>
-        /// The original DSN string used to create this instance
+        /// The original DSN string used to create this instance.
         /// </summary>
         public override string ToString() => _dsn;
     }

--- a/src/Sentry.Protocol/Exceptions/Mechanism.cs
+++ b/src/Sentry.Protocol/Exceptions/Mechanism.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// Sentry Exception Mechanism
+    /// Sentry Exception Mechanism.
     /// </summary>
     /// <remarks>
     /// The exception mechanism is an optional field residing in the Exception Interface.
@@ -17,23 +17,23 @@ namespace Sentry.Protocol
     public class Mechanism
     {
         /// <summary>
-        /// Keys found inside of the Exception Dictionary to inform if the exception was handled and which mechanism tracked it
+        /// Keys found inside of the Exception Dictionary to inform if the exception was handled and which mechanism tracked it.
         /// </summary>
         public static readonly string HandledKey = "Sentry:Handled";
 
         /// <summary>
-        /// Key found inside of the Exception.Data to inform if the exception which mechanism tracked it
+        /// Key found inside of the Exception.Data to inform if the exception which mechanism tracked it.
         /// </summary>
         public static readonly string MechanismKey = "Sentry:Mechanism";
 
         [DataMember(Name = "data", EmitDefaultValue = false)]
-        internal Dictionary<string, object> InternalData { get; private set; }
+        internal Dictionary<string, object>? InternalData { get; private set; }
 
         [DataMember(Name = "meta", EmitDefaultValue = false)]
-        internal Dictionary<string, object> InternalMeta { get; private set; }
+        internal Dictionary<string, object>? InternalMeta { get; private set; }
 
         /// <summary>
-        /// Required unique identifier of this mechanism determining rendering and processing of the mechanism data
+        /// Required unique identifier of this mechanism determining rendering and processing of the mechanism data.
         /// </summary>
         /// <remarks>
         /// The type attribute is required to send any exception mechanism attribute,
@@ -41,28 +41,28 @@ namespace Sentry.Protocol
         /// In this case, set the type to "generic". See below for an example.
         /// </remarks>
         [DataMember(Name = "type", EmitDefaultValue = false)]
-        public string Type { get; set; }
+        public string? Type { get; set; }
 
         /// <summary>
-        /// Optional human readable description of the error mechanism and a possible hint on how to solve this error
+        /// Optional human readable description of the error mechanism and a possible hint on how to solve this error.
         /// </summary>
         [DataMember(Name = "description", EmitDefaultValue = false)]
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
-        /// Optional fully qualified URL to an online help resource, possible interpolated with error parameters
+        /// Optional fully qualified URL to an online help resource, possible interpolated with error parameters.
         /// </summary>
         [DataMember(Name = "help_link", EmitDefaultValue = false)]
-        public string HelpLink { get; set; }
+        public string? HelpLink { get; set; }
 
         /// <summary>
-        /// Optional flag indicating whether the exception has been handled by the user (e.g. via try..catch)
+        /// Optional flag indicating whether the exception has been handled by the user (e.g. via try..catch).
         /// </summary>
         [DataMember(Name = "handled", EmitDefaultValue = false)]
         public bool? Handled { get; set; }
 
         /// <summary>
-        /// Optional information from the operating system or runtime on the exception mechanism
+        /// Optional information from the operating system or runtime on the exception mechanism.
         /// </summary>
         /// <remarks>
         /// The mechanism meta data usually carries error codes reported by the runtime or operating system,
@@ -71,11 +71,11 @@ namespace Sentry.Protocol
         /// For proprietary or vendor-specific error codes, adding these values will give additional information to the user.
         /// </remarks>
         /// <see href="https://docs.sentry.io/clientdev/interfaces/mechanism/#meta-information"/>
-        public IDictionary<string, object> Meta => InternalMeta ?? (InternalMeta = new Dictionary<string, object>());
+        public IDictionary<string, object> Meta => InternalMeta ??= new Dictionary<string, object>();
 
         /// <summary>
-        /// Arbitrary extra data that might help the user understand the error thrown by this mechanism
+        /// Arbitrary extra data that might help the user understand the error thrown by this mechanism.
         /// </summary>
-        public IDictionary<string, object> Data => InternalData ?? (InternalData = new Dictionary<string, object>());
+        public IDictionary<string, object> Data => InternalData ??= new Dictionary<string, object>();
     }
 }

--- a/src/Sentry.Protocol/Exceptions/SentryException.cs
+++ b/src/Sentry.Protocol/Exceptions/SentryException.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// Sentry Exception interface
+    /// Sentry Exception interface.
     /// </summary>
     /// <see href="https://docs.sentry.io/clientdev/interfaces/exception/"/>
     [DataContract]
@@ -13,25 +13,25 @@ namespace Sentry.Protocol
     {
         // Not serialized since not part of the protocol yet.
         // Used by Sentry SDK though to transfer data from Exception.Data to Event.Data when parsing.
-        internal Dictionary<string, object> InternalData { get; private set; }
+        internal Dictionary<string, object>? InternalData { get; private set; }
 
         /// <summary>
-        /// Exception Type
+        /// Exception Type.
         /// </summary>
         [DataMember(Name = "type", EmitDefaultValue = false)]
-        public string Type { get; set; }
+        public string? Type { get; set; }
 
         /// <summary>
-        /// The exception value
+        /// The exception value.
         /// </summary>
         [DataMember(Name = "value", EmitDefaultValue = false)]
-        public string Value { get; set; }
+        public string? Value { get; set; }
 
         /// <summary>
-        /// The optional module, or package which the exception type lives in
+        /// The optional module, or package which the exception type lives in.
         /// </summary>
         [DataMember(Name = "module", EmitDefaultValue = false)]
-        public string Module { get; set; }
+        public string? Module { get; set; }
 
         /// <summary>
         /// An optional value which refers to a thread in the threads interface.
@@ -42,18 +42,18 @@ namespace Sentry.Protocol
         public int ThreadId { get; set; }
 
         /// <summary>
-        /// Stack trace
+        /// Stack trace.
         /// </summary>
         /// <see href="https://docs.sentry.io/clientdev/interfaces/stacktrace/"/>
         [DataMember(Name = "stacktrace", EmitDefaultValue = false)]
-        public SentryStackTrace Stacktrace { get; set; }
+        public SentryStackTrace? Stacktrace { get; set; }
 
         /// <summary>
         /// An optional mechanism that created this exception.
         /// </summary>
         /// <see href="https://docs.sentry.io/clientdev/interfaces/mechanism/"/>
         [DataMember(Name = "mechanism", EmitDefaultValue = false)]
-        public Mechanism Mechanism { get; set; }
+        public Mechanism? Mechanism { get; set; }
 
         /// <summary>
         /// Arbitrary extra data that related to this error
@@ -63,6 +63,6 @@ namespace Sentry.Protocol
         /// For this reason this property is not serialized.
         /// The data is moved to the event level on Extra until such support is added
         /// </remarks>
-        public IDictionary<string, object> Data => InternalData ?? (InternalData = new Dictionary<string, object>());
+        public IDictionary<string, object> Data => InternalData ??= new Dictionary<string, object>();
     }
 }

--- a/src/Sentry.Protocol/Exceptions/SentryStackFrame.cs
+++ b/src/Sentry.Protocol/Exceptions/SentryStackFrame.cs
@@ -5,77 +5,77 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// A frame of a stacktrace
+    /// A frame of a stacktrace.
     /// </summary>
     /// <see href="https://docs.sentry.io/clientdev/interfaces/stacktrace/"/>
     [DataContract]
     public class SentryStackFrame
     {
         [DataMember(Name = "pre_context", EmitDefaultValue = false)]
-        internal List<string> InternalPreContext { get; private set; }
+        internal List<string>? InternalPreContext { get; private set; }
 
         [DataMember(Name = "post_context", EmitDefaultValue = false)]
-        internal List<string> InternalPostContext { get; private set; }
+        internal List<string>? InternalPostContext { get; private set; }
 
         [DataMember(Name = "vars", EmitDefaultValue = false)]
-        internal Dictionary<string, string> InternalVars { get; private set; }
+        internal Dictionary<string, string>? InternalVars { get; private set; }
 
         [DataMember(Name = "frames_omitted ", EmitDefaultValue = false)]
-        internal List<int> InternalFramesOmitted { get; private set; }
+        internal List<int>? InternalFramesOmitted { get; private set; }
 
         /// <summary>
-        /// The relative file path to the call
+        /// The relative file path to the call.
         /// </summary>
         [DataMember(Name = "filename", EmitDefaultValue = false)]
-        public string FileName { get; set; }
+        public string? FileName { get; set; }
 
         /// <summary>
-        /// The name of the function being called
+        /// The name of the function being called.
         /// </summary>
         [DataMember(Name = "function", EmitDefaultValue = false)]
-        public string Function { get; set; }
+        public string? Function { get; set; }
 
         /// <summary>
-        /// Platform-specific module path
+        /// Platform-specific module path.
         /// </summary>
         [DataMember(Name = "module", EmitDefaultValue = false)]
-        public string Module { get; set; }
+        public string? Module { get; set; }
 
         // Optional fields
 
         /// <summary>
-        /// The line number of the call
+        /// The line number of the call.
         /// </summary>
         [DataMember(Name = "lineno", EmitDefaultValue = false)]
         public int? LineNumber { get; set; }
 
         /// <summary>
-        /// The column number of the call
+        /// The column number of the call.
         /// </summary>
         [DataMember(Name = "colno", EmitDefaultValue = false)]
         public int? ColumnNumber { get; set; }
 
         /// <summary>
-        /// The absolute path to filename
+        /// The absolute path to filename.
         /// </summary>
         [DataMember(Name = "abs_path", EmitDefaultValue = false)]
-        public string AbsolutePath { get; set; }
+        public string? AbsolutePath { get; set; }
 
         /// <summary>
-        /// Source code in filename at line number
+        /// Source code in filename at line number.
         /// </summary>
         [DataMember(Name = "context_line", EmitDefaultValue = false)]
-        public string ContextLine { get; set; }
+        public string? ContextLine { get; set; }
 
         /// <summary>
-        /// A list of source code lines before context_line (in order) – usually [lineno - 5:lineno]
+        /// A list of source code lines before context_line (in order) – usually [lineno - 5:lineno].
         /// </summary>
-        public IList<string> PreContext => InternalPreContext ?? (InternalPreContext = new List<string>());
+        public IList<string> PreContext => InternalPreContext ??= new List<string>();
 
         /// <summary>
-        /// A list of source code lines after context_line (in order) – usually [lineno + 1:lineno + 5]
+        /// A list of source code lines after context_line (in order) – usually [lineno + 1:lineno + 5].
         /// </summary>
-        public IList<string> PostContext => InternalPostContext ?? (InternalPostContext = new List<string>());
+        public IList<string> PostContext => InternalPostContext ??= new List<string>();
 
         /// <summary>
         /// Signifies whether this frame is related to the execution of the relevant code in this stacktrace.
@@ -90,7 +90,7 @@ namespace Sentry.Protocol
         /// <summary>
         /// A mapping of variables which were available within this frame (usually context-locals).
         /// </summary>
-        public IDictionary<string, string> Vars => InternalVars ?? (InternalVars = new Dictionary<string, string>());
+        public IDictionary<string, string> Vars => InternalVars ??= new Dictionary<string, string>();
 
         /// <summary>
         /// Which frames were omitted, if any.
@@ -104,19 +104,19 @@ namespace Sentry.Protocol
         /// and went until the 9th (the number of frames omitted is end-start).
         /// The values should be based on a one-index.
         /// </example>
-        public IList<int> FramesOmitted => InternalFramesOmitted ?? (InternalFramesOmitted = new List<int>());
+        public IList<int> FramesOmitted => InternalFramesOmitted ??= new List<int>();
 
         /// <summary>
-        /// The assembly where the code resides
+        /// The assembly where the code resides.
         /// </summary>
         [DataMember(Name = "package", EmitDefaultValue = false)]
-        public string Package { get; set; }
+        public string? Package { get; set; }
 
         /// <summary>
         /// This can override the platform for a single frame. Otherwise the platform of the event is assumed.
         /// </summary>
         [DataMember(Name = "platform", EmitDefaultValue = false)]
-        public string Platform { get; set; }
+        public string? Platform { get; set; }
 
         /// <summary>
         /// Optionally an address of the debug image to reference.
@@ -133,11 +133,11 @@ namespace Sentry.Protocol
         public long? SymbolAddress { get; set; }
 
         /// <summary>
-        /// The instruction offset
+        /// The instruction offset.
         /// </summary>
         /// <remarks>
         /// The official docs refer to it as 'The difference between instruction address and symbol address in bytes.'
-        /// In .NET this means the IL Offset within the assembly
+        /// In .NET this means the IL Offset within the assembly.
         /// </remarks>
         [DataMember(Name = "instruction_offset", EmitDefaultValue = false)]
         public long? InstructionOffset { get; set; }

--- a/src/Sentry.Protocol/Exceptions/SentryStackTrace.cs
+++ b/src/Sentry.Protocol/Exceptions/SentryStackTrace.cs
@@ -5,27 +5,28 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// Sentry Stacktrace interface
+    /// Sentry Stacktrace interface.
     /// </summary>
     /// <remarks>
-    /// A stacktrace contains a list of frames, each with various bits (most optional) describing the context of that frame. Frames should be sorted from oldest to newest.
+    /// A stacktrace contains a list of frames, each with various bits (most optional) describing the context of that frame.
+    /// Frames should be sorted from oldest to newest.
     /// </remarks>
     /// <see href="https://docs.sentry.io/clientdev/interfaces/stacktrace/"/>
     [DataContract]
     public class SentryStackTrace
     {
         [DataMember(Name = "frames", EmitDefaultValue = false)]
-        internal IList<SentryStackFrame> InternalFrames { get; private set; }
+        internal IList<SentryStackFrame>? InternalFrames { get; private set; }
 
         /// <summary>
-        /// The list of frames in the stack
+        /// The list of frames in the stack.
         /// </summary>
         /// <remarks>
         /// The list of frames should be ordered by the oldest call first.
         /// </remarks>
         public IList<SentryStackFrame> Frames
         {
-            get => InternalFrames ?? (InternalFrames = new List<SentryStackFrame>());
+            get => InternalFrames ??= new List<SentryStackFrame>();
             set => InternalFrames = value;
         }
     }

--- a/src/Sentry.Protocol/IScopeOptions.cs
+++ b/src/Sentry.Protocol/IScopeOptions.cs
@@ -3,7 +3,7 @@ using System;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// Options used by <see cref="BaseScope"/>
+    /// Options used by <see cref="BaseScope"/>.
     /// </summary>
     public interface IScopeOptions
     {
@@ -18,6 +18,7 @@ namespace Sentry.Protocol
         /// The maximum breadcrumbs per scope.
         /// </value>
         int MaxBreadcrumbs { get; }
+
         /// <summary>
         /// Invoked before storing a new breadcrumb
         /// </summary>

--- a/src/Sentry.Protocol/IScopeOptions.cs
+++ b/src/Sentry.Protocol/IScopeOptions.cs
@@ -20,12 +20,12 @@ namespace Sentry.Protocol
         int MaxBreadcrumbs { get; }
 
         /// <summary>
-        /// Invoked before storing a new breadcrumb
+        /// Invoked before storing a new breadcrumb.
         /// </summary>
         /// <remarks>
         /// Allows the callback handler access to a breadcrumb and allows modification
         /// or totally dropping the breadcrumb by returning null.
         /// </remarks>
-        Func<Breadcrumb, Breadcrumb> BeforeBreadcrumb { get; }
+        Func<Breadcrumb, Breadcrumb>? BeforeBreadcrumb { get; }
     }
 }

--- a/src/Sentry.Protocol/LogEntry.cs
+++ b/src/Sentry.Protocol/LogEntry.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// Sentry Message interface
+    /// Sentry Message interface.
     /// </summary>
     /// <remarks>
     /// This interface enables support to structured logging.
@@ -20,24 +20,24 @@ namespace Sentry.Protocol
     public class LogEntry
     {
         /// <summary>
-        /// The raw message string (uninterpolated)
+        /// The raw message string (un-interpolated).
         /// </summary>
         /// <remarks>
         /// Must be no more than 1000 characters in length.
         /// </remarks>
         [DataMember(Name = "message", EmitDefaultValue = false)]
-        public string Message { get; set; }
+        public string? Message { get; set; }
 
         /// <summary>
-        /// The optional list of formatting parameters
+        /// The optional list of formatting parameters.
         /// </summary>
         [DataMember(Name = "params", EmitDefaultValue = false)]
-        public IEnumerable<object> Params { get; set; }
+        public IEnumerable<object>? Params { get; set; }
 
         /// <summary>
-        /// The formatted message
+        /// The formatted message.
         /// </summary>
         [DataMember(Name = "formatted", EmitDefaultValue = false)]
-        public string Formatted { get; set; }
+        public string? Formatted { get; set; }
     }
 }

--- a/src/Sentry.Protocol/Package.cs
+++ b/src/Sentry.Protocol/Package.cs
@@ -3,13 +3,13 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// Represents a package used to compose the SDK
+    /// Represents a package used to compose the SDK.
     /// </summary>
     [DataContract]
     public class Package
     {
         /// <summary>
-        /// The name of the package
+        /// The name of the package.
         /// </summary>
         /// <example>
         /// nuget:Sentry
@@ -19,7 +19,7 @@ namespace Sentry.Protocol
         public string Name { get; }
 
         /// <summary>
-        /// The version of the package
+        /// The version of the package.
         /// </summary>
         /// <example>
         /// 1.0.0-rc1
@@ -28,7 +28,7 @@ namespace Sentry.Protocol
         public string Version { get; }
 
         /// <summary>
-        /// Creates a new instance of a <see cref="Package"/>
+        /// Creates a new instance of a <see cref="Package"/>.
         /// </summary>
         /// <param name="name">The package name.</param>
         /// <param name="version">The package version.</param>

--- a/src/Sentry.Protocol/Request.cs
+++ b/src/Sentry.Protocol/Request.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// Sentry HTTP interface
+    /// Sentry HTTP interface.
     /// </summary>
     /// <example>
     /// "request": {
@@ -28,49 +28,54 @@ namespace Sentry.Protocol
     public class Request
     {
         [DataMember(Name = "env", EmitDefaultValue = false)]
-        internal Dictionary<string, string> InternalEnv { get; set; }
+        internal Dictionary<string, string>? InternalEnv { get; set; }
 
         [DataMember(Name = "other", EmitDefaultValue = false)]
-        internal Dictionary<string, string> InternalOther { get; set; }
+        internal Dictionary<string, string>? InternalOther { get; set; }
 
         [DataMember(Name = "headers", EmitDefaultValue = false)]
-        internal Dictionary<string, string> InternalHeaders { get; set; }
+        internal Dictionary<string, string>? InternalHeaders { get; set; }
 
         /// <summary>
         /// Gets or sets the full request URL, if available.
         /// </summary>
         /// <value>The request URL.</value>
         [DataMember(Name = "url", EmitDefaultValue = false)]
-        public string Url { get; set; }
+        public string? Url { get; set; }
+
         /// <summary>
         /// Gets or sets the method of the request.
         /// </summary>
         /// <value>The HTTP method.</value>
         [DataMember(Name = "method", EmitDefaultValue = false)]
-        public string Method { get; set; }
+        public string? Method { get; set; }
+
         // byte[] or Memory<T>?
         // TODO: serializable object or string?
         /// <summary>
         /// Submitted data in whatever format makes most sense.
         /// </summary>
         /// <remarks>
-        /// This data should not be provided by default as it can get quite large
+        /// This data should not be provided by default as it can get quite large.
         /// </remarks>
         /// <value>The request payload.</value>
         [DataMember(Name = "data", EmitDefaultValue = false)]
-        public object Data { get; set; }
+        public object? Data { get; set; }
+
         /// <summary>
         /// Gets or sets the unparsed query string.
         /// </summary>
         /// <value>The query string.</value>
         [DataMember(Name = "query_string", EmitDefaultValue = false)]
-        public string QueryString { get; set; }
+        public string? QueryString { get; set; }
+
         /// <summary>
         /// Gets or sets the cookies.
         /// </summary>
         /// <value>The cookies.</value>
         [DataMember(Name = "cookies", EmitDefaultValue = false)]
-        public string Cookies { get; set; }
+        public string? Cookies { get; set; }
+
         /// <summary>
         /// Gets or sets the headers.
         /// </summary>
@@ -78,7 +83,7 @@ namespace Sentry.Protocol
         /// If a header appears multiple times it needs to be merged according to the HTTP standard for header merging.
         /// </remarks>
         /// <value>The headers.</value>
-        public IDictionary<string, string> Headers => InternalHeaders ?? (InternalHeaders = new Dictionary<string, string>());
+        public IDictionary<string, string> Headers => InternalHeaders ??= new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the optional environment data.
@@ -87,22 +92,21 @@ namespace Sentry.Protocol
         /// This is where information such as IIS/CGI keys go that are not HTTP headers.
         /// </remarks>
         /// <value>The env.</value>
-        public IDictionary<string, string> Env => InternalEnv ?? (InternalEnv = new Dictionary<string, string>());
+        public IDictionary<string, string> Env => InternalEnv ??= new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets some optional other data.
         /// </summary>
         /// <value>The other.</value>
-        public IDictionary<string, string> Other => InternalOther ?? (InternalOther = new Dictionary<string, string>());
+        public IDictionary<string, string> Other => InternalOther ??= new Dictionary<string, string>();
 
         /// <summary>
-        /// Clones this instance
+        /// Clones this instance.
         /// </summary>
         /// <remarks>
         /// This is a shallow copy.
         /// References like <see cref="Data"/> could hold a mutable, non-thread-safe object.
         /// </remarks>
-        /// <returns></returns>
         public Request Clone()
         {
             var request = new Request();
@@ -112,37 +116,18 @@ namespace Sentry.Protocol
             return request;
         }
 
-        internal void CopyTo(Request request)
+        internal void CopyTo(Request? request)
         {
             if (request == null)
             {
                 return;
             }
 
-            if (request.Url == null)
-            {
-                request.Url = Url;
-            }
-
-            if (request.Method == null)
-            {
-                request.Method = Method;
-            }
-
-            if (request.Data == null)
-            {
-                request.Data = Data;
-            }
-
-            if (request.QueryString == null)
-            {
-                request.QueryString = QueryString;
-            }
-
-            if (request.Cookies == null)
-            {
-                request.Cookies = Cookies;
-            }
+            request.Url ??= Url;
+            request.Method ??= Method;
+            request.Data ??= Data;
+            request.QueryString ??= QueryString;
+            request.Cookies ??= Cookies;
 
             InternalEnv?.TryCopyTo(request.Env);
             InternalOther?.TryCopyTo(request.Other);

--- a/src/Sentry.Protocol/SdkVersion.cs
+++ b/src/Sentry.Protocol/SdkVersion.cs
@@ -2,16 +2,15 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
 
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// Information about the SDK to be sent with the SentryEvent
+    /// Information about the SDK to be sent with the SentryEvent.
     /// </summary>
-    /// <remarks>Requires Sentry version 8.4 or higher</remarks>
+    /// <remarks>Requires Sentry version 8.4 or higher.</remarks>
     [DataContract]
     public class SdkVersion
     {
@@ -19,33 +18,34 @@ namespace Sentry.Protocol
             new Lazy<ConcurrentBag<Package>>(LazyThreadSafetyMode.PublicationOnly);
 
         [DataMember(Name = "packages", EmitDefaultValue = false)]
-        internal ConcurrentBag<Package> InternalPackages
+        internal ConcurrentBag<Package>? InternalPackages
             => _lazyPackages.IsValueCreated
                 ? _lazyPackages.Value
                 : null;
 
         /// <summary>
-        /// SDK packages
+        /// SDK packages.
         /// </summary>
-        /// <remarks>This property is not required</remarks>
+        /// <remarks>This property is not required.</remarks>
         public IEnumerable<Package> Packages => _lazyPackages.Value;
 
         /// <summary>
-        /// SDK name
+        /// SDK name.
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name
+        public string? Name
         {
             get;
             // For integrations to set their name
             [EditorBrowsable(EditorBrowsableState.Never)]
             set;
         }
+
         /// <summary>
-        /// SDK Version
+        /// SDK Version.
         /// </summary>
         [DataMember(Name = "version", EmitDefaultValue = false)]
-        public string Version
+        public string? Version
         {
             get;
             // For integrations to set their version
@@ -54,7 +54,7 @@ namespace Sentry.Protocol
         }
 
         /// <summary>
-        /// Add a package used to compose the SDK
+        /// Add a package used to compose the SDK.
         /// </summary>
         /// <param name="name">The package name.</param>
         /// <param name="version">The package version.</param>

--- a/src/Sentry.Protocol/Sentry.Protocol.csproj
+++ b/src/Sentry.Protocol/Sentry.Protocol.csproj
@@ -1,15 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.3;net46;net45</TargetFrameworks>
     <Description>The Sentry Protocol used to communicate with Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <!-- Disable nullability warnings on older frameworks because there is no nullability info for BCL -->
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
     <DefineConstants>HAS_VALUE_TUPLE;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
 

--- a/src/Sentry.Protocol/SentryEvent.cs
+++ b/src/Sentry.Protocol/SentryEvent.cs
@@ -80,7 +80,7 @@ namespace Sentry
         /// The name of the platform.
         /// </summary>
         [DataMember(Name = "platform", EmitDefaultValue = false)]
-        public string Platform { get; set; }
+        public string? Platform { get; set; }
 
         /// <summary>
         /// Identifies the host SDK from which the event was recorded.

--- a/src/Sentry.Protocol/SentryEvent.cs
+++ b/src/Sentry.Protocol/SentryEvent.cs
@@ -127,7 +127,6 @@ namespace Sentry
         /// <summary>
         /// Creates a new instance of <see cref="T:Sentry.SentryEvent" />.
         /// </summary>
-        // TODO: this method can be removed with a breaking change.
         public SentryEvent() : this(null)
         {
         }
@@ -136,7 +135,7 @@ namespace Sentry
         /// Creates a Sentry event with optional Exception details and default values like Id and Timestamp.
         /// </summary>
         /// <param name="exception">The exception.</param>
-        public SentryEvent(Exception? exception = null)
+        public SentryEvent(Exception? exception)
             : this(exception, null)
         {
         }

--- a/src/Sentry.Protocol/SentryEvent.cs
+++ b/src/Sentry.Protocol/SentryEvent.cs
@@ -10,7 +10,7 @@ using Sentry.Protocol;
 namespace Sentry
 {
     /// <summary>
-    /// An event to be sent to Sentry
+    /// An event to be sent to Sentry.
     /// </summary>
     /// <seealso href="https://docs.sentry.io/clientdev/attributes/" />
     /// <inheritdoc />
@@ -19,7 +19,7 @@ namespace Sentry
     public class SentryEvent : BaseScope
     {
         [DataMember(Name = "modules", EmitDefaultValue = false)]
-        internal IDictionary<string, string> InternalModules { get; set; }
+        internal IDictionary<string, string>? InternalModules { get; set; }
 
         [DataMember(Name = "event_id", EmitDefaultValue = false)]
         private string SerializableEventId => EventId.ToString();
@@ -32,32 +32,32 @@ namespace Sentry
         /// to add the relevant data to the event prior to sending to Sentry.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Exception Exception { get; }
+        public Exception? Exception { get; }
 
         /// <summary>
-        /// The unique identifier of this event
+        /// The unique identifier of this event.
         /// </summary>
         /// <remarks>
         /// Hexadecimal string representing a uuid4 value.
-        /// The length is exactly 32 characters (no dashes!)
+        /// The length is exactly 32 characters (no dashes!).
         /// </remarks>
         public SentryId EventId { get; }
 
         /// <summary>
-        /// Indicates when the event was created
+        /// Indicates when the event was created.
         /// </summary>
         /// <example>2018-04-03T17:41:36</example>
         [DataMember(Name = "timestamp", EmitDefaultValue = false)]
         public DateTimeOffset Timestamp { get; }
 
         /// <summary>
-        /// Gets the message that describes this event
+        /// Gets the message that describes this event.
         /// </summary>
         [DataMember(Name = "message", EmitDefaultValue = false)]
-        public string Message { get; set; }
+        public string? Message { get; set; }
 
         /// <summary>
-        /// Gets the structured message that describes this event
+        /// Gets the structured message that describes this event.
         /// </summary>
         /// <remarks>
         /// This helps Sentry group events together as the grouping happens
@@ -65,19 +65,19 @@ namespace Sentry
         /// </remarks>
         /// <example>
         /// LogEntry will have a template like: 'user {0} logged in'
-        /// Or structured logging template '{user} has logged in'
+        /// Or structured logging template: '{user} has logged in'
         /// </example>
         [DataMember(Name = "logentry", EmitDefaultValue = false)]
-        public LogEntry LogEntry { get; set; }
+        public LogEntry? LogEntry { get; set; }
 
         /// <summary>
-        /// Name of the logger (or source) of the event
+        /// Name of the logger (or source) of the event.
         /// </summary>
         [DataMember(Name = "logger", EmitDefaultValue = false)]
-        public string Logger { get; set; }
+        public string? Logger { get; set; }
 
         /// <summary>
-        /// The name of the platform
+        /// The name of the platform.
         /// </summary>
         [DataMember(Name = "platform", EmitDefaultValue = false)]
         public string Platform { get; set; }
@@ -86,67 +86,69 @@ namespace Sentry
         /// Identifies the host SDK from which the event was recorded.
         /// </summary>
         [DataMember(Name = "server_name", EmitDefaultValue = false)]
-        public string ServerName { get; set; }
+        public string? ServerName { get; set; }
 
         /// <summary>
         /// The release version of the application.
         /// </summary>
         [DataMember(Name = "release", EmitDefaultValue = false)]
-        public string Release { get; set; }
+        public string? Release { get; set; }
 
         [DataMember(Name = "exception", EmitDefaultValue = false)]
-        internal SentryValues<SentryException> SentryExceptionValues { get; set; }
+        internal SentryValues<SentryException>? SentryExceptionValues { get; set; }
 
         [DataMember(Name = "threads", EmitDefaultValue = false)]
-        internal SentryValues<SentryThread> SentryThreadValues { get; set; }
+        internal SentryValues<SentryThread>? SentryThreadValues { get; set; }
 
         /// <summary>
-        /// The Sentry Exception interface
+        /// The Sentry Exception interface.
         /// </summary>
-        public IEnumerable<SentryException> SentryExceptions
+        public IEnumerable<SentryException>? SentryExceptions
         {
             get => SentryExceptionValues?.Values ?? Enumerable.Empty<SentryException>();
-            set => SentryExceptionValues = value == null ? null : new SentryValues<SentryException>(value);
+            set => SentryExceptionValues = value != null ? new SentryValues<SentryException>(value) : null;
         }
 
         /// <summary>
-        /// The Sentry Thread interface
+        /// The Sentry Thread interface.
         /// </summary>
         /// <see href="https://docs.sentry.io/clientdev/interfaces/threads/"/>
-        public IEnumerable<SentryThread> SentryThreads
+        public IEnumerable<SentryThread>? SentryThreads
         {
             get => SentryThreadValues?.Values ?? Enumerable.Empty<SentryThread>();
-            set => SentryThreadValues = value == null ? null : new SentryValues<SentryThread>(value);
+            set => SentryThreadValues = value != null ? new SentryValues<SentryThread>(value) : null;
         }
 
         /// <summary>
         /// A list of relevant modules and their versions.
         /// </summary>
-        public IDictionary<string, string> Modules => InternalModules ?? (InternalModules = new Dictionary<string, string>());
+        public IDictionary<string, string> Modules => InternalModules ??= new Dictionary<string, string>();
 
         /// <summary>
-        /// Creates a new instance of <see cref="T:Sentry.SentryEvent" />
+        /// Creates a new instance of <see cref="T:Sentry.SentryEvent" />.
         /// </summary>
-        /// <inheritdoc />
+        // TODO: this method can be removed with a breaking change.
         public SentryEvent() : this(null)
-        { }
+        {
+        }
 
         /// <summary>
-        /// Creates a Sentry event with optional Exception details and default values like Id and Timestamp
+        /// Creates a Sentry event with optional Exception details and default values like Id and Timestamp.
         /// </summary>
         /// <param name="exception">The exception.</param>
-        public SentryEvent(Exception exception)
+        public SentryEvent(Exception? exception = null)
             : this(exception, null)
-        { }
+        {
+        }
 
         internal SentryEvent(
-            Exception exception = null,
+            Exception? exception = null,
             DateTimeOffset? timestamp = null,
             Guid id = default,
-            IScopeOptions options = null)
-            : base (options)
+            IScopeOptions? options = null)
+            : base(options)
         {
-            EventId = id == default ? Guid.NewGuid() : id;
+            EventId = id != default ? id : Guid.NewGuid();
 
             Timestamp = timestamp ?? DateTimeOffset.UtcNow;
             Exception = exception;

--- a/src/Sentry.Protocol/SentryId.cs
+++ b/src/Sentry.Protocol/SentryId.cs
@@ -3,25 +3,24 @@ using System;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// The identifier of an event in Sentry
+    /// The identifier of an event in Sentry.
     /// </summary>
     public readonly struct SentryId
     {
         private readonly Guid _eventId;
 
         /// <summary>
-        /// An empty sentry id
+        /// An empty sentry id.
         /// </summary>
         public static readonly SentryId Empty = Guid.Empty;
 
         /// <summary>
-        /// Creates a new instance of a Sentry Id
+        /// Creates a new instance of a Sentry Id.
         /// </summary>
-        /// <param name="guid"></param>
         public SentryId(Guid guid) => _eventId = guid;
 
         /// <summary>
-        /// Sentry Id in the format Sentry recognizes
+        /// Sentry Id in the format Sentry recognizes.
         /// </summary>
         /// <remarks>
         /// Default <see cref="ToString"/> of <see cref="Guid"/> includes
@@ -31,15 +30,13 @@ namespace Sentry.Protocol
         public override string ToString() => _eventId.ToString("n");
 
         /// <summary>
-        /// The <see cref="Guid"/> from the <see cref="SentryId"/>
+        /// The <see cref="Guid"/> from the <see cref="SentryId"/>.
         /// </summary>
-        /// <param name="sentryId"></param>
         public static implicit operator Guid(SentryId sentryId) => sentryId._eventId;
 
         /// <summary>
-        /// A <see cref="SentryId"/> from a <see cref="Guid"/>
+        /// A <see cref="SentryId"/> from a <see cref="Guid"/>.
         /// </summary>
-        /// <param name="guid"></param>
         public static implicit operator SentryId(Guid guid) => new SentryId(guid);
     }
 }

--- a/src/Sentry.Protocol/SentryLevel.cs
+++ b/src/Sentry.Protocol/SentryLevel.cs
@@ -3,32 +3,36 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// The level of the event sent to Sentry
+    /// The level of the event sent to Sentry.
     /// </summary>
     public enum SentryLevel : short
     {
         /// <summary>
-        /// Debug
+        /// Debug.
         /// </summary>
         [EnumMember(Value = "debug")]
         Debug,
+
         /// <summary>
-        /// Informational
+        /// Informational.
         /// </summary>
         [EnumMember(Value = "info")]
         Info,
+
         /// <summary>
-        /// Warning
+        /// Warning.
         /// </summary>
         [EnumMember(Value = "warning")]
         Warning,
+
         /// <summary>
-        /// Error
+        /// Error.
         /// </summary>
         [EnumMember(Value = "error")]
         Error,
+
         /// <summary>
-        /// Fatal
+        /// Fatal.
         /// </summary>
         [EnumMember(Value = "fatal")]
         Fatal

--- a/src/Sentry.Protocol/SentryThread.cs
+++ b/src/Sentry.Protocol/SentryThread.cs
@@ -3,23 +3,23 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// A thread running at the time of an event
+    /// A thread running at the time of an event.
     /// </summary>
     /// <see href="https://docs.sentry.io/clientdev/interfaces/threads/"/>
     [DataContract]
     public class SentryThread
     {
         /// <summary>
-        /// The Id of the thread
+        /// The Id of the thread.
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
         public int? Id { get; set; }
 
         /// <summary>
-        /// The name of the thread
+        /// The name of the thread.
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string  Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Whether the crash happened on this thread.
@@ -34,10 +34,10 @@ namespace Sentry.Protocol
         public bool? Current { get; set; }
 
         /// <summary>
-        /// Stack trace
+        /// Stack trace.
         /// </summary>
         /// <see href="https://docs.sentry.io/clientdev/interfaces/stacktrace/"/>
         [DataMember(Name = "stacktrace", EmitDefaultValue = false)]
-        public SentryStackTrace Stacktrace { get; set; }
+        public SentryStackTrace? Stacktrace { get; set; }
     }
 }

--- a/src/Sentry.Protocol/SentryValues.cs
+++ b/src/Sentry.Protocol/SentryValues.cs
@@ -5,22 +5,20 @@ using System.Runtime.Serialization;
 namespace Sentry.Protocol
 {
     /// <summary>
-    /// Helps serialization of Sentry protocol types which include a values property
+    /// Helps serialization of Sentry protocol types which include a values property.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
     [DataContract]
     public class SentryValues<T>
     {
         /// <summary>
-        /// The values
+        /// The values.
         /// </summary>
         [DataMember(Name = "values", EmitDefaultValue = false)]
         public IEnumerable<T> Values { get; }
 
         /// <summary>
-        /// Creates an instance from the specified <see cref="IEnumerable{T}"/>
+        /// Creates an instance from the specified <see cref="IEnumerable{T}"/>.
         /// </summary>
-        /// <param name="values"></param>
-        public SentryValues(IEnumerable<T> values) => Values = values ?? Enumerable.Empty<T>();
+        public SentryValues(IEnumerable<T>? values) => Values = values ?? Enumerable.Empty<T>();
     }
 }

--- a/src/Sentry.Protocol/User.cs
+++ b/src/Sentry.Protocol/User.cs
@@ -80,11 +80,8 @@ namespace Sentry.Protocol
             }
 
             user.Email ??= Email;
-
             user.Id ??= Id;
-
             user.Username ??= Username;
-
             user.IpAddress ??= IpAddress;
 
             user.InternalOther ??= InternalOther?.ToDictionary(

--- a/src/Sentry.Protocol/User.cs
+++ b/src/Sentry.Protocol/User.cs
@@ -18,7 +18,7 @@ namespace Sentry.Protocol
         /// The user's email address.
         /// </value>
         [DataMember(Name = "email", EmitDefaultValue = false)]
-        public string Email { get; set; }
+        public string? Email { get; set; }
 
         /// <summary>
         /// The unique ID of the user.
@@ -27,7 +27,7 @@ namespace Sentry.Protocol
         /// The unique identifier.
         /// </value>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         /// <summary>
         /// The IP of the user.
@@ -36,26 +36,26 @@ namespace Sentry.Protocol
         /// The user's IP address.
         /// </value>
         [DataMember(Name = "ip_address", EmitDefaultValue = false)]
-        public string IpAddress { get; set; }
+        public string? IpAddress { get; set; }
 
         /// <summary>
-        /// The username of the user
+        /// The username of the user.
         /// </summary>
         /// <value>
         /// The user's username.
         /// </value>
         [DataMember(Name = "username", EmitDefaultValue = false)]
-        public string Username { get; set; }
+        public string? Username { get; set; }
 
         [DataMember(Name = "other", EmitDefaultValue = false)]
-        internal IDictionary<string, string> InternalOther;
+        internal IDictionary<string, string>? InternalOther;
 
         /// <summary>
-        /// Additional information about the user
+        /// Additional information about the user.
         /// </summary>
         public IDictionary<string, string> Other
         {
-            get => InternalOther ?? (InternalOther = new Dictionary<string, string>());
+            get => InternalOther ??= new Dictionary<string, string>();
             set => InternalOther = value;
         }
 
@@ -72,38 +72,25 @@ namespace Sentry.Protocol
             return user;
         }
 
-        internal void CopyTo(User user)
+        internal void CopyTo(User? user)
         {
             if (user == null)
             {
                 return;
             }
 
-            if (user.Email == null)
-            {
-                user.Email = Email;
-            }
+            user.Email ??= Email;
 
-            if (user.Id == null)
-            {
-                user.Id = Id;
-            }
+            user.Id ??= Id;
 
-            if (user.Username == null)
-            {
-                user.Username = Username;
-            }
+            user.Username ??= Username;
 
-            if (user.IpAddress == null)
-            {
-                user.IpAddress = IpAddress;
-            }
+            user.IpAddress ??= IpAddress;
 
-            if (user.InternalOther == null)
-            {
-                user.InternalOther = InternalOther?.ToDictionary(entry => entry.Key,
-                                                  entry => entry.Value);
-            }
+            user.InternalOther ??= InternalOther?.ToDictionary(
+                entry => entry.Key,
+                entry => entry.Value
+            );
         }
     }
 }

--- a/src/Sentry/DsnAttribute.cs
+++ b/src/Sentry/DsnAttribute.cs
@@ -3,9 +3,8 @@ using System;
 namespace Sentry
 {
     /// <summary>
-    /// A way to configure the DSN via attribute defined at the entry-assembly
+    /// A way to configure the DSN via attribute defined at the entry-assembly.
     /// </summary>
-    /// <inheritdoc />
     [AttributeUsage(AttributeTargets.Assembly)]
     public class DsnAttribute : Attribute
     {
@@ -15,10 +14,8 @@ namespace Sentry
         public string Dsn { get; }
 
         /// <summary>
-        /// Creates a new instance of <see cref="T:Sentry.DsnAttribute" />
+        /// Creates a new instance of <see cref="T:Sentry.DsnAttribute" />.
         /// </summary>
-        /// <param name="dsn"></param>
-        /// <inheritdoc />
         public DsnAttribute(string dsn) => Dsn = dsn;
     }
 }

--- a/src/Sentry/Extensibility/BaseRequestPayloadExtractor.cs
+++ b/src/Sentry/Extensibility/BaseRequestPayloadExtractor.cs
@@ -8,9 +8,9 @@ namespace Sentry.Extensibility
         /// <summary>
         /// Extract the payload of the <see cref="IHttpRequest"/>.
         /// </summary>
-        public object? ExtractPayload(IHttpRequest request)
+        public object? ExtractPayload(IHttpRequest? request)
         {
-            if (request.Body == null
+            if (request?.Body == null
                 || !request.Body.CanSeek
                 || !request.Body.CanRead
                 || !IsSupported(request))

--- a/src/Sentry/Extensibility/BaseRequestPayloadExtractor.cs
+++ b/src/Sentry/Extensibility/BaseRequestPayloadExtractor.cs
@@ -6,13 +6,12 @@ namespace Sentry.Extensibility
     public abstract class BaseRequestPayloadExtractor : IRequestPayloadExtractor
     {
         /// <summary>
-        /// Extract the payload of the <see cref="IHttpRequest"/>
+        /// Extract the payload of the <see cref="IHttpRequest"/>.
         /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
-        public object ExtractPayload(IHttpRequest request)
+        public object? ExtractPayload(IHttpRequest request)
         {
-            if (!request.Body.CanSeek
+            if (request.Body == null
+                || !request.Body.CanSeek
                 || !request.Body.CanRead
                 || !IsSupported(request))
             {
@@ -33,17 +32,13 @@ namespace Sentry.Extensibility
         }
 
         /// <summary>
-        /// Whether this implementation supports the <see cref="IHttpRequest"/>
+        /// Whether this implementation supports the <see cref="IHttpRequest"/>.
         /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
         protected abstract bool IsSupported(IHttpRequest request);
 
         /// <summary>
         /// The extraction that gets called in case <see cref="IsSupported"/> is true.
         /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
-        protected abstract object DoExtractPayLoad(IHttpRequest request);
+        protected abstract object? DoExtractPayLoad(IHttpRequest request);
     }
 }

--- a/src/Sentry/Extensibility/BaseRequestPayloadExtractor.cs
+++ b/src/Sentry/Extensibility/BaseRequestPayloadExtractor.cs
@@ -8,9 +8,16 @@ namespace Sentry.Extensibility
         /// <summary>
         /// Extract the payload of the <see cref="IHttpRequest"/>.
         /// </summary>
-        public object? ExtractPayload(IHttpRequest? request)
+        public object? ExtractPayload(IHttpRequest request)
         {
-            if (request?.Body == null
+            // Not to throw on code that ignores nullability warnings.
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            if (request is null)
+            {
+                return null;
+            }
+
+            if (request.Body == null
                 || !request.Body.CanSeek
                 || !request.Body.CanRead
                 || !IsSupported(request))

--- a/src/Sentry/Extensibility/DefaultRequestPayloadExtractor.cs
+++ b/src/Sentry/Extensibility/DefaultRequestPayloadExtractor.cs
@@ -11,34 +11,29 @@ namespace Sentry.Extensibility
         /// <summary>
         /// Whether the <see cref="IHttpRequest"/> is supported.
         /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
         protected override bool IsSupported(IHttpRequest request) => true;
 
         /// <summary>
         /// Extracts the request body of the <see cref="IHttpRequest"/> as a string.
         /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
-        protected override object DoExtractPayLoad(IHttpRequest request)
+        protected override object? DoExtractPayLoad(IHttpRequest request)
         {
             // https://github.com/dotnet/corefx/blob/master/src/Common/src/CoreLib/System/IO/StreamReader.cs#L186
             // Default parameters other than 'leaveOpen'
-            using (var reader = new StreamReader(request.Body, Encoding.UTF8, true, 1024,
+            using var reader = new StreamReader(request.Body, Encoding.UTF8, true, 1024,
                 // Make sure StreamReader does not close the stream:
-                leaveOpen: true))
-            {
-                // This can't be turned into async because it's called by sync API, i.e: _logger.LogError()
-                // But at this point the stream should already be buffered: Model binding happened,
-                // request is buffered so data is still in memory, no blocking call is done below.
-                // A custom serializer that would take the stream and read from it into the output stream would add more value
-                // as it would avoid the need to create the following (possibly huge) string
-                // Note: Using ReadToEndAsync instead of ReadToEnd because in ASP.NET Core 3 sync calls will throw.
-                var body = reader.ReadToEndAsync().GetAwaiter().GetResult();
-                return body.Length == 0
-                    ? null
-                    : body;
-            }
+                leaveOpen: true);
+
+            // This can't be turned into async because it's called by sync API, i.e: _logger.LogError()
+            // But at this point the stream should already be buffered: Model binding happened,
+            // request is buffered so data is still in memory, no blocking call is done below.
+            // A custom serializer that would take the stream and read from it into the output stream would add more value
+            // as it would avoid the need to create the following (possibly huge) string
+            // Note: Using ReadToEndAsync instead of ReadToEnd because in ASP.NET Core 3 sync calls will throw.
+            var body = reader.ReadToEndAsync().GetAwaiter().GetResult();
+            return body.Length != 0
+                ? body
+                : null;
         }
     }
 }

--- a/src/Sentry/Extensibility/DiagnosticLoggerExtensions.cs
+++ b/src/Sentry/Extensibility/DiagnosticLoggerExtensions.cs
@@ -7,74 +7,74 @@ namespace Sentry.Extensibility
     internal static class DiagnosticLoggerExtensions
     {
         public static void LogDebug<TArg>(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             string message,
             TArg arg)
             => logger.LogIfEnabled(SentryLevel.Debug, message, arg);
 
         public static void LogDebug<TArg, TArg2>(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             string message,
             TArg arg,
             TArg2 arg2)
             => logger.LogIfEnabled(SentryLevel.Debug, message, arg, arg2);
 
         public static void LogDebug(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             string message)
             => logger.LogIfEnabled(SentryLevel.Debug, message);
 
         public static void LogInfo(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             string message)
             => logger.LogIfEnabled(SentryLevel.Info, message);
 
         public static void LogInfo<TArg>(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             string message,
             TArg arg)
             => logger.LogIfEnabled(SentryLevel.Info, message, arg);
 
         public static void LogInfo<TArg, TArg2>(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             string message,
             TArg arg,
             TArg2 arg2)
             => logger.LogIfEnabled(SentryLevel.Info, message, arg, arg2);
 
         public static void LogWarning(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             string message)
             => logger.LogIfEnabled(SentryLevel.Warning, message);
 
         public static void LogWarning<TArg>(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             string message,
             TArg arg)
             => logger.LogIfEnabled(SentryLevel.Warning, message, arg);
 
         public static void LogWarning<TArg, TArg2>(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             string message,
             TArg arg,
             TArg2 arg2)
             => logger.LogIfEnabled(SentryLevel.Warning, message, arg, arg2);
 
         public static void LogError(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             string message,
             Exception? exception = null)
             => logger.LogIfEnabled(SentryLevel.Error, message, exception);
 
         public static void LogError<TArg>(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             string message,
             Exception exception,
             TArg arg)
             => logger.LogIfEnabled(SentryLevel.Error, message, exception, arg);
 
         public static void LogError<TArg, TArg2>(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             string message,
             Exception exception,
             TArg arg,
@@ -82,52 +82,52 @@ namespace Sentry.Extensibility
             => logger.LogIfEnabled(SentryLevel.Error, message, exception, arg, arg2);
 
         public static void LogFatal(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             string message,
             Exception? exception = null)
             => logger.LogIfEnabled(SentryLevel.Fatal, message, exception);
 
         internal static void LogIfEnabled(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             SentryLevel level,
             string message,
             Exception? exception = null)
         {
-            if (logger?.IsEnabled(level) == true)
+            if (logger.IsEnabled(level))
             {
                 logger.Log(level, message, exception);
             }
         }
 
         internal static void LogIfEnabled<TArg>(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             SentryLevel level,
             string message,
             TArg arg,
             Exception? exception = null)
         {
-            if (logger?.IsEnabled(level) == true)
+            if (logger.IsEnabled(level))
             {
                 logger.Log(level, message, exception, arg);
             }
         }
 
         internal static void LogIfEnabled<TArg, TArg2>(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             SentryLevel level,
             string message,
             TArg arg,
             TArg2 arg2,
             Exception? exception = null)
         {
-            if (logger?.IsEnabled(level) == true)
+            if (logger.IsEnabled(level))
             {
                 logger.Log(level, message, exception, arg, arg2);
             }
         }
 
         internal static void LogIfEnabled<TArg, TArg2, TArg3>(
-            this IDiagnosticLogger? logger,
+            this IDiagnosticLogger logger,
             SentryLevel level,
             string message,
             TArg arg,
@@ -135,7 +135,7 @@ namespace Sentry.Extensibility
             TArg3 arg3,
             Exception? exception = null)
         {
-            if (logger?.IsEnabled(level) == true)
+            if (logger.IsEnabled(level))
             {
                 logger.Log(level, message, exception, arg, arg2, arg3);
             }

--- a/src/Sentry/Extensibility/DiagnosticLoggerExtensions.cs
+++ b/src/Sentry/Extensibility/DiagnosticLoggerExtensions.cs
@@ -7,74 +7,74 @@ namespace Sentry.Extensibility
     internal static class DiagnosticLoggerExtensions
     {
         public static void LogDebug<TArg>(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             string message,
             TArg arg)
             => logger.LogIfEnabled(SentryLevel.Debug, message, arg);
 
         public static void LogDebug<TArg, TArg2>(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             string message,
             TArg arg,
             TArg2 arg2)
             => logger.LogIfEnabled(SentryLevel.Debug, message, arg, arg2);
 
         public static void LogDebug(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             string message)
             => logger.LogIfEnabled(SentryLevel.Debug, message);
 
         public static void LogInfo(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             string message)
             => logger.LogIfEnabled(SentryLevel.Info, message);
 
         public static void LogInfo<TArg>(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             string message,
             TArg arg)
             => logger.LogIfEnabled(SentryLevel.Info, message, arg);
 
         public static void LogInfo<TArg, TArg2>(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             string message,
             TArg arg,
             TArg2 arg2)
             => logger.LogIfEnabled(SentryLevel.Info, message, arg, arg2);
 
         public static void LogWarning(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             string message)
             => logger.LogIfEnabled(SentryLevel.Warning, message);
 
         public static void LogWarning<TArg>(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             string message,
             TArg arg)
             => logger.LogIfEnabled(SentryLevel.Warning, message, arg);
 
         public static void LogWarning<TArg, TArg2>(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             string message,
             TArg arg,
             TArg2 arg2)
             => logger.LogIfEnabled(SentryLevel.Warning, message, arg, arg2);
 
         public static void LogError(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             string message,
-            Exception exception = null)
+            Exception? exception = null)
             => logger.LogIfEnabled(SentryLevel.Error, message, exception);
 
         public static void LogError<TArg>(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             string message,
             Exception exception,
             TArg arg)
             => logger.LogIfEnabled(SentryLevel.Error, message, exception, arg);
 
         public static void LogError<TArg, TArg2>(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             string message,
             Exception exception,
             TArg arg,
@@ -82,16 +82,16 @@ namespace Sentry.Extensibility
             => logger.LogIfEnabled(SentryLevel.Error, message, exception, arg, arg2);
 
         public static void LogFatal(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             string message,
-            Exception exception = null)
+            Exception? exception = null)
             => logger.LogIfEnabled(SentryLevel.Fatal, message, exception);
 
         internal static void LogIfEnabled(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             SentryLevel level,
             string message,
-            Exception exception = null)
+            Exception? exception = null)
         {
             if (logger?.IsEnabled(level) == true)
             {
@@ -100,11 +100,11 @@ namespace Sentry.Extensibility
         }
 
         internal static void LogIfEnabled<TArg>(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             SentryLevel level,
             string message,
             TArg arg,
-            Exception exception = null)
+            Exception? exception = null)
         {
             if (logger?.IsEnabled(level) == true)
             {
@@ -113,12 +113,12 @@ namespace Sentry.Extensibility
         }
 
         internal static void LogIfEnabled<TArg, TArg2>(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             SentryLevel level,
             string message,
             TArg arg,
             TArg2 arg2,
-            Exception exception = null)
+            Exception? exception = null)
         {
             if (logger?.IsEnabled(level) == true)
             {
@@ -127,13 +127,13 @@ namespace Sentry.Extensibility
         }
 
         internal static void LogIfEnabled<TArg, TArg2, TArg3>(
-            this IDiagnosticLogger logger,
+            this IDiagnosticLogger? logger,
             SentryLevel level,
             string message,
             TArg arg,
             TArg2 arg2,
             TArg3 arg3,
-            Exception exception = null)
+            Exception? exception = null)
         {
             if (logger?.IsEnabled(level) == true)
             {

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -12,49 +12,52 @@ namespace Sentry.Extensibility
         /// <summary>
         /// The singleton instance.
         /// </summary>
-        public static DisabledHub Instance = new DisabledHub();
+        public static readonly DisabledHub Instance = new DisabledHub();
 
         /// <summary>
         /// Always disabled.
         /// </summary>
         public bool IsEnabled => false;
 
-        private DisabledHub() { }
+        private DisabledHub()
+        {
+        }
 
         /// <summary>
         /// No-Op.
         /// </summary>
-        /// <param name="configureScope"></param>
-        public void ConfigureScope(Action<Scope> configureScope) { }
+        public void ConfigureScope(Action<Scope> configureScope)
+        {
+        }
+
         /// <summary>
         /// No-Op.
         /// </summary>
-        /// <param name="configureScope"></param>
-        /// <returns></returns>
         public Task ConfigureScopeAsync(Func<Scope, Task> configureScope) => Task.CompletedTask;
 
         /// <summary>
         /// No-Op.
         /// </summary>
-        /// <returns></returns>
         public IDisposable PushScope() => this;
+
         /// <summary>
         /// No-Op.
         /// </summary>
-        /// <param name="state"></param>
-        /// <typeparam name="TState"></typeparam>
-        /// <returns></returns>
         public IDisposable PushScope<TState>(TState state) => this;
 
         /// <summary>
         /// No-Op.
         /// </summary>
-        public void WithScope(Action<Scope> scopeCallback) { }
+        public void WithScope(Action<Scope> scopeCallback)
+        {
+        }
 
         /// <summary>
         /// No-Op.
         /// </summary>
-        public void BindClient(ISentryClient client) { }
+        public void BindClient(ISentryClient client)
+        {
+        }
 
         /// <summary>
         /// No-Op.
@@ -69,7 +72,9 @@ namespace Sentry.Extensibility
         /// <summary>
         /// No-Op.
         /// </summary>
-        public void Dispose() { }
+        public void Dispose()
+        {
+        }
 
         /// <summary>
         /// No-Op.

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -59,7 +59,7 @@ namespace Sentry.Extensibility
         /// <summary>
         /// No-Op.
         /// </summary>
-        public SentryId CaptureEvent(SentryEvent evt, Scope scope = null) => SentryId.Empty;
+        public SentryId CaptureEvent(SentryEvent evt, Scope? scope = null) => SentryId.Empty;
 
         /// <summary>
         /// No-Op.

--- a/src/Sentry/Extensibility/FormRequestPayloadExtractor.cs
+++ b/src/Sentry/Extensibility/FormRequestPayloadExtractor.cs
@@ -11,10 +11,8 @@ namespace Sentry.Extensibility
         private const string SupportedContentType = "application/x-www-form-urlencoded";
 
         /// <summary>
-        /// Supports <see cref="IHttpRequest"/> with content type application/x-www-form-urlencoded
+        /// Supports <see cref="IHttpRequest"/> with content type application/x-www-form-urlencoded.
         /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
         protected override bool IsSupported(IHttpRequest request)
             => SupportedContentType
                 .Equals(request.ContentType, StringComparison.InvariantCulture);
@@ -22,9 +20,7 @@ namespace Sentry.Extensibility
         /// <summary>
         /// Extracts the request form data as a dictionary.
         /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
-        protected override object DoExtractPayLoad(IHttpRequest request)
+        protected override object? DoExtractPayLoad(IHttpRequest request)
             => request.Form?.ToDictionary(k => k.Key, v => v.Value);
     }
 }

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -9,7 +9,7 @@ using Sentry.Protocol;
 namespace Sentry.Extensibility
 {
     /// <summary>
-    /// An implementation of <see cref="IHub" /> which forwards any call to <see cref="SentrySdk" />
+    /// An implementation of <see cref="IHub" /> which forwards any call to <see cref="SentrySdk" />.
     /// </summary>
     /// <remarks>
     /// Allows testing classes which otherwise would need to depend on static <see cref="SentrySdk" />
@@ -27,109 +27,109 @@ namespace Sentry.Extensibility
         private HubAdapter() { }
 
         /// <summary>
-        /// Forwards the call to <see cref="SentrySdk"/>
+        /// Forwards the call to <see cref="SentrySdk"/>.
         /// </summary>
         public bool IsEnabled { [DebuggerStepThrough] get => SentrySdk.IsEnabled; }
 
         /// <summary>
-        /// Forwards the call to <see cref="SentrySdk"/>
+        /// Forwards the call to <see cref="SentrySdk"/>.
         /// </summary>
         public SentryId LastEventId { [DebuggerStepThrough] get => SentrySdk.LastEventId; }
 
         /// <summary>
-        /// Forwards the call to <see cref="SentrySdk"/>
+        /// Forwards the call to <see cref="SentrySdk"/>.
         /// </summary>
         [DebuggerStepThrough]
         public void ConfigureScope(Action<Scope> configureScope)
             => SentrySdk.ConfigureScope(configureScope);
 
         /// <summary>
-        /// Forwards the call to <see cref="SentrySdk"/>
+        /// Forwards the call to <see cref="SentrySdk"/>.
         /// </summary>
         [DebuggerStepThrough]
         public Task ConfigureScopeAsync(Func<Scope, Task> configureScope)
             => SentrySdk.ConfigureScopeAsync(configureScope);
 
         /// <summary>
-        /// Forwards the call to <see cref="SentrySdk"/>
+        /// Forwards the call to <see cref="SentrySdk"/>.
         /// </summary>
         [DebuggerStepThrough]
         public IDisposable PushScope()
             => SentrySdk.PushScope();
 
         /// <summary>
-        /// Forwards the call to <see cref="SentrySdk"/>
+        /// Forwards the call to <see cref="SentrySdk"/>.
         /// </summary>
         [DebuggerStepThrough]
         public IDisposable PushScope<TState>(TState state)
             => SentrySdk.PushScope(state);
 
         /// <summary>
-        /// Forwards the call to <see cref="SentrySdk"/>
+        /// Forwards the call to <see cref="SentrySdk"/>.
         /// </summary>
         [DebuggerStepThrough]
         public void WithScope(Action<Scope> scopeCallback)
             => SentrySdk.WithScope(scopeCallback);
 
         /// <summary>
-        /// Forwards the call to <see cref="SentrySdk"/>
+        /// Forwards the call to <see cref="SentrySdk"/>.
         /// </summary>
         [DebuggerStepThrough]
         public void BindClient(ISentryClient client)
             => SentrySdk.BindClient(client);
 
         /// <summary>
-        /// Forwards the call to <see cref="SentrySdk"/>
+        /// Forwards the call to <see cref="SentrySdk"/>.
         /// </summary>
         [DebuggerStepThrough]
         public void AddBreadcrumb(
             string message,
-            string category = null,
-            string type = null,
-            IDictionary<string, string> data = null,
+            string? category = null,
+            string? type = null,
+            IDictionary<string, string>? data = null,
             BreadcrumbLevel level = default)
             => SentrySdk.AddBreadcrumb(message, category, type, data, level);
 
         /// <summary>
-        /// Forwards the call to <see cref="SentrySdk"/>
+        /// Forwards the call to <see cref="SentrySdk"/>.
         /// </summary>
         [DebuggerStepThrough]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void AddBreadcrumb(
             ISystemClock clock,
             string message,
-            string category = null,
-            string type = null,
-            IDictionary<string, string> data = null,
+            string? category = null,
+            string? type = null,
+            IDictionary<string, string>? data = null,
             BreadcrumbLevel level = default)
             => SentrySdk.AddBreadcrumb(
-                clock: clock,
-                message: message,
-                type: type,
-                data: data,
-                category: category,
-                level: level);
+                clock,
+                message,
+                category,
+                type,
+                data,
+                level);
 
         /// <summary>
-        /// Forwards the call to <see cref="SentrySdk"/>
+        /// Forwards the call to <see cref="SentrySdk"/>.
         /// </summary>
         [DebuggerStepThrough]
         public SentryId CaptureEvent(SentryEvent evt)
             => SentrySdk.CaptureEvent(evt);
 
         /// <summary>
-        /// Forwards the call to <see cref="SentrySdk"/>
+        /// Forwards the call to <see cref="SentrySdk"/>.
         /// </summary>
         [DebuggerStepThrough]
         public SentryId CaptureException(Exception exception)
             => SentrySdk.CaptureException(exception);
 
         /// <summary>
-        /// Forwards the call to <see cref="SentrySdk"/>
+        /// Forwards the call to <see cref="SentrySdk"/>.
         /// </summary>
         [DebuggerStepThrough]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public SentryId CaptureEvent(SentryEvent evt, Scope scope)
+        public SentryId CaptureEvent(SentryEvent evt, Scope? scope)
             => SentrySdk.CaptureEvent(evt, scope);
 
         /// <summary>

--- a/src/Sentry/Extensibility/IBackgroundWorker.cs
+++ b/src/Sentry/Extensibility/IBackgroundWorker.cs
@@ -11,15 +11,16 @@ namespace Sentry.Extensibility
         /// <summary>
         /// Attempts to queue the event with the worker.
         /// </summary>
-        /// <param name="event"></param>
         /// <returns>True of queueing was successful. Otherwise, false.</returns>
         bool EnqueueEvent(SentryEvent @event);
+
         /// <summary>
         /// Flushes events asynchronously.
         /// </summary>
         /// <param name="timeout">How long to wait for flush to finish.</param>
         /// <returns>A task to await for the flush operation.</returns>
         Task FlushAsync(TimeSpan timeout);
+
         /// <summary>
         /// Current count of items queued up.
         /// </summary>

--- a/src/Sentry/Extensibility/IDiagnosticLogger.cs
+++ b/src/Sentry/Extensibility/IDiagnosticLogger.cs
@@ -21,6 +21,6 @@ namespace Sentry.Extensibility
         /// <param name="message">The message.</param>
         /// <param name="exception">An optional Exception.</param>
         /// <param name="args">Optional arguments for string template.</param>
-        void Log(SentryLevel logLevel, string message, Exception exception = null, params object[] args);
+        void Log(SentryLevel logLevel, string message, Exception? exception = null, params object?[] args);
     }
 }

--- a/src/Sentry/Extensibility/IDiagnosticLogger.cs
+++ b/src/Sentry/Extensibility/IDiagnosticLogger.cs
@@ -9,11 +9,10 @@ namespace Sentry.Extensibility
     public interface IDiagnosticLogger
     {
         /// <summary>
-        /// Whether the logger is enabled or not to the specified <see cref="SentryLevel"/>
+        /// Whether the logger is enabled or not to the specified <see cref="SentryLevel"/>.
         /// </summary>
-        /// <param name="level"></param>
-        /// <returns></returns>
         bool IsEnabled(SentryLevel level);
+
         /// <summary>
         /// Log an internal SDK message.
         /// </summary>

--- a/src/Sentry/Extensibility/IExceptionFilter.cs
+++ b/src/Sentry/Extensibility/IExceptionFilter.cs
@@ -11,7 +11,7 @@ namespace Sentry.Extensibility
         /// Whether to filter out or not the exception.
         /// </summary>
         /// <param name="ex">The exception about to be captured.</param>
-        /// <returns><c>true</c> if [the event should be filtered out]; otherwise, <c>false</c></returns>.
+        /// <returns><c>true</c> if [the event should be filtered out]; otherwise, <c>false</c>.</returns>
         bool Filter(Exception ex);
     }
 }

--- a/src/Sentry/Extensibility/IHttpRequest.cs
+++ b/src/Sentry/Extensibility/IHttpRequest.cs
@@ -12,17 +12,20 @@ namespace Sentry.Extensibility
         /// The content length.
         /// </summary>
         long? ContentLength { get; }
+
         /// <summary>
         /// The content type.
         /// </summary>
-        string ContentType { get; }
+        string? ContentType { get; }
+
         /// <summary>
         /// The request body.
         /// </summary>
-        Stream Body { get; }
+        Stream? Body { get; }
+
         /// <summary>
         /// Represents the parsed form values sent with the HttpRequest.
         /// </summary>
-        IEnumerable<KeyValuePair<string, IEnumerable<string>>> Form { get; }
+        IEnumerable<KeyValuePair<string, IEnumerable<string>>>? Form { get; }
     }
 }

--- a/src/Sentry/Extensibility/IRequestPayloadExtractor.cs
+++ b/src/Sentry/Extensibility/IRequestPayloadExtractor.cs
@@ -10,6 +10,6 @@ namespace Sentry.Extensibility
         /// </summary>
         /// <param name="request">The HTTP Request object.</param>
         /// <returns>The extracted payload.</returns>
-        object ExtractPayload(IHttpRequest request);
+        object? ExtractPayload(IHttpRequest request);
     }
 }

--- a/src/Sentry/Extensibility/IRequestPayloadExtractor.cs
+++ b/src/Sentry/Extensibility/IRequestPayloadExtractor.cs
@@ -10,6 +10,6 @@ namespace Sentry.Extensibility
         /// </summary>
         /// <param name="request">The HTTP Request object.</param>
         /// <returns>The extracted payload.</returns>
-        object? ExtractPayload(IHttpRequest? request);
+        object? ExtractPayload(IHttpRequest request);
     }
 }

--- a/src/Sentry/Extensibility/IRequestPayloadExtractor.cs
+++ b/src/Sentry/Extensibility/IRequestPayloadExtractor.cs
@@ -10,6 +10,6 @@ namespace Sentry.Extensibility
         /// </summary>
         /// <param name="request">The HTTP Request object.</param>
         /// <returns>The extracted payload.</returns>
-        object? ExtractPayload(IHttpRequest request);
+        object? ExtractPayload(IHttpRequest? request);
     }
 }

--- a/src/Sentry/Extensibility/ISentryEventExceptionProcessor.cs
+++ b/src/Sentry/Extensibility/ISentryEventExceptionProcessor.cs
@@ -3,7 +3,7 @@ using System;
 namespace Sentry.Extensibility
 {
     /// <summary>
-    /// Process exceptions and augments the event with its data
+    /// Process exceptions and augments the event with its data.
     /// </summary>
     public interface ISentryEventExceptionProcessor
     {

--- a/src/Sentry/Extensibility/ISentryEventExceptionProcessor.cs
+++ b/src/Sentry/Extensibility/ISentryEventExceptionProcessor.cs
@@ -12,6 +12,6 @@ namespace Sentry.Extensibility
         /// </summary>
         /// <param name="exception">The exception to process.</param>
         /// <param name="sentryEvent">The event to add data to.</param>
-        void Process(Exception? exception, SentryEvent sentryEvent);
+        void Process(Exception exception, SentryEvent sentryEvent);
     }
 }

--- a/src/Sentry/Extensibility/ISentryEventExceptionProcessor.cs
+++ b/src/Sentry/Extensibility/ISentryEventExceptionProcessor.cs
@@ -12,6 +12,6 @@ namespace Sentry.Extensibility
         /// </summary>
         /// <param name="exception">The exception to process.</param>
         /// <param name="sentryEvent">The event to add data to.</param>
-        void Process(Exception exception, SentryEvent sentryEvent);
+        void Process(Exception? exception, SentryEvent sentryEvent);
     }
 }

--- a/src/Sentry/Extensibility/ISentryEventProcessor.cs
+++ b/src/Sentry/Extensibility/ISentryEventProcessor.cs
@@ -15,6 +15,6 @@ namespace Sentry.Extensibility
         /// Returning null will stop the processing pipeline.
         /// Meaning the event should no longer be processed nor send.
         /// </remarks>
-        SentryEvent Process(SentryEvent @event);
+        SentryEvent? Process(SentryEvent @event);
     }
 }

--- a/src/Sentry/Extensibility/ISentryStackTraceFactory.cs
+++ b/src/Sentry/Extensibility/ISentryStackTraceFactory.cs
@@ -13,6 +13,6 @@ namespace Sentry.Extensibility
         /// </summary>
         /// <param name="exception">The exception to create the stacktrace from.</param>
         /// <returns>A Sentry stack trace.</returns>
-        SentryStackTrace Create(Exception exception = null);
+        SentryStackTrace? Create(Exception? exception = null);
     }
 }

--- a/src/Sentry/Extensibility/ITransport.cs
+++ b/src/Sentry/Extensibility/ITransport.cs
@@ -4,12 +4,12 @@ using System.Threading.Tasks;
 namespace Sentry.Extensibility
 {
     /// <summary>
-    /// An abstraction to the transport of the event
+    /// An abstraction to the transport of the event.
     /// </summary>
     public interface ITransport
     {
         /// <summary>
-        /// Sends the <see cref="SentryEvent" /> to Sentry asynchronously
+        /// Sends the <see cref="SentryEvent" /> to Sentry asynchronously.
         /// </summary>
         /// <param name="event">The event to send to Sentry.</param>
         /// <param name="cancellationToken">The cancellation token.</param>

--- a/src/Sentry/Extensibility/RequestBodyExtractionDispatcher.cs
+++ b/src/Sentry/Extensibility/RequestBodyExtractionDispatcher.cs
@@ -71,7 +71,7 @@ namespace Sentry.Extensibility
             }
 
             _options.DiagnosticLogger?.LogWarning("Ignoring request with Size {0} and configuration RequestSize {1}",
-                request.ContentLength, size);
+                request?.ContentLength, size);
 
             return null;
         }

--- a/src/Sentry/Extensibility/RequestBodyExtractionDispatcher.cs
+++ b/src/Sentry/Extensibility/RequestBodyExtractionDispatcher.cs
@@ -31,17 +31,17 @@ namespace Sentry.Extensibility
         /// </summary>
         /// <param name="request">The request.</param>
         /// <returns>A serializable representation of the payload.</returns>
-        public object? ExtractPayload(IHttpRequest request)
+        public object? ExtractPayload(IHttpRequest? request)
         {
             var size = _sizeSwitch();
 
             switch (size)
             {
-                case RequestSize.Small when request.ContentLength < 1_000:
-                case RequestSize.Medium when request.ContentLength < 10_000:
+                case RequestSize.Small when request?.ContentLength < 1_000:
+                case RequestSize.Medium when request?.ContentLength < 10_000:
                 case RequestSize.Always:
                     _options.DiagnosticLogger?.LogDebug("Attempting to read request body of size: {0}, configured max: {1}.",
-                        request.ContentLength, size);
+                        request?.ContentLength, size);
 
                     foreach (var extractor in Extractors)
                     {
@@ -64,7 +64,7 @@ namespace Sentry.Extensibility
             }
 
             _options.DiagnosticLogger?.LogWarning("Ignoring request with Size {0} and configuration RequestSize {1}",
-                request.ContentLength, size);
+                request?.ContentLength, size);
 
             return null;
         }

--- a/src/Sentry/Extensibility/RequestBodyExtractionDispatcher.cs
+++ b/src/Sentry/Extensibility/RequestBodyExtractionDispatcher.cs
@@ -31,8 +31,15 @@ namespace Sentry.Extensibility
         /// </summary>
         /// <param name="request">The request.</param>
         /// <returns>A serializable representation of the payload.</returns>
-        public object? ExtractPayload(IHttpRequest? request)
+        public object? ExtractPayload(IHttpRequest request)
         {
+            // Not to throw on code that ignores nullability warnings.
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            if (request is null)
+            {
+                return null;
+            }
+
             var size = _sizeSwitch();
 
             switch (size)
@@ -41,7 +48,7 @@ namespace Sentry.Extensibility
                 case RequestSize.Medium when request?.ContentLength < 10_000:
                 case RequestSize.Always:
                     _options.DiagnosticLogger?.LogDebug("Attempting to read request body of size: {0}, configured max: {1}.",
-                        request?.ContentLength, size);
+                        request.ContentLength, size);
 
                     foreach (var extractor in Extractors)
                     {
@@ -64,7 +71,7 @@ namespace Sentry.Extensibility
             }
 
             _options.DiagnosticLogger?.LogWarning("Ignoring request with Size {0} and configuration RequestSize {1}",
-                request?.ContentLength, size);
+                request.ContentLength, size);
 
             return null;
         }

--- a/src/Sentry/Extensibility/RequestBodyExtractionDispatcher.cs
+++ b/src/Sentry/Extensibility/RequestBodyExtractionDispatcher.cs
@@ -14,7 +14,7 @@ namespace Sentry.Extensibility
         internal IEnumerable<IRequestPayloadExtractor> Extractors { get; }
 
         /// <summary>
-        /// Creates a new instance of <see cref="RequestBodyExtractionDispatcher"/>
+        /// Creates a new instance of <see cref="RequestBodyExtractionDispatcher"/>.
         /// </summary>
         /// <param name="extractors">Extractors to use.</param>
         /// <param name="options">Sentry Options.</param>
@@ -31,13 +31,8 @@ namespace Sentry.Extensibility
         /// </summary>
         /// <param name="request">The request.</param>
         /// <returns>A serializable representation of the payload.</returns>
-        public object ExtractPayload(IHttpRequest request)
+        public object? ExtractPayload(IHttpRequest request)
         {
-            if (request == null)
-            {
-                return null;
-            }
-
             var size = _sizeSwitch();
 
             switch (size)

--- a/src/Sentry/Extensibility/RequestSize.cs
+++ b/src/Sentry/Extensibility/RequestSize.cs
@@ -10,14 +10,17 @@ namespace Sentry.Extensibility
         /// </summary>
         /// <remarks>This is the default value. Opt-in is required.</remarks>
         None,
+
         /// <summary>
         /// A small payload is extracted.
         /// </summary>
         Small,
+
         /// <summary>
         /// A medium payload is extracted.
         /// </summary>
         Medium,
+
         /// <summary>
         /// The SDK will always capture the request body. Sentry might truncate or reject the event if too large.
         /// </summary>

--- a/src/Sentry/Extensibility/SentryEventExceptionProcessor.cs
+++ b/src/Sentry/Extensibility/SentryEventExceptionProcessor.cs
@@ -3,9 +3,9 @@ using System;
 namespace Sentry.Extensibility
 {
     /// <summary>
-    /// Process an exception type and augments the event with its data
+    /// Process an exception type and augments the event with its data.
     /// </summary>
-    /// <typeparam name="TException">The type of the exception to process</typeparam>
+    /// <typeparam name="TException">The type of the exception to process.</typeparam>
     /// <inheritdoc />
     public abstract class SentryEventExceptionProcessor<TException>
         : ISentryEventExceptionProcessor

--- a/src/Sentry/Extensibility/SentryEventExceptionProcessor.cs
+++ b/src/Sentry/Extensibility/SentryEventExceptionProcessor.cs
@@ -12,7 +12,7 @@ namespace Sentry.Extensibility
         where TException : Exception
     {
         /// <inheritdoc />
-        public void Process(Exception exception, SentryEvent sentryEvent)
+        public void Process(Exception? exception, SentryEvent sentryEvent)
         {
             if (exception is TException specificException)
             {

--- a/src/Sentry/Extensibility/SentryStackTraceFactory.cs
+++ b/src/Sentry/Extensibility/SentryStackTraceFactory.cs
@@ -111,7 +111,6 @@ namespace Sentry.Extensibility
         /// <summary>
         /// Create a <see cref="SentryStackFrame"/> from a <see cref="StackFrame"/>.
         /// </summary>
-        // TODO: should this really ignore isCurrentStackTrace?
         protected virtual SentryStackFrame CreateFrame(StackFrame stackFrame, bool isCurrentStackTrace) => InternalCreateFrame(stackFrame, true);
 
         /// <summary>

--- a/src/Sentry/Extensibility/SentryStackTraceFactory.cs
+++ b/src/Sentry/Extensibility/SentryStackTraceFactory.cs
@@ -82,7 +82,6 @@ namespace Sentry.Extensibility
             var frames = stackTrace.GetFrames();
             if (frames == null)
             {
-                // TODO: this probably can never happen
                 _options.DiagnosticLogger?.LogDebug("No stack frames found. AttachStacktrace: '{0}', isCurrentStackTrace: '{1}'",
                     _options.AttachStacktrace, isCurrentStackTrace);
 

--- a/src/Sentry/Extensibility/SentryStackTraceFactory.cs
+++ b/src/Sentry/Extensibility/SentryStackTraceFactory.cs
@@ -46,7 +46,7 @@ namespace Sentry.Extensibility
         /// <param name="exception">The exception.</param>
         /// <returns>A StackTrace.</returns>
         protected virtual StackTrace CreateStackTrace(Exception? exception) =>
-            exception == null
+            exception is null
                 ? new StackTrace(true)
                 : new StackTrace(exception, true);
 

--- a/src/Sentry/Extensibility/SentryStackTraceFactory.cs
+++ b/src/Sentry/Extensibility/SentryStackTraceFactory.cs
@@ -16,9 +16,8 @@ namespace Sentry.Extensibility
         private readonly SentryOptions _options;
 
         /// <summary>
-        /// Creates an instance of <see cref="SentryStackTraceFactory"/>
+        /// Creates an instance of <see cref="SentryStackTraceFactory"/>.
         /// </summary>
-        /// <param name="options"></param>
         public SentryStackTraceFactory(SentryOptions options) => _options = options;
 
         /// <summary>
@@ -26,7 +25,7 @@ namespace Sentry.Extensibility
         /// </summary>
         /// <param name="exception">The exception to create the stacktrace from.</param>
         /// <returns>A Sentry stack trace.</returns>
-        public SentryStackTrace Create(Exception exception = null)
+        public SentryStackTrace? Create(Exception? exception = null)
         {
             var isCurrentStackTrace = exception == null && _options.AttachStacktrace;
 
@@ -46,8 +45,10 @@ namespace Sentry.Extensibility
         /// </summary>
         /// <param name="exception">The exception.</param>
         /// <returns>A StackTrace.</returns>
-        protected virtual StackTrace CreateStackTrace(Exception exception) =>
-            exception == null ? new StackTrace(true) : new StackTrace(exception, true);
+        protected virtual StackTrace CreateStackTrace(Exception? exception) =>
+            exception == null
+                ? new StackTrace(true)
+                : new StackTrace(exception, true);
 
         /// <summary>
         /// Creates a <see cref="SentryStackTrace"/> from the <see cref="StackTrace"/>.
@@ -55,7 +56,7 @@ namespace Sentry.Extensibility
         /// <param name="stackTrace">The stack trace.</param>
         /// <param name="isCurrentStackTrace">Whether this is the current stack trace.</param>
         /// <returns>SentryStackTrace</returns>
-        internal SentryStackTrace Create(StackTrace stackTrace, bool isCurrentStackTrace)
+        internal SentryStackTrace? Create(StackTrace stackTrace, bool isCurrentStackTrace)
         {
             var frames = CreateFrames(stackTrace, isCurrentStackTrace)
                 // Sentry expects the frames to be sent in reversed order
@@ -68,47 +69,41 @@ namespace Sentry.Extensibility
                 stacktrace.Frames.Add(frame);
             }
 
-            return stacktrace.Frames.Count == 0
-                ? null
-                : stacktrace;
+            return stacktrace.Frames.Count != 0
+                ? stacktrace
+                : null;
         }
 
         /// <summary>
         /// Creates an enumerator of <see cref="SentryStackFrame"/> from a <see cref="StackTrace"/>.
         /// </summary>
-        /// <param name="stackTrace"></param>
-        /// <param name="isCurrentStackTrace"></param>
-        /// <returns></returns>
         internal IEnumerable<SentryStackFrame> CreateFrames(StackTrace stackTrace, bool isCurrentStackTrace)
         {
-            var frames = stackTrace?.GetFrames();
+            var frames = stackTrace.GetFrames();
             if (frames == null)
             {
+                // TODO: this probably can never happen
                 _options.DiagnosticLogger?.LogDebug("No stack frames found. AttachStacktrace: '{0}', isCurrentStackTrace: '{1}'",
                     _options.AttachStacktrace, isCurrentStackTrace);
 
                 yield break;
             }
 
-            var firstFrames = true;
+            var firstFrame = true;
             foreach (var stackFrame in frames)
             {
                 // Remove the frames until the call for capture with the SDK
-                if (firstFrames
+                if (firstFrame
                     && isCurrentStackTrace
-                    && stackFrame.GetMethod() is MethodBase method
+                    && stackFrame.GetMethod() is { } method
                     && method.DeclaringType?.AssemblyQualifiedName?.StartsWith("Sentry") == true)
                 {
                     continue;
                 }
 
-                firstFrames = false;
+                firstFrame = false;
 
-                var frame = CreateFrame(stackFrame, isCurrentStackTrace);
-                if (frame != null)
-                {
-                    yield return frame;
-                }
+                yield return CreateFrame(stackFrame, isCurrentStackTrace);
             }
         }
 
@@ -117,9 +112,7 @@ namespace Sentry.Extensibility
         /// <summary>
         /// Create a <see cref="SentryStackFrame"/> from a <see cref="StackFrame"/>.
         /// </summary>
-        /// <param name="stackFrame"></param>
-        /// <param name="isCurrentStackTrace"></param>
-        /// <returns></returns>
+        // TODO: should this really ignore isCurrentStackTrace?
         protected virtual SentryStackFrame CreateFrame(StackFrame stackFrame, bool isCurrentStackTrace) => InternalCreateFrame(stackFrame, true);
 
         /// <summary>
@@ -129,7 +122,7 @@ namespace Sentry.Extensibility
         {
             const string unknownRequiredField = "(unknown)";
             var frame = new SentryStackFrame();
-            if (GetMethod(stackFrame) is MethodBase method)
+            if (GetMethod(stackFrame) is { } method)
             {
                 // TODO: SentryStackFrame.TryParse and skip frame instead of these unknown values:
                 frame.Module = method.DeclaringType?.FullName ?? unknownRequiredField;
@@ -172,33 +165,17 @@ namespace Sentry.Extensibility
         /// Get a <see cref="MethodBase"/> from <see cref="StackFrame"/>.
         /// </summary>
         /// <param name="stackFrame">The <see cref="StackFrame"/></param>.
-        /// <returns></returns>
         protected virtual MethodBase GetMethod(StackFrame stackFrame) => stackFrame.GetMethod();
 
-        private bool IsSystemModuleName(string moduleName)
+        private bool IsSystemModuleName(string? moduleName)
         {
             if (string.IsNullOrEmpty(moduleName))
             {
                 return false;
             }
 
-            foreach (var include in _options.InAppInclude)
-            {
-                if (moduleName.StartsWith(include, StringComparison.Ordinal))
-                {
-                    return false;
-                }
-            }
-
-            foreach (var exclude in _options.InAppExclude)
-            {
-                if (moduleName.StartsWith(exclude, StringComparison.Ordinal))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return _options.InAppInclude?.Any(include => moduleName.StartsWith(include, StringComparison.Ordinal)) != true &&
+                   _options.InAppExclude?.Any(exclude => moduleName.StartsWith(exclude, StringComparison.Ordinal)) == true;
         }
 
         /// <summary>
@@ -239,7 +216,7 @@ namespace Sentry.Extensibility
         /// </summary>
         internal static void DemangleAnonymousFunction(SentryStackFrame frame)
         {
-            if (frame?.Function == null)
+            if (frame.Function == null)
             {
                 return;
             }

--- a/src/Sentry/Http/ISentryHttpClientFactory.cs
+++ b/src/Sentry/Http/ISentryHttpClientFactory.cs
@@ -3,7 +3,7 @@ using System.Net.Http;
 namespace Sentry.Http
 {
     /// <summary>
-    /// Sentry <see cref="HttpClient"/> factory
+    /// Sentry <see cref="HttpClient"/> factory.
     /// </summary>
     public interface ISentryHttpClientFactory
     {
@@ -12,7 +12,7 @@ namespace Sentry.Http
         /// </summary>
         /// <param name="dsn">The DSN.</param>
         /// <param name="options">The options.</param>
-        /// <returns><see cref="HttpClient"/></returns>
+        /// <returns><see cref="HttpClient"/>.</returns>
         HttpClient Create(Dsn dsn, SentryOptions options);
     }
 }

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using Sentry.Infrastructure;
 using Sentry.Protocol;
 
@@ -24,7 +23,7 @@ namespace Sentry
         /// <param name="level">Breadcrumb level.</param>
         public static void AddBreadcrumb(
             this IHub hub,
-            string message,
+            string? message,
             string? category = null,
             string? type = null,
             IDictionary<string, string>? data = null,
@@ -54,7 +53,7 @@ namespace Sentry
         public static void AddBreadcrumb(
             this IHub hub,
             ISystemClock? clock,
-            string message,
+            string? message,
             string? category = null,
             string? type = null,
             IDictionary<string, string>? data = null,

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -2,63 +2,62 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
 using Sentry.Infrastructure;
 using Sentry.Protocol;
 
 namespace Sentry
 {
     /// <summary>
-    /// Extension methods for <see cref="IHub"/>
+    /// Extension methods for <see cref="IHub"/>.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class HubExtensions
     {
         /// <summary>
-        /// Adds a breadcrumb to the current scope
+        /// Adds a breadcrumb to the current scope.
         /// </summary>
-        /// <param name="hub">The Hub which holds the scope stack</param>
-        /// <param name="message">The message</param>
-        /// <param name="category">Category</param>
-        /// <param name="type">Breadcrumb type</param>
-        /// <param name="data">Additional data</param>
-        /// <param name="level">Breadcrumb level</param>
+        /// <param name="hub">The Hub which holds the scope stack.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="category">Category.</param>
+        /// <param name="type">Breadcrumb type.</param>
+        /// <param name="data">Additional data.</param>
+        /// <param name="level">Breadcrumb level.</param>
         public static void AddBreadcrumb(
             this IHub hub,
             string message,
-            string category = null,
-            string type = null,
-            IDictionary<string, string> data = null,
+            string? category = null,
+            string? type = null,
+            IDictionary<string, string>? data = null,
             BreadcrumbLevel level = default)
             => hub.AddBreadcrumb(
                 clock: null,
                 message: message,
-                type: type,
-                data: data != null ? new Dictionary<string,string>(data) : null,
                 category: category,
+                type: type,
+                data: data != null ? new Dictionary<string, string>(data) : null,
                 level: level);
 
         /// <summary>
-        /// Adds a breadcrumb using a custom <see cref="ISystemClock"/> which allows better testability
+        /// Adds a breadcrumb using a custom <see cref="ISystemClock"/> which allows better testability.
         /// </summary>
-        /// <param name="hub">The Hub which holds the scope stack</param>
-        /// <param name="clock">The system clock</param>
-        /// <param name="message">The message</param>
-        /// <param name="category">Category</param>
-        /// <param name="type">Breadcrumb type</param>
-        /// <param name="data">Additional data</param>
-        /// <param name="level">Breadcrumb level</param>
+        /// <param name="hub">The Hub which holds the scope stack.</param>
+        /// <param name="clock">The system clock.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="category">Category.</param>
+        /// <param name="type">Breadcrumb type.</param>
+        /// <param name="data">Additional data.</param>
+        /// <param name="level">Breadcrumb level.</param>
         /// <remarks>
-        /// This method is to be used by integrations to allow testing
+        /// This method is to be used by integrations to allow testing.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void AddBreadcrumb(
             this IHub hub,
-            ISystemClock clock,
+            ISystemClock? clock,
             string message,
-            string category = null,
-            string type = null,
-            IDictionary<string, string> data = null,
+            string? category = null,
+            string? type = null,
+            IDictionary<string, string>? data = null,
             BreadcrumbLevel level = default)
             => hub.ConfigureScope(
                 s => s.AddBreadcrumb(
@@ -70,10 +69,8 @@ namespace Sentry
                     level: level));
 
         /// <summary>
-        /// Pushes a new scope while locking it which stop new scope creation
+        /// Pushes a new scope while locking it which stop new scope creation.
         /// </summary>
-        /// <param name="hub"></param>
-        /// <returns></returns>
         public static IDisposable PushAndLockScope(this IHub hub) => new LockedScope(hub);
 
         /// <summary>
@@ -81,16 +78,14 @@ namespace Sentry
         /// </summary>
         /// <remarks>
         /// This is useful to stop following scope creation by other integrations
-        /// like Loggers which guarantee log messages are not lost
+        /// like Loggers which guarantee log messages are not lost.
         /// </remarks>
-        /// <param name="hub"></param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void LockScope(this IHub hub) => hub.ConfigureScope(c => c.Locked = true);
 
         /// <summary>
         /// Unlocks the current scope to allow subsequent calls to <see cref="ISentryScopeManager.PushScope"/> create new scopes.
         /// </summary>
-        /// <param name="hub"></param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void UnlockScope(this IHub hub) => hub.ConfigureScope(c => c.Locked = false);
 

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -23,18 +23,27 @@ namespace Sentry
         /// <param name="level">Breadcrumb level.</param>
         public static void AddBreadcrumb(
             this IHub hub,
-            string? message,
+            string message,
             string? category = null,
             string? type = null,
             IDictionary<string, string>? data = null,
             BreadcrumbLevel level = default)
-            => hub.AddBreadcrumb(
+        {
+            // Not to throw on code that ignores nullability warnings.
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            if (hub is null)
+            {
+                return;
+            }
+
+            hub.AddBreadcrumb(
                 null,
                 message,
                 category,
                 type,
                 data != null ? new Dictionary<string, string>(data) : null,
                 level);
+        }
 
         /// <summary>
         /// Adds a breadcrumb using a custom <see cref="ISystemClock"/> which allows better testability.
@@ -53,12 +62,20 @@ namespace Sentry
         public static void AddBreadcrumb(
             this IHub hub,
             ISystemClock? clock,
-            string? message,
+            string message,
             string? category = null,
             string? type = null,
             IDictionary<string, string>? data = null,
             BreadcrumbLevel level = default)
-            => hub.ConfigureScope(
+        {
+            // Not to throw on code that ignores nullability warnings.
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            if (hub is null)
+            {
+                return;
+            }
+
+            hub.ConfigureScope(
                 s => s.AddBreadcrumb(
                     (clock ?? SystemClock.Clock).GetUtcNow(),
                     message,
@@ -66,6 +83,7 @@ namespace Sentry
                     type,
                     data != null ? new Dictionary<string, string>(data) : null,
                     level));
+        }
 
         /// <summary>
         /// Pushes a new scope while locking it which stop new scope creation.

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -30,12 +30,12 @@ namespace Sentry
             IDictionary<string, string>? data = null,
             BreadcrumbLevel level = default)
             => hub.AddBreadcrumb(
-                clock: null,
-                message: message,
-                category: category,
-                type: type,
-                data: data != null ? new Dictionary<string, string>(data) : null,
-                level: level);
+                null,
+                message,
+                category,
+                type,
+                data != null ? new Dictionary<string, string>(data) : null,
+                level);
 
         /// <summary>
         /// Adds a breadcrumb using a custom <see cref="ISystemClock"/> which allows better testability.
@@ -61,12 +61,12 @@ namespace Sentry
             BreadcrumbLevel level = default)
             => hub.ConfigureScope(
                 s => s.AddBreadcrumb(
-                    timestamp: (clock ?? SystemClock.Clock).GetUtcNow(),
-                    message: message,
-                    category: category,
-                    type: type,
-                    data: data != null ? new Dictionary<string, string>(data) : null,
-                    level: level));
+                    (clock ?? SystemClock.Clock).GetUtcNow(),
+                    message,
+                    category,
+                    type,
+                    data != null ? new Dictionary<string, string>(data) : null,
+                    level));
 
         /// <summary>
         /// Pushes a new scope while locking it which stop new scope creation.
@@ -95,8 +95,6 @@ namespace Sentry
 
             public LockedScope(IHub hub)
             {
-                Debug.Assert(hub != null);
-
                 _scope = hub.PushScope();
                 hub.LockScope();
             }

--- a/src/Sentry/IHub.cs
+++ b/src/Sentry/IHub.cs
@@ -3,12 +3,12 @@ using Sentry.Protocol;
 namespace Sentry
 {
     /// <summary>
-    /// SDK API contract which combines a client and scope management
+    /// SDK API contract which combines a client and scope management.
     /// </summary>
     /// <remarks>
     /// The contract of which <see cref="T:Sentry.SentrySdk" /> exposes statically.
     /// This interface exist to allow better testability of integrations which otherwise
-    /// would require dependency to the static <see cref="T:Sentry.SentrySdk" />
+    /// would require dependency to the static <see cref="T:Sentry.SentrySdk" />.
     /// </remarks>
     /// <inheritdoc cref="ISentryClient" />
     /// <inheritdoc cref="ISentryScopeManager" />
@@ -17,7 +17,7 @@ namespace Sentry
         ISentryScopeManager
     {
         /// <summary>
-        /// Last event id recorded in the current scope
+        /// Last event id recorded in the current scope.
         /// </summary>
         SentryId LastEventId { get; }
     }

--- a/src/Sentry/ISentryClient.cs
+++ b/src/Sentry/ISentryClient.cs
@@ -5,22 +5,22 @@ using Sentry.Protocol;
 namespace Sentry
 {
     /// <summary>
-    /// Sentry Client interface
+    /// Sentry Client interface.
     /// </summary>
     public interface ISentryClient
     {
         /// <summary>
-        /// Whether the client is enabled or not
+        /// Whether the client is enabled or not.
         /// </summary>
         bool IsEnabled { get; }
 
         /// <summary>
-        /// Capture the event
+        /// Capture the event.
         /// </summary>
-        /// <param name="evt">The event to be captured</param>
+        /// <param name="evt">The event to be captured.</param>
         /// <param name="scope">An optional scope to be applied to the event.</param>
-        /// <returns>The Id of the event</returns>
-        SentryId CaptureEvent(SentryEvent evt, Scope scope = null);
+        /// <returns>The Id of the event.</returns>
+        SentryId CaptureEvent(SentryEvent evt, Scope? scope = null);
 
         /// <summary>
         /// Flushes events queued up.

--- a/src/Sentry/ISentryScopeManager.cs
+++ b/src/Sentry/ISentryScopeManager.cs
@@ -4,11 +4,11 @@ using System.Threading.Tasks;
 namespace Sentry
 {
     /// <summary>
-    /// Scope management
+    /// Scope management.
     /// </summary>
     /// <remarks>
     /// An implementation shall create new scopes and allow consumers
-    /// modify the current scope
+    /// modify the current scope.
     /// </remarks>
     public interface ISentryScopeManager
     {
@@ -32,23 +32,22 @@ namespace Sentry
         void BindClient(ISentryClient client);
 
         /// <summary>
-        /// Pushes a new scope into the stack which is removed upon Dispose
+        /// Pushes a new scope into the stack which is removed upon Dispose.
         /// </summary>
         /// <returns>A disposable which removes the scope
-        /// from the environment when invoked</returns>
+        /// from the environment when invoked.</returns>
         IDisposable PushScope();
 
         /// <summary>
-        /// Pushes a new scope into the stack which is removed upon Dispose
+        /// Pushes a new scope into the stack which is removed upon Dispose.
         /// </summary>
-        /// <param name="state">A state to associate with the scope</param>
-        /// <typeparam name="TState"></typeparam>
+        /// <param name="state">A state to associate with the scope.</param>
         /// <returns>A disposable which removes the scope
-        /// from the environment when invoked</returns>
+        /// from the environment when invoked.</returns>
         IDisposable PushScope<TState>(TState state);
 
         /// <summary>
-        /// Runs the callback with a new scope which gets dropped at the end
+        /// Runs the callback with a new scope which gets dropped at the end.
         /// </summary>
         /// <remarks>
         /// Pushes a new scope, runs the callback, pops the scope.

--- a/src/Sentry/Infrastructure/ConsoleDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/ConsoleDiagnosticLogger.cs
@@ -5,10 +5,10 @@ using Sentry.Protocol;
 namespace Sentry.Infrastructure
 {
     /// <summary>
-    /// Console logger used by the SDK to report its internal logging
+    /// Console logger used by the SDK to report its internal logging.
     /// </summary>
     /// <remarks>
-    /// The default logger, usually replaced by a higher level logging adapter like Microsoft.Extensions.Logging
+    /// The default logger, usually replaced by a higher level logging adapter like Microsoft.Extensions.Logging.
     /// </remarks>
     public class ConsoleDiagnosticLogger : IDiagnosticLogger
     {
@@ -17,24 +17,17 @@ namespace Sentry.Infrastructure
         /// <summary>
         /// Creates a new instance of <see cref="ConsoleDiagnosticLogger"/>.
         /// </summary>
-        /// <param name="minimalLevel"></param>
         public ConsoleDiagnosticLogger(SentryLevel minimalLevel) => _minimalLevel = minimalLevel;
 
         /// <summary>
         /// Whether the logger is enabled to the defined level.
         /// </summary>
-        /// <param name="level"></param>
-        /// <returns></returns>
         public bool IsEnabled(SentryLevel level) => level >= _minimalLevel;
 
         /// <summary>
-        /// Log message with level, exception and parameters
+        /// Log message with level, exception and parameters.
         /// </summary>
-        /// <param name="logLevel"></param>
-        /// <param name="message"></param>
-        /// <param name="exception"></param>
-        /// <param name="args"></param>
-        public void Log(SentryLevel logLevel, string message, Exception exception = null, params object[] args)
+        public void Log(SentryLevel logLevel, string message, Exception? exception = null, params object?[] args)
             => Console.Write($@"{logLevel,7}: {string.Format(message, args)}
 {exception}");
     }

--- a/src/Sentry/Infrastructure/DebugDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/DebugDiagnosticLogger.cs
@@ -6,7 +6,7 @@ using Sentry.Protocol;
 namespace Sentry.Infrastructure
 {
     /// <summary>
-    /// Debug logger used by the SDK to report its internal logging
+    /// Debug logger used by the SDK to report its internal logging.
     /// </summary>
     /// <remarks>
     /// Logger available when compiled in Debug mode. It's useful when debugging apps running under IIS which have no output to Console logger.
@@ -18,24 +18,17 @@ namespace Sentry.Infrastructure
         /// <summary>
         /// Creates a new instance of <see cref="DebugDiagnosticLogger"/>.
         /// </summary>
-        /// <param name="minimalLevel"></param>
         public DebugDiagnosticLogger(SentryLevel minimalLevel) => _minimalLevel = minimalLevel;
 
         /// <summary>
         /// Whether the logger is enabled to the defined level.
         /// </summary>
-        /// <param name="level"></param>
-        /// <returns></returns>
         public bool IsEnabled(SentryLevel level) => level >= _minimalLevel;
 
         /// <summary>
-        /// Log message with level, exception and parameters
+        /// Log message with level, exception and parameters.
         /// </summary>
-        /// <param name="logLevel"></param>
-        /// <param name="message"></param>
-        /// <param name="exception"></param>
-        /// <param name="args"></param>
-        public void Log(SentryLevel logLevel, string message, Exception exception = null, params object[] args)
+        public void Log(SentryLevel logLevel, string message, Exception? exception = null, params object?[] args)
             => Debug.Write($@"{logLevel,7}: {string.Format(message, args)}
 {exception}");
     }

--- a/src/Sentry/Infrastructure/ISystemClock.cs
+++ b/src/Sentry/Infrastructure/ISystemClock.cs
@@ -3,7 +3,7 @@ using System;
 namespace Sentry.Infrastructure
 {
     /// <summary>
-    /// An abstraction to the system clock
+    /// An abstraction to the system clock.
     /// </summary>
     /// <remarks>
     /// Agree to disagree with closing this: https://github.com/aspnet/Common/issues/151

--- a/src/Sentry/Infrastructure/SystemClock.cs
+++ b/src/Sentry/Infrastructure/SystemClock.cs
@@ -3,13 +3,13 @@ using System;
 namespace Sentry.Infrastructure
 {
     /// <summary>
-    /// Implementation of <see cref="ISystemClock"/> to help testability
+    /// Implementation of <see cref="ISystemClock"/> to help testability.
     /// </summary>
     /// <seealso cref="Sentry.Infrastructure.ISystemClock" />
     public sealed class SystemClock : ISystemClock
     {
         /// <summary>
-        /// System clock singleton
+        /// System clock singleton.
         /// </summary>
         public static readonly SystemClock Clock = new SystemClock();
 
@@ -19,7 +19,6 @@ namespace Sentry.Infrastructure
         /// <remarks>
         /// Used for testability, calls: DateTimeOffset.UtcNow
         /// </remarks>
-        /// <returns></returns>
         public DateTimeOffset GetUtcNow() => DateTimeOffset.UtcNow;
     }
 }

--- a/src/Sentry/Integrations/AppDomainProcessExitIntegration.cs
+++ b/src/Sentry/Integrations/AppDomainProcessExitIntegration.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using Sentry.Internal;
 
 namespace Sentry.Integrations
@@ -15,6 +16,7 @@ namespace Sentry.Integrations
 
         public void Register(IHub hub, SentryOptions options)
         {
+            Debug.Assert(hub != null);
             _hub = hub;
             _appDomain.ProcessExit += HandleProcessExit;
         }

--- a/src/Sentry/Integrations/AppDomainProcessExitIntegration.cs
+++ b/src/Sentry/Integrations/AppDomainProcessExitIntegration.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using Sentry.Internal;
 
 namespace Sentry.Integrations
@@ -7,16 +6,15 @@ namespace Sentry.Integrations
     internal class AppDomainProcessExitIntegration : IInternalSdkIntegration
     {
         private readonly IAppDomain _appDomain;
-        private IHub _hub;
+        private IHub? _hub;
 
-        public AppDomainProcessExitIntegration(IAppDomain appDomain = null)
+        public AppDomainProcessExitIntegration(IAppDomain? appDomain = null)
         {
             _appDomain = appDomain ?? AppDomainAdapter.Instance;
         }
 
         public void Register(IHub hub, SentryOptions options)
         {
-            Debug.Assert(hub != null);
             _hub = hub;
             _appDomain.ProcessExit += HandleProcessExit;
         }

--- a/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using Sentry.Internal;
 using System.Runtime.ExceptionServices;
 using System.Security;
@@ -10,14 +9,13 @@ namespace Sentry.Integrations
     internal class AppDomainUnhandledExceptionIntegration : IInternalSdkIntegration
     {
         private readonly IAppDomain _appDomain;
-        private IHub _hub;
+        private IHub? _hub;
 
-        internal AppDomainUnhandledExceptionIntegration(IAppDomain appDomain = null)
+        internal AppDomainUnhandledExceptionIntegration(IAppDomain? appDomain = null)
             => _appDomain = appDomain ?? AppDomainAdapter.Instance;
 
         public void Register(IHub hub, SentryOptions _)
         {
-            Debug.Assert(hub != null);
             _hub = hub;
             _appDomain.UnhandledException += Handle;
         }

--- a/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using Sentry.Internal;
 using System.Runtime.ExceptionServices;
 using System.Security;
@@ -16,6 +17,7 @@ namespace Sentry.Integrations
 
         public void Register(IHub hub, SentryOptions _)
         {
+            Debug.Assert(hub != null);
             _hub = hub;
             _appDomain.UnhandledException += Handle;
         }

--- a/src/Sentry/Integrations/ISdkIntegration.cs
+++ b/src/Sentry/Integrations/ISdkIntegration.cs
@@ -1,7 +1,7 @@
 namespace Sentry.Integrations
 {
     /// <summary>
-    /// An SDK Integration
+    /// An SDK Integration.
     /// </summary>
     public interface ISdkIntegration
     {

--- a/src/Sentry/Integrations/TaskUnobservedTaskExceptionIntegration.cs
+++ b/src/Sentry/Integrations/TaskUnobservedTaskExceptionIntegration.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using Sentry.Internal;
 using System.Runtime.ExceptionServices;
 using System.Security;
@@ -11,14 +10,13 @@ namespace Sentry.Integrations
     internal class TaskUnobservedTaskExceptionIntegration : IInternalSdkIntegration
     {
         private readonly IAppDomain _appDomain;
-        private IHub _hub;
+        private IHub? _hub;
 
-        internal TaskUnobservedTaskExceptionIntegration(IAppDomain appDomain = null)
+        internal TaskUnobservedTaskExceptionIntegration(IAppDomain? appDomain = null)
             => _appDomain = appDomain ?? AppDomainAdapter.Instance;
 
         public void Register(IHub hub, SentryOptions _)
         {
-            Debug.Assert(hub != null);
             _hub = hub;
             _appDomain.UnobservedTaskException += Handle;
         }

--- a/src/Sentry/Internal/AppDomainAdapter.cs
+++ b/src/Sentry/Internal/AppDomainAdapter.cs
@@ -25,11 +25,11 @@ namespace Sentry.Internal
             TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
         }
 
-        public event UnhandledExceptionEventHandler UnhandledException;
+        public event UnhandledExceptionEventHandler? UnhandledException;
 
-        public event EventHandler ProcessExit;
+        public event EventHandler? ProcessExit;
 
-        public event EventHandler<UnobservedTaskExceptionEventArgs> UnobservedTaskException;
+        public event EventHandler<UnobservedTaskExceptionEventArgs>? UnobservedTaskException;
 
         private void OnProcessExit(object sender, EventArgs e) => ProcessExit?.Invoke(sender, e);
 

--- a/src/Sentry/Internal/ApplicationVersionLocator.cs
+++ b/src/Sentry/Internal/ApplicationVersionLocator.cs
@@ -5,9 +5,9 @@ namespace Sentry.Internal
 {
     internal static class ApplicationVersionLocator
     {
-        public static string GetCurrent() => GetCurrent(Assembly.GetEntryAssembly());
+        public static string? GetCurrent() => GetCurrent(Assembly.GetEntryAssembly());
 
-        internal static string GetCurrent(Assembly asm)
+        internal static string? GetCurrent(Assembly? asm)
         {
             var version = asm?.GetNameAndVersion().Version;
 

--- a/src/Sentry/Internal/BackgroundWorker.cs
+++ b/src/Sentry/Internal/BackgroundWorker.cs
@@ -17,7 +17,7 @@ namespace Sentry.Internal
         private readonly int _maxItems;
         private int _currentItems;
 
-        private event EventHandler OnFlushObjectReceived;
+        private event EventHandler? OnFlushObjectReceived;
 
         internal Task WorkerTask { get; }
 
@@ -26,15 +26,15 @@ namespace Sentry.Internal
         public BackgroundWorker(
             ITransport transport,
             SentryOptions options)
-            : this(transport, options, null, null)
+            : this(transport, options, null)
         {
         }
 
         internal BackgroundWorker(
             ITransport transport,
             SentryOptions options,
-            CancellationTokenSource shutdownSource = null,
-            ConcurrentQueue<SentryEvent> queue = null)
+            CancellationTokenSource? shutdownSource = null,
+            ConcurrentQueue<SentryEvent>? queue = null)
         {
             Debug.Assert(transport != null);
             Debug.Assert(options != null);
@@ -57,7 +57,7 @@ namespace Sentry.Internal
                     .ConfigureAwait(false));
         }
 
-        public bool EnqueueEvent(SentryEvent @event)
+        public bool EnqueueEvent(SentryEvent? @event)
         {
             if (_disposed)
             {

--- a/src/Sentry/Internal/Constants.cs
+++ b/src/Sentry/Internal/Constants.cs
@@ -9,10 +9,12 @@ namespace Sentry.Internal
         /// Sentry DSN environment variable.
         /// </summary>
         public const string DsnEnvironmentVariable = "SENTRY_DSN";
+
         /// <summary>
         /// Sentry release environment variable.
         /// </summary>
         public const string ReleaseEnvironmentVariable = "SENTRY_RELEASE";
+
         /// <summary>
         /// Sentry environment, environment variable.
         /// </summary>

--- a/src/Sentry/Internal/DelegateEventProcessor.cs
+++ b/src/Sentry/Internal/DelegateEventProcessor.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using Sentry.Extensibility;
 
 namespace Sentry.Internal
@@ -10,7 +9,6 @@ namespace Sentry.Internal
 
         public DelegateEventProcessor(Func<SentryEvent, SentryEvent> func)
         {
-            Debug.Assert(func != null);
             _func = func;
         }
 

--- a/src/Sentry/Internal/DsnLocator.cs
+++ b/src/Sentry/Internal/DsnLocator.cs
@@ -8,17 +8,16 @@ namespace Sentry.Internal
         /// <summary>
         /// Attempts to find a DSN string statically (via env var, asm attribute). Returns Disabled token otherwise.
         /// </summary>
-        /// <returns></returns>
-        internal static string FindDsnStringOrDisable(Assembly asm = null)
+        internal static string FindDsnStringOrDisable(Assembly? asm = null)
             => Environment.GetEnvironmentVariable(Constants.DsnEnvironmentVariable)
                ?? FindDsn(asm)
                ?? Protocol.Constants.DisableSdkDsnValue;
 
         /// <summary>
-        /// Attempts to find a DSN string from the entry assembly's DsnAttribute
+        /// Attempts to find a DSN string from the entry assembly's DsnAttribute.
         /// </summary>
-        /// <returns>DSN string or null if none found</returns>
-        internal static string FindDsn(Assembly asm = null)
+        /// <returns>DSN string or null if none found.</returns>
+        internal static string? FindDsn(Assembly? asm = null)
             => (asm ?? Assembly.GetEntryAssembly())?.GetCustomAttribute<DsnAttribute>()?.Dsn;
     }
 }

--- a/src/Sentry/Internal/EnvironmentLocator.cs
+++ b/src/Sentry/Internal/EnvironmentLocator.cs
@@ -4,14 +4,14 @@ namespace Sentry.Internal
 {
     internal static class EnvironmentLocator
     {
-        private static readonly Lazy<string> Environment = new Lazy<string>(Locate);
+        private static readonly Lazy<string?> Environment = new Lazy<string?>(Locate);
 
         /// <summary>
-        /// Attempts to locate the environment the app is running in
+        /// Attempts to locate the environment the app is running in.
         /// </summary>
         /// <returns>The Environment name or null, if it couldn't be located.</returns>
-        public static string Current => Environment.Value;
+        public static string? Current => Environment.Value;
 
-        internal static string Locate() => System.Environment.GetEnvironmentVariable(Constants.EnvironmentEnvironmentVariable);
+        internal static string? Locate() => System.Environment.GetEnvironmentVariable(Constants.EnvironmentEnvironmentVariable);
     }
 }

--- a/src/Sentry/Internal/Http/DefaultSentryHttpClientFactory.cs
+++ b/src/Sentry/Internal/Http/DefaultSentryHttpClientFactory.cs
@@ -12,8 +12,8 @@ namespace Sentry.Internal.Http
     /// <inheritdoc />
     internal class DefaultSentryHttpClientFactory : ISentryHttpClientFactory
     {
-        private readonly Action<HttpClientHandler, Dsn> _configureHandler;
-        private readonly Action<HttpClient, Dsn> _configureClient;
+        private readonly Action<HttpClientHandler, Dsn>? _configureHandler;
+        private readonly Action<HttpClient, Dsn>? _configureClient;
 
         /// <summary>
         /// Creates a new instance of <see cref="DefaultSentryHttpClientFactory"/>
@@ -21,8 +21,8 @@ namespace Sentry.Internal.Http
         /// <param name="configureHandler">An optional configuration callback</param>
         /// <param name="configureClient">An optional HttpClient configuration callback</param>
         public DefaultSentryHttpClientFactory(
-            Action<HttpClientHandler, Dsn> configureHandler = null,
-            Action<HttpClient, Dsn> configureClient = null)
+            Action<HttpClientHandler, Dsn>? configureHandler = null,
+            Action<HttpClient, Dsn>? configureClient = null)
         {
             _configureHandler = configureHandler;
             _configureClient = configureClient;
@@ -65,7 +65,7 @@ namespace Sentry.Internal.Http
                 options.DiagnosticLogger?.LogDebug("No response compression supported by HttpClientHandler.");
             }
 
-            if (_configureHandler is Action<HttpClientHandler, Dsn> configureHandler)
+            if (_configureHandler is { } configureHandler)
             {
                 options.DiagnosticLogger?.LogDebug("Invoking user-defined HttpClientHandler configuration action.");
                 configureHandler.Invoke(httpClientHandler, dsn);
@@ -98,10 +98,10 @@ namespace Sentry.Internal.Http
 
             client.DefaultRequestHeaders.Add("Accept", "application/json");
 
-            if (_configureClient is Action<HttpClient, Dsn> configureClient)
+            if (_configureClient is { } configureClient)
             {
                 options.DiagnosticLogger?.LogDebug("Invoking user-defined HttpClient configuration action.");
-                configureClient?.Invoke(client, dsn);
+                configureClient.Invoke(client, dsn);
             }
 
             return client;

--- a/src/Sentry/Internal/Http/GzipBufferedRequestBodyHandler.cs
+++ b/src/Sentry/Internal/Http/GzipBufferedRequestBodyHandler.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace Sentry.Internal.Http
 {
     /// <summary>
-    /// Compresses the body of an HTTP request with GZIP while buffering the result
+    /// Compresses the body of an HTTP request with GZIP while buffering the result.
     /// </summary>
     /// <remarks>
     /// This handler doesn't use 'Content-Encoding: chunked' as it sets the 'Content-Length' of the request.
@@ -23,9 +23,9 @@ namespace Sentry.Internal.Http
         private readonly CompressionLevel _compressionLevel;
 
         /// <summary>
-        /// Creates a new instance of <see cref="T:Sentry.Internal.Http.GzipBufferedRequestBodyHandler" />
+        /// Creates a new instance of <see cref="T:Sentry.Internal.Http.GzipBufferedRequestBodyHandler" />.
         /// </summary>
-        /// <param name="innerHandler">The actual handler which handles the request</param>
+        /// <param name="innerHandler">The actual handler which handles the request.</param>
         /// <param name="compressionLevel">The compression level to use.</param>
         /// <exception cref="T:System.InvalidOperationException">Constructing this type with <see cref="T:System.IO.Compression.CompressionLevel" />
         /// of value <see cref="F:System.IO.Compression.CompressionLevel.NoCompression" /> is an invalid operation.</exception>
@@ -42,11 +42,10 @@ namespace Sentry.Internal.Http
         }
 
         /// <summary>
-        /// Compresses the request body and sends a request with a buffered stream
+        /// Compresses the request body and sends a request with a buffered stream.
         /// </summary>
-        /// <param name="request">The HTTP request to compress</param>
-        /// <param name="cancellationToken">The cancellation token</param>
-        /// <returns></returns>
+        /// <param name="request">The HTTP request to compress.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <inheritdoc />
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,

--- a/src/Sentry/Internal/Http/GzipRequestBodyHandler.cs
+++ b/src/Sentry/Internal/Http/GzipRequestBodyHandler.cs
@@ -20,9 +20,9 @@ namespace Sentry.Internal.Http
         private readonly CompressionLevel _compressionLevel;
 
         /// <summary>
-        /// Creates a new instance of <see cref="T:Sentry.Internal.Http.GzipRequestBodyHandler" />
+        /// Creates a new instance of <see cref="T:Sentry.Internal.Http.GzipRequestBodyHandler" />.
         /// </summary>
-        /// <param name="innerHandler">The actual handler which handles the request</param>
+        /// <param name="innerHandler">The actual handler which handles the request.</param>
         /// <param name="compressionLevel">The compression level to use.</param>
         /// <exception cref="T:System.InvalidOperationException">Constructing this type with <see cref="T:System.IO.Compression.CompressionLevel" />
         /// of value <see cref="F:System.IO.Compression.CompressionLevel.NoCompression" /> is an invalid operation.</exception>
@@ -39,10 +39,10 @@ namespace Sentry.Internal.Http
         }
 
         /// <summary>
-        /// Sends the request while compressing it's payload
+        /// Sends the request while compressing its payload.
         /// </summary>
-        /// <param name="request">The HTTP request to compress</param>
-        /// <param name="cancellationToken">The cancellation token</param>
+        /// <param name="request">The HTTP request to compress.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
         /// <inheritdoc />
         protected override Task<HttpResponseMessage> SendAsync(

--- a/src/Sentry/Internal/Http/HttpTransport.cs
+++ b/src/Sentry/Internal/Http/HttpTransport.cs
@@ -33,7 +33,7 @@ namespace Sentry.Internal.Http
             _addAuth = addAuth;
         }
 
-        public async Task CaptureEventAsync(SentryEvent @event, CancellationToken cancellationToken = default)
+        public async Task CaptureEventAsync(SentryEvent? @event, CancellationToken cancellationToken = default)
         {
             if (@event == null)
             {
@@ -68,7 +68,7 @@ namespace Sentry.Internal.Http
         {
             var request = new HttpRequestMessage
             {
-                RequestUri = _options.Dsn.SentryUri,
+                RequestUri = _options.Dsn?.SentryUri,
                 Method = HttpMethod.Post,
                 Content = new StringContent(JsonSerializer.SerializeObject(@event))
             };

--- a/src/Sentry/Internal/Http/HttpTransport.cs
+++ b/src/Sentry/Internal/Http/HttpTransport.cs
@@ -33,13 +33,8 @@ namespace Sentry.Internal.Http
             _addAuth = addAuth;
         }
 
-        public async Task CaptureEventAsync(SentryEvent? @event, CancellationToken cancellationToken = default)
+        public async Task CaptureEventAsync(SentryEvent @event, CancellationToken cancellationToken = default)
         {
-            if (@event == null)
-            {
-                return;
-            }
-
             var request = CreateRequest(@event);
 
             var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);

--- a/src/Sentry/Internal/Http/RetryAfterHandler.cs
+++ b/src/Sentry/Internal/Http/RetryAfterHandler.cs
@@ -9,7 +9,7 @@ using Sentry.Infrastructure;
 namespace Sentry.Internal.Http
 {
     /// <summary>
-    /// Retry After Handler which short-circuit requests following an HTTP 429
+    /// Retry After Handler which short-circuit requests following an HTTP 429.
     /// </summary>
     /// <seealso href="https://tools.ietf.org/html/rfc6585#section-4" />
     /// <seealso href="https://docs.sentry.io/clientdev/overview/#writing-an-sdk"/>
@@ -38,7 +38,7 @@ namespace Sentry.Internal.Http
             => _clock = clock ?? throw new ArgumentNullException(nameof(clock));
 
         /// <summary>
-        /// Sends an HTTP request to the inner handler while verifying the Response status code for HTTP 429
+        /// Sends an HTTP request to the inner handler while verifying the Response status code for HTTP 429.
         /// </summary>
         /// <param name="request">The HTTP request message to send to the server.</param>
         /// <param name="cancellationToken">A cancellation token to cancel operation.</param>

--- a/src/Sentry/Internal/Http/SentryHeaders.cs
+++ b/src/Sentry/Internal/Http/SentryHeaders.cs
@@ -10,22 +10,21 @@ namespace Sentry.Internal.Http
         public const string SentryAuthHeader = "X-Sentry-Auth";
 
         /// <summary>
-        /// Creates a function that when invoked returns a valid authentication header
+        /// Creates a function that when invoked returns a valid authentication header.
         /// </summary>
         /// <param name="sentryVersion">The sentry version.</param>
         /// <param name="clientVersion">The client version.</param>
         /// <param name="publicKey">The public key.</param>
         /// <param name="secretKey">The secret key.</param>
         /// <param name="clock">The clock.</param>
-        /// <returns></returns>
         public static Action<HttpRequestHeaders> AddSentryAuth(
             int sentryVersion,
             string clientVersion,
             string publicKey,
-            string secretKey,
-            ISystemClock clock = null)
+            string? secretKey,
+            ISystemClock? clock = null)
         {
-            clock = clock ?? SystemClock.Clock;
+            clock ??= SystemClock.Clock;
 
             var baseAuthHeader = $"Sentry sentry_version={sentryVersion}," +
                $"sentry_client={clientVersion}," +

--- a/src/Sentry/Internal/Http/SentrySuccessfulResponseBody.cs
+++ b/src/Sentry/Internal/Http/SentrySuccessfulResponseBody.cs
@@ -3,14 +3,14 @@
 namespace Sentry.Internal.Http
 {
     /// <summary>
-    /// The payload of a response to a successful call to Sentry
+    /// The payload of a response to a successful call to Sentry.
     /// </summary>
     /// <seealso href="https://docs.sentry.io/clientdev/overview/#reading-the-response"/>
     // ReSharper disable All
     internal class SentrySuccessfulResponseBody
     {
         /// <summary>
-        /// The id generated for the event or the one created by the SDK if any
+        /// The id generated for the event or the one created by the SDK if any.
         /// </summary>
         /// <example>
         /// fc6d8c0c43fc4630ad850ee518f1b9d0
@@ -18,7 +18,7 @@ namespace Sentry.Internal.Http
 #pragma warning disable IDE1006 // Naming Styles
 #pragma warning disable S1144 // Unused private types or members should be removed
 #pragma warning disable S3459 // Unassigned members should be removed
-        public string id { get; set; }
+        public string? id { get; set; }
     }
 }
 #endif

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Sentry.Extensibility;
@@ -11,7 +10,7 @@ namespace Sentry.Internal
     internal class Hub : IHub, IDisposable
     {
         private readonly SentryOptions _options;
-        private readonly ISdkIntegration[] _integrations;
+        private readonly ISdkIntegration[]? _integrations;
         private readonly IDisposable _rootScope;
 
         private readonly SentryClient _ownedClient;
@@ -98,7 +97,7 @@ namespace Sentry.Internal
 
         public void BindClient(ISentryClient client) => ScopeManager.BindClient(client);
 
-        public SentryId CaptureEvent(SentryEvent evt, Scope scope = null)
+        public SentryId CaptureEvent(SentryEvent evt, Scope? scope = null)
         {
             try
             {
@@ -143,9 +142,9 @@ namespace Sentry.Internal
                 }
             }
 
-            _ownedClient?.Dispose();
+            _ownedClient.Dispose();
             _rootScope.Dispose();
-            ScopeManager?.Dispose();
+            ScopeManager.Dispose();
         }
 
         public SentryId LastEventId

--- a/src/Sentry/Internal/IInternalScopeManager.cs
+++ b/src/Sentry/Internal/IInternalScopeManager.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Sentry.Internal

--- a/src/Sentry/Internal/IInternalSdkIntegration.cs
+++ b/src/Sentry/Internal/IInternalSdkIntegration.cs
@@ -6,7 +6,7 @@ namespace Sentry.Internal
     internal interface IInternalSdkIntegration : ISdkIntegration
     {
         /// <summary>
-        /// Unregisters this integration with the hub
+        /// Unregisters this integration with the hub.
         /// </summary>
         /// <remarks>
         /// This method is invoked when the Hub is disposed.

--- a/src/Sentry/Internal/JsonSerializer.cs
+++ b/src/Sentry/Internal/JsonSerializer.cs
@@ -13,7 +13,7 @@ namespace Sentry.Internal
             NullValueHandling = NullValueHandling.Ignore,
             ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
             Formatting = Formatting.None,
-            Converters = new[] { StringEnumConverter },
+            Converters = new JsonConverter[] { StringEnumConverter },
             DateFormatHandling = DateFormatHandling.IsoDateFormat
         };
 

--- a/src/Sentry/Internal/JsonSerializer.cs
+++ b/src/Sentry/Internal/JsonSerializer.cs
@@ -6,6 +6,7 @@ namespace Sentry.Internal
     internal static class JsonSerializer
     {
         private static readonly StringEnumConverter StringEnumConverter = new StringEnumConverter();
+
         private static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
         {
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -21,11 +21,11 @@ namespace Sentry.Internal
             SentryStackTraceFactoryAccessor = sentryStackTraceFactoryAccessor;
         }
 
-        public void Process(Exception exception, SentryEvent sentryEvent)
+        public void Process(Exception? exception, SentryEvent sentryEvent)
         {
             Debug.Assert(sentryEvent != null);
 
-            _options.DiagnosticLogger?.LogDebug("Running processor on exception: {0}", exception.Message);
+            _options.DiagnosticLogger?.LogDebug("Running processor on exception: {0}", exception?.Message);
 
             var sentryExceptions = CreateSentryException(exception)
                 // Otherwise realization happens on the worker thread before sending event.
@@ -59,7 +59,7 @@ namespace Sentry.Internal
             }
         }
 
-        internal IEnumerable<SentryException> CreateSentryException(Exception exception)
+        internal IEnumerable<SentryException> CreateSentryException(Exception? exception)
         {
             Debug.Assert(exception != null);
 

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -21,13 +21,8 @@ namespace Sentry.Internal
             SentryStackTraceFactoryAccessor = sentryStackTraceFactoryAccessor;
         }
 
-        public void Process(Exception? exception, SentryEvent sentryEvent)
+        public void Process(Exception exception, SentryEvent sentryEvent)
         {
-            if (exception is null)
-            {
-                return;
-            }
-
             Debug.Assert(sentryEvent != null);
 
             _options.DiagnosticLogger?.LogDebug("Running processor on exception: {0}", exception.Message);

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -23,9 +23,12 @@ namespace Sentry.Internal
 
         public void Process(Exception? exception, SentryEvent sentryEvent)
         {
+            if (exception == null)
+                return;
+
             Debug.Assert(sentryEvent != null);
 
-            _options.DiagnosticLogger?.LogDebug("Running processor on exception: {0}", exception?.Message);
+            _options.DiagnosticLogger?.LogDebug("Running processor on exception: {0}", exception.Message);
 
             var sentryExceptions = CreateSentryException(exception)
                 // Otherwise realization happens on the worker thread before sending event.
@@ -59,10 +62,8 @@ namespace Sentry.Internal
             }
         }
 
-        internal IEnumerable<SentryException> CreateSentryException(Exception? exception)
+        internal IEnumerable<SentryException> CreateSentryException(Exception exception)
         {
-            Debug.Assert(exception != null);
-
             if (exception is AggregateException ae)
             {
                 foreach (var inner in ae.InnerExceptions.SelectMany(CreateSentryException))

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -23,8 +23,10 @@ namespace Sentry.Internal
 
         public void Process(Exception? exception, SentryEvent sentryEvent)
         {
-            if (exception == null)
+            if (exception is null)
+            {
                 return;
+            }
 
             Debug.Assert(sentryEvent != null);
 

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -27,21 +27,18 @@ namespace Sentry.Internal
 
             _options.DiagnosticLogger?.LogDebug("Running processor on exception: {0}", exception.Message);
 
-            if (exception != null)
-            {
-                var sentryExceptions = CreateSentryException(exception)
-                    // Otherwise realization happens on the worker thread before sending event.
-                    .ToList();
+            var sentryExceptions = CreateSentryException(exception)
+                // Otherwise realization happens on the worker thread before sending event.
+                .ToList();
 
-                MoveExceptionExtrasToEvent(sentryEvent, sentryExceptions);
+            MoveExceptionExtrasToEvent(sentryEvent, sentryExceptions);
 
-                sentryEvent.SentryExceptions = sentryExceptions;
-            }
+            sentryEvent.SentryExceptions = sentryExceptions;
         }
 
         // SentryException.Extra is not supported by Sentry yet.
         // Move the extras to the Event Extra while marking
-        // by index the Exception which owns it
+        // by index the Exception which owns it.
         private static void MoveExceptionExtrasToEvent(
             SentryEvent sentryEvent,
             IReadOnlyList<SentryException> sentryExceptions)
@@ -50,7 +47,7 @@ namespace Sentry.Internal
             {
                 var sentryException = sentryExceptions[i];
 
-                if (!(sentryException.Data?.Count > 0))
+                if (sentryException.Data.Count <= 0)
                 {
                     continue;
                 }
@@ -116,11 +113,13 @@ namespace Sentry.Internal
             {
                 mechanism.HelpLink = exception.HelpLink;
             }
+
             if (exception.Data[Mechanism.HandledKey] is bool handled)
             {
                 mechanism.Handled = handled;
                 exception.Data.Remove(Mechanism.HandledKey);
             }
+
             if (exception.Data[Mechanism.MechanismKey] is string mechanismName)
             {
                 mechanism.Type = mechanismName;

--- a/src/Sentry/Internal/MainSentryEventProcessor.cs
+++ b/src/Sentry/Internal/MainSentryEventProcessor.cs
@@ -16,8 +16,9 @@ namespace Sentry.Internal
 {
     internal class MainSentryEventProcessor : ISentryEventProcessor
     {
-        private readonly Lazy<string> _release = new Lazy<string>(ReleaseLocator.GetCurrent);
-        private readonly Lazy<Runtime> _runtime = new Lazy<Runtime>(() =>
+        private readonly Lazy<string?> _release = new Lazy<string?>(ReleaseLocator.GetCurrent);
+
+        private readonly Lazy<Runtime?> _runtime = new Lazy<Runtime?>(() =>
         {
             var current = PlatformAbstractions.Runtime.Current;
             return current != null
@@ -38,8 +39,8 @@ namespace Sentry.Internal
         private readonly SentryOptions _options;
         internal Func<ISentryStackTraceFactory> SentryStackTraceFactoryAccessor { get; }
 
-        internal string Release => _release.Value;
-        internal Runtime Runtime => _runtime.Value;
+        internal string? Release => _release.Value;
+        internal Runtime? Runtime => _runtime.Value;
 
         public MainSentryEventProcessor(
             SentryOptions options,
@@ -55,7 +56,7 @@ namespace Sentry.Internal
         {
             _options.DiagnosticLogger?.LogDebug("Running main event processor on: Event {0}", @event.EventId);
 
-            if (!@event.Contexts.ContainsKey(Runtime.Type))
+            if (!@event.Contexts.ContainsKey(Runtime.Type) && Runtime != null)
             {
                 @event.Contexts[Runtime.Type] = Runtime;
             }
@@ -69,36 +70,42 @@ namespace Sentry.Internal
                 }
             }
 
-            if (TimeZoneInfo.Local is TimeZoneInfo timeZoneInfo)
+            if (TimeZoneInfo.Local is { } timeZoneInfo)
             {
                 @event.Contexts.Device.Timezone = timeZoneInfo;
             }
 
             const string currentUiCultureKey = "CurrentUICulture";
             if (!@event.Contexts.ContainsKey(currentUiCultureKey)
-                && CultureInfoToDictionary(CultureInfo.CurrentUICulture) is IDictionary<string, string> currentUiCultureMap)
+                && CultureInfoToDictionary(CultureInfo.CurrentUICulture) is { } currentUiCultureMap)
             {
                 @event.Contexts[currentUiCultureKey] = currentUiCultureMap;
             }
 
             const string cultureInfoKey = "CurrentCulture";
             if (!@event.Contexts.ContainsKey(cultureInfoKey)
-                && CultureInfoToDictionary(CultureInfo.CurrentCulture) is IDictionary<string, string> currentCultureMap)
+                && CultureInfoToDictionary(CultureInfo.CurrentCulture) is { } currentCultureMap)
             {
                 @event.Contexts[cultureInfoKey] = currentCultureMap;
             }
 
             @event.Platform = Protocol.Constants.Platform;
 
-            // SDK Name/Version might have be already set by an outer package
-            // e.g: ASP.NET Core can set itself as the SDK
-            if (@event.Sdk.Version == null && @event.Sdk.Name == null)
+            if (@event.Sdk != null)
             {
-                @event.Sdk.Name = Constants.SdkName;
-                @event.Sdk.Version = NameAndVersion.Version;
-            }
+                // SDK Name/Version might have be already set by an outer package
+                // e.g: ASP.NET Core can set itself as the SDK
+                if (@event.Sdk.Version == null && @event.Sdk.Name == null)
+                {
+                    @event.Sdk.Name = Constants.SdkName;
+                    @event.Sdk.Version = NameAndVersion.Version;
+                }
 
-            @event.Sdk.AddPackage(ProtocolPackageName, NameAndVersion.Version);
+                if (NameAndVersion.Version != null)
+                {
+                    @event.Sdk.AddPackage(ProtocolPackageName, NameAndVersion.Version);
+                }
+            }
 
             // Report local user if opt-in PII, no user was already set to event and feature not opted-out:
             if (_options.SendDefaultPii && _options.IsEnvironmentUser && !@event.HasUser())
@@ -148,9 +155,9 @@ namespace Sentry.Internal
                         Stacktrace = stackTrace
                     };
 
-                    @event.SentryThreads = @event.SentryThreads.Any()
+                    @event.SentryThreads = @event.SentryThreads?.Any() == true
                         ? new List<SentryThread>(@event.SentryThreads) { thread }
-                        : new[] { thread } as IEnumerable<SentryThread>;
+                        : new[] { thread }.AsEnumerable();
                 }
             }
 
@@ -171,13 +178,8 @@ namespace Sentry.Internal
             return @event;
         }
 
-        private static IDictionary<string, string> CultureInfoToDictionary(CultureInfo cultureInfo)
+        private static IDictionary<string, string>? CultureInfoToDictionary(CultureInfo cultureInfo)
         {
-            if (cultureInfo is null)
-            {
-                return null;
-            }
-
             var dic = new Dictionary<string, string>();
 
             if (!string.IsNullOrWhiteSpace(cultureInfo.Name))
@@ -188,7 +190,7 @@ namespace Sentry.Internal
             {
                 dic.Add("DisplayName", cultureInfo.DisplayName);
             }
-            if (cultureInfo.Calendar is Calendar cal)
+            if (cultureInfo.Calendar is { } cal)
             {
                 dic.Add("Calendar", cal.GetType().Name);
             }

--- a/src/Sentry/Internal/OptionalHub.cs
+++ b/src/Sentry/Internal/OptionalHub.cs
@@ -33,7 +33,7 @@ namespace Sentry.Internal
             _hub = new Hub(options);
         }
 
-        public SentryId CaptureEvent(SentryEvent evt, Scope scope = null) => _hub.CaptureEvent(evt, scope);
+        public SentryId CaptureEvent(SentryEvent evt, Scope? scope = null) => _hub.CaptureEvent(evt, scope);
 
         public Task FlushAsync(TimeSpan timeout) => _hub.FlushAsync(timeout);
 
@@ -45,7 +45,8 @@ namespace Sentry.Internal
 
         public IDisposable PushScope() => _hub.PushScope();
 
-        public IDisposable PushScope<TState>(TState state) => _hub.PushScope(state);
+        public IDisposable PushScope<TState>(TState state)
+            => _hub.PushScope(state);
 
         public void WithScope(Action<Scope> scopeCallback) => _hub.WithScope(scopeCallback);
 

--- a/src/Sentry/Internal/ReleaseLocator.cs
+++ b/src/Sentry/Internal/ReleaseLocator.cs
@@ -8,7 +8,7 @@ namespace Sentry.Internal
         /// Attempts to locate the application release
         /// </summary>
         /// <returns>The app release or null, if it couldn't be located.</returns>
-        public static string GetCurrent()
+        public static string? GetCurrent()
             => Environment.GetEnvironmentVariable(Constants.ReleaseEnvironmentVariable)
                 ?? ApplicationVersionLocator.GetCurrent();
     }

--- a/src/Sentry/Internal/SdkComposer.cs
+++ b/src/Sentry/Internal/SdkComposer.cs
@@ -24,12 +24,15 @@ namespace Sentry.Internal
                 return worker;
             }
 
-            // TODO: what to do here if Dsn is null?
+            if (_options.Dsn is null)
+            {
+                throw new InvalidOperationException("The DSN is expected to be set at this point.");
+            }
 
             var addAuth = SentryHeaders.AddSentryAuth(
                 _options.SentryVersion,
                 _options.ClientVersion,
-                _options.Dsn!.PublicKey,
+                _options.Dsn.PublicKey,
                 _options.Dsn.SecretKey);
 
             if (_options.SentryHttpClientFactory is { } factory)

--- a/src/Sentry/Internal/SdkComposer.cs
+++ b/src/Sentry/Internal/SdkComposer.cs
@@ -1,6 +1,5 @@
 using System;
 using Sentry.Extensibility;
-using Sentry.Http;
 using Sentry.Internal.Http;
 
 namespace Sentry.Internal
@@ -17,7 +16,7 @@ namespace Sentry.Internal
 
         public IBackgroundWorker CreateBackgroundWorker()
         {
-            if (_options.BackgroundWorker is IBackgroundWorker worker)
+            if (_options.BackgroundWorker is { } worker)
             {
                 _options.DiagnosticLogger?.LogDebug("Using IBackgroundWorker set through options: {0}.",
                     worker.GetType().Name);
@@ -25,13 +24,15 @@ namespace Sentry.Internal
                 return worker;
             }
 
+            // TODO: what to do here if Dsn is null?
+
             var addAuth = SentryHeaders.AddSentryAuth(
                 _options.SentryVersion,
                 _options.ClientVersion,
-                _options.Dsn.PublicKey,
+                _options.Dsn!.PublicKey,
                 _options.Dsn.SecretKey);
 
-            if (_options.SentryHttpClientFactory is ISentryHttpClientFactory factory)
+            if (_options.SentryHttpClientFactory is { } factory)
             {
                 _options.DiagnosticLogger?.LogDebug("Using ISentryHttpClientFactory set through options: {0}.",
                     factory.GetType().Name);

--- a/src/Sentry/Internal/SentryScopeManager.cs
+++ b/src/Sentry/Internal/SentryScopeManager.cs
@@ -35,18 +35,18 @@ namespace Sentry.Internal
             return current[current.Length - 1];
         }
 
-        public void ConfigureScope(Action<Scope> configureScope)
+        public void ConfigureScope(Action<Scope>? configureScope)
         {
             _options.DiagnosticLogger?.LogDebug("Configuring the scope.");
             var scope = GetCurrent();
-            configureScope.Invoke(scope.Key);
+            configureScope?.Invoke(scope.Key);
         }
 
-        public Task ConfigureScopeAsync(Func<Scope, Task> configureScope)
+        public Task ConfigureScopeAsync(Func<Scope, Task>? configureScope)
         {
             _options.DiagnosticLogger?.LogDebug("Configuring the scope asynchronously.");
             var scope = GetCurrent();
-            return configureScope.Invoke(scope.Key) ?? Task.CompletedTask;
+            return configureScope?.Invoke(scope.Key) ?? Task.CompletedTask;
         }
 
         public IDisposable PushScope() => PushScope<object>(null!); // NRTs don't work well with generics

--- a/src/Sentry/Internal/Web/SystemWebHttpRequest.cs
+++ b/src/Sentry/Internal/Web/SystemWebHttpRequest.cs
@@ -10,12 +10,15 @@ namespace Sentry.Internal.Web
     internal class SystemWebHttpRequest : IHttpRequest
     {
         private readonly HttpRequest _request;
+
         public long? ContentLength => _request?.ContentLength;
-        public string ContentType => _request?.ContentType;
-        public Stream Body => _request?.InputStream;
-        public IEnumerable<KeyValuePair<string, IEnumerable<string>>> Form
-            => _request?.Form.AllKeys.Select(kv => new KeyValuePair<string, IEnumerable<string>>(kv, _request.Form.GetValues(kv)))
-            ?? Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>();
+
+        public string? ContentType => _request?.ContentType;
+
+        public Stream? Body => _request?.InputStream;
+
+        public IEnumerable<KeyValuePair<string, IEnumerable<string>>>? Form
+            => _request.Form.AllKeys.Select(kv => new KeyValuePair<string, IEnumerable<string>>(kv, _request.Form.GetValues(kv)));
 
         public SystemWebHttpRequest(HttpRequest request) => _request = request;
     }

--- a/src/Sentry/Internal/Web/SystemWebRequestEventProcessor.cs
+++ b/src/Sentry/Internal/Web/SystemWebRequestEventProcessor.cs
@@ -20,7 +20,7 @@ namespace Sentry.Internal.Web
             PayloadExtractor = payloadExtractor ?? throw new ArgumentNullException(nameof(payloadExtractor));
         }
 
-        public SentryEvent Process(SentryEvent @event)
+        public SentryEvent? Process(SentryEvent? @event)
         {
             var context = HttpContext.Current;
             if (context is null || @event is null)
@@ -77,7 +77,7 @@ namespace Sentry.Internal.Web
                 }
 
                 @event.User.IpAddress = context.Request.UserHostAddress;
-                if (context.User.Identity is IIdentity identity)
+                if (context.User.Identity is { } identity)
                 {
                     @event.User.Username = identity.Name;
                     var other = new Dictionary<string, string>
@@ -88,7 +88,7 @@ namespace Sentry.Internal.Web
                 }
                 if (context.User is ClaimsPrincipal claimsPrincipal)
                 {
-                    if (claimsPrincipal.FindFirst(ClaimTypes.NameIdentifier) is Claim claim)
+                    if (claimsPrincipal.FindFirst(ClaimTypes.NameIdentifier) is { } claim)
                     {
                         @event.User.Id = claim.Value;
                     }

--- a/src/Sentry/Reflection/AssemblyExtensions.cs
+++ b/src/Sentry/Reflection/AssemblyExtensions.cs
@@ -5,29 +5,29 @@ using Sentry.Protocol;
 namespace Sentry.Reflection
 {
     /// <summary>
-    /// Extension methods to <see cref="Assembly"/>
+    /// Extension methods to <see cref="Assembly"/>.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class AssemblyExtensions
     {
         /// <summary>
-        /// Get the assemblies Name and Version
+        /// Get the assemblies Name and Version.
         /// </summary>
         /// <remarks>
-        /// Attempts to read the version from <see cref="AssemblyInformationalVersionAttribute"/>
-        /// If not available, falls back to <see cref="AssemblyName.Version"/>
+        /// Attempts to read the version from <see cref="AssemblyInformationalVersionAttribute"/>.
+        /// If not available, falls back to <see cref="AssemblyName.Version"/>.
         /// </remarks>
-        /// <param name="asm">The assembly to get the name and version from</param>
+        /// <param name="asm">The assembly to get the name and version from.</param>
         /// <returns>The SdkVersion.</returns>
         public static SdkVersion GetNameAndVersion(this Assembly asm)
         {
             var asmName = asm.GetName();
             var name = asmName.Name;
-            var version = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-                          ?.InformationalVersion
-                      ?? asmName.Version.ToString();
+            var version =
+                asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                ?? asmName.Version.ToString();
 
-            return new SdkVersion { Name = name, Version = version };
+            return new SdkVersion {Name = name, Version = version};
         }
     }
 }

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -81,17 +81,15 @@ namespace Sentry
         /// <summary>
         /// Creates a scope with the specified options.
         /// </summary>
-        public Scope(SentryOptions? options = null)
+        public Scope(SentryOptions? options)
             : base(options)
         {
             Options = options ?? new SentryOptions();
         }
 
-        /// <summary>
-        /// Creates a scope.
-        /// </summary>
-        // TODO: this method can be removed with a breaking change.
-        public Scope() : this(null)
+        // For testing. Should explicitly require SentryOptions.
+        internal Scope()
+            : this(new SentryOptions())
         {
         }
 

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -7,7 +7,7 @@ using Sentry.Protocol;
 namespace Sentry
 {
     /// <summary>
-    /// Scope data to be sent with the event
+    /// Scope data to be sent with the event.
     /// </summary>
     /// <remarks>
     /// Scope data is sent together with any event captured
@@ -25,6 +25,7 @@ namespace Sentry
         private readonly object _lastEventIdSync = new object();
 
         private SentryId _lastEventId;
+
         internal SentryId LastEventId
         {
             get
@@ -50,21 +51,22 @@ namespace Sentry
 
         private readonly Lazy<ConcurrentBag<ISentryEventExceptionProcessor>> _lazyExceptionProcessors =
             new Lazy<ConcurrentBag<ISentryEventExceptionProcessor>>(LazyThreadSafetyMode.PublicationOnly);
+
         /// <summary>
-        /// A list of exception processors
+        /// A list of exception processors.
         /// </summary>
         internal ConcurrentBag<ISentryEventExceptionProcessor> ExceptionProcessors => _lazyExceptionProcessors.Value;
 
-
         private readonly Lazy<ConcurrentBag<ISentryEventProcessor>> _lazyEventProcessors =
             new Lazy<ConcurrentBag<ISentryEventProcessor>>(LazyThreadSafetyMode.PublicationOnly);
+
         /// <summary>
-        /// A list of event processors
+        /// A list of event processors.
         /// </summary>
         internal ConcurrentBag<ISentryEventProcessor> EventProcessors => _lazyEventProcessors.Value;
 
         /// <summary>
-        /// An event that fires when the scope evaluates
+        /// An event that fires when the scope evaluates.
         /// </summary>
         /// <remarks>
         /// This allows registering an event handler that is invoked in case
@@ -74,47 +76,41 @@ namespace Sentry
         /// but execution at a later time, when more data is available.
         /// </remarks>
         /// <see cref="Evaluate"/>
-        internal event EventHandler OnEvaluating;
+        internal event EventHandler? OnEvaluating;
 
         /// <summary>
-        /// Creates a scope with the specified options
+        /// Creates a scope with the specified options.
         /// </summary>
-        /// <param name="options"></param>
-        /// <inheritdoc />
-        public Scope(SentryOptions options)
-        : base(options)
+        public Scope(SentryOptions? options = null)
+            : base(options)
         {
             Options = options ?? new SentryOptions();
         }
 
-        // For testing. Should explicitly require SentryOptions
-        internal Scope()
-            : this(new SentryOptions())
-        { }
+        /// <summary>
+        /// Creates a scope.
+        /// </summary>
+        // TODO: this method can be removed with a breaking change.
+        public Scope() : this(null)
+        {
+        }
 
         /// <summary>
         /// Clones the current <see cref="Scope"/>.
         /// </summary>
-        /// <returns></returns>
         public Scope Clone()
         {
             var clone = new Scope(Options);
             this.Apply(clone);
 
-            if (EventProcessors != null)
+            foreach (var processor in EventProcessors)
             {
-                foreach (var processor in EventProcessors)
-                {
-                    clone.EventProcessors.Add(processor);
-                }
+                clone.EventProcessors.Add(processor);
             }
 
-            if (ExceptionProcessors != null)
+            foreach (var processor in ExceptionProcessors)
             {
-                foreach (var processor in ExceptionProcessors)
-                {
-                    clone.ExceptionProcessors.Add(processor);
-                }
+                clone.ExceptionProcessors.Add(processor);
             }
 
             return clone;

--- a/src/Sentry/ScopeExtensions.cs
+++ b/src/Sentry/ScopeExtensions.cs
@@ -14,18 +14,14 @@ namespace Sentry
     public static class ScopeExtensions
     {
         /// <summary>
-        /// Invokes all event processor providers available
+        /// Invokes all event processor providers available.
         /// </summary>
         /// <param name="scope">The Scope which holds the processor providers.</param>
-        /// <returns></returns>
         public static IEnumerable<ISentryEventProcessor> GetAllEventProcessors(this Scope scope)
         {
-            if (scope.Options is SentryOptions options)
+            foreach (var processor in scope.Options.GetAllEventProcessors())
             {
-                foreach (var processor in options.GetAllEventProcessors())
-                {
-                    yield return processor;
-                }
+                yield return processor;
             }
 
             foreach (var processor in scope.EventProcessors)
@@ -35,18 +31,14 @@ namespace Sentry
         }
 
         /// <summary>
-        /// Invokes all exception processor providers available
+        /// Invokes all exception processor providers available.
         /// </summary>
         /// <param name="scope">The Scope which holds the processor providers.</param>
-        /// <returns></returns>
         public static IEnumerable<ISentryEventExceptionProcessor> GetAllExceptionProcessors(this Scope scope)
         {
-            if (scope.Options is SentryOptions options)
+            foreach (var processor in scope.Options.GetAllExceptionProcessors())
             {
-                foreach (var processor in options.GetAllExceptionProcessors())
-                {
-                    yield return processor;
-                }
+                yield return processor;
             }
 
             foreach (var processor in scope.ExceptionProcessors)
@@ -56,7 +48,7 @@ namespace Sentry
         }
 
         /// <summary>
-        /// Add an exception processor
+        /// Add an exception processor.
         /// </summary>
         /// <param name="scope">The Scope to hold the processor.</param>
         /// <param name="processor">The exception processor.</param>
@@ -64,7 +56,7 @@ namespace Sentry
             => scope.ExceptionProcessors.Add(processor);
 
         /// <summary>
-        /// Add the exception processors
+        /// Add the exception processors.
         /// </summary>
         /// <param name="scope">The Scope to hold the processor.</param>
         /// <param name="processors">The exception processors.</param>

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -1,25 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <PackageId>Sentry</PackageId>
     <AssemblyName>Sentry</AssemblyName>
     <RootNamespace>Sentry</RootNamespace>
     <Description>Official SDK for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
     <NoWarn Condition="$(TargetFramework) == 'netstandard2.0'">$(NoWarn);RS0017</NoWarn>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <!-- Disable nullability warnings on older frameworks because there is no nullability info for BCL -->
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
+    <Nullable>annotations</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Sentry.PlatformAbstractions" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Newtonsoft.Json" Version="6.0.8" />
     <Reference Include="System.Web" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Sentry.PlatformAbstractions" Version="1.1.1" />
-  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Sentry.Protocol\Sentry.Protocol.csproj" />
   </ItemGroup>

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -10,11 +10,11 @@ using Sentry.Protocol;
 namespace Sentry
 {
     /// <summary>
-    /// Sentry client used to send events to Sentry
+    /// Sentry client used to send events to Sentry.
     /// </summary>
     /// <remarks>
     /// This client captures events by queueing those to its
-    /// internal background worker which sends events to Sentry
+    /// internal background worker which sends events to Sentry.
     /// </remarks>
     /// <inheritdoc cref="ISentryClient" />
     /// <inheritdoc cref="IDisposable" />
@@ -26,17 +26,17 @@ namespace Sentry
         private readonly Lazy<Random> _random = new Lazy<Random>(() => new Random(), LazyThreadSafetyMode.PublicationOnly);
         internal Random Random => _random.Value;
 
-        // Internal for testing
+        // Internal for testing.
         internal IBackgroundWorker Worker { get; }
 
-        /// <inheritdoc />
         /// <summary>
-        /// Whether the client is enabled
+        /// Whether the client is enabled.
         /// </summary>
+        /// <inheritdoc />
         public bool IsEnabled => true;
 
         /// <summary>
-        /// Creates a new instance of <see cref="SentryClient"/>
+        /// Creates a new instance of <see cref="SentryClient"/>.
         /// </summary>
         /// <param name="options">The configuration for this client.</param>
         public SentryClient(SentryOptions options)
@@ -44,7 +44,7 @@ namespace Sentry
 
         internal SentryClient(
             SentryOptions options,
-            IBackgroundWorker worker)
+            IBackgroundWorker? worker)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
 
@@ -63,25 +63,19 @@ namespace Sentry
         }
 
         /// <summary>
-        /// Queues the event to be sent to Sentry
+        /// Queues the event to be sent to Sentry.
         /// </summary>
         /// <remarks>
         /// An optional scope, if provided, will be applied to the event.
         /// </remarks>
         /// <param name="event">The event to send to Sentry.</param>
         /// <param name="scope">The optional scope to augment the event with.</param>
-        /// <returns></returns>
         /// <inheritdoc />
-        public SentryId CaptureEvent(SentryEvent @event, Scope scope = null)
+        public SentryId CaptureEvent(SentryEvent @event, Scope? scope = null)
         {
             if (_disposed)
             {
                 throw new ObjectDisposedException(nameof(SentryClient));
-            }
-
-            if (@event == null)
-            {
-                return SentryId.Empty;
             }
 
             try
@@ -102,11 +96,11 @@ namespace Sentry
         /// <returns>A task to await for the flush operation.</returns>
         public Task FlushAsync(TimeSpan timeout) => Worker.FlushAsync(timeout);
 
-        private SentryId DoSendEvent(SentryEvent @event, Scope scope)
+        private SentryId DoSendEvent(SentryEvent @event, Scope? scope)
         {
-            if (_options.SampleRate is float sample)
+            if (_options.SampleRate != null)
             {
-                if (Random.NextDouble() > sample)
+                if (Random.NextDouble() > _options.SampleRate.Value)
                 {
                     _options.DiagnosticLogger?.LogDebug("Event sampled.");
                     return SentryId.Empty;

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -187,7 +187,7 @@ namespace Sentry
             _options.DiagnosticLogger?.LogDebug("Calling the BeforeSend callback");
             try
             {
-                @event = _options.BeforeSend?.Invoke(@event);
+                @event = _options.BeforeSend?.Invoke(@event!);
             }
             catch (Exception e)
             {

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -71,11 +71,16 @@ namespace Sentry
         /// <param name="event">The event to send to Sentry.</param>
         /// <param name="scope">The optional scope to augment the event with.</param>
         /// <inheritdoc />
-        public SentryId CaptureEvent(SentryEvent @event, Scope? scope = null)
+        public SentryId CaptureEvent(SentryEvent? @event, Scope? scope = null)
         {
             if (_disposed)
             {
                 throw new ObjectDisposedException(nameof(SentryClient));
+            }
+
+            if (@event == null)
+            {
+                return SentryId.Empty;
             }
 
             try

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -187,7 +187,7 @@ namespace Sentry
             _options.DiagnosticLogger?.LogDebug("Calling the BeforeSend callback");
             try
             {
-                @event = @event != null ? _options.BeforeSend?.Invoke(@event) : null;
+                @event = _options.BeforeSend?.Invoke(@event);
             }
             catch (Exception e)
             {

--- a/src/Sentry/SentryClientExtensions.cs
+++ b/src/Sentry/SentryClientExtensions.cs
@@ -32,7 +32,7 @@ namespace Sentry
         /// <returns>The Id of the event</returns>
         public static SentryId CaptureMessage(
             this ISentryClient client,
-            string? message,
+            string message,
             SentryLevel level = SentryLevel.Info)
         {
             return !client.IsEnabled

--- a/src/Sentry/SentryClientExtensions.cs
+++ b/src/Sentry/SentryClientExtensions.cs
@@ -32,7 +32,7 @@ namespace Sentry
         /// <returns>The Id of the event</returns>
         public static SentryId CaptureMessage(
             this ISentryClient client,
-            string message,
+            string? message,
             SentryLevel level = SentryLevel.Info)
         {
             return !client.IsEnabled

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -32,12 +32,12 @@ namespace Sentry
         /// <summary>
         /// A list of exception processors
         /// </summary>
-        internal ISentryEventExceptionProcessor[] ExceptionProcessors { get; set; } = Array.Empty<ISentryEventExceptionProcessor>();
+        internal ISentryEventExceptionProcessor[] ExceptionProcessors { get; set; }
 
         /// <summary>
         /// A list of event processors
         /// </summary>
-        internal ISentryEventProcessor[] EventProcessors { get; set; } = Array.Empty<ISentryEventProcessor>();
+        internal ISentryEventProcessor[] EventProcessors { get; set; }
 
         /// <summary>
         /// A list of providers of <see cref="ISentryEventProcessor"/>
@@ -56,9 +56,9 @@ namespace Sentry
 
         internal IExceptionFilter[] ExceptionFilters { get; set; } = Array.Empty<IExceptionFilter>();
 
-        internal IBackgroundWorker BackgroundWorker { get; set; }
+        internal IBackgroundWorker? BackgroundWorker { get; set; }
 
-        internal ISentryHttpClientFactory SentryHttpClientFactory { get; set; }
+        internal ISentryHttpClientFactory? SentryHttpClientFactory { get; set; }
 
         /// <summary>
         /// A list of namespaces (or prefixes) considered not part of application code
@@ -114,7 +114,7 @@ namespace Sentry
         /// automatically set as ServerName. This property can serve as an override.
         /// This is relevant only to server applications.
         /// </remarks>
-        public string ServerName { get; set; }
+        public string? ServerName { get; set; }
 
         /// <summary>
         /// Whether to send the stack trace of a event captured without an exception
@@ -147,6 +147,7 @@ namespace Sentry
         /// </example>
         /// <see href="https://docs.sentry.io/clientdev/features/#event-sampling"/>
         private float? _sampleRate;
+
         /// <summary>
         /// The optional sample rate.
         /// </summary>
@@ -172,16 +173,19 @@ namespace Sentry
         /// 14.1.16.32451
         /// </example>
         /// <remarks>
+        /// <para>
         /// This value will generally be something along the lines of the git SHA for the given project.
         /// If not explicitly defined via configuration or environment variable (SENTRY_RELEASE).
         /// It will attempt o read it from:
         /// <see cref="System.Reflection.AssemblyInformationalVersionAttribute"/>
-        ///
+        /// </para>
+        /// <para>
         /// Don't rely on discovery if your release is: '1.0.0' or '0.0.0'. Since those are
         /// default values for new projects, they are not considered valid by the discovery process.
+        /// </para>
         /// </remarks>
         /// <seealso href="https://docs.sentry.io/learn/releases/"/>
-        public string Release { get; set; }
+        public string? Release { get; set; }
 
         /// <summary>
         /// The environment the application is running
@@ -195,12 +199,12 @@ namespace Sentry
         /// Production, Staging
         /// </example>
         /// <seealso href="https://docs.sentry.io/learn/environments/"/>
-        public string Environment { get; set; }
+        public string? Environment { get; set; }
 
         /// <summary>
         /// The Data Source Name of a given project in Sentry.
         /// </summary>
-        public Dsn Dsn { get; set; }
+        public Dsn? Dsn { get; set; }
 
         /// <summary>
         /// A callback to invoke before sending an event to Sentry
@@ -210,7 +214,7 @@ namespace Sentry
         /// a chance to inspect and/or modify the event before it's sent. If the event
         /// should not be sent at all, return null from the callback.
         /// </remarks>
-        public Func<SentryEvent, SentryEvent> BeforeSend { get; set; }
+        public Func<SentryEvent, SentryEvent>? BeforeSend { get; set; }
 
         /// <summary>
         /// A callback invoked when a breadcrumb is about to be stored.
@@ -218,9 +222,10 @@ namespace Sentry
         /// <remarks>
         /// Gives a chance to inspect and modify/reject a breadcrumb.
         /// </remarks>
-        public Func<Breadcrumb, Breadcrumb> BeforeBreadcrumb { get; set; }
+        public Func<Breadcrumb, Breadcrumb>? BeforeBreadcrumb { get; set; }
 
         private int _maxQueueItems = 30;
+
         /// <summary>
         /// The maximum number of events to keep while the worker attempts to send them
         /// </summary>
@@ -283,7 +288,7 @@ namespace Sentry
         /// <summary>
         /// An optional web proxy
         /// </summary>
-        public IWebProxy HttpProxy { get; set; }
+        public IWebProxy? HttpProxy { get; set; }
 
         /// <summary>
         /// A callback invoked when a <see cref="SentryClient"/> is created.
@@ -293,17 +298,17 @@ namespace Sentry
         /// </remarks>
         [Obsolete("Please use '" + nameof(CreateHttpClientHandler) + "' instead. " +
                   "You can create an instance of '" + nameof(HttpClientHandler) + "' and modify it at once.")]
-        public Action<HttpClientHandler, Dsn> ConfigureHandler { get; set; }
+        public Action<HttpClientHandler, Dsn>? ConfigureHandler { get; set; }
 
         /// <summary>
         /// Creates the inner most <see cref="HttpClientHandler"/>.
         /// </summary>
-        public Func<Dsn, HttpClientHandler> CreateHttpClientHandler { get; set; }
+        public Func<Dsn, HttpClientHandler>? CreateHttpClientHandler { get; set; }
 
         /// <summary>
         /// A callback invoked when a <see cref="SentryClient"/> is created.
         /// </summary>
-        public Action<HttpClient, Dsn> ConfigureClient { get; set; }
+        public Action<HttpClient, Dsn>? ConfigureClient { get; set; }
 
         private volatile bool _debug;
 
@@ -328,7 +333,8 @@ namespace Sentry
         /// </remarks>
         public SentryLevel DiagnosticsLevel { get; set; } = SentryLevel.Debug;
 
-        private volatile IDiagnosticLogger _diagnosticLogger;
+        private volatile IDiagnosticLogger? _diagnosticLogger;
+
         /// <summary>
         /// The implementation of the logger.
         /// </summary>
@@ -336,7 +342,7 @@ namespace Sentry
         /// The <see cref="Debug"/> flag has to be switched on for this logger to be used at all.
         /// When debugging is turned off, this property is made null and any internal logging results in a no-op.
         /// </remarks>
-        public IDiagnosticLogger DiagnosticLogger
+        public IDiagnosticLogger? DiagnosticLogger
         {
             get => Debug ? _diagnosticLogger : null;
             set
@@ -423,7 +429,7 @@ namespace Sentry
                 new AppDomainProcessExitIntegration(),
             };
 
-            InAppExclude = new string[] {
+            InAppExclude = new[] {
                     "System.",
                     "Sentry.",
                     "Microsoft.",

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO.Compression;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using Sentry.Extensibility;
@@ -9,7 +10,6 @@ using Sentry.Integrations;
 using Sentry.Internal;
 using Sentry.Protocol;
 #if SYSTEM_WEB
-using System.Linq;
 using Sentry.Internal.Web;
 #endif
 using static Sentry.Internal.Constants;
@@ -23,7 +23,7 @@ namespace Sentry
     public class SentryOptions : IScopeOptions
     {
         private readonly Func<ISentryStackTraceFactory> _sentryStackTraceFactoryAccessor;
-        internal ISentryStackTraceFactory SentryStackTraceFactory { get; set; }
+        internal ISentryStackTraceFactory? SentryStackTraceFactory { get; set; }
 
         internal string ClientVersion { get; } = SdkName;
 
@@ -32,29 +32,29 @@ namespace Sentry
         /// <summary>
         /// A list of exception processors
         /// </summary>
-        internal ISentryEventExceptionProcessor[] ExceptionProcessors { get; set; }
+        internal ISentryEventExceptionProcessor[]? ExceptionProcessors { get; set; }
 
         /// <summary>
         /// A list of event processors
         /// </summary>
-        internal ISentryEventProcessor[] EventProcessors { get; set; }
+        internal ISentryEventProcessor[]? EventProcessors { get; set; }
 
         /// <summary>
         /// A list of providers of <see cref="ISentryEventProcessor"/>
         /// </summary>
-        internal Func<IEnumerable<ISentryEventProcessor>>[] EventProcessorsProviders { get; set; }
+        internal Func<IEnumerable<ISentryEventProcessor>>[]? EventProcessorsProviders { get; set; }
 
         /// <summary>
         /// A list of providers of <see cref="ISentryEventExceptionProcessor"/>
         /// </summary>
-        internal Func<IEnumerable<ISentryEventExceptionProcessor>>[] ExceptionProcessorsProviders { get; set; }
+        internal Func<IEnumerable<ISentryEventExceptionProcessor>>[]? ExceptionProcessorsProviders { get; set; }
 
         /// <summary>
-        /// A list of integrations to be added when the SDK is initialized
+        /// A list of integrations to be added when the SDK is initialized.
         /// </summary>
-        internal ISdkIntegration[] Integrations { get; set; }
+        internal ISdkIntegration[]? Integrations { get; set; }
 
-        internal IExceptionFilter[] ExceptionFilters { get; set; } = Array.Empty<IExceptionFilter>();
+        internal IExceptionFilter[]? ExceptionFilters { get; set; } = Array.Empty<IExceptionFilter>();
 
         internal IBackgroundWorker? BackgroundWorker { get; set; }
 
@@ -71,7 +71,7 @@ namespace Sentry
         /// <example>
         /// 'System.', 'Microsoft.'
         /// </example>
-        internal string[] InAppExclude { get; set; }
+        internal string[]? InAppExclude { get; set; }
 
         /// <summary>
         /// A list of namespaces (or prefixes) considered part of application code
@@ -85,7 +85,7 @@ namespace Sentry
         /// 'System.CustomNamespace', 'Microsoft.Azure.App'
         /// </example>
         /// <seealso href="https://docs.sentry.io/error-reporting/configuration/?platform=csharp#in-app-include"/>
-        internal string[] InAppInclude { get; set; }
+        internal string[]? InAppInclude { get; set; }
 
         /// <summary>
         /// Whether to include default Personal Identifiable information
@@ -390,11 +390,11 @@ namespace Sentry
         public SentryOptions()
         {
             EventProcessorsProviders = new Func<IEnumerable<ISentryEventProcessor>>[] {
-                () => EventProcessors
+                () => EventProcessors ?? Enumerable.Empty<ISentryEventProcessor>()
             };
 
             ExceptionProcessorsProviders = new Func<IEnumerable<ISentryEventExceptionProcessor>>[] {
-                () => ExceptionProcessors
+                () => ExceptionProcessors ?? Enumerable.Empty<ISentryEventExceptionProcessor>()
             };
 
             SentryStackTraceFactory = new SentryStackTraceFactory(this);

--- a/src/Sentry/SentryOptionsExtensions.cs
+++ b/src/Sentry/SentryOptionsExtensions.cs
@@ -16,7 +16,7 @@ namespace Sentry
     public static class SentryOptionsExtensions
     {
         /// <summary>
-        /// Disables the strategy to detect duplicate events
+        /// Disables the strategy to detect duplicate events.
         /// </summary>
         /// <remarks>
         /// In case a second event is being sent out from the same exception, that event will be discarded.
@@ -25,19 +25,22 @@ namespace Sentry
         /// </remarks>
         /// <param name="options">The SentryOptions to remove the processor from.</param>
         public static void DisableDuplicateEventDetection(this SentryOptions options)
-            => options.EventProcessors = options.EventProcessors.Where(p => p.GetType() != typeof(DuplicateEventDetectionEventProcessor)).ToArray();
+            => options.EventProcessors =
+                options.EventProcessors?.Where(p => p.GetType() != typeof(DuplicateEventDetectionEventProcessor)).ToArray();
 
         /// <summary>
-        /// Disables the capture of errors through <see cref="AppDomain.UnhandledException"/>
+        /// Disables the capture of errors through <see cref="AppDomain.UnhandledException"/>.
         /// </summary>
         /// <param name="options">The SentryOptions to remove the integration from.</param>
-        public static void DisableAppDomainUnhandledExceptionCapture(this SentryOptions options) => options.RemoveIntegration<AppDomainUnhandledExceptionIntegration>();
+        public static void DisableAppDomainUnhandledExceptionCapture(this SentryOptions options) =>
+            options.RemoveIntegration<AppDomainUnhandledExceptionIntegration>();
 
         /// <summary>
         /// Disables the capture of errors through <see cref="AppDomain.ProcessExit"/>
         /// </summary>
         /// <param name="options">The SentryOptions to remove the integration from.</param>
-        public static void DisableAppDomainProcessExitFlush(this SentryOptions options) => options.RemoveIntegration<AppDomainProcessExitIntegration>();
+        public static void DisableAppDomainProcessExitFlush(this SentryOptions options) =>
+            options.RemoveIntegration<AppDomainProcessExitIntegration>();
 
         /// <summary>
         /// Add an integration
@@ -45,7 +48,9 @@ namespace Sentry
         /// <param name="options">The SentryOptions to hold the processor.</param>
         /// <param name="integration">The integration.</param>
         public static void AddIntegration(this SentryOptions options, ISdkIntegration integration)
-            => options.Integrations = options.Integrations.Concat(new[] { integration }).ToArray();
+            => options.Integrations = options.Integrations != null
+                ? options.Integrations.Concat(new[] {integration}).ToArray()
+                : new[] {integration};
 
         /// <summary>
         /// Removes all integrations of type <typeparamref name="TIntegration"/>.
@@ -54,7 +59,7 @@ namespace Sentry
         /// <param name="options">The SentryOptions to remove the integration(s) from.</param>
         /// <returns></returns>
         internal static void RemoveIntegration<TIntegration>(this SentryOptions options) where TIntegration : ISdkIntegration
-            => options.Integrations = options.Integrations.Where(p => p.GetType() != typeof(TIntegration)).ToArray();
+            => options.Integrations = options.Integrations?.Where(p => p.GetType() != typeof(TIntegration)).ToArray();
 
         /// <summary>
         /// Add an exception filter.
@@ -62,48 +67,53 @@ namespace Sentry
         /// <param name="options">The SentryOptions to hold the processor.</param>
         /// <param name="exceptionFilter">The exception filter to add.</param>
         public static void AddExceptionFilter(this SentryOptions options, IExceptionFilter exceptionFilter)
-            => options.ExceptionFilters = options.ExceptionFilters.Concat(new[] { exceptionFilter }).ToArray();
+            => options.ExceptionFilters = options.ExceptionFilters != null
+                ? options.ExceptionFilters.Concat(new[] {exceptionFilter}).ToArray()
+                : new[] {exceptionFilter};
 
         /// <summary>
         /// Ignore exception of type <typeparamref name="TException"/> or derived.
         /// </summary>
         /// <typeparam name="TException">The type of the exception to ignore.</typeparam>
         /// <param name="options">The SentryOptions to store the exceptions type ignore.</param>
-        /// <returns></returns>
         public static void AddExceptionFilterForType<TException>(this SentryOptions options) where TException : Exception
             => options.AddExceptionFilter(new ExceptionTypeFilter<TException>());
 
         /// <summary>
-        /// Add prefix to exclude from 'InApp' stack trace list
+        /// Add prefix to exclude from 'InApp' stack trace list.
         /// </summary>
-        /// <param name="options"></param>
-        /// <param name="prefix"></param>
         public static void AddInAppExclude(this SentryOptions options, string prefix)
-            => options.InAppExclude = options.InAppExclude.Concat(new[] { prefix }).ToArray();
+            => options.InAppExclude = options.InAppExclude != null
+                ? options.InAppExclude.Concat(new[] {prefix}).ToArray()
+                : new[] {prefix};
 
         /// <summary>
         /// Add prefix to include as in 'InApp' stack trace.
         /// </summary>
-        /// <param name="options"></param>
-        /// <param name="prefix"></param>
         public static void AddInAppInclude(this SentryOptions options, string prefix)
-            => options.InAppInclude = options.InAppInclude.Concat(new[] { prefix }).ToArray();
+            => options.InAppInclude = options.InAppInclude != null
+                ? options.InAppInclude.Concat(new[] {prefix}).ToArray()
+                : new[] {prefix};
 
         /// <summary>
-        /// Add an exception processor
+        /// Add an exception processor.
         /// </summary>
         /// <param name="options">The SentryOptions to hold the processor.</param>
         /// <param name="processor">The exception processor.</param>
         public static void AddExceptionProcessor(this SentryOptions options, ISentryEventExceptionProcessor processor)
-            => options.ExceptionProcessors = options.ExceptionProcessors.Concat(new[] { processor }).ToArray();
+            => options.ExceptionProcessors = options.ExceptionProcessors != null
+                ? options.ExceptionProcessors.Concat(new[] {processor}).ToArray()
+                : new[] {processor};
 
         /// <summary>
-        /// Add the exception processors
+        /// Add the exception processors.
         /// </summary>
         /// <param name="options">The SentryOptions to hold the processor.</param>
         /// <param name="processors">The exception processors.</param>
         public static void AddExceptionProcessors(this SentryOptions options, IEnumerable<ISentryEventExceptionProcessor> processors)
-            => options.ExceptionProcessors = options.ExceptionProcessors.Concat(processors).ToArray();
+            => options.ExceptionProcessors = options.ExceptionProcessors != null
+                ? options.ExceptionProcessors.Concat(processors).ToArray()
+                : processors.ToArray();
 
         /// <summary>
         /// Adds an event processor which is invoked when creating a <see cref="SentryEvent"/>.
@@ -111,7 +121,9 @@ namespace Sentry
         /// <param name="options">The SentryOptions to hold the processor.</param>
         /// <param name="processor">The event processor.</param>
         public static void AddEventProcessor(this SentryOptions options, ISentryEventProcessor processor)
-            => options.EventProcessors = options.EventProcessors.Concat(new[] { processor }).ToArray();
+            => options.EventProcessors = options.EventProcessors != null
+                ? options.EventProcessors.Concat(new[] {processor}).ToArray()
+                : new[] {processor};
 
         /// <summary>
         /// Adds event processors which are invoked when creating a <see cref="SentryEvent"/>.
@@ -119,7 +131,9 @@ namespace Sentry
         /// <param name="options">The SentryOptions to hold the processor.</param>
         /// <param name="processors">The event processors.</param>
         public static void AddEventProcessors(this SentryOptions options, IEnumerable<ISentryEventProcessor> processors)
-            => options.EventProcessors = options.EventProcessors.Concat(processors).ToArray();
+            => options.EventProcessors = options.EventProcessors != null
+                ? options.EventProcessors.Concat(processors).ToArray()
+                : processors.ToArray();
 
         /// <summary>
         /// Adds an event processor provider which is invoked when creating a <see cref="SentryEvent"/>.
@@ -127,34 +141,37 @@ namespace Sentry
         /// <param name="options">The SentryOptions to hold the processor provider.</param>
         /// <param name="processorProvider">The event processor provider.</param>
         public static void AddEventProcessorProvider(this SentryOptions options, Func<IEnumerable<ISentryEventProcessor>> processorProvider)
-            => options.EventProcessorsProviders = options.EventProcessorsProviders.Concat(new[] { processorProvider }).ToArray();
+            => options.EventProcessorsProviders = options.EventProcessorsProviders != null
+                ? options.EventProcessorsProviders.Concat(new[] {processorProvider}).ToArray()
+                : new[] {processorProvider};
 
         /// <summary>
-        /// Add the exception processor provider
+        /// Add the exception processor provider.
         /// </summary>
         /// <param name="options">The SentryOptions to hold the processor provider.</param>
         /// <param name="processorProvider">The exception processor provider.</param>
-        public static void AddExceptionProcessorProvider(this SentryOptions options, Func<IEnumerable<ISentryEventExceptionProcessor>> processorProvider)
-            => options.ExceptionProcessorsProviders = options.ExceptionProcessorsProviders.Concat(new[] { processorProvider }).ToArray();
+        public static void AddExceptionProcessorProvider(this SentryOptions options,
+            Func<IEnumerable<ISentryEventExceptionProcessor>> processorProvider)
+            => options.ExceptionProcessorsProviders = options.ExceptionProcessorsProviders != null
+                ? options.ExceptionProcessorsProviders.Concat(new[] {processorProvider}).ToArray()
+                : new[] {processorProvider};
 
         /// <summary>
-        /// Invokes all event processor providers available
+        /// Invokes all event processor providers available.
         /// </summary>
         /// <param name="options">The SentryOptions which holds the processor providers.</param>
-        /// <returns></returns>
         public static IEnumerable<ISentryEventProcessor> GetAllEventProcessors(this SentryOptions options)
-            => options.EventProcessorsProviders.SelectMany(p => p());
+            => options.EventProcessorsProviders?.SelectMany(p => p()) ?? Enumerable.Empty<ISentryEventProcessor>();
 
         /// <summary>
-        /// Invokes all exception processor providers available
+        /// Invokes all exception processor providers available.
         /// </summary>
         /// <param name="options">The SentryOptions which holds the processor providers.</param>
-        /// <returns></returns>
         public static IEnumerable<ISentryEventExceptionProcessor> GetAllExceptionProcessors(this SentryOptions options)
-            => options.ExceptionProcessorsProviders.SelectMany(p => p());
+            => options.ExceptionProcessorsProviders?.SelectMany(p => p()) ?? Enumerable.Empty<ISentryEventExceptionProcessor>();
 
         /// <summary>
-        /// Use custom <see cref="ISentryStackTraceFactory" />
+        /// Use custom <see cref="ISentryStackTraceFactory" />.
         /// </summary>
         /// <param name="options">The SentryOptions to hold the processor provider.</param>
         /// <param name="sentryStackTraceFactory">The stack trace factory.</param>
@@ -184,7 +201,8 @@ namespace Sentry
 #else
                     options.DiagnosticLogger = new ConsoleDiagnosticLogger(options.DiagnosticsLevel);
 #endif
-                    options.DiagnosticLogger?.LogDebug("Logging enabled with ConsoleDiagnosticLogger and min level: {0}", options.DiagnosticsLevel);
+                    options.DiagnosticLogger?.LogDebug("Logging enabled with ConsoleDiagnosticLogger and min level: {0}",
+                        options.DiagnosticsLevel);
                 }
             }
             else

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -190,7 +190,7 @@ namespace Sentry
         /// <seealso href="https://docs.sentry.io/clientdev/interfaces/breadcrumbs/"/>
         [DebuggerStepThrough]
         public static void AddBreadcrumb(
-            string message,
+            string? message,
             string? category = null,
             string? type = null,
             IDictionary<string, string>? data = null,
@@ -213,8 +213,8 @@ namespace Sentry
         [DebuggerStepThrough]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void AddBreadcrumb(
-            ISystemClock clock,
-            string message,
+            ISystemClock? clock,
+            string? message,
             string? category = null,
             string? type = null,
             IDictionary<string, string>? data = null,

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -12,7 +12,7 @@ using Sentry.Protocol;
 namespace Sentry
 {
     /// <summary>
-    /// Sentry SDK entrypoint
+    /// Sentry SDK entrypoint.
     /// </summary>
     /// <remarks>
     /// This is a facade to the SDK instance.
@@ -24,12 +24,12 @@ namespace Sentry
         private static IHub _hub = DisabledHub.Instance;
 
         /// <summary>
-        /// Last event id recorded in the current scope
+        /// Last event id recorded in the current scope.
         /// </summary>
         public static SentryId LastEventId { [DebuggerStepThrough] get => _hub.LastEventId; }
 
         /// <summary>
-        /// Initializes the SDK while attempting to locate the DSN
+        /// Initializes the SDK while attempting to locate the DSN.
         /// </summary>
         /// <remarks>
         /// If the DSN is not found, the SDK will not change state.
@@ -37,29 +37,29 @@ namespace Sentry
         public static IDisposable Init() => Init(DsnLocator.FindDsnStringOrDisable());
 
         /// <summary>
-        /// Initializes the SDK with the specified DSN
+        /// Initializes the SDK with the specified DSN.
         /// </summary>
         /// <remarks>
-        /// An empty string is interpreted as a disabled SDK
+        /// An empty string is interpreted as a disabled SDK.
         /// </remarks>
         /// <seealso href="https://docs.sentry.io/clientdev/overview/#usage-for-end-users"/>
-        /// <param name="dsn">The dsn</param>
-        public static IDisposable Init(string dsn)
-            => string.IsNullOrWhiteSpace(dsn)
-                ? DisabledHub.Instance
-                : Init(c => c.Dsn = new Dsn(dsn));
+        /// <param name="dsn">The dsn.</param>
+        public static IDisposable Init(string? dsn)
+            => !string.IsNullOrWhiteSpace(dsn)
+                ? Init(new Dsn(dsn))
+                : DisabledHub.Instance;
 
         /// <summary>
-        /// Initializes the SDK with the specified DSN
+        /// Initializes the SDK with the specified DSN.
         /// </summary>
-        /// <param name="dsn">The dsn</param>
+        /// <param name="dsn">The dsn.</param>
         public static IDisposable Init(Dsn dsn) => Init(c => c.Dsn = dsn);
 
         /// <summary>
         /// Initializes the SDK with an optional configuration options callback.
         /// </summary>
         /// <param name="configureOptions">The configure options.</param>
-        public static IDisposable Init(Action<SentryOptions> configureOptions)
+        public static IDisposable Init(Action<SentryOptions>? configureOptions)
         {
             var options = new SentryOptions();
             configureOptions?.Invoke(options);
@@ -68,11 +68,11 @@ namespace Sentry
         }
 
         /// <summary>
-        /// Initializes the SDK with the specified options instance
+        /// Initializes the SDK with the specified options instance.
         /// </summary>
         /// <param name="options">The options instance</param>
         /// <remarks>
-        /// Used by integrations which have their own delegates
+        /// Used by integrations which have their own delegates.
         /// </remarks>
         /// <returns>A disposable to close the SDK.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -105,7 +105,7 @@ namespace Sentry
         public static Task FlushAsync(TimeSpan timeout) => _hub.FlushAsync(timeout);
 
         /// <summary>
-        /// Close the SDK
+        /// Close the SDK.
         /// </summary>
         /// <remarks>
         /// Flushes the events and disables the SDK.
@@ -128,29 +128,30 @@ namespace Sentry
             {
                 _ = Interlocked.CompareExchange(ref _hub, DisabledHub.Instance, _localHub);
                 (_localHub as IDisposable)?.Dispose();
-                _localHub = null;
+
+                // TODO: is this necessary?
+                _localHub = null!;
             }
         }
 
         /// <summary>
-        /// Whether the SDK is enabled or not
+        /// Whether the SDK is enabled or not.
         /// </summary>
         public static bool IsEnabled { [DebuggerStepThrough] get => _hub.IsEnabled; }
 
         /// <summary>
-        /// Creates a new scope that will terminate when disposed
+        /// Creates a new scope that will terminate when disposed.
         /// </summary>
         /// <remarks>
         /// Pushes a new scope while inheriting the current scope's data.
         /// </remarks>
-        /// <typeparam name="TState"></typeparam>
-        /// <param name="state">A state object to be added to the scope</param>
+        /// <param name="state">A state object to be added to the scope.</param>
         /// <returns>A disposable that when disposed, ends the created scope.</returns>
         [DebuggerStepThrough]
         public static IDisposable PushScope<TState>(TState state) => _hub.PushScope(state);
 
         /// <summary>
-        /// Creates a new scope that will terminate when disposed
+        /// Creates a new scope that will terminate when disposed.
         /// </summary>
         /// <returns>A disposable that when disposed, ends the created scope.</returns>
         [DebuggerStepThrough]
@@ -164,21 +165,21 @@ namespace Sentry
         public static void BindClient(ISentryClient client) => _hub.BindClient(client);
 
         /// <summary>
-        /// Adds a breadcrumb to the current Scope
+        /// Adds a breadcrumb to the current Scope.
         /// </summary>
         /// <param name="message">
         /// If a message is provided it’s rendered as text and the whitespace is preserved.
         /// Very long text might be abbreviated in the UI.</param>
+        /// <param name="category">
+        /// Categories are dotted strings that indicate what the crumb is or where it comes from.
+        /// Typically it’s a module name or a descriptive string.
+        /// For instance ui.click could be used to indicate that a click happened in the UI or flask could be used to indicate that the event originated in the Flask framework.
+        /// </param>
         /// <param name="type">
         /// The type of breadcrumb.
         /// The default type is default which indicates no specific handling.
         /// Other types are currently http for HTTP requests and navigation for navigation events.
         /// <seealso href="https://docs.sentry.io/clientdev/interfaces/breadcrumbs/#breadcrumb-types"/>
-        /// </param>
-        /// <param name="category">
-        /// Categories are dotted strings that indicate what the crumb is or where it comes from.
-        /// Typically it’s a module name or a descriptive string.
-        /// For instance ui.click could be used to indicate that a click happened in the UI or flask could be used to indicate that the event originated in the Flask framework.
         /// </param>
         /// <param name="data">
         /// Data associated with this breadcrumb.
@@ -190,23 +191,23 @@ namespace Sentry
         [DebuggerStepThrough]
         public static void AddBreadcrumb(
             string message,
-            string category = null,
-            string type = null,
-            IDictionary<string, string> data = null,
+            string? category = null,
+            string? type = null,
+            IDictionary<string, string>? data = null,
             BreadcrumbLevel level = default)
             => _hub.AddBreadcrumb(message, category, type, data, level);
 
         /// <summary>
-        /// Adds a breadcrumb to the current scope
+        /// Adds a breadcrumb to the current scope.
         /// </summary>
         /// <remarks>
         /// This overload is intended to be used by integrations only.
         /// The objective is to allow better testability by allowing control of the timestamp set to the breadcrumb.
         /// </remarks>
-        /// <param name="clock">An optional <see cref="ISystemClock"/></param>
+        /// <param name="clock">An optional <see cref="ISystemClock"/>.</param>
         /// <param name="message">The message.</param>
-        /// <param name="type">The type.</param>
         /// <param name="category">The category.</param>
+        /// <param name="type">The type.</param>
         /// <param name="data">The data.</param>
         /// <param name="level">The level.</param>
         [DebuggerStepThrough]
@@ -214,14 +215,14 @@ namespace Sentry
         public static void AddBreadcrumb(
             ISystemClock clock,
             string message,
-            string category = null,
-            string type = null,
-            IDictionary<string, string> data = null,
+            string? category = null,
+            string? type = null,
+            IDictionary<string, string>? data = null,
             BreadcrumbLevel level = default)
             => _hub.AddBreadcrumb(clock, message, category, type, data, level);
 
         /// <summary>
-        /// Runs the callback with a new scope which gets dropped at the end
+        /// Runs the callback with a new scope which gets dropped at the end.
         /// </summary>
         /// <remarks>
         /// Pushes a new scope, runs the callback, pops the scope.
@@ -241,10 +242,10 @@ namespace Sentry
             => _hub.ConfigureScope(configureScope);
 
         /// <summary>
-        /// Configures the scope asynchronously
+        /// Configures the scope asynchronously.
         /// </summary>
         /// <param name="configureScope">The configure scope callback.</param>
-        /// <returns>The Id of the event</returns>
+        /// <returns>The Id of the event.</returns>
         [DebuggerStepThrough]
         public static Task ConfigureScopeAsync(Func<Scope, Task> configureScope)
             => _hub.ConfigureScopeAsync(configureScope);
@@ -253,7 +254,7 @@ namespace Sentry
         /// Captures the event.
         /// </summary>
         /// <param name="evt">The event.</param>
-        /// <returns>The Id of the event</returns>
+        /// <returns>The Id of the event.</returns>
         [DebuggerStepThrough]
         public static SentryId CaptureEvent(SentryEvent evt)
             => _hub.CaptureEvent(evt);
@@ -263,17 +264,17 @@ namespace Sentry
         /// </summary>
         /// <param name="evt">The event.</param>
         /// <param name="scope">The scope.</param>
-        /// <returns>The Id of the event</returns>
+        /// <returns>The Id of the event.</returns>
         [DebuggerStepThrough]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static SentryId CaptureEvent(SentryEvent evt, Scope scope)
+        public static SentryId CaptureEvent(SentryEvent evt, Scope? scope)
             => _hub.CaptureEvent(evt, scope);
 
         /// <summary>
         /// Captures the exception.
         /// </summary>
         /// <param name="exception">The exception.</param>
-        /// <returns>The Id of the event</returns>
+        /// <returns>The Id of the even.t</returns>
         [DebuggerStepThrough]
         public static SentryId CaptureException(Exception exception)
             => _hub.CaptureException(exception);
@@ -283,7 +284,7 @@ namespace Sentry
         /// </summary>
         /// <param name="message">The message to send.</param>
         /// <param name="level">The message level.</param>
-        /// <returns>The Id of the event</returns>
+        /// <returns>The Id of the event.</returns>
         [DebuggerStepThrough]
         public static SentryId CaptureMessage(string message, SentryLevel level = SentryLevel.Info)
             => _hub.CaptureMessage(message, level);

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -129,7 +129,6 @@ namespace Sentry
                 _ = Interlocked.CompareExchange(ref _hub, DisabledHub.Instance, _localHub);
                 (_localHub as IDisposable)?.Dispose();
 
-                // TODO: is this necessary?
                 _localHub = null!;
             }
         }
@@ -190,7 +189,7 @@ namespace Sentry
         /// <seealso href="https://docs.sentry.io/clientdev/interfaces/breadcrumbs/"/>
         [DebuggerStepThrough]
         public static void AddBreadcrumb(
-            string? message,
+            string message,
             string? category = null,
             string? type = null,
             IDictionary<string, string>? data = null,
@@ -214,7 +213,7 @@ namespace Sentry
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void AddBreadcrumb(
             ISystemClock? clock,
-            string? message,
+            string message,
             string? category = null,
             string? type = null,
             IDictionary<string, string>? data = null,

--- a/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
@@ -43,15 +43,6 @@ namespace Sentry.Tests.Internals.Http
         private readonly Fixture _fixture = new Fixture();
 
         [Fact]
-        public async Task CaptureEventAsync_NullEvent_NoOp()
-        {
-            var sut = _fixture.GetSut();
-            await sut.CaptureEventAsync(null);
-            _ = await _fixture.HttpMessageHandler.DidNotReceive()
-                    .VerifyableSendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>());
-        }
-
-        [Fact]
         public async Task CaptureEventAsync_CancellationToken_PassedToClient()
         {
             var source = new CancellationTokenSource();

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
@@ -20,17 +20,6 @@ namespace Sentry.Tests.Internals
         private readonly Fixture _fixture = new Fixture();
 
         [Fact]
-        public void Process_NullException_NoSentryException()
-        {
-            var sut = _fixture.GetSut();
-            var evt = new SentryEvent();
-            sut.Process(null, evt);
-
-            Assert.Null(evt.Exception);
-            Assert.Null(evt.SentryExceptionValues);
-        }
-
-        [Fact]
         public void Process_ExceptionAndEventWithoutExtra_ExtraIsNull()
         {
             var sut = _fixture.GetSut();


### PR DESCRIPTION
**Work in progress**

### Some notes:

___

There are two sides to nullable reference types. One is the metadata we provide to users as part of the published library, which helps them correct nullability issues in their integration with Sentry, the other is for static analysis within Sentry itself. While the former can be achieved on all .NET frameworks with backporting (using NuGet package [Nullable](https://www.nuget.org/packages/Nullable)), the latter can only be done with .NET Core 3.0+ or .NET Std 2.1+. The reason for that is, because earlier versions of the framework are not annotated with NRT attributes, enabling warnings on them will result in huge amount of false positives. So as a solution, the `<Nullable>` project property is set to `enable` only when targeting `netstandard2.1`, while on other targets it's set to `annotations` (which allows us to annotate, but doesn't produce warnings for our code). Since `netstandard2.1` target wasn't there, I added it. This is the framework we should be using when developing in the IDE, so that we get proper nullability warnings/insights. As long as that target is also built on CI, we will get warnings there as well. The added bonus of this approach is that warnings are not duplicated per target either (otherwise we'd have one nullability warning per framework).

___

Note that NRTs works at compile time and not runtime and since it's not actually part of the type system but rather a mere annotation, it doesn't protect against `NullReferenceException`s. That said, I would suggest not to check for null and rely on static analysis to tell users when they're wrong. Thanks to backporting, NRTs should be available for users targeting older versions of the framework too. Ideally, we should also either hide nullable parameters behind overloads or default them to null so it's a bit more clear.

___

Some methods were easy enough to analyze in terms of nullability. Some were more difficult. Because there methods that rely a lot on mutability, it was hard to determine whether the value can be null or not at a specific point. In most cases I just marked such instances as nullable. It revealed many places where nulls were not handled. I added some TODOs for these.

___

I've noticed some types are designed as data contracts with public get/set properties. I see that some of these properties are meant to be required, but since it cannot be enforced at a type system level without a constructor (until C# 9 and records), I marked them as nullable. That's because you simply can't know whether they've been set to a valid value or not. Code that interacts with those types needs to be aware of that too.

___

There were some instances of defensive programming in the code base that checked method parameters for null even when they weren't really expected to be null. I marked those instances as nullable to be safe, but we should ideally avoid defensive programming and let type system and static analysis take care of such situations for us. In the future we should consider refactoring this.

___

I found that some method overloads can be simplified by using default parameter value of null where null was expected anyway. Unfortunately, removing overloads is a breaking change so I kept them and added a corresponding TODO to remember for the future.

___

As I was annotating stuff, I also cleaned up some XML docs by adding a period in the end where applicable (accessibility) and removing empty nodes (e.g. `<returns></returns>`).

___

With the advent of .NET 5 we should probably consider dropping runtime-specific target frameworks (i.e. `net461` etc) and only keep .NET Standard.

___

Closes #229
Related to #503 
Related to #504