### PR TITLE
Rename LogEntry to SentryMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# vNext
+
+* Rename `LogEntry` to `SentryMessage`. Change type of `SentryEvent.Message` from `string` to `SentryMessage`.
+
 # 3.0.0-alpha.0
 
 ## What’s Changed

--- a/samples/Sentry.Samples.Console.Customized/Program.cs
+++ b/samples/Sentry.Samples.Console.Customized/Program.cs
@@ -163,7 +163,7 @@ internal static class Program
                 {
                     Message = new SentryMessage
                     {
-                        Raw = msg,
+                        Message = msg,
                         Formatted = string.Format(msg, i, count)
                     },
                     Level = SentryLevel.Debug
@@ -178,7 +178,7 @@ internal static class Program
             // would get disposed by the container on app shutdown
 
             var evt = new SentryEvent();
-            evt.Message = new SentryMessage {Raw = "Starting new client"};
+            evt.Message = "Starting new client";
             evt.AddBreadcrumb("Breadcrumb directly to the event");
             evt.User.Username = "some@user";
             // Group all events with the following fingerprint:

--- a/samples/Sentry.Samples.Console.Customized/Program.cs
+++ b/samples/Sentry.Samples.Console.Customized/Program.cs
@@ -161,9 +161,9 @@ internal static class Program
                 const string msg = "{0} of {1} items we'll wait to flush to Sentry!";
                 SentrySdk.CaptureEvent(new SentryEvent
                 {
-                    LogEntry = new LogEntry
+                    Message = new SentryMessage
                     {
-                        Message = msg,
+                        Raw = msg,
                         Formatted = string.Format(msg, i, count)
                     },
                     Level = SentryLevel.Debug
@@ -178,7 +178,7 @@ internal static class Program
             // would get disposed by the container on app shutdown
 
             var evt = new SentryEvent();
-            evt.Message ="Starting new client";
+            evt.Message = new SentryMessage {Raw = "Starting new client"};
             evt.AddBreadcrumb("Breadcrumb directly to the event");
             evt.User.Username = "some@user";
             // Group all events with the following fingerprint:

--- a/src/Sentry.Extensions.Logging/SentryLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryLogger.cs
@@ -59,7 +59,7 @@ namespace Sentry.Extensions.Logging
                 var @event = new SentryEvent(exception)
                 {
                     Logger = CategoryName,
-                    Message = message,
+                    Message = new SentryMessage{ Raw = message },
                     Level = logLevel.ToSentryLevel()
                 };
 
@@ -71,10 +71,10 @@ namespace Sentry.Extensions.Logging
                         {
                             // Original format found, use Sentry logEntry interface
                             @event.Message = null;
-                            @event.LogEntry = new LogEntry
+                            @event.Message = new SentryMessage
                             {
                                 Formatted = message,
-                                Message = template
+                                Raw = template
                             };
                             continue;
                         }

--- a/src/Sentry.Extensions.Logging/SentryLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryLogger.cs
@@ -59,7 +59,7 @@ namespace Sentry.Extensions.Logging
                 var @event = new SentryEvent(exception)
                 {
                     Logger = CategoryName,
-                    Message = new SentryMessage{ Raw = message },
+                    Message = message,
                     Level = logLevel.ToSentryLevel()
                 };
 
@@ -70,11 +70,10 @@ namespace Sentry.Extensions.Logging
                         if (property.Key == "{OriginalFormat}" && property.Value is string template)
                         {
                             // Original format found, use Sentry logEntry interface
-                            @event.Message = null;
                             @event.Message = new SentryMessage
                             {
                                 Formatted = message,
-                                Raw = template
+                                Message = template
                             };
                             continue;
                         }

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -106,7 +106,7 @@ namespace Sentry.Log4Net
 
             if (!string.IsNullOrWhiteSpace(loggingEvent.RenderedMessage))
             {
-                evt.Message = new SentryMessage {Raw = loggingEvent.RenderedMessage};
+                evt.Message = loggingEvent.RenderedMessage;
             }
 
             evt.SetExtras(GetLoggingEventProperties(loggingEvent));

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -106,7 +106,7 @@ namespace Sentry.Log4Net
 
             if (!string.IsNullOrWhiteSpace(loggingEvent.RenderedMessage))
             {
-                evt.Message = loggingEvent.RenderedMessage;
+                evt.Message = new SentryMessage {Raw = loggingEvent.RenderedMessage};
             }
 
             evt.SetExtras(GetLoggingEventProperties(loggingEvent));

--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -326,11 +326,10 @@ namespace Sentry.NLog
 
                 var evt = new SentryEvent(exception)
                 {
-                    Message = null,
-                    LogEntry = new LogEntry
+                    Message = new SentryMessage
                     {
                         Formatted = formatted,
-                        Message = template
+                        Raw = template
                     },
                     Logger = logEvent.LoggerName,
                     Level = logEvent.Level.ToSentryLevel(),

--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -329,7 +329,7 @@ namespace Sentry.NLog
                     Message = new SentryMessage
                     {
                         Formatted = formatted,
-                        Raw = template
+                        Message = template
                     },
                     Logger = logEvent.LoggerName,
                     Level = logEvent.Level.ToSentryLevel(),

--- a/src/Sentry.Serilog/SentrySink.cs
+++ b/src/Sentry.Serilog/SentrySink.cs
@@ -87,11 +87,10 @@ namespace Sentry.Serilog
                 var evt = new SentryEvent(exception)
                 {
                     Logger = context,
-                    Message = null,
-                    LogEntry = new LogEntry
+                    Message = new SentryMessage
                     {
                         Formatted = formatted,
-                        Message = template
+                        Raw = template
                     },
                     Level = logEvent.Level.ToSentryLevel()
                 };

--- a/src/Sentry.Serilog/SentrySink.cs
+++ b/src/Sentry.Serilog/SentrySink.cs
@@ -90,7 +90,7 @@ namespace Sentry.Serilog
                     Message = new SentryMessage
                     {
                         Formatted = formatted,
-                        Raw = template
+                        Message = template
                     },
                     Level = logEvent.Level.ToSentryLevel()
                 };

--- a/src/Sentry/Protocol/SentryEvent.cs
+++ b/src/Sentry/Protocol/SentryEvent.cs
@@ -51,12 +51,6 @@ namespace Sentry
         public DateTimeOffset Timestamp { get; }
 
         /// <summary>
-        /// Gets the message that describes this event.
-        /// </summary>
-        [DataMember(Name = "message", EmitDefaultValue = false)]
-        public string? Message { get; set; }
-
-        /// <summary>
         /// Gets the structured message that describes this event.
         /// </summary>
         /// <remarks>
@@ -64,11 +58,11 @@ namespace Sentry
         /// on the template message instead of the result string message.
         /// </remarks>
         /// <example>
-        /// LogEntry will have a template like: 'user {0} logged in'
+        /// SentryMessage will have a template like: 'user {0} logged in'
         /// Or structured logging template: '{user} has logged in'
         /// </example>
         [DataMember(Name = "logentry", EmitDefaultValue = false)]
-        public LogEntry? LogEntry { get; set; }
+        public SentryMessage? Message { get; set; }
 
         /// <summary>
         /// Name of the logger (or source) of the event.

--- a/src/Sentry/Protocol/SentryMessage.cs
+++ b/src/Sentry/Protocol/SentryMessage.cs
@@ -26,7 +26,7 @@ namespace Sentry.Protocol
         /// Must be no more than 1000 characters in length.
         /// </remarks>
         [DataMember(Name = "message", EmitDefaultValue = false)]
-        public string? Raw { get; set; }
+        public string? Message { get; set; }
 
         /// <summary>
         /// The optional list of formatting parameters.
@@ -39,5 +39,10 @@ namespace Sentry.Protocol
         /// </summary>
         [DataMember(Name = "formatted", EmitDefaultValue = false)]
         public string? Formatted { get; set; }
+
+        /// <summary>
+        /// Coerces <see cref="System.String"/> into <see cref="SentryMessage"/>.
+        /// </summary>
+        public static implicit operator SentryMessage(string? message) => new SentryMessage {Message = message};
     }
 }

--- a/src/Sentry/Protocol/SentryMessage.cs
+++ b/src/Sentry/Protocol/SentryMessage.cs
@@ -17,7 +17,7 @@ namespace Sentry.Protocol
     /// </example>
     /// <seealso href="https://docs.sentry.io/clientdev/interfaces/message/"/>
     [DataContract]
-    public class LogEntry
+    public class SentryMessage
     {
         /// <summary>
         /// The raw message string (un-interpolated).
@@ -26,7 +26,7 @@ namespace Sentry.Protocol
         /// Must be no more than 1000 characters in length.
         /// </remarks>
         [DataMember(Name = "message", EmitDefaultValue = false)]
-        public string? Message { get; set; }
+        public string? Raw { get; set; }
 
         /// <summary>
         /// The optional list of formatting parameters.

--- a/src/Sentry/SentryClientExtensions.cs
+++ b/src/Sentry/SentryClientExtensions.cs
@@ -40,10 +40,7 @@ namespace Sentry
                 : client.CaptureEvent(
                     new SentryEvent
                     {
-                        Message = new SentryMessage
-                        {
-                            Raw = message
-                        },
+                        Message = message,
                         Level = level
                     }
                 );

--- a/src/Sentry/SentryClientExtensions.cs
+++ b/src/Sentry/SentryClientExtensions.cs
@@ -35,14 +35,18 @@ namespace Sentry
             string message,
             SentryLevel level = SentryLevel.Info)
         {
-            return !client.IsEnabled
-                   || string.IsNullOrWhiteSpace(message)
+            return !client.IsEnabled || string.IsNullOrWhiteSpace(message)
                 ? new SentryId()
-                : client.CaptureEvent(new SentryEvent
-                {
-                    Message = message,
-                    Level = level
-                });
+                : client.CaptureEvent(
+                    new SentryEvent
+                    {
+                        Message = new SentryMessage
+                        {
+                            Raw = message
+                        },
+                        Level = level
+                    }
+                );
         }
     }
 }

--- a/test/Sentry.AspNetCore.Tests/IntegrationMockedBackgroundWorker.cs
+++ b/test/Sentry.AspNetCore.Tests/IntegrationMockedBackgroundWorker.cs
@@ -90,7 +90,7 @@ namespace Else.AspNetCore.Tests
 
             _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p =>
                     p.Message.Formatted == $"Test {param} log"
-                    && p.Message.Raw == expectedMessage));
+                    && p.Message.Message == expectedMessage));
         }
 
         [Fact]
@@ -119,7 +119,7 @@ namespace Else.AspNetCore.Tests
             var client = ServiceProvider.GetRequiredService<ISentryClient>();
             _ = client.CaptureMessage(expectedMessage);
 
-            _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p => p.Message == expectedMessage));
+            _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p => p.Message.Message == expectedMessage));
         }
 
         [Fact]
@@ -131,7 +131,7 @@ namespace Else.AspNetCore.Tests
             var client = ServiceProvider.GetRequiredService<IHub>();
             _ = client.CaptureMessage(expectedMessage);
 
-            _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p => p.Message == expectedMessage));
+            _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p => p.Message.Message == expectedMessage));
         }
 
         [Fact]

--- a/test/Sentry.AspNetCore.Tests/IntegrationMockedBackgroundWorker.cs
+++ b/test/Sentry.AspNetCore.Tests/IntegrationMockedBackgroundWorker.cs
@@ -75,7 +75,7 @@ namespace Else.AspNetCore.Tests
             var logger = ServiceProvider.GetRequiredService<ILogger<IntegrationMockedBackgroundWorker>>();
             logger.LogError(expectedMessage);
 
-            _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p => p.LogEntry.Formatted == expectedMessage));
+            _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p => p.Message.Formatted == expectedMessage));
         }
 
         [Fact]
@@ -89,8 +89,8 @@ namespace Else.AspNetCore.Tests
             logger.LogError(expectedMessage, param);
 
             _ = Worker.Received(1).EnqueueEvent(Arg.Is<SentryEvent>(p =>
-                    p.LogEntry.Formatted == $"Test {param} log"
-                    && p.LogEntry.Message == expectedMessage));
+                    p.Message.Formatted == $"Test {param} log"
+                    && p.Message.Raw == expectedMessage));
         }
 
         [Fact]

--- a/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
+++ b/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
@@ -123,7 +123,7 @@ namespace Sentry.Log4Net.Tests
             sut.DoAppend(evt);
 
             _ = _fixture.Hub.Received(1)
-                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Message == expected));
+                    .CaptureEvent(Arg.Is<SentryEvent>(e => e.Message.Message == expected));
         }
 
         [Fact]

--- a/test/Sentry.NLog.Tests/SentryTargetTests.cs
+++ b/test/Sentry.NLog.Tests/SentryTargetTests.cs
@@ -386,7 +386,7 @@ namespace Sentry.NLog.Tests
 
             _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(p =>
                     p.Message.Formatted == $"Test {param} log"
-                    && p.Message.Raw == expectedMessage));
+                    && p.Message.Message == expectedMessage));
         }
 
         [Fact]

--- a/test/Sentry.NLog.Tests/SentryTargetTests.cs
+++ b/test/Sentry.NLog.Tests/SentryTargetTests.cs
@@ -287,7 +287,7 @@ namespace Sentry.NLog.Tests
             manager.GetLogger("sentry").Log(evt);
 
             _ = _fixture.Hub.Received(1)
-                        .CaptureEvent(Arg.Is<SentryEvent>(e => e.LogEntry.Formatted == expected));
+                        .CaptureEvent(Arg.Is<SentryEvent>(e => e.Message.Formatted == expected));
         }
 
         [Fact]
@@ -385,8 +385,8 @@ namespace Sentry.NLog.Tests
             sut.Error(expectedMessage, param);
 
             _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(p =>
-                    p.LogEntry.Formatted == $"Test {param} log"
-                    && p.LogEntry.Message == expectedMessage));
+                    p.Message.Formatted == $"Test {param} log"
+                    && p.Message.Raw == expectedMessage));
         }
 
         [Fact]

--- a/test/Sentry.Serilog.Tests/SentrySinkTests.cs
+++ b/test/Sentry.Serilog.Tests/SentrySinkTests.cs
@@ -258,7 +258,7 @@ namespace Sentry.Serilog.Tests
 
             _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(p =>
                     p.Message.Formatted == $"Test {param} log"
-                    && p.Message.Raw == expectedMessage));
+                    && p.Message.Message == expectedMessage));
         }
 
         [Fact]

--- a/test/Sentry.Serilog.Tests/SentrySinkTests.cs
+++ b/test/Sentry.Serilog.Tests/SentrySinkTests.cs
@@ -162,7 +162,7 @@ namespace Sentry.Serilog.Tests
             sut.Emit(evt);
 
             _ = _fixture.Hub.Received(1)
-                .CaptureEvent(Arg.Is<SentryEvent>(e => e.LogEntry.Formatted == expected));
+                .CaptureEvent(Arg.Is<SentryEvent>(e => e.Message.Formatted == expected));
         }
 
         [Fact]
@@ -257,8 +257,8 @@ namespace Sentry.Serilog.Tests
             sut.Emit(evt);
 
             _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(p =>
-                    p.LogEntry.Formatted == $"Test {param} log"
-                    && p.LogEntry.Message == expectedMessage));
+                    p.Message.Formatted == $"Test {param} log"
+                    && p.Message.Raw == expectedMessage));
         }
 
         [Fact]

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryExceptionTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryExceptionTests.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
-using Sentry.Tests.Protocol;
+using Sentry.Protocol;
 using Xunit;
 
-namespace Sentry.Protocol.Tests.Exceptions
+namespace Sentry.Tests.Protocol.Exceptions
 {
     public class SentryExceptionTests
     {

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
@@ -1,7 +1,7 @@
-using Sentry.Tests.Protocol;
+using Sentry.Protocol;
 using Xunit;
 
-namespace Sentry.Protocol.Tests.Exceptions
+namespace Sentry.Tests.Protocol.Exceptions
 {
     public class SentryStackFrameTests
     {

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryStackTraceTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryStackTraceTests.cs
@@ -1,7 +1,8 @@
 using System.Collections.Generic;
+using Sentry.Protocol;
 using Xunit;
 
-namespace Sentry.Protocol.Tests.Exceptions
+namespace Sentry.Tests.Protocol.Exceptions
 {
     public class SentryStackTraceTests
     {

--- a/test/Sentry.Tests/Protocol/SentryEventTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryEventTests.cs
@@ -48,7 +48,7 @@ namespace Sentry.Tests.Protocol
             Assert.Equal("{\"modules\":{\"module_key\":\"module_value\"}," +
                          "\"event_id\":\"4b780f4cec0342a78ef8a41c9d5621f8\"," +
                          "\"timestamp\":\"9999-12-31T23:59:59.9999999+00:00\"," +
-                         "\"message\":{\"message\":\"message\",\"formatted\":\"structured_message\"}," +
+                         "\"logentry\":{\"message\":\"message\",\"formatted\":\"structured_message\"}," +
                          "\"logger\":\"logger\"," +
                          "\"platform\":\"csharp\"," +
                          "\"server_name\":\"server_name\"," +

--- a/test/Sentry.Tests/Protocol/SentryEventTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryEventTests.cs
@@ -22,10 +22,10 @@ namespace Sentry.Tests.Protocol
                 Environment = "environment",
                 Level = SentryLevel.Fatal,
                 Logger = "logger",
-                Message = "message",
                 Message = new SentryMessage
                 {
-                    Raw = "structured_message"
+                    Message = "message",
+                    Formatted = "structured_message"
                 },
                 Modules = { { "module_key", "module_value" } },
                 Release = "release",

--- a/test/Sentry.Tests/Protocol/SentryEventTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryEventTests.cs
@@ -48,8 +48,7 @@ namespace Sentry.Tests.Protocol
             Assert.Equal("{\"modules\":{\"module_key\":\"module_value\"}," +
                          "\"event_id\":\"4b780f4cec0342a78ef8a41c9d5621f8\"," +
                          "\"timestamp\":\"9999-12-31T23:59:59.9999999+00:00\"," +
-                         "\"message\":\"message\"," +
-                         "\"logentry\":{\"message\":\"structured_message\"}," +
+                         "\"message\":{\"message\":\"message\",\"formatted\":\"structured_message\"}," +
                          "\"logger\":\"logger\"," +
                          "\"platform\":\"csharp\"," +
                          "\"server_name\":\"server_name\"," +

--- a/test/Sentry.Tests/Protocol/SentryEventTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryEventTests.cs
@@ -23,9 +23,9 @@ namespace Sentry.Tests.Protocol
                 Level = SentryLevel.Fatal,
                 Logger = "logger",
                 Message = "message",
-                LogEntry = new LogEntry
+                Message = new SentryMessage
                 {
-                    Message = "structured_message"
+                    Raw = "structured_message"
                 },
                 Modules = { { "module_key", "module_value" } },
                 Release = "release",

--- a/test/Sentry.Tests/Protocol/SentryMessageTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryMessageTests.cs
@@ -11,7 +11,7 @@ namespace Sentry.Tests.Protocol
         {
             var sut = new SentryMessage
             {
-                Raw = "Message {eventId} {name}",
+                Message = "Message {eventId} {name}",
                 Params = new object[] { 100, "test-name" },
                 Formatted = "Message 100 test-name"
             };
@@ -36,7 +36,7 @@ namespace Sentry.Tests.Protocol
         public static IEnumerable<object[]> TestCases()
         {
             yield return new object[] { (new SentryMessage(), "{}") };
-            yield return new object[] { (new SentryMessage { Raw = "some message" }, "{\"message\":\"some message\"}") };
+            yield return new object[] { (new SentryMessage { Message = "some message" }, "{\"message\":\"some message\"}") };
             yield return new object[] { (new SentryMessage { Params = new[] { "param" } }, "{\"params\":[\"param\"]}") };
             yield return new object[] { (new SentryMessage { Formatted = "some formatted" }, "{\"formatted\":\"some formatted\"}") };
         }

--- a/test/Sentry.Tests/Protocol/SentryMessageTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryMessageTests.cs
@@ -4,14 +4,14 @@ using Xunit;
 
 namespace Sentry.Tests.Protocol
 {
-    public class LogEntryTests
+    public class SentryMessageTests
     {
         [Fact]
         public void SerializeObject_AllPropertiesSetToNonDefault_SerializesValidObject()
         {
-            var sut = new LogEntry
+            var sut = new SentryMessage
             {
-                Message = "Message {eventId} {name}",
+                Raw = "Message {eventId} {name}",
                 Params = new object[] { 100, "test-name" },
                 Formatted = "Message 100 test-name"
             };
@@ -26,7 +26,7 @@ namespace Sentry.Tests.Protocol
 
         [Theory]
         [MemberData(nameof(TestCases))]
-        public void SerializeObject_TestCase_SerializesAsExpected((LogEntry msg, string serialized) @case)
+        public void SerializeObject_TestCase_SerializesAsExpected((SentryMessage msg, string serialized) @case)
         {
             var actual = JsonSerializer.SerializeObject(@case.msg);
 
@@ -35,10 +35,10 @@ namespace Sentry.Tests.Protocol
 
         public static IEnumerable<object[]> TestCases()
         {
-            yield return new object[] { (new LogEntry(), "{}") };
-            yield return new object[] { (new LogEntry { Message = "some message" }, "{\"message\":\"some message\"}") };
-            yield return new object[] { (new LogEntry { Params = new[] { "param" } }, "{\"params\":[\"param\"]}") };
-            yield return new object[] { (new LogEntry { Formatted = "some formatted" }, "{\"formatted\":\"some formatted\"}") };
+            yield return new object[] { (new SentryMessage(), "{}") };
+            yield return new object[] { (new SentryMessage { Raw = "some message" }, "{\"message\":\"some message\"}") };
+            yield return new object[] { (new SentryMessage { Params = new[] { "param" } }, "{\"params\":[\"param\"]}") };
+            yield return new object[] { (new SentryMessage { Formatted = "some formatted" }, "{\"formatted\":\"some formatted\"}") };
         }
     }
 }

--- a/test/Sentry.Tests/SentryClientExtensionsTests.cs
+++ b/test/Sentry.Tests/SentryClientExtensionsTests.cs
@@ -60,7 +60,7 @@ namespace Sentry.Tests
             const string expectedMessage = "message";
             _ = _sut.IsEnabled.Returns(true);
             _ = _sut.CaptureMessage(expectedMessage);
-            _ = _sut.Received(1).CaptureEvent(Arg.Is<SentryEvent>(e => e.Message == expectedMessage));
+            _ = _sut.Received(1).CaptureEvent(Arg.Is<SentryEvent>(e => e.Message.Message == expectedMessage));
         }
 
         [Fact]


### PR DESCRIPTION
https://github.com/getsentry/sentry-dotnet/projects/3#card-46040296

Open questions:

- What should `event.Message = "foo"` be replaced with? I replaced them with `event.Message = new SentryMessage { Raw = "foo" }` but not sure if it's correct.
- Should `LogEntryFilter` and related also be renamed?