### PR TITLE
deserialize event

### DIFF
--- a/src/Sentry/Internal/Json.cs
+++ b/src/Sentry/Internal/Json.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -41,6 +42,7 @@ namespace Sentry.Internal
             Serializer.Serialize(writer, obj);
         }
 
+        [return: MaybeNull]
         public static T DeserializeFromStream<T>(Stream stream)
         {
             using var reader = CreateReader(stream);
@@ -55,6 +57,7 @@ namespace Sentry.Internal
             return buffer.ToArray();
         }
 
+        [return: MaybeNull]
         public static T DeserializeFromByteArray<T>(byte[] data)
         {
             using var buffer = new MemoryStream(data);
@@ -64,6 +67,7 @@ namespace Sentry.Internal
         public static string Serialize(object obj) =>
             Encoding.GetString(SerializeToByteArray(obj));
 
+        [return: MaybeNull]
         public static T Deserialize<T>(string json) =>
             DeserializeFromByteArray<T>(Encoding.GetBytes(json));
 

--- a/src/Sentry/Protocol/Breadcrumb.cs
+++ b/src/Sentry/Protocol/Breadcrumb.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace Sentry.Protocol
 {
@@ -15,7 +16,7 @@ namespace Sentry.Protocol
     public sealed class Breadcrumb
     {
         [DataMember(Name = "timestamp", EmitDefaultValue = false)]
-        private string SerializableTimestamp => Timestamp.ToString("yyyy-MM-ddTHH\\:mm\\:ssZ", DateTimeFormatInfo.InvariantInfo);
+        private string SerializableTimestamp => Timestamp.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffZ", DateTimeFormatInfo.InvariantInfo);
 
         /// <summary>
         /// A timestamp representing when the breadcrumb occurred.
@@ -104,6 +105,7 @@ namespace Sentry.Protocol
         /// <param name="data">The data.</param>
         /// <param name="category">The category.</param>
         /// <param name="level">The level.</param>
+        [JsonConstructor]
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal Breadcrumb(
             DateTimeOffset? timestamp = null,

--- a/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
@@ -204,7 +204,12 @@ namespace Sentry.Protocol.Envelopes
                 var bufferLength = (int)(payloadLength ?? stream.Length);
                 var buffer = await stream.ReadByteChunkAsync(bufferLength, cancellationToken).ConfigureAwait(false);
 
-                return new JsonSerializable(Json.DeserializeFromByteArray<SentryEvent>(buffer));
+                if (Json.DeserializeFromByteArray<SentryEvent>(buffer) is { } @event)
+                {
+                    return new JsonSerializable(@event);
+                }
+
+                throw new InvalidOperationException("Can't deserialize payload.");
             }
 
             // User report
@@ -213,7 +218,13 @@ namespace Sentry.Protocol.Envelopes
                 var bufferLength = (int)(payloadLength ?? stream.Length);
                 var buffer = await stream.ReadByteChunkAsync(bufferLength, cancellationToken).ConfigureAwait(false);
 
-                return new JsonSerializable(Json.DeserializeFromByteArray<UserFeedback>(buffer));
+
+                if (Json.DeserializeFromByteArray<UserFeedback>(buffer) is { } userFeedback)
+                {
+                    return new JsonSerializable(userFeedback);
+                }
+
+                throw new InvalidOperationException("Can't deserialize payload.");
             }
 
             // Arbitrary payload

--- a/src/Sentry/Protocol/SentryEvent.cs
+++ b/src/Sentry/Protocol/SentryEvent.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
-using Sentry.Internal;
 using Sentry.Protocol;
 using Constants = Sentry.Protocol.Constants;
 
@@ -25,25 +24,6 @@ namespace Sentry
 
         [DataMember(Name = "modules", EmitDefaultValue = false)]
         private IDictionary<string, string>? _modules;
-
-        [DataMember(Name = "fingerprint", EmitDefaultValue = false)]
-        private IEnumerable<string>? _fingerprint;
-
-        // Default values are null so no serialization of empty objects or arrays
-        [DataMember(Name = "breadcrumbs", EmitDefaultValue = false)]
-        private Queue<Breadcrumb>? _breadcrumbs;
-
-        [DataMember(Name = "extra", EmitDefaultValue = false)]
-        private Dictionary<string, object?>? InternalExtra { get; set; }
-
-        [DataMember(Name = "tags", EmitDefaultValue = false)]
-        private Dictionary<string, string>? InternalTags { get; set; }
-
-        [DataMember(Name = "exception", EmitDefaultValue = false)]
-        private SentryValues<SentryException>? SentryExceptionValues { get; set; }
-
-        [DataMember(Name = "threads", EmitDefaultValue = false)]
-        private SentryValues<SentryThread>? SentryThreadValues { get; set; }
 
         /// <summary>
         /// The <see cref="System.Exception"/> used to create this event.
@@ -110,6 +90,9 @@ namespace Sentry
         [DataMember(Name = "release", EmitDefaultValue = false)]
         public string? Release { get; set; }
 
+        [DataMember(Name = "exception", EmitDefaultValue = false)]
+        internal SentryValues<SentryException>? SentryExceptionValues { get; set; }
+
         /// <summary>
         /// The Sentry Exception interface.
         /// </summary>
@@ -118,6 +101,9 @@ namespace Sentry
             get => SentryExceptionValues?.Values ?? Enumerable.Empty<SentryException>();
             set => SentryExceptionValues = value != null ? new SentryValues<SentryException>(value) : null;
         }
+
+        [DataMember(Name = "threads", EmitDefaultValue = false)]
+        private SentryValues<SentryThread>? SentryThreadValues { get; set; }
 
         /// <summary>
         /// The Sentry Thread interface.
@@ -144,7 +130,6 @@ namespace Sentry
 
         [DataMember(Name = "request", EmitDefaultValue = false)]
         private Request? _request;
-
         /// <inheritdoc />
         public Request Request
         {
@@ -180,6 +165,9 @@ namespace Sentry
         [DataMember(Name = "sdk", EmitDefaultValue = false)]
         public SdkVersion Sdk { get; internal set; } = new SdkVersion();
 
+        [DataMember(Name = "fingerprint", EmitDefaultValue = false)]
+        private IEnumerable<string>? _fingerprint;
+
         /// <inheritdoc />
         public IEnumerable<string> Fingerprint
         {
@@ -187,14 +175,22 @@ namespace Sentry
             set => _fingerprint = value;
         }
 
-        /// <inheritdoc />
-        public IEnumerable<Breadcrumb> Breadcrumbs => _breadcrumbs ??= new Queue<Breadcrumb>();
+        // Default values are null so no serialization of empty objects or arrays
+        [DataMember(Name = "breadcrumbs", EmitDefaultValue = false)]
+        private List<Breadcrumb>? _breadcrumbs;
 
         /// <inheritdoc />
-        public IReadOnlyDictionary<string, object?> Extra => InternalExtra ??= new Dictionary<string, object?>();
+        public IEnumerable<Breadcrumb> Breadcrumbs => _breadcrumbs ??= new List<Breadcrumb>();
 
+        [DataMember(Name = "extra", EmitDefaultValue = false)]
+        private Dictionary<string, object?>? _internalExtra;
         /// <inheritdoc />
-        public IReadOnlyDictionary<string, string> Tags => InternalTags ??= new Dictionary<string, string>();
+        public IReadOnlyDictionary<string, object?> Extra => _internalExtra ??= new Dictionary<string, object?>();
+
+        [DataMember(Name = "tags", EmitDefaultValue = false)]
+        private Dictionary<string, string>? _tags;
+        /// <inheritdoc />
+        public IReadOnlyDictionary<string, string> Tags => _tags ??= new Dictionary<string, string>();
 
         /// <summary>
         /// Creates a new instance of <see cref="T:Sentry.SentryEvent" />.

--- a/src/Sentry/Protocol/SentryEvent.cs
+++ b/src/Sentry/Protocol/SentryEvent.cs
@@ -24,7 +24,26 @@ namespace Sentry
         public IScopeOptions? ScopeOptions { get; }
 
         [DataMember(Name = "modules", EmitDefaultValue = false)]
-        internal IDictionary<string, string>? InternalModules { get; set; }
+        private IDictionary<string, string>? _modules;
+
+        [DataMember(Name = "fingerprint", EmitDefaultValue = false)]
+        private IEnumerable<string>? _fingerprint;
+
+        // Default values are null so no serialization of empty objects or arrays
+        [DataMember(Name = "breadcrumbs", EmitDefaultValue = false)]
+        private Queue<Breadcrumb>? _breadcrumbs;
+
+        [DataMember(Name = "extra", EmitDefaultValue = false)]
+        private Dictionary<string, object?>? InternalExtra { get; set; }
+
+        [DataMember(Name = "tags", EmitDefaultValue = false)]
+        private Dictionary<string, string>? InternalTags { get; set; }
+
+        [DataMember(Name = "exception", EmitDefaultValue = false)]
+        private SentryValues<SentryException>? SentryExceptionValues { get; set; }
+
+        [DataMember(Name = "threads", EmitDefaultValue = false)]
+        private SentryValues<SentryThread>? SentryThreadValues { get; set; }
 
         /// <summary>
         /// The <see cref="System.Exception"/> used to create this event.
@@ -91,12 +110,6 @@ namespace Sentry
         [DataMember(Name = "release", EmitDefaultValue = false)]
         public string? Release { get; set; }
 
-        [DataMember(Name = "exception", EmitDefaultValue = false)]
-        internal SentryValues<SentryException>? SentryExceptionValues { get; set; }
-
-        [DataMember(Name = "threads", EmitDefaultValue = false)]
-        internal SentryValues<SentryThread>? SentryThreadValues { get; set; }
-
         /// <summary>
         /// The Sentry Exception interface.
         /// </summary>
@@ -119,7 +132,7 @@ namespace Sentry
         /// <summary>
         /// A list of relevant modules and their versions.
         /// </summary>
-        public IDictionary<string, string> Modules => InternalModules ??= new Dictionary<string, string>();
+        public IDictionary<string, string> Modules => _modules ??= new Dictionary<string, string>();
 
         /// <inheritdoc />
         [DataMember(Name = "level", EmitDefaultValue = false)]
@@ -168,24 +181,20 @@ namespace Sentry
         public SdkVersion Sdk { get; internal set; } = new SdkVersion();
 
         /// <inheritdoc />
-        [DataMember(Name = "fingerprint", EmitDefaultValue = false)]
-        [DontSerializeEmpty]
-        public IEnumerable<string> Fingerprint { get; set; } = Enumerable.Empty<string>();
+        public IEnumerable<string> Fingerprint
+        {
+            get => _fingerprint ?? Enumerable.Empty<string>();
+            set => _fingerprint = value;
+        }
 
         /// <inheritdoc />
-        [DataMember(Name = "breadcrumbs", EmitDefaultValue = false)]
-        [DontSerializeEmpty]
-        public IEnumerable<Breadcrumb> Breadcrumbs { get; } = new List<Breadcrumb>();
+        public IEnumerable<Breadcrumb> Breadcrumbs => _breadcrumbs ??= new Queue<Breadcrumb>();
 
         /// <inheritdoc />
-        [DataMember(Name = "extra", EmitDefaultValue = false)]
-        [DontSerializeEmpty]
-        public IReadOnlyDictionary<string, object?> Extra { get; } = new Dictionary<string, object?>();
+        public IReadOnlyDictionary<string, object?> Extra => InternalExtra ??= new Dictionary<string, object?>();
 
         /// <inheritdoc />
-        [DataMember(Name = "tags", EmitDefaultValue = false)]
-        [DontSerializeEmpty]
-        public IReadOnlyDictionary<string, string> Tags { get; } = new Dictionary<string, string>();
+        public IReadOnlyDictionary<string, string> Tags => InternalTags ??= new Dictionary<string, string>();
 
         /// <summary>
         /// Creates a new instance of <see cref="T:Sentry.SentryEvent" />.

--- a/src/Sentry/Protocol/SentryId.cs
+++ b/src/Sentry/Protocol/SentryId.cs
@@ -74,7 +74,12 @@ namespace Sentry.Protocol
             Type objectType,
             SentryId existingValue,
             bool hasExistingValue,
-            JsonSerializer serializer) =>
-            new SentryId(Guid.Parse((string)reader.Value));
+            JsonSerializer serializer)
+            => reader.Value switch
+            {
+                string o => new SentryId(Guid.Parse(o)),
+                _ => SentryId.Empty
+            };
+
     }
 }

--- a/src/Sentry/Protocol/SentryValues.cs
+++ b/src/Sentry/Protocol/SentryValues.cs
@@ -14,7 +14,7 @@ namespace Sentry.Protocol
         /// The values.
         /// </summary>
         [DataMember(Name = "values", EmitDefaultValue = false)]
-        public IEnumerable<T> Values { get; }
+        public IEnumerable<T> Values { get; private set; }
 
         /// <summary>
         /// Creates an instance from the specified <see cref="IEnumerable{T}"/>.

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -130,22 +130,18 @@ namespace Sentry
 
         /// <inheritdoc />
         [DataMember(Name = "fingerprint", EmitDefaultValue = false)]
-        [DontSerializeEmpty]
         public IEnumerable<string> Fingerprint { get; set; } = Enumerable.Empty<string>();
 
         /// <inheritdoc />
         [DataMember(Name = "breadcrumbs", EmitDefaultValue = false)]
-        [DontSerializeEmpty]
         public IEnumerable<Breadcrumb> Breadcrumbs { get; } = new ConcurrentQueue<Breadcrumb>();
 
         /// <inheritdoc />
         [DataMember(Name = "extra", EmitDefaultValue = false)]
-        [DontSerializeEmpty]
         public IReadOnlyDictionary<string, object?> Extra { get; } = new ConcurrentDictionary<string, object?>();
 
         /// <inheritdoc />
         [DataMember(Name = "tags", EmitDefaultValue = false)]
-        [DontSerializeEmpty]
         public IReadOnlyDictionary<string, string> Tags { get; } = new ConcurrentDictionary<string, string>();
 
         /// <summary>

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -96,7 +96,7 @@ namespace NotSentry.Tests
                 .Select(i => i.Source)
                 .OfType<SentryEvent>()
                 .Single()
-                .SentryExceptions;
+                .SentryExceptionValues;
 
             stackTrace.Should().BeNull();
         }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -96,7 +96,7 @@ namespace NotSentry.Tests
                 .Select(i => i.Source)
                 .OfType<SentryEvent>()
                 .Single()
-                .SentryExceptionValues;
+                .SentryExceptions;
 
             stackTrace.Should().BeNull();
         }

--- a/test/Sentry.Tests/Protocol/Context/AppTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/AppTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
-using Sentry.Tests.Protocol;
+using FluentAssertions;
+using Newtonsoft.Json;
 using Xunit;
+using JsonSerializer = Sentry.Tests.Protocol.JsonSerializer;
 
 // ReSharper disable once CheckNamespace
 namespace Sentry.Protocol.Tests.Context
@@ -21,15 +23,10 @@ namespace Sentry.Protocol.Tests.Context
                 StartTime = DateTimeOffset.MaxValue
             };
 
-            var actual = JsonSerializer.SerializeObject(sut);
+            var actualString  = JsonSerializer.SerializeObject(sut);
 
-            Assert.Equal("{\"type\":\"app\"," +
-                         "\"app_start_time\":\"9999-12-31T23:59:59.9999999+00:00\"," +
-                         "\"device_app_hash\":\"93fd0e9a\"," +
-                         "\"build_type\":\"nightly\"," +
-                         "\"app_name\":\"Sentry.Test.App\"," +
-                         "\"app_version\":\"8b03fd7\"," +
-                         "\"app_build\":\"1.23152\"}", actual);
+            var actual = JsonConvert.DeserializeObject<App>(actualString);
+            actual.Should().BeEquivalentTo(sut);
         }
 
         [Fact]

--- a/test/Sentry.Tests/Protocol/Context/BrowserTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/BrowserTests.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
-using Sentry.Tests.Protocol;
+using FluentAssertions;
+using Newtonsoft.Json;
 using Xunit;
+using JsonSerializer = Sentry.Tests.Protocol.JsonSerializer;
 
 // ReSharper disable once CheckNamespace
 namespace Sentry.Protocol.Tests.Context
@@ -16,9 +18,10 @@ namespace Sentry.Protocol.Tests.Context
                 Name = "Internet Explorer",
             };
 
-            var actual = JsonSerializer.SerializeObject(sut);
+            var actualString  = JsonSerializer.SerializeObject(sut);
 
-            Assert.Equal("{\"type\":\"browser\",\"name\":\"Internet Explorer\",\"version\":\"6\"}", actual);
+            var actual = JsonConvert.DeserializeObject<Browser>(actualString);
+            actual.Should().BeEquivalentTo(sut);
         }
 
         [Fact]

--- a/test/Sentry.Tests/Protocol/Context/ContextsTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/ContextsTests.cs
@@ -1,5 +1,7 @@
-using Sentry.Tests.Protocol;
+using FluentAssertions;
+using Newtonsoft.Json;
 using Xunit;
+using JsonSerializer = Sentry.Tests.Protocol.JsonSerializer;
 
 // ReSharper disable once CheckNamespace
 namespace Sentry.Protocol.Tests.Context
@@ -11,9 +13,12 @@ namespace Sentry.Protocol.Tests.Context
         {
             var sut = new Contexts();
 
-            var actual = JsonSerializer.SerializeObject(sut);
+            var actualString  = JsonSerializer.SerializeObject(sut);
 
-            Assert.Equal("{}", actual);
+            var actual = JsonConvert.DeserializeObject<Contexts>(actualString);
+            actual.Should().BeEquivalentTo(sut);
+
+            Assert.Equal("{}", actualString);
         }
 
         [Fact]
@@ -26,9 +31,12 @@ namespace Sentry.Protocol.Tests.Context
                 [expectedKey] = os
             };
 
-            var actual = JsonSerializer.SerializeObject(sut);
+            var actualString  = JsonSerializer.SerializeObject(sut);
 
-            Assert.Equal("{\"server\":{\"type\":\"os\",\"name\":\"Linux\"}}", actual);
+            var actual = JsonConvert.DeserializeObject<Contexts>(actualString);
+            actual.Should().BeEquivalentTo(sut);
+
+            Assert.Equal("{\"server\":{\"type\":\"os\",\"name\":\"Linux\"}}", actualString);
         }
 
         [Fact]
@@ -36,9 +44,13 @@ namespace Sentry.Protocol.Tests.Context
         {
             var sut = new Contexts();
             sut.Device.Architecture = "x86";
-            var actual = JsonSerializer.SerializeObject(sut);
 
-            Assert.Equal("{\"device\":{\"type\":\"device\",\"arch\":\"x86\"}}", actual);
+            var actualString  = JsonSerializer.SerializeObject(sut);
+
+            var actual = JsonConvert.DeserializeObject<Contexts>(actualString);
+            actual.Should().BeEquivalentTo(sut);
+
+            Assert.Equal("{\"device\":{\"type\":\"device\",\"arch\":\"x86\"}}", actualString);
         }
 
         [Fact]
@@ -46,9 +58,13 @@ namespace Sentry.Protocol.Tests.Context
         {
             var sut = new Contexts();
             sut.App.Name = "My.App";
-            var actual = JsonSerializer.SerializeObject(sut);
 
-            Assert.Equal("{\"app\":{\"type\":\"app\",\"app_name\":\"My.App\"}}", actual);
+            var actualString  = JsonSerializer.SerializeObject(sut);
+
+            var actual = JsonConvert.DeserializeObject<Contexts>(actualString);
+            actual.Should().BeEquivalentTo(sut);
+
+            Assert.Equal("{\"app\":{\"type\":\"app\",\"app_name\":\"My.App\"}}", actualString);
         }
 
         [Fact]
@@ -56,9 +72,13 @@ namespace Sentry.Protocol.Tests.Context
         {
             var sut = new Contexts();
             sut.Gpu.Name = "My.Gpu";
-            var actual = JsonSerializer.SerializeObject(sut);
 
-            Assert.Equal("{\"gpu\":{\"type\":\"gpu\",\"name\":\"My.Gpu\"}}", actual);
+            var actualString  = JsonSerializer.SerializeObject(sut);
+
+            var actual = JsonConvert.DeserializeObject<Contexts>(actualString);
+            actual.Should().BeEquivalentTo(sut);
+
+            Assert.Equal("{\"gpu\":{\"type\":\"gpu\",\"name\":\"My.Gpu\"}}", actualString);
         }
 
         [Fact]
@@ -66,29 +86,41 @@ namespace Sentry.Protocol.Tests.Context
         {
             var sut = new Contexts();
             sut.Runtime.Version = "2.1.1.100";
-            var actual = JsonSerializer.SerializeObject(sut);
 
-            Assert.Equal("{\"runtime\":{\"type\":\"runtime\",\"version\":\"2.1.1.100\"}}", actual);
+            var actualString  = JsonSerializer.SerializeObject(sut);
+
+            var actual = JsonConvert.DeserializeObject<Contexts>(actualString);
+            actual.Should().BeEquivalentTo(sut);
+
+            Assert.Equal("{\"runtime\":{\"type\":\"runtime\",\"version\":\"2.1.1.100\"}}", actualString);
         }
 
         [Fact]
         public void Ctor_SingleBrowserPropertySet_SerializeSingleProperty()
         {
-            var contexts = new Contexts();
-            contexts.Browser.Name = "Netscape 1";
-            var actual = JsonSerializer.SerializeObject(contexts);
+            var sut = new Contexts();
+            sut.Browser.Name = "Netscape 1";
 
-            Assert.Equal("{\"browser\":{\"type\":\"browser\",\"name\":\"Netscape 1\"}}", actual);
+            var actualString  = JsonSerializer.SerializeObject(sut);
+
+            var actual = JsonConvert.DeserializeObject<Contexts>(actualString);
+            actual.Should().BeEquivalentTo(sut);
+
+            Assert.Equal("{\"browser\":{\"type\":\"browser\",\"name\":\"Netscape 1\"}}", actualString);
         }
 
         [Fact]
         public void Ctor_SingleOperatingSystemPropertySet_SerializeSingleProperty()
         {
-            var contexts = new Contexts();
-            contexts.OperatingSystem.Name = "BeOS 1";
-            var actual = JsonSerializer.SerializeObject(contexts);
+            var sut = new Contexts();
+            sut.OperatingSystem.Name = "BeOS 1";
 
-            Assert.Equal("{\"os\":{\"type\":\"os\",\"name\":\"BeOS 1\"}}", actual);
+            var actualString  = JsonSerializer.SerializeObject(sut);
+
+            var actual = JsonConvert.DeserializeObject<Contexts>(actualString);
+            actual.Should().BeEquivalentTo(sut);
+
+            Assert.Equal("{\"os\":{\"type\":\"os\",\"name\":\"BeOS 1\"}}", actualString);
         }
 
         [Fact]

--- a/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
@@ -369,13 +369,13 @@ namespace Sentry.Tests.Protocol.Envelopes
                 },
                 Modules = { { "module_key", "module_value" } },
                 Release = "release",
-                // SentryExceptions = new[] { new SentryException { Value = "exception_value" } },
+                // SentryExceptions = new SentryException[0],
+                // SentryExceptions = new [] { new SentryException { Value = "exception_value" } },
                 SentryThreads = new[] { new SentryThread { Crashed = true } },
                 ServerName = "server_name",
                 Transaction = "transaction",
             };
 
-            @event.AddBreadcrumb(new Breadcrumb(timestamp, "crumb"));
             @event.SetExtra("extra_key", "extra_value");
             @event.Fingerprint = new[] {"fingerprint"};
             @event.SetTag("tag_key", "tag_value");

--- a/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
@@ -350,11 +350,35 @@ namespace Sentry.Tests.Protocol.Envelopes
         public async Task Roundtrip_WithEvent_Success()
         {
             // Arrange
-            var @event = new SentryEvent
+            var ex = new Exception("exception message");
+            var timestamp = DateTimeOffset.MaxValue;
+            var id = Guid.Parse("4b780f4c-ec03-42a7-8ef8-a41c9d5621f8");
+            var @event = new SentryEvent(ex, timestamp, id)
             {
-                Message = "Foo bar",
-                Environment = "release"
+                User = new User { Id = "user-id" },
+                Request = new Request { Method = "POST" },
+                Contexts = new Contexts { ["context_key"] = "context_value" },
+                Sdk = new SdkVersion { Name = "SDK-test" },
+                Environment = "environment",
+                Level = SentryLevel.Fatal,
+                Logger = "logger",
+                Message = new SentryMessage
+                {
+                    Message = "message",
+                    Formatted = "structured_message"
+                },
+                Modules = { { "module_key", "module_value" } },
+                Release = "release",
+                // SentryExceptions = new[] { new SentryException { Value = "exception_value" } },
+                SentryThreads = new[] { new SentryThread { Crashed = true } },
+                ServerName = "server_name",
+                Transaction = "transaction",
             };
+
+            @event.AddBreadcrumb(new Breadcrumb(timestamp, "crumb"));
+            @event.SetExtra("extra_key", "extra_value");
+            @event.Fingerprint = new[] {"fingerprint"};
+            @event.SetTag("tag_key", "tag_value");
 
             using var envelope = Envelope.FromEvent(@event);
 
@@ -374,7 +398,7 @@ namespace Sentry.Tests.Protocol.Envelopes
             envelopeRoundtrip.Items.Should().ContainSingle();
 
             var payloadContent = (envelopeRoundtrip.Items[0].Payload as JsonSerializable)?.Source;
-            payloadContent.Should().BeEquivalentTo(@event);
+            payloadContent.Should().BeEquivalentTo(@event, o => o.Excluding(x => x.Exception));
         }
 
         [Fact]


### PR DESCRIPTION
Resolves #614
Resolves #615

We need to figure out:

1. Why assigning to SentryException fail to deserialize
2. Deserializing `Contexts` is tricky since it correctly adds to the map, but it's unaware that a well known key such as `browser` should actually deserialize to `Browser`. We need a custom serializer.
3. Complete all Serialization tests into a two-way serialize->deserialize
4. Have snapshot tests to make sure that we know when we break compatibility with already serialized events (that will exist on devices once we ship this).