### PR TITLE
fix: runtime current is equal

### DIFF
--- a/test/Sentry.Tests/PlatformAbstractions/RuntimeTests.cs
+++ b/test/Sentry.Tests/PlatformAbstractions/RuntimeTests.cs
@@ -6,9 +6,9 @@ namespace Sentry.Tests.PlatformAbstractions
     public class RuntimeTests
     {
         [Fact]
-        public void Current_SameInstance()
+        public void Current_Equal()
         {
-            Assert.Same(Runtime.Current, Runtime.Current);
+            Assert.Equal(Runtime.Current, Runtime.Current);
         }
     }
 }


### PR DESCRIPTION
The field is lazily instantiated but makes no sense to synchronize, so matching for Same here means a flaky test with little value