### PR TITLE
Hook for BaseScope.Apply

### DIFF
--- a/src/Sentry.Protocol/BaseScopeExtensions.cs
+++ b/src/Sentry.Protocol/BaseScopeExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using Sentry.Protocol;
 
 // ReSharper disable once CheckNamespace
@@ -308,38 +307,8 @@ namespace Sentry
         /// <param name="state">The state object to apply.</param>
         public static void Apply(this BaseScope scope, object state)
         {
-            switch (state)
-            {
-                case string scopeString:
-                    // TODO: find unique key to support multiple single-string scopes
-                    scope.SetTag("scope", scopeString);
-                    break;
-                case IEnumerable<KeyValuePair<string, string>> keyValStringString:
-                    scope.SetTags(keyValStringString
-                        .Where(kv => !string.IsNullOrEmpty(kv.Value)));
-                    break;
-                case IEnumerable<KeyValuePair<string, object>> keyValStringObject:
-                    {
-                        scope.SetTags(keyValStringObject
-                            .Select(k => new KeyValuePair<string, string>(
-                                k.Key,
-                                k.Value?.ToString()))
-                            .Where(kv => !string.IsNullOrEmpty(kv.Value)));
-
-                        break;
-                    }
-#if HAS_VALUE_TUPLE
-                case ValueTuple<string, string> tupleStringString:
-                    if (!string.IsNullOrEmpty(tupleStringString.Item2))
-                    {
-                        scope.SetTag(tupleStringString.Item1, tupleStringString.Item2);
-                    }
-                    break;
-#endif
-                default:
-                    scope.SetExtra("state", state);
-                    break;
-            }
+            var processor = scope.ScopeOptions.SentryScopeProcessor ?? new DefaultSentryScopeProcessor();
+            processor.Apply(scope, state);
         }
     }
 }

--- a/src/Sentry.Protocol/DefaultSentryScopeProcessor.cs
+++ b/src/Sentry.Protocol/DefaultSentryScopeProcessor.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Sentry.Protocol
+{
+    public class DefaultSentryScopeProcessor : ISentryScopeProcessor
+    {
+        public void Apply(BaseScope scope, object state)
+        {
+            switch (state)
+            {
+                case string scopeString:
+                    // TODO: find unique key to support multiple single-string scopes
+                    scope.SetTag("scope", scopeString);
+                    break;
+                case IEnumerable<KeyValuePair<string, string>> keyValStringString:
+                    scope.SetTags(keyValStringString
+                        .Where(kv => !string.IsNullOrEmpty(kv.Value)));
+                    break;
+                case IEnumerable<KeyValuePair<string, object>> keyValStringObject:
+                {
+                    scope.SetTags(keyValStringObject
+                        .Select(k => new KeyValuePair<string, string>(
+                            k.Key,
+                            k.Value?.ToString()))
+                        .Where(kv => !string.IsNullOrEmpty(kv.Value)));
+
+                    break;
+                }
+#if HAS_VALUE_TUPLE
+                case ValueTuple<string, string> tupleStringString:
+                    if (!string.IsNullOrEmpty(tupleStringString.Item2))
+                    {
+                        scope.SetTag(tupleStringString.Item1, tupleStringString.Item2);
+                    }
+                    break;
+#endif
+                default:
+                    scope.SetExtra("state", state);
+                    break;
+            }
+        }
+    }
+}

--- a/src/Sentry.Protocol/IScopeOptions.cs
+++ b/src/Sentry.Protocol/IScopeOptions.cs
@@ -8,6 +8,11 @@ namespace Sentry.Protocol
     public interface IScopeOptions
     {
         /// <summary>
+        /// Configured scope processor.
+        /// </summary>
+        ISentryScopeProcessor SentryScopeProcessor { get; set; }
+
+        /// <summary>
         /// Gets or sets the maximum breadcrumbs.
         /// </summary>
         /// <remarks>

--- a/src/Sentry.Protocol/ISentryScopeProcessor.cs
+++ b/src/Sentry.Protocol/ISentryScopeProcessor.cs
@@ -1,0 +1,7 @@
+namespace Sentry.Protocol
+{
+    public interface ISentryScopeProcessor
+    {
+        void Apply(BaseScope scope, object state);
+    }
+}

--- a/src/Sentry/Internal/SentryScopeManager.cs
+++ b/src/Sentry/Internal/SentryScopeManager.cs
@@ -58,9 +58,15 @@ namespace Sentry.Internal
 
             if (scope.Key.Locked)
             {
-                // TODO: keep state on current scope?
                 _options?.DiagnosticLogger?.LogDebug("Locked scope. No new scope pushed.");
-                return DisabledHub.Instance;
+
+                // Apply to current scope
+                if (state != null)
+                {
+                    scope.Key.Apply(state);
+                }
+
+                return new ScopeSnapshot(_options, currentScopeAndClientStack, this);
             }
 
             var clonedScope = scope.Key.Clone();

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -60,6 +60,9 @@ namespace Sentry
 
         internal ISentryHttpClientFactory SentryHttpClientFactory { get; set; }
 
+        /// <inheritdoc />
+        public ISentryScopeProcessor SentryScopeProcessor { get; set; } = new DefaultSentryScopeProcessor();
+
         /// <summary>
         /// A list of namespaces (or prefixes) considered not part of application code
         /// </summary>


### PR DESCRIPTION
Related to #594

@bruno-garcia I've looked at how existing `Func<IEnumerable<ISentryEventProcessor>>[]` and etc. work, but they don't make sense to me. Can you guide me in regards to what I should do to make it usable from ASP.NET Core?