### PR TITLE
Refactor Dsn type

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ void Main()
 {
     using (SentrySdk.Init(o =>
     {
-        o.Dsn = new Dsn("dsn");
+        o.Dsn = "dsn";
         o.Proxy = new WebProxy("https://localhost:3128");
     }))
     {

--- a/benchmarks/Sentry.Benchmarks/CaptureExceptionDuplicateDetectionBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/CaptureExceptionDuplicateDetectionBenchmarks.cs
@@ -12,7 +12,7 @@ namespace Sentry.Benchmarks
 
         private static Action<SentryOptions> SharedConfig => (o =>
         {
-            o.Dsn = new Dsn(Constants.ValidDsn);
+            o.Dsn = Constants.ValidDsn;
             o.SentryHttpClientFactory = new FakeHttpClientFactory();
         });
 

--- a/benchmarks/Sentry.Benchmarks/FakeHttpClientFactory.cs
+++ b/benchmarks/Sentry.Benchmarks/FakeHttpClientFactory.cs
@@ -10,7 +10,7 @@ namespace Sentry.Benchmarks
 {
     internal class FakeHttpClientFactory : ISentryHttpClientFactory
     {
-        public HttpClient Create(Dsn dsn, SentryOptions options) => new HttpClient(new FakeMessageHandler());
+        public HttpClient Create(SentryOptions options) => new HttpClient(new FakeMessageHandler());
     }
 
     internal class FakeMessageHandler : HttpMessageHandler

--- a/samples/Sentry.Samples.Console.Customized/Program.cs
+++ b/samples/Sentry.Samples.Console.Customized/Program.cs
@@ -96,14 +96,14 @@ internal static class Program
             o.HttpProxy = null; //new WebProxy("https://localhost:3128");
 
             // Example customizing the HttpClientHandlers created
-            o.CreateHttpClientHandler = dsn => new HttpClientHandler
+            o.CreateHttpClientHandler = () => new HttpClientHandler
             {
                 ServerCertificateCustomValidationCallback = (sender, certificate, chain, sslPolicyErrors) =>
                     !certificate.Archived
             };
 
             // Access to the HttpClient created to serve the SentryClint
-            o.ConfigureClient = (client, dsn) =>
+            o.ConfigureClient = client =>
             {
                 client.DefaultRequestHeaders.TryAddWithoutValidation("CustomHeader", new[] { "my value" });
             };
@@ -187,8 +187,7 @@ internal static class Program
             SentrySdk.CaptureEvent(evt);
 
             // Using a different DSN:
-            var adminDsn = new Dsn(AdminDsn);
-            using (var adminClient = new SentryClient(new SentryOptions { Dsn = adminDsn }))
+            using (var adminClient = new SentryClient(new SentryOptions { Dsn = AdminDsn }))
             {
                 // Make believe web framework middleware
                 var middleware = new AdminPartMiddleware(adminClient, null);

--- a/samples/Sentry.Samples.NLog/Program.cs
+++ b/samples/Sentry.Samples.NLog/Program.cs
@@ -109,7 +109,7 @@ namespace Sentry.Samples.NLog
 
                     // If DSN is not set, the SDK will look for an environment variable called SENTRY_DSN. If
                     // nothing is found, SDK is disabled.
-                    o.Dsn = new Dsn(DsnSample);
+                    o.Dsn = DsnSample;
 
                     o.AttachStacktrace = true;
                     o.SendDefaultPii = true; // Send Personal Identifiable information like the username of the user logged in to the device

--- a/samples/Sentry.Samples.Serilog/Program.cs
+++ b/samples/Sentry.Samples.Serilog/Program.cs
@@ -18,7 +18,7 @@ internal static class Program
                 o.MinimumBreadcrumbLevel = LogEventLevel.Debug; // Debug and higher are stored as breadcrumbs (default os Information)
                 o.MinimumEventLevel = LogEventLevel.Error; // Error and higher is sent as event (default is Error)
                 // If DSN is not set, the SDK will look for an environment variable called SENTRY_DSN. If nothing is found, SDK is disabled.
-                o.Dsn = new Dsn("https://80aed643f81249d4bed3e30687b310ab@o447951.ingest.sentry.io/5428537");
+                o.Dsn = "https://80aed643f81249d4bed3e30687b310ab@o447951.ingest.sentry.io/5428537";
                 o.AttachStacktrace = true;
                 o.SendDefaultPii = true; // send PII like the username of the user logged in to the device
                 // Other configuration

--- a/src/Sentry.Extensions.Logging/SentryLoggingOptions.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggingOptions.cs
@@ -41,21 +41,6 @@ namespace Sentry.Extensions.Logging
         public LogLevel MinimumEventLevel { get; set; } = LogLevel.Error;
 
         /// <summary>
-        /// The DSN which defines where events are sent
-        /// </summary>
-        public new string? Dsn
-        {
-            get => base.Dsn?.ToString();
-            set
-            {
-                if (value != null && !Sentry.Dsn.IsDisabled(value))
-                {
-                    base.Dsn = new Dsn(value);
-                }
-            }
-        }
-
-        /// <summary>
         /// Whether to initialize this SDK through this integration
         /// </summary>
         public bool InitializeSdk { get; set; } = true;

--- a/src/Sentry.NLog/ConfigurationExtensions.cs
+++ b/src/Sentry.NLog/ConfigurationExtensions.cs
@@ -98,7 +98,7 @@ namespace NLog
 
             if (dsn != null && options.Dsn == null)
             {
-                options.Dsn = new Dsn(dsn);
+                options.Dsn = dsn;
             }
 
             configuration.AddTarget(targetName, target);

--- a/src/Sentry.NLog/ConfigurationExtensions.cs
+++ b/src/Sentry.NLog/ConfigurationExtensions.cs
@@ -96,7 +96,7 @@ namespace NLog
                 Layout = "${message}",
             };
 
-            if (dsn != null && options.Dsn == null)
+            if (dsn != null && string.IsNullOrWhiteSpace(options.Dsn))
             {
                 options.Dsn = dsn;
             }

--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -274,7 +274,7 @@ namespace Sentry.NLog
             var customDsn = Dsn?.Render(LogEventInfo.CreateNullEvent());
             if (!string.IsNullOrEmpty(customDsn))
             {
-                Options.Dsn = new Dsn(customDsn);
+                Options.Dsn = customDsn;
             }
 
             var customRelease = Release?.Render(LogEventInfo.CreateNullEvent());

--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -186,7 +186,7 @@ namespace Serilog
         {
             if (!string.IsNullOrWhiteSpace(dsn))
             {
-                sentrySerilogOptions.Dsn = new Dsn(dsn);
+                sentrySerilogOptions.Dsn = dsn;
             }
 
             if (minimumEventLevel.HasValue)

--- a/src/Sentry/Http/ISentryHttpClientFactory.cs
+++ b/src/Sentry/Http/ISentryHttpClientFactory.cs
@@ -10,9 +10,8 @@ namespace Sentry.Http
         /// <summary>
         /// Creates an HttpClient using the specified options.
         /// </summary>
-        /// <param name="dsn">The DSN.</param>
         /// <param name="options">The options.</param>
         /// <returns><see cref="HttpClient"/>.</returns>
-        HttpClient Create(Dsn dsn, SentryOptions options);
+        HttpClient Create(SentryOptions options);
     }
 }

--- a/src/Sentry/Internal/Http/HttpTransport.cs
+++ b/src/Sentry/Internal/Http/HttpTransport.cs
@@ -7,7 +7,6 @@ using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Sentry.Extensibility;
-using Sentry.Protocol;
 
 namespace Sentry.Internal.Http
 {
@@ -61,9 +60,16 @@ namespace Sentry.Internal.Http
 
         internal HttpRequestMessage CreateRequest(SentryEvent @event)
         {
+            if (string.IsNullOrWhiteSpace(_options.Dsn))
+            {
+                throw new InvalidOperationException("The DSN is expected to be set at this point.");
+            }
+
+            var dsn = Dsn.Parse(_options.Dsn);
+
             var request = new HttpRequestMessage
             {
-                RequestUri = _options.Dsn?.SentryUri,
+                RequestUri = dsn.GetStoreEndpointUri(),
                 Method = HttpMethod.Post,
                 Content = new StringContent(JsonSerializer.SerializeObject(@event))
             };

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -24,7 +24,7 @@ namespace Sentry.Internal
             Debug.Assert(options != null);
             _options = options;
 
-            if (string.IsNullOrWhiteSpace(options.Dsn))
+            if (options.Dsn is null)
             {
                 var dsn = DsnLocator.FindDsnStringOrDisable();
 

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -24,7 +24,7 @@ namespace Sentry.Internal
             Debug.Assert(options != null);
             _options = options;
 
-            if (options.Dsn == null)
+            if (string.IsNullOrWhiteSpace(options.Dsn))
             {
                 var dsn = DsnLocator.FindDsnStringOrDisable();
 

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -28,7 +28,7 @@ namespace Sentry.Internal
             {
                 var dsn = DsnLocator.FindDsnStringOrDisable();
 
-                if (string.IsNullOrWhiteSpace(dsn))
+                if (Dsn.TryParse(dsn) is null)
                 {
                     const string msg = "Attempt to instantiate a Hub without a DSN.";
                     options.DiagnosticLogger?.LogFatal(msg);

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -26,9 +26,9 @@ namespace Sentry.Internal
 
             if (options.Dsn == null)
             {
-                var dsn = Dsn.TryParse(DsnLocator.FindDsnStringOrDisable());
+                var dsn = DsnLocator.FindDsnStringOrDisable();
 
-                if (dsn is null)
+                if (string.IsNullOrWhiteSpace(dsn))
                 {
                     const string msg = "Attempt to instantiate a Hub without a DSN.";
                     options.DiagnosticLogger?.LogFatal(msg);

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -26,12 +26,15 @@ namespace Sentry.Internal
 
             if (options.Dsn == null)
             {
-                if (!Dsn.TryParse(DsnLocator.FindDsnStringOrDisable(), out var dsn))
+                var dsn = Dsn.TryParse(DsnLocator.FindDsnStringOrDisable());
+
+                if (dsn is null)
                 {
                     const string msg = "Attempt to instantiate a Hub without a DSN.";
                     options.DiagnosticLogger?.LogFatal(msg);
                     throw new InvalidOperationException(msg);
                 }
+
                 options.Dsn = dsn;
             }
 

--- a/src/Sentry/Internal/OptionalHub.cs
+++ b/src/Sentry/Internal/OptionalHub.cs
@@ -19,7 +19,7 @@ namespace Sentry.Internal
         {
             options.SetupLogging();
 
-            if (options.Dsn == null)
+            if (string.IsNullOrWhiteSpace(options.Dsn))
             {
                 var dsn = DsnLocator.FindDsnStringOrDisable();
 

--- a/src/Sentry/Internal/OptionalHub.cs
+++ b/src/Sentry/Internal/OptionalHub.cs
@@ -23,7 +23,7 @@ namespace Sentry.Internal
             {
                 var dsn = DsnLocator.FindDsnStringOrDisable();
 
-                if (string.IsNullOrWhiteSpace(dsn))
+                if (Dsn.TryParse(dsn) is null)
                 {
                     options.DiagnosticLogger?.LogWarning("Init was called but no DSN was provided nor located. Sentry SDK will be disabled.");
                     _hub = DisabledHub.Instance;

--- a/src/Sentry/Internal/OptionalHub.cs
+++ b/src/Sentry/Internal/OptionalHub.cs
@@ -21,12 +21,15 @@ namespace Sentry.Internal
 
             if (options.Dsn == null)
             {
-                if (!Dsn.TryParse(DsnLocator.FindDsnStringOrDisable(), out var dsn))
+                var dsn = Dsn.TryParse(DsnLocator.FindDsnStringOrDisable());
+
+                if (dsn is null)
                 {
                     options.DiagnosticLogger?.LogWarning("Init was called but no DSN was provided nor located. Sentry SDK will be disabled.");
                     _hub = DisabledHub.Instance;
                     return;
                 }
+
                 options.Dsn = dsn;
             }
 

--- a/src/Sentry/Internal/OptionalHub.cs
+++ b/src/Sentry/Internal/OptionalHub.cs
@@ -19,7 +19,7 @@ namespace Sentry.Internal
         {
             options.SetupLogging();
 
-            if (string.IsNullOrWhiteSpace(options.Dsn))
+            if (options.Dsn is null)
             {
                 var dsn = DsnLocator.FindDsnStringOrDisable();
 

--- a/src/Sentry/Internal/OptionalHub.cs
+++ b/src/Sentry/Internal/OptionalHub.cs
@@ -21,9 +21,9 @@ namespace Sentry.Internal
 
             if (options.Dsn == null)
             {
-                var dsn = Dsn.TryParse(DsnLocator.FindDsnStringOrDisable());
+                var dsn = DsnLocator.FindDsnStringOrDisable();
 
-                if (dsn is null)
+                if (string.IsNullOrWhiteSpace(dsn))
                 {
                     options.DiagnosticLogger?.LogWarning("Init was called but no DSN was provided nor located. Sentry SDK will be disabled.");
                     _hub = DisabledHub.Instance;

--- a/src/Sentry/Internal/SdkComposer.cs
+++ b/src/Sentry/Internal/SdkComposer.cs
@@ -11,7 +11,7 @@ namespace Sentry.Internal
         public SdkComposer(SentryOptions options)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
-            if (string.IsNullOrWhiteSpace(options.Dsn)) throw new ArgumentException("No DSN defined in the SentryOptions");
+            if (options.Dsn is null) throw new ArgumentException("No DSN defined in the SentryOptions");
         }
 
         public IBackgroundWorker CreateBackgroundWorker()

--- a/src/Sentry/Internal/SdkComposer.cs
+++ b/src/Sentry/Internal/SdkComposer.cs
@@ -24,16 +24,19 @@ namespace Sentry.Internal
                 return worker;
             }
 
-            if (_options.Dsn is null)
+            if (string.IsNullOrWhiteSpace(_options.Dsn))
             {
                 throw new InvalidOperationException("The DSN is expected to be set at this point.");
             }
 
+            var dsn = Dsn.Parse(_options.Dsn);
+
             var addAuth = SentryHeaders.AddSentryAuth(
                 _options.SentryVersion,
                 _options.ClientVersion,
-                _options.Dsn.PublicKey,
-                _options.Dsn.SecretKey);
+                dsn.PublicKey,
+                dsn.SecretKey
+            );
 
             if (_options.SentryHttpClientFactory is { } factory)
             {
@@ -47,7 +50,7 @@ namespace Sentry.Internal
 #pragma warning restore 618
             }
 
-            var httpClient = factory.Create(_options.Dsn, _options);
+            var httpClient = factory.Create(_options);
 
             return new BackgroundWorker(new HttpTransport(_options, httpClient, addAuth), _options);
         }

--- a/src/Sentry/Internal/SdkComposer.cs
+++ b/src/Sentry/Internal/SdkComposer.cs
@@ -24,7 +24,7 @@ namespace Sentry.Internal
                 return worker;
             }
 
-            if (string.IsNullOrWhiteSpace(_options.Dsn))
+            if (_options.Dsn is null)
             {
                 throw new InvalidOperationException("The DSN is expected to be set at this point.");
             }

--- a/src/Sentry/Internal/SdkComposer.cs
+++ b/src/Sentry/Internal/SdkComposer.cs
@@ -11,7 +11,7 @@ namespace Sentry.Internal
         public SdkComposer(SentryOptions options)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
-            if (options.Dsn == null) throw new ArgumentException("No DSN defined in the SentryOptions");
+            if (string.IsNullOrWhiteSpace(options.Dsn)) throw new ArgumentException("No DSN defined in the SentryOptions");
         }
 
         public IBackgroundWorker CreateBackgroundWorker()

--- a/src/Sentry/Protocol/Dsn.cs
+++ b/src/Sentry/Protocol/Dsn.cs
@@ -24,7 +24,7 @@ namespace Sentry
 
         public Uri SentryUri { get; }
 
-        public Dsn(
+        private Dsn(
             string originalString,
             string projectId,
             string? path,

--- a/src/Sentry/Protocol/Dsn.cs
+++ b/src/Sentry/Protocol/Dsn.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using Sentry.Protocol;
 
 // ReSharper disable once CheckNamespace
@@ -12,58 +10,29 @@ namespace Sentry
     /// <remarks>
     /// <see href="https://docs.sentry.io/quickstart/#configure-the-dsn"/>
     /// </remarks>
-    public class Dsn
+    public sealed class Dsn
     {
-        private readonly string _dsn;
+        public string OriginalString { get; }
 
-        /// <summary>
-        /// The project ID which the authenticated user is bound to.
-        /// </summary>
         public string ProjectId { get; }
 
-        /// <summary>
-        /// An optional path of which Sentry is hosted.
-        /// </summary>
         public string? Path { get; }
 
-        /// <summary>
-        /// The optional secret key to authenticate the SDK.
-        /// </summary>
         public string? SecretKey { get; }
 
-        /// <summary>
-        /// The required public key to authenticate the SDK.
-        /// </summary>
         public string PublicKey { get; }
 
-        /// <summary>
-        /// The URI used to communicate with Sentry.
-        /// </summary>
         public Uri SentryUri { get; }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Dsn"/> class.
-        /// </summary>
-        /// <param name="dsn">The DSN in the format: {PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}</param>
-        /// <remarks>
-        /// A legacy DSN containing a secret will also be accepted: {PROTOCOL}://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PATH}{PROJECT_ID}
-        /// </remarks>
-        public Dsn(string dsn)
+        public Dsn(
+            string originalString,
+            string projectId,
+            string? path,
+            string? secretKey,
+            string publicKey,
+            Uri sentryUri)
         {
-            var parsed = Parse(dsn, true);
-            Debug.Assert(parsed != null, "Parse should throw instead of returning null!");
-
-            _dsn = parsed.Item1;
-            ProjectId = parsed.Item2;
-            Path = parsed.Item3;
-            SecretKey = parsed.Item4;
-            PublicKey = parsed.Item5;
-            SentryUri = parsed.Item6;
-        }
-
-        private Dsn(string dsn, string projectId, string? path, string? secretKey, string publicKey, Uri sentryUri)
-        {
-            _dsn = dsn;
+            OriginalString = originalString;
             ProjectId = projectId;
             Path = path;
             SecretKey = secretKey;
@@ -71,79 +40,26 @@ namespace Sentry
             SentryUri = sentryUri;
         }
 
-        /// <summary>
-        /// Determines whether the specified DSN means a disabled SDK or not..
-        /// </summary>
-        /// <param name="dsn">The DSN.</param>
-        /// <returns>
-        ///   <c>true</c> if the string represents a disabled DSN; otherwise, <c>false</c>.
-        /// </returns>
-        public static bool IsDisabled(string dsn) =>
+        public override string ToString() => OriginalString;
+
+        internal static bool IsDisabled(string dsn) =>
             Constants.DisableSdkDsnValue.Equals(dsn, StringComparison.OrdinalIgnoreCase);
 
-        /// <summary>
-        /// Tries to parse the string into a <see cref="Dsn"/>.
-        /// </summary>
-        /// <param name="dsn">The string to attempt parsing.</param>
-        /// <param name="finalDsn">The <see cref="Dsn"/> when successfully parsed.</param>
-        /// <returns><c>true</c> if the string is a valid <see cref="Dsn"/> as was successfully parsed. Otherwise, <c>false</c>.</returns>
-        public static bool TryParse(string dsn, [NotNullWhen(true)] out Dsn? finalDsn)
+        internal static Dsn Parse(string dsn)
         {
-            try
-            {
-                var parsed = Parse(dsn, false);
-                if (parsed == null)
-                {
-                    finalDsn = null;
-                    return false;
-                }
-
-                finalDsn = new Dsn(parsed.Item1, parsed.Item2, parsed.Item3, parsed.Item4, parsed.Item5, parsed.Item6);
-                return true;
-            }
-            catch
-            {
-                // Parse should not throw though!
-                finalDsn = null;
-                return false;
-            }
-        }
-
-        private static Tuple<string, string, string, string?, string, Uri>? Parse(string dsn, bool throwOnError)
-        {
-            Uri uri;
-            if (throwOnError)
-            {
-                uri = new Uri(dsn); // Throws the UriFormatException one would expect
-            }
-            else if (Uri.TryCreate(dsn, UriKind.Absolute, out var parsedUri))
-            {
-                uri = parsedUri;
-            }
-            else
-            {
-                return null;
-            }
+            var uri = new Uri(dsn);
 
             // uri.UserInfo returns empty string instead of null when no user info data is provided
             if (string.IsNullOrWhiteSpace(uri.UserInfo))
             {
-                if (throwOnError)
-                {
-                    throw new ArgumentException("Invalid DSN: No public key provided.");
-                }
-                return null;
+                throw new ArgumentException("Invalid DSN: No public key provided.");
             }
 
             var keys = uri.UserInfo.Split(':');
             var publicKey = keys[0];
             if (string.IsNullOrWhiteSpace(publicKey))
             {
-                if (throwOnError)
-                {
-                    throw new ArgumentException("Invalid DSN: No public key provided.");
-                }
-                return null;
+                throw new ArgumentException("Invalid DSN: No public key provided.");
             }
 
             string? secretKey = null;
@@ -157,27 +73,43 @@ namespace Sentry
 
             if (string.IsNullOrWhiteSpace(projectId))
             {
-                if (throwOnError)
-                {
-                    throw new ArgumentException("Invalid DSN: A Project Id is required.");
-                }
-                return null;
+                throw new ArgumentException("Invalid DSN: A Project Id is required.");
             }
 
-            var builder = new UriBuilder
+            var sentryUri = new UriBuilder
             {
                 Scheme = uri.Scheme,
                 Host = uri.DnsSafeHost,
                 Port = uri.Port,
                 Path = $"{path}/api/{projectId}/store/"
-            };
+            }.Uri;
 
-            return Tuple.Create(dsn, projectId, path, secretKey, publicKey, builder.Uri);
+            return new Dsn(
+                dsn,
+                projectId,
+                path,
+                secretKey,
+                publicKey,
+                sentryUri
+            );
         }
 
-        /// <summary>
-        /// The original DSN string used to create this instance.
-        /// </summary>
-        public override string ToString() => _dsn;
+        internal static Dsn? TryParse(string? dsn)
+        {
+            if (string.IsNullOrWhiteSpace(dsn))
+            {
+                return null;
+            }
+
+            try
+            {
+                return Parse(dsn);
+            }
+            catch
+            {
+                // Parse should not throw though!
+                return null;
+            }
+        }
     }
 }

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -201,7 +201,7 @@ namespace Sentry
         /// <summary>
         /// The Data Source Name of a given project in Sentry.
         /// </summary>
-        public Dsn? Dsn { get; set; }
+        public string? Dsn { get; set; }
 
         /// <summary>
         /// A callback to invoke before sending an event to Sentry
@@ -295,17 +295,17 @@ namespace Sentry
         /// </remarks>
         [Obsolete("Please use '" + nameof(CreateHttpClientHandler) + "' instead. " +
                   "You can create an instance of '" + nameof(HttpClientHandler) + "' and modify it at once.")]
-        public Action<HttpClientHandler, Dsn>? ConfigureHandler { get; set; }
+        public Action<HttpClientHandler>? ConfigureHandler { get; set; }
 
         /// <summary>
         /// Creates the inner most <see cref="HttpClientHandler"/>.
         /// </summary>
-        public Func<Dsn, HttpClientHandler>? CreateHttpClientHandler { get; set; }
+        public Func<HttpClientHandler>? CreateHttpClientHandler { get; set; }
 
         /// <summary>
         /// A callback invoked when a <see cref="SentryClient"/> is created.
         /// </summary>
-        public Action<HttpClient, Dsn>? ConfigureClient { get; set; }
+        public Action<HttpClient>? ConfigureClient { get; set; }
 
         private volatile bool _debug;
 

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -46,7 +46,7 @@ namespace Sentry
         /// <param name="dsn">The dsn.</param>
         public static IDisposable Init(string? dsn)
             => !string.IsNullOrWhiteSpace(dsn)
-                ? Init(new Dsn(dsn))
+                ? Init(Dsn.Parse(dsn))
                 : DisabledHub.Instance;
 
         /// <summary>
@@ -80,11 +80,14 @@ namespace Sentry
         {
             if (options.Dsn == null)
             {
-                if (!Dsn.TryParse(DsnLocator.FindDsnStringOrDisable(), out var dsn))
+                var dsn = Dsn.TryParse(DsnLocator.FindDsnStringOrDisable());
+
+                if (dsn is null)
                 {
                     options.DiagnosticLogger?.LogWarning("Init was called but no DSN was provided nor located. Sentry SDK will be disabled.");
                     return DisabledHub.Instance;
                 }
+
                 options.Dsn = dsn;
             }
 

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -71,17 +71,17 @@ namespace Sentry
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IDisposable Init(SentryOptions options)
         {
-            var dsn = !string.IsNullOrWhiteSpace(options.Dsn)
-                ? options.Dsn
-                : DsnLocator.FindDsnStringOrDisable();
-
-            options.Dsn = dsn;
-
-            var dsnParsed = Dsn.TryParse(dsn);
-            if (dsnParsed is null)
+            if (string.IsNullOrWhiteSpace(options.Dsn))
             {
-                options.DiagnosticLogger?.LogWarning("Init was called but no DSN was provided nor located. Sentry SDK will be disabled.");
-                return DisabledHub.Instance;
+                var dsn = DsnLocator.FindDsnStringOrDisable();
+
+                if (Dsn.TryParse(dsn) is null)
+                {
+                    options.DiagnosticLogger?.LogWarning("Init was called but no DSN was provided nor located. Sentry SDK will be disabled.");
+                    return DisabledHub.Instance;
+                }
+
+                options.Dsn = dsn;
             }
 
             return UseHub(new Hub(options));

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -71,7 +71,7 @@ namespace Sentry
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IDisposable Init(SentryOptions options)
         {
-            if (string.IsNullOrWhiteSpace(options.Dsn))
+            if (options.Dsn is null)
             {
                 var dsn = DsnLocator.FindDsnStringOrDisable();
 

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -71,7 +71,7 @@ namespace Sentry
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IDisposable Init(SentryOptions options)
         {
-            if (options.Dsn == null)
+            if (string.IsNullOrWhiteSpace(options.Dsn))
             {
                 var dsn = DsnLocator.FindDsnStringOrDisable();
 

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -44,16 +44,9 @@ namespace Sentry
         /// </remarks>
         /// <seealso href="https://docs.sentry.io/clientdev/overview/#usage-for-end-users"/>
         /// <param name="dsn">The dsn.</param>
-        public static IDisposable Init(string? dsn)
-            => !string.IsNullOrWhiteSpace(dsn)
-                ? Init(Dsn.Parse(dsn))
-                : DisabledHub.Instance;
-
-        /// <summary>
-        /// Initializes the SDK with the specified DSN.
-        /// </summary>
-        /// <param name="dsn">The dsn.</param>
-        public static IDisposable Init(Dsn dsn) => Init(c => c.Dsn = dsn);
+        public static IDisposable Init(string? dsn) => !string.IsNullOrWhiteSpace(dsn)
+            ? Init(c => c.Dsn = dsn)
+            : DisabledHub.Instance;
 
         /// <summary>
         /// Initializes the SDK with an optional configuration options callback.
@@ -80,9 +73,9 @@ namespace Sentry
         {
             if (options.Dsn == null)
             {
-                var dsn = Dsn.TryParse(DsnLocator.FindDsnStringOrDisable());
+                var dsn = DsnLocator.FindDsnStringOrDisable();
 
-                if (dsn is null)
+                if (string.IsNullOrWhiteSpace(dsn))
                 {
                     options.DiagnosticLogger?.LogWarning("Init was called but no DSN was provided nor located. Sentry SDK will be disabled.");
                     return DisabledHub.Instance;

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -69,23 +69,7 @@ namespace Sentry
         /// </remarks>
         /// <returns>A disposable to close the SDK.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static IDisposable Init(SentryOptions options)
-        {
-            if (options.Dsn is null)
-            {
-                var dsn = DsnLocator.FindDsnStringOrDisable();
-
-                if (Dsn.TryParse(dsn) is null)
-                {
-                    options.DiagnosticLogger?.LogWarning("Init was called but no DSN was provided nor located. Sentry SDK will be disabled.");
-                    return DisabledHub.Instance;
-                }
-
-                options.Dsn = dsn;
-            }
-
-            return UseHub(new Hub(options));
-        }
+        public static IDisposable Init(SentryOptions options) => UseHub(new Hub(options));
 
         internal static IDisposable UseHub(IHub hub)
         {

--- a/test/Sentry.AspNetCore.Tests/AspNetSentrySdkTestFixture.cs
+++ b/test/Sentry.AspNetCore.Tests/AspNetSentrySdkTestFixture.cs
@@ -18,8 +18,7 @@ namespace Sentry.AspNetCore.Tests
             _ = builder.UseSentry(options =>
             {
                 options.Dsn = DsnSamples.ValidDsnWithSecret;
-                options.SentryHttpClientFactory = new DelegateHttpClientFactory((d, o)
-                        => sentryHttpClient);
+                options.SentryHttpClientFactory = new DelegateHttpClientFactory(o => sentryHttpClient);
 
                 Configure?.Invoke(options);
             });

--- a/test/Sentry.AspNetCore.Tests/DelegateHttpClientFactory.cs
+++ b/test/Sentry.AspNetCore.Tests/DelegateHttpClientFactory.cs
@@ -6,11 +6,11 @@ namespace Sentry.AspNetCore.Tests
 {
     internal class DelegateHttpClientFactory : ISentryHttpClientFactory
     {
-        private readonly Func<Dsn, SentryOptions, HttpClient> _clientFactory;
+        private readonly Func<SentryOptions, HttpClient> _clientFactory;
 
-        public DelegateHttpClientFactory(Func<Dsn, SentryOptions, HttpClient> clientFactory)
+        public DelegateHttpClientFactory(Func<SentryOptions, HttpClient> clientFactory)
             => _clientFactory = clientFactory;
 
-        public HttpClient Create(Dsn dsn, SentryOptions options) => _clientFactory(dsn, options);
+        public HttpClient Create(SentryOptions options) => _clientFactory(options);
     }
 }

--- a/test/Sentry.AspNetCore.Tests/MiddlewareLoggerIntegration.cs
+++ b/test/Sentry.AspNetCore.Tests/MiddlewareLoggerIntegration.cs
@@ -46,7 +46,7 @@ namespace Sentry.AspNetCore.Tests
                 };
                 loggingOptions.InitializeSdk = false;
 
-                var hub = new Hub(new SentryOptions { Dsn = DsnSamples.Valid });
+                var hub = new Hub(new SentryOptions { Dsn = DsnSamples.ValidDsnWithSecret });
                 hub.BindClient(Client);
                 Hub = hub;
                 var provider = new SentryLoggerProvider(hub, Clock, loggingOptions);

--- a/test/Sentry.NLog.Tests/SentryTargetTests.cs
+++ b/test/Sentry.NLog.Tests/SentryTargetTests.cs
@@ -26,7 +26,7 @@ namespace Sentry.NLog.Tests
 
         private class Fixture
         {
-            public SentryNLogOptions Options { get; set; } = new SentryNLogOptions { Dsn = Valid };
+            public SentryNLogOptions Options { get; set; } = new SentryNLogOptions { Dsn = ValidDsnWithSecret };
 
             public IHub Hub { get; set; } = Substitute.For<IHub>();
 
@@ -521,7 +521,7 @@ namespace Sentry.NLog.Tests
         [Fact]
         public void Dsn_ReturnsDsnFromOptions_Instance()
         {
-            var expectedDsn = new Dsn("https://a@sentry.io/1");
+            var expectedDsn = "https://a@sentry.io/1";
             _fixture.Options.Dsn = expectedDsn;
             var target = (SentryTarget)_fixture.GetTarget();
             Assert.Equal(expectedDsn.ToString(), target.Options.Dsn.ToString());
@@ -530,7 +530,7 @@ namespace Sentry.NLog.Tests
         [Fact]
         public void Dsn_SupportsNLogLayout_Lookup()
         {
-            var expectedDsn = new Dsn("https://a@sentry.io/1");
+            var expectedDsn = "https://a@sentry.io/1";
             var target = (SentryTarget)_fixture.GetTarget();
             target.Dsn = "${var:mydsn}";
             var logFactory = new LogFactory();

--- a/test/Sentry.Testing/DelegateHttpClientFactory.cs
+++ b/test/Sentry.Testing/DelegateHttpClientFactory.cs
@@ -6,11 +6,11 @@ namespace Sentry.Testing
 {
     public class DelegateHttpClientFactory : ISentryHttpClientFactory
     {
-        private readonly Func<Dsn, SentryOptions, HttpClient> _clientFactory;
+        private readonly Func<SentryOptions, HttpClient> _clientFactory;
 
-        public DelegateHttpClientFactory(Func<Dsn, SentryOptions, HttpClient> clientFactory)
+        public DelegateHttpClientFactory(Func<SentryOptions, HttpClient> clientFactory)
             => _clientFactory = clientFactory;
 
-        public HttpClient Create(Dsn dsn, SentryOptions options) => _clientFactory(dsn, options);
+        public HttpClient Create(SentryOptions options) => _clientFactory(options);
     }
 }

--- a/test/Sentry.Testing/DsnSamples.cs
+++ b/test/Sentry.Testing/DsnSamples.cs
@@ -15,10 +15,5 @@ namespace Sentry
         /// Missing ProjectId
         /// </summary>
         public const string InvalidDsn = "https://d4d82fc1c2c4032a83f3a29aa3a3aff@fake-sentry.io:65535/";
-
-        /// <summary>
-        /// Valid DSN instance
-        /// </summary>
-        public static readonly Dsn Valid = new Dsn(ValidDsnWithSecret);
     }
 }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -19,7 +19,7 @@ namespace NotSentry.Tests
 
             public Fixture()
             {
-                SentryOptions.Dsn = DsnSamples.Valid;
+                SentryOptions.Dsn = DsnSamples.ValidDsnWithSecret;
                 SentryOptions.BackgroundWorker = Worker;
             }
 

--- a/test/Sentry.Tests/Internals/DefaultSentryHttpClientFactoryTests.cs
+++ b/test/Sentry.Tests/Internals/DefaultSentryHttpClientFactoryTests.cs
@@ -15,11 +15,11 @@ namespace Sentry.Tests.Internals
         {
             public SentryOptions HttpOptions { get; set; } = new SentryOptions
             {
-                Dsn = DsnSamples.Valid
+                Dsn = DsnSamples.ValidDsnWithSecret
             };
 
-            public Action<HttpClientHandler, Dsn> ConfigureHandler { get; set; }
-            public Action<HttpClient, Dsn> ConfigureClient { get; set; }
+            public Action<HttpClientHandler> ConfigureHandler { get; set; }
+            public Action<HttpClient> ConfigureClient { get; set; }
 
             public DefaultSentryHttpClientFactory GetSut()
                 => new DefaultSentryHttpClientFactory(ConfigureHandler, ConfigureClient);
@@ -28,19 +28,11 @@ namespace Sentry.Tests.Internals
         private readonly Fixture _fixture = new Fixture();
 
         [Fact]
-        public void Create_NullDsn_ThrowsArgumentNullException()
-        {
-            var sut = _fixture.GetSut();
-            var ex = Assert.Throws<ArgumentNullException>(() => sut.Create(null, _fixture.HttpOptions));
-            Assert.Equal("dsn", ex.ParamName);
-        }
-
-        [Fact]
         public void Create_Returns_HttpClient()
         {
             var sut = _fixture.GetSut();
 
-            Assert.NotNull(sut.Create(DsnSamples.Valid, _fixture.HttpOptions));
+            Assert.NotNull(sut.Create(_fixture.HttpOptions));
         }
 
         [Fact]
@@ -50,7 +42,7 @@ namespace Sentry.Tests.Internals
 
             var sut = _fixture.GetSut();
 
-            var client = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            var client = sut.Create(_fixture.HttpOptions);
 
             foreach (var handler in client.GetMessageHandlers())
             {
@@ -67,7 +59,7 @@ namespace Sentry.Tests.Internals
 
             var sut = _fixture.GetSut();
 
-            var client = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            var client = sut.Create(_fixture.HttpOptions);
 
             Assert.Contains(client.GetMessageHandlers(), h => h.GetType() == typeof(GzipBufferedRequestBodyHandler));
         }
@@ -81,7 +73,7 @@ namespace Sentry.Tests.Internals
             _fixture.HttpOptions.RequestBodyCompressionBuffered = false;
             var sut = _fixture.GetSut();
 
-            var client = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            var client = sut.Create(_fixture.HttpOptions);
 
             Assert.Contains(client.GetMessageHandlers(), h => h.GetType() == typeof(GzipRequestBodyHandler));
         }
@@ -91,7 +83,7 @@ namespace Sentry.Tests.Internals
         {
             var sut = _fixture.GetSut();
 
-            var client = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            var client = sut.Create(_fixture.HttpOptions);
 
             Assert.Equal(typeof(RetryAfterHandler), client.GetMessageHandlers().First().GetType());
         }
@@ -102,14 +94,14 @@ namespace Sentry.Tests.Internals
             _fixture.HttpOptions.DecompressionMethods = DecompressionMethods.None;
 
             var configureHandlerInvoked = false;
-            _fixture.ConfigureHandler = (handler, dsn) =>
+            _fixture.ConfigureHandler = (handler) =>
             {
                 Assert.Equal(DecompressionMethods.None, handler.AutomaticDecompression);
                 configureHandlerInvoked = true;
             };
             var sut = _fixture.GetSut();
 
-            _ = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            _ = sut.Create(_fixture.HttpOptions);
 
             Assert.True(configureHandlerInvoked);
         }
@@ -118,14 +110,14 @@ namespace Sentry.Tests.Internals
         public void Create_DecompressionMethodDefault_AllBitsSet()
         {
             var configureHandlerInvoked = false;
-            _fixture.ConfigureHandler = (handler, dsn) =>
+            _fixture.ConfigureHandler = (handler) =>
             {
                 Assert.Equal(~DecompressionMethods.None, handler.AutomaticDecompression);
                 configureHandlerInvoked = true;
             };
             var sut = _fixture.GetSut();
 
-            _ = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            _ = sut.Create(_fixture.HttpOptions);
 
             Assert.True(configureHandlerInvoked);
         }
@@ -134,14 +126,14 @@ namespace Sentry.Tests.Internals
         public void Create_DefaultHeaders_AcceptJson()
         {
             var configureHandlerInvoked = false;
-            _fixture.ConfigureClient = (client, dsn) =>
+            _fixture.ConfigureClient = (client) =>
             {
                 Assert.Equal("application/json", client.DefaultRequestHeaders.Accept.ToString());
                 configureHandlerInvoked = true;
             };
             var sut = _fixture.GetSut();
 
-            _ = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            _ = sut.Create(_fixture.HttpOptions);
 
             Assert.True(configureHandlerInvoked);
         }
@@ -151,14 +143,14 @@ namespace Sentry.Tests.Internals
         {
             _fixture.HttpOptions.HttpProxy = new WebProxy("https://proxy.sentry.io:31337");
             var configureHandlerInvoked = false;
-            _fixture.ConfigureHandler = (handler, dsn) =>
+            _fixture.ConfigureHandler = (handler) =>
             {
                 Assert.Same(_fixture.HttpOptions.HttpProxy, handler.Proxy);
                 configureHandlerInvoked = true;
             };
             var sut = _fixture.GetSut();
 
-            _ = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            _ = sut.Create(_fixture.HttpOptions);
 
             Assert.True(configureHandlerInvoked);
         }
@@ -167,10 +159,10 @@ namespace Sentry.Tests.Internals
         public void Create_ProvidedCreateHttpClientHandler_ReturnedHandlerUsed()
         {
             var handler = Substitute.For<HttpClientHandler>();
-            _fixture.HttpOptions.CreateHttpClientHandler = _ => handler;
+            _fixture.HttpOptions.CreateHttpClientHandler = () => handler;
             var sut = _fixture.GetSut();
 
-            var client = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            var client = sut.Create(_fixture.HttpOptions);
 
             Assert.Contains(client.GetMessageHandlers(), h => ReferenceEquals(handler, h));
         }
@@ -181,7 +173,7 @@ namespace Sentry.Tests.Internals
             _fixture.HttpOptions.CreateHttpClientHandler = null;
             var sut = _fixture.GetSut();
 
-            var client = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            var client = sut.Create(_fixture.HttpOptions);
 
             Assert.Contains(client.GetMessageHandlers(), h => h.GetType() == typeof(HttpClientHandler));
         }
@@ -189,10 +181,10 @@ namespace Sentry.Tests.Internals
         [Fact]
         public void Create_NullReturnedCreateHttpClientHandler_HttpClientHandlerUsed()
         {
-            _fixture.HttpOptions.CreateHttpClientHandler = _ => null;
+            _fixture.HttpOptions.CreateHttpClientHandler = () => null;
             var sut = _fixture.GetSut();
 
-            var client = sut.Create(DsnSamples.Valid, _fixture.HttpOptions);
+            var client = sut.Create(_fixture.HttpOptions);
 
             Assert.Contains(client.GetMessageHandlers(), h => h.GetType() == typeof(HttpClientHandler));
         }

--- a/test/Sentry.Tests/Internals/Http/GzipBufferedRequestBodyHandlerTests.cs
+++ b/test/Sentry.Tests/Internals/Http/GzipBufferedRequestBodyHandlerTests.cs
@@ -23,7 +23,9 @@ namespace Sentry.Tests.Internals.Http
 
             public Fixture()
             {
-                Message = new HttpRequestMessage(HttpMethod.Post, DsnSamples.Valid.SentryUri)
+                var uri = Dsn.Parse(DsnSamples.ValidDsnWithSecret).GetStoreEndpointUri();
+
+                Message = new HttpRequestMessage(HttpMethod.Post, uri)
                 {
                     Content = new StringContent(new string('a', MessageCharCount))
                 };

--- a/test/Sentry.Tests/Internals/Http/GzipRequestBodyHandlerTests.cs
+++ b/test/Sentry.Tests/Internals/Http/GzipRequestBodyHandlerTests.cs
@@ -23,7 +23,9 @@ namespace Sentry.Tests.Internals.Http
 
             public Fixture()
             {
-                Message = new HttpRequestMessage(HttpMethod.Post, DsnSamples.Valid.SentryUri)
+                var uri = Dsn.Parse(DsnSamples.ValidDsnWithSecret).GetStoreEndpointUri();
+
+                Message = new HttpRequestMessage(HttpMethod.Post, uri)
                 {
                     Content = new StringContent(new string('a', MessageCharCount))
                 };

--- a/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
@@ -20,7 +20,7 @@ namespace Sentry.Tests.Internals.Http
         {
             public SentryOptions SentryOptions { get; set; } = new SentryOptions
             {
-                Dsn = DsnSamples.Valid,
+                Dsn = DsnSamples.ValidDsnWithSecret,
                 DiagnosticLogger = Substitute.For<IDiagnosticLogger>()
             };
 
@@ -142,7 +142,9 @@ namespace Sentry.Tests.Internals.Http
             var evt = new SentryEvent();
             var actual = sut.CreateRequest(evt);
 
-            Assert.Equal(_fixture.SentryOptions.Dsn.SentryUri, actual.RequestUri);
+            var uri = Dsn.Parse(_fixture.SentryOptions.Dsn!).GetStoreEndpointUri();
+
+            Assert.Equal(uri, actual.RequestUri);
         }
 
         [Fact]

--- a/test/Sentry.Tests/Protocol/DsnSamples.cs
+++ b/test/Sentry.Tests/Protocol/DsnSamples.cs
@@ -19,6 +19,6 @@ namespace Sentry.Protocol.Tests
         /// <summary>
         /// Valid DSN instance
         /// </summary>
-        public static Dsn Valid = new Dsn(ValidDsnWithSecret);
+        public static Dsn Valid = Dsn.Parse(ValidDsnWithSecret);
     }
 }

--- a/test/Sentry.Tests/Protocol/DsnSamples.cs
+++ b/test/Sentry.Tests/Protocol/DsnSamples.cs
@@ -1,5 +1,4 @@
-// ReSharper disable once CheckNamespace
-namespace Sentry.Protocol.Tests
+namespace Sentry.Tests.Protocol
 {
     public static class DsnSamples
     {
@@ -15,10 +14,5 @@ namespace Sentry.Protocol.Tests
         /// Missing ProjectId
         /// </summary>
         public const string InvalidDsn = "https://d4d82fc1c2c4032a83f3a29aa3a3aff@fake-sentry.io:65535/";
-
-        /// <summary>
-        /// Valid DSN instance
-        /// </summary>
-        public static Dsn Valid = Dsn.Parse(ValidDsnWithSecret);
     }
 }

--- a/test/Sentry.Tests/Protocol/DsnTests.cs
+++ b/test/Sentry.Tests/Protocol/DsnTests.cs
@@ -17,15 +17,15 @@ namespace Sentry.Tests.Protocol
         [Fact]
         public void Ctor_SampleValidDsnWithoutSecret_CorrectlyConstructs()
         {
-            var dsn = Dsn.Parse(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithoutSecret);
-            Assert.Equal(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithoutSecret, dsn.ToString());
+            var dsn = Dsn.Parse(DsnSamples.ValidDsnWithoutSecret);
+            Assert.Equal(DsnSamples.ValidDsnWithoutSecret, dsn.ToString());
         }
 
         [Fact]
         public void Ctor_SampleValidDsnWithSecret_CorrectlyConstructs()
         {
-            var dsn = Dsn.Parse(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithSecret);
-            Assert.Equal(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithSecret, dsn.ToString());
+            var dsn = Dsn.Parse(DsnSamples.ValidDsnWithSecret);
+            Assert.Equal(DsnSamples.ValidDsnWithSecret, dsn.ToString());
         }
 
         [Fact]
@@ -139,19 +139,19 @@ namespace Sentry.Tests.Protocol
         [Fact]
         public void TryParse_SampleValidDsnWithoutSecret_Succeeds()
         {
-            Assert.NotNull(Dsn.TryParse(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithoutSecret));
+            Assert.NotNull(Dsn.TryParse(DsnSamples.ValidDsnWithoutSecret));
         }
 
         [Fact]
         public void TryParse_SampleValidDsnWithSecret_Succeeds()
         {
-            Assert.NotNull(Dsn.TryParse(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithSecret));
+            Assert.NotNull(Dsn.TryParse(DsnSamples.ValidDsnWithSecret));
         }
 
         [Fact]
         public void TryParse_SampleInvalidDsn_Fails()
         {
-            Assert.Null(Dsn.TryParse(Sentry.Protocol.Tests.DsnSamples.InvalidDsn));
+            Assert.Null(Dsn.TryParse(DsnSamples.InvalidDsn));
         }
 
         [Fact]
@@ -258,10 +258,10 @@ namespace Sentry.Tests.Protocol
         }
 
         [Fact]
-        public void IsDisabled_ValidDsn_False() => Assert.False(Dsn.IsDisabled(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithSecret));
+        public void IsDisabled_ValidDsn_False() => Assert.False(Dsn.IsDisabled(DsnSamples.ValidDsnWithSecret));
 
         [Fact]
-        public void IsDisabled_InvalidDsn_False() => Assert.False(Dsn.IsDisabled(Sentry.Protocol.Tests.DsnSamples.InvalidDsn));
+        public void IsDisabled_InvalidDsn_False() => Assert.False(Dsn.IsDisabled(DsnSamples.InvalidDsn));
 
         [Fact]
         public void IsDisabled_NullDsn_False() => Assert.False(Dsn.IsDisabled(null));
@@ -299,15 +299,17 @@ namespace Sentry.Tests.Protocol
             if (@case == null) throw new ArgumentNullException(nameof(@case));
             if (dsn == null) throw new ArgumentNullException(nameof(dsn));
 
-            Assert.Equal(@case.Scheme, dsn.SentryUri.Scheme);
+            var uri = dsn.GetStoreEndpointUri();
+
+            Assert.Equal(@case.Scheme, uri.Scheme);
             Assert.Equal(@case.PublicKey, dsn.PublicKey);
             Assert.Equal(@case.SecretKey, dsn.SecretKey);
             Assert.Equal(@case.ProjectId, dsn.ProjectId);
             Assert.Equal(@case.Path, dsn.Path);
-            Assert.Equal(@case.Host, dsn.SentryUri.Host);
-            Assert.Equal(@case.Port, dsn.SentryUri.Port);
+            Assert.Equal(@case.Host, uri.Host);
+            Assert.Equal(@case.Port, uri.Port);
 
-            Assert.Equal(@case, dsn.SentryUri);
+            Assert.Equal(@case, uri);
         }
     }
 }

--- a/test/Sentry.Tests/Protocol/DsnTests.cs
+++ b/test/Sentry.Tests/Protocol/DsnTests.cs
@@ -10,35 +10,35 @@ namespace Sentry.Tests.Protocol
         public void ToString_SameAsInput()
         {
             var @case = new DsnTestCase();
-            var dsn = new Dsn(@case);
+            var dsn = Dsn.Parse(@case);
             Assert.Equal(@case.ToString(), dsn.ToString());
         }
 
         [Fact]
         public void Ctor_SampleValidDsnWithoutSecret_CorrectlyConstructs()
         {
-            var dsn = new Dsn(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithoutSecret);
+            var dsn = Dsn.Parse(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithoutSecret);
             Assert.Equal(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithoutSecret, dsn.ToString());
         }
 
         [Fact]
         public void Ctor_SampleValidDsnWithSecret_CorrectlyConstructs()
         {
-            var dsn = new Dsn(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithSecret);
+            var dsn = Dsn.Parse(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithSecret);
             Assert.Equal(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithSecret, dsn.ToString());
         }
 
         [Fact]
         public void Ctor_NotUri_ThrowsUriFormatException()
         {
-            var ex = Assert.Throws<UriFormatException>(() => new Dsn("Not a URI"));
+            var ex = Assert.Throws<UriFormatException>(() => Dsn.Parse("Not a URI"));
             Assert.Equal("Invalid URI: The format of the URI could not be determined.", ex.Message);
         }
 
         [Fact]
         public void Ctor_DisableSdk_ThrowsUriFormatException()
         {
-            var ex = Assert.Throws<UriFormatException>(() => new Dsn(Constants.DisableSdkDsnValue));
+            var ex = Assert.Throws<UriFormatException>(() => Dsn.Parse(Constants.DisableSdkDsnValue));
             Assert.Equal("Invalid URI: The URI is empty.", ex.Message);
         }
 
@@ -46,7 +46,7 @@ namespace Sentry.Tests.Protocol
         public void Ctor_ValidDsn_CorrectlyConstructs()
         {
             var @case = new DsnTestCase();
-            var dsn = new Dsn(@case);
+            var dsn = Dsn.Parse(@case);
 
             AssertEqual(@case, dsn);
         }
@@ -55,7 +55,7 @@ namespace Sentry.Tests.Protocol
         public void Ctor_MissingScheme_ThrowsUriFormatException()
         {
             var @case = new DsnTestCase { Scheme = null };
-            var ex = Assert.Throws<UriFormatException>(() => new Dsn(@case));
+            var ex = Assert.Throws<UriFormatException>(() => Dsn.Parse(@case));
             Assert.Equal("Invalid URI: The format of the URI could not be determined.", ex.Message);
         }
 
@@ -63,7 +63,7 @@ namespace Sentry.Tests.Protocol
         public void Ctor_FutureScheme_ValidDsn()
         {
             var @case = new DsnTestCase { Scheme = "hypothetical" };
-            var dsn = new Dsn(@case);
+            var dsn = Dsn.Parse(@case);
             AssertEqual(@case, dsn);
         }
 
@@ -71,7 +71,7 @@ namespace Sentry.Tests.Protocol
         public void Ctor_EmptyPath_ValidDsn()
         {
             var @case = new DsnTestCase { Path = string.Empty };
-            var dsn = new Dsn(@case);
+            var dsn = Dsn.Parse(@case);
             AssertEqual(@case, dsn);
         }
 
@@ -79,7 +79,7 @@ namespace Sentry.Tests.Protocol
         public void Ctor_MissingSecretKey_GetterReturnsNull()
         {
             var @case = new DsnTestCase { SecretKey = null };
-            var sut = new Dsn(@case);
+            var sut = Dsn.Parse(@case);
             Assert.Null(sut.SecretKey);
         }
 
@@ -87,7 +87,7 @@ namespace Sentry.Tests.Protocol
         public void Ctor_MissingPublicKey_ThrowsArgumentException()
         {
             var @case = new DsnTestCase { PublicKey = null };
-            var ex = Assert.Throws<ArgumentException>(() => new Dsn(@case));
+            var ex = Assert.Throws<ArgumentException>(() => Dsn.Parse(@case));
             Assert.Equal("Invalid DSN: No public key provided.", ex.Message);
         }
 
@@ -95,7 +95,7 @@ namespace Sentry.Tests.Protocol
         public void Ctor_MissingPublicAndSecretKey_ThrowsArgumentException()
         {
             var @case = new DsnTestCase { PublicKey = null, SecretKey = null, UserInfoSeparator = null, CredentialSeparator = null };
-            var ex = Assert.Throws<ArgumentException>(() => new Dsn(@case));
+            var ex = Assert.Throws<ArgumentException>(() => Dsn.Parse(@case));
             Assert.Equal("Invalid DSN: No public key provided.", ex.Message);
         }
 
@@ -103,7 +103,7 @@ namespace Sentry.Tests.Protocol
         public void Ctor_MissingProjectId_ThrowsArgumentException()
         {
             var @case = new DsnTestCase { ProjectId = null };
-            var ex = Assert.Throws<ArgumentException>(() => new Dsn(@case));
+            var ex = Assert.Throws<ArgumentException>(() => Dsn.Parse(@case));
             Assert.Equal("Invalid DSN: A Project Id is required.", ex.Message);
         }
 
@@ -111,7 +111,7 @@ namespace Sentry.Tests.Protocol
         public void Ctor_InvalidPort_ThrowsUriFormatException()
         {
             var @case = new DsnTestCase { Port = -1 };
-            var ex = Assert.Throws<UriFormatException>(() => new Dsn(@case));
+            var ex = Assert.Throws<UriFormatException>(() => Dsn.Parse(@case));
             Assert.Equal("Invalid URI: Invalid port specified.", ex.Message);
         }
 
@@ -119,63 +119,59 @@ namespace Sentry.Tests.Protocol
         public void Ctor_InvalidHost_ThrowsUriFormatException()
         {
             var @case = new DsnTestCase { Host = null };
-            var ex = Assert.Throws<UriFormatException>(() => new Dsn(@case));
+            var ex = Assert.Throws<UriFormatException>(() => Dsn.Parse(@case));
             Assert.Equal("Invalid URI: The hostname could not be parsed.", ex.Message);
         }
 
         [Fact]
         public void Ctor_EmptyStringDsn_ThrowsUriFormatException()
         {
-            var ex = Assert.Throws<UriFormatException>(() => new Dsn(string.Empty));
+            var ex = Assert.Throws<UriFormatException>(() => Dsn.Parse(string.Empty));
             Assert.Equal("Invalid URI: The URI is empty.", ex.Message);
         }
 
         [Fact]
         public void Ctor_NullDsn_ThrowsArgumentNull()
         {
-            _ = Assert.Throws<ArgumentNullException>(() => new Dsn(null));
+            _ = Assert.Throws<ArgumentNullException>(() => Dsn.Parse(null));
         }
 
         [Fact]
         public void TryParse_SampleValidDsnWithoutSecret_Succeeds()
         {
-            Assert.True(Dsn.TryParse(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithoutSecret, out var dsn));
-            Assert.NotNull(dsn);
+            Assert.NotNull(Dsn.TryParse(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithoutSecret));
         }
 
         [Fact]
         public void TryParse_SampleValidDsnWithSecret_Succeeds()
         {
-            Assert.True(Dsn.TryParse(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithSecret, out var dsn));
-            Assert.NotNull(dsn);
+            Assert.NotNull(Dsn.TryParse(Sentry.Protocol.Tests.DsnSamples.ValidDsnWithSecret));
         }
 
         [Fact]
         public void TryParse_SampleInvalidDsn_Fails()
         {
-            Assert.False(Dsn.TryParse(Sentry.Protocol.Tests.DsnSamples.InvalidDsn, out var dsn));
-            Assert.Null(dsn);
+            Assert.Null(Dsn.TryParse(Sentry.Protocol.Tests.DsnSamples.InvalidDsn));
         }
 
         [Fact]
         public void TryParse_NotUri_Fails()
         {
-            Assert.False(Dsn.TryParse("Not a URI", out var dsn));
-            Assert.Null(dsn);
+            Assert.Null(Dsn.TryParse("Not a URI"));
         }
 
         [Fact]
         public void TryParse_DisabledSdk_Fails()
         {
-            Assert.False(Dsn.TryParse(Constants.DisableSdkDsnValue, out var dsn));
-            Assert.Null(dsn);
+            Assert.Null(Dsn.TryParse(Constants.DisableSdkDsnValue));
         }
 
         [Fact]
         public void TryParse_ValidDsn_Succeeds()
         {
             var @case = new DsnTestCase();
-            Assert.True(Dsn.TryParse(@case, out var dsn));
+            var dsn = Dsn.TryParse(@case);
+            Assert.NotNull(dsn);
 
             AssertEqual(@case, dsn);
         }
@@ -184,15 +180,15 @@ namespace Sentry.Tests.Protocol
         public void TryParse_MissingScheme_Fails()
         {
             var @case = new DsnTestCase { Scheme = null };
-            Assert.False(Dsn.TryParse(@case, out var dsn));
-            Assert.Null(dsn);
+            Assert.Null(Dsn.TryParse(@case));
         }
 
         [Fact]
         public void TryParse_FutureScheme_Succeeds()
         {
             var @case = new DsnTestCase { Scheme = "hypothetical" };
-            Assert.True(Dsn.TryParse(@case, out var dsn));
+            var dsn = Dsn.TryParse(@case);
+            Assert.NotNull(dsn);
             AssertEqual(@case, dsn);
         }
 
@@ -200,7 +196,8 @@ namespace Sentry.Tests.Protocol
         public void TryParse_EmptyPath_Succeeds()
         {
             var @case = new DsnTestCase { Path = string.Empty };
-            Assert.True(Dsn.TryParse(@case, out var dsn));
+            var dsn = Dsn.TryParse(@case);
+            Assert.NotNull(dsn);
             AssertEqual(@case, dsn);
         }
 
@@ -208,7 +205,8 @@ namespace Sentry.Tests.Protocol
         public void TryParse_MissingSecretKey_Succeeds()
         {
             var @case = new DsnTestCase { SecretKey = null };
-            Assert.True(Dsn.TryParse(@case, out var dsn));
+            var dsn = Dsn.TryParse(@case);
+            Assert.NotNull(dsn);
             AssertEqual(@case, dsn);
         }
 
@@ -216,54 +214,47 @@ namespace Sentry.Tests.Protocol
         public void TryParse_MissingPublicKey_Fails()
         {
             var @case = new DsnTestCase { PublicKey = null };
-            Assert.False(Dsn.TryParse(@case, out var dsn));
-            Assert.Null(dsn);
+            Assert.Null(Dsn.TryParse(@case));
         }
 
         [Fact]
         public void TryParse_MissingPublicAndSecretKey_Fails()
         {
             var @case = new DsnTestCase { PublicKey = null, SecretKey = null, UserInfoSeparator = null, CredentialSeparator = null };
-            Assert.False(Dsn.TryParse(@case, out var dsn));
-            Assert.Null(dsn);
+            Assert.Null(Dsn.TryParse(@case));
         }
 
         [Fact]
         public void TryParse_MissingProjectId_Fails()
         {
             var @case = new DsnTestCase { ProjectId = null };
-            Assert.False(Dsn.TryParse(@case, out var dsn));
-            Assert.Null(dsn);
+            Assert.Null(Dsn.TryParse(@case));
         }
 
         [Fact]
         public void TryParse_InvalidPort_Fails()
         {
             var @case = new DsnTestCase { Port = -1 };
-            Assert.False(Dsn.TryParse(@case, out var dsn));
-            Assert.Null(dsn);
+            Assert.Null(Dsn.TryParse(@case));
         }
 
         [Fact]
         public void TryParse_InvalidHost_Fails()
         {
             var @case = new DsnTestCase { Host = null };
-            Assert.False(Dsn.TryParse(@case, out var dsn));
-            Assert.Null(dsn);
+            Assert.Null(Dsn.TryParse(@case));
         }
 
         [Fact]
         public void TryParse_EmptyStringDsn_ThrowsUriFormatException()
         {
-            Assert.False(Dsn.TryParse(string.Empty, out var dsn));
-            Assert.Null(dsn);
+            Assert.Null(Dsn.TryParse(string.Empty));
         }
 
         [Fact]
         public void TryParse_NullDsn_ThrowsArgumentNull()
         {
-            Assert.False(Dsn.TryParse(null, out var dsn));
-            Assert.Null(dsn);
+            Assert.Null(Dsn.TryParse(null));
         }
 
         [Fact]

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -332,8 +332,8 @@ namespace Sentry.Tests
         {
             var invoked = false;
             _fixture.BackgroundWorker = null;
-            _fixture.SentryOptions.Dsn = DsnSamples.Valid;
-            _fixture.SentryOptions.ConfigureClient = (client, dsn) => invoked = true;
+            _fixture.SentryOptions.Dsn = DsnSamples.ValidDsnWithSecret;
+            _fixture.SentryOptions.ConfigureClient = (client) => invoked = true;
 
             using (_fixture.GetSut())
             {
@@ -346,9 +346,9 @@ namespace Sentry.Tests
         {
             var invoked = false;
             _fixture.BackgroundWorker = null;
-            _fixture.SentryOptions.Dsn = DsnSamples.Valid;
+            _fixture.SentryOptions.Dsn = DsnSamples.ValidDsnWithSecret;
 #pragma warning disable 618 // Tests will be removed once obsolete code gets removed
-            _fixture.SentryOptions.ConfigureHandler = (handler, dsn) => invoked = true;
+            _fixture.SentryOptions.ConfigureHandler = (handler) => invoked = true;
 #pragma warning restore 618
 
             using (_fixture.GetSut())
@@ -362,8 +362,8 @@ namespace Sentry.Tests
         {
             var invoked = false;
             _fixture.BackgroundWorker = null;
-            _fixture.SentryOptions.Dsn = DsnSamples.Valid;
-            _fixture.SentryOptions.CreateHttpClientHandler = (dsn) =>
+            _fixture.SentryOptions.Dsn = DsnSamples.ValidDsnWithSecret;
+            _fixture.SentryOptions.CreateHttpClientHandler = () =>
             {
                 invoked = true;
                 return Substitute.For<HttpClientHandler>();
@@ -378,7 +378,7 @@ namespace Sentry.Tests
         [Fact]
         public void Ctor_NullBackgroundWorker_ConcreteBackgroundWorker()
         {
-            _fixture.SentryOptions.Dsn = DsnSamples.Valid;
+            _fixture.SentryOptions.Dsn = DsnSamples.ValidDsnWithSecret;
 
             using (var sut = new SentryClient(_fixture.SentryOptions))
             {

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -67,7 +67,7 @@ namespace Sentry.Tests
         [Fact]
         public void Init_DsnInstance_EnablesSdk()
         {
-            var dsn = new Dsn(ValidDsnWithoutSecret);
+            var dsn = Dsn.Parse(ValidDsnWithoutSecret);
             using (SentrySdk.Init(dsn))
                 Assert.True(SentrySdk.IsEnabled);
         }

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -65,14 +65,6 @@ namespace Sentry.Tests
         }
 
         [Fact]
-        public void Init_DsnInstance_EnablesSdk()
-        {
-            var dsn = Dsn.Parse(ValidDsnWithoutSecret);
-            using (SentrySdk.Init(dsn))
-                Assert.True(SentrySdk.IsEnabled);
-        }
-
-        [Fact]
         public void Init_CallbackWithoutDsn_ValidDsnEnvironmentVariable_LocatesDsnEnvironmentVariable()
         {
             EnvironmentVariableGuard.WithVariable(
@@ -360,7 +352,7 @@ namespace Sentry.Tests
             const string expected = "test";
             using (SentrySdk.Init(o =>
             {
-                o.Dsn = Valid;
+                o.Dsn = ValidDsnWithSecret;
                 o.BackgroundWorker = worker;
             }))
             {


### PR DESCRIPTION
First pass: make parsing more linear.

Note I replaced the outdated `TryParse(out)` pattern with nullable `TryParse`. The original pattern was established way before value tuples or NRTs were added to the language, so I personally think there's no point in using it anymore. And `out` parameters are very ugly.

Second pass: make it internal?

I tried making Dsn internal (#235) but it caused a lot of issues. The majority of the pain comes from `SentryOptions` where `Dsn` is currently used in a bunch of delegate signatures. We could replace that with `string` but then it will be unclear what that string represents.

https://github.com/getsentry/sentry-dotnet/blob/709a5bb43078d0d130da95354ca7a98b0b847679/src/Sentry/SentryOptions.cs#L296-L310

Note: temporarily removed xmldocs to make it a bit easier to work with.