### PR TITLE
Add IDiagnosticLogger that routes to ITestOutputHelper

### DIFF
--- a/test/Sentry.Testing/TestOutputDiagnosticLogger.cs
+++ b/test/Sentry.Testing/TestOutputDiagnosticLogger.cs
@@ -1,0 +1,32 @@
+using System;
+using Sentry.Extensibility;
+using Xunit.Abstractions;
+
+namespace Sentry.Testing
+{
+    public class TestOutputDiagnosticLogger : IDiagnosticLogger
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+        private readonly SentryLevel _minimumLevel;
+
+        public TestOutputDiagnosticLogger(
+            ITestOutputHelper testOutputHelper,
+            SentryLevel minimumLevel = SentryLevel.Debug)
+        {
+            _testOutputHelper = testOutputHelper;
+            _minimumLevel = minimumLevel;
+        }
+
+        public bool IsEnabled(SentryLevel level) => level >= _minimumLevel;
+
+        public void Log(SentryLevel logLevel, string message, Exception exception = null, params object[] args)
+        {
+            var formattedMessage = string.Format(message, args);
+
+            _testOutputHelper.WriteLine($@"
+[{logLevel}]: {formattedMessage}
+    Exception: {exception?.ToString() ?? "<none>"}
+".Trim());
+        }
+    }
+}

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -12,17 +12,29 @@ using Sentry.Internal.Http;
 using Sentry.Protocol.Envelopes;
 using Sentry.Testing;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Sentry.Tests.Internals.Http
 {
     public class CachingTransportTests
     {
+        private readonly IDiagnosticLogger _logger;
+
+        public CachingTransportTests(ITestOutputHelper testOutputHelper)
+        {
+            _logger = new TestOutputDiagnosticLogger(testOutputHelper);
+        }
+
         [Fact(Timeout = 7000)]
         public async Task WorksInBackground()
         {
             // Arrange
             using var cacheDirectory = new TempDirectory();
-            var options = new SentryOptions {CacheDirectoryPath = cacheDirectory.Path};
+            var options = new SentryOptions
+            {
+                DiagnosticLogger = _logger,
+                CacheDirectoryPath = cacheDirectory.Path
+            };
 
             using var innerTransport = new FakeTransport();
             await using var transport = new CachingTransport(innerTransport, options);
@@ -49,7 +61,11 @@ namespace Sentry.Tests.Internals.Http
         {
             // Arrange
             using var cacheDirectory = new TempDirectory();
-            var options = new SentryOptions {CacheDirectoryPath = cacheDirectory.Path};
+            var options = new SentryOptions
+            {
+                DiagnosticLogger = _logger,
+                CacheDirectoryPath = cacheDirectory.Path
+            };
 
             using var innerTransport = new FakeTransport();
             await using var transport = new CachingTransport(innerTransport, options);
@@ -75,6 +91,7 @@ namespace Sentry.Tests.Internals.Http
             using var cacheDirectory = new TempDirectory();
             var options = new SentryOptions
             {
+                DiagnosticLogger = _logger,
                 CacheDirectoryPath = cacheDirectory.Path,
                 MaxQueueItems = 2
             };
@@ -105,7 +122,11 @@ namespace Sentry.Tests.Internals.Http
         {
             // Arrange
             using var cacheDirectory = new TempDirectory();
-            var options = new SentryOptions {CacheDirectoryPath = cacheDirectory.Path};
+            var options = new SentryOptions
+            {
+                DiagnosticLogger = _logger,
+                CacheDirectoryPath = cacheDirectory.Path
+            };
 
             // Send some envelopes with a failing transport to make sure they all stay in cache
             {
@@ -144,7 +165,11 @@ namespace Sentry.Tests.Internals.Http
         {
             // Arrange
             using var cacheDirectory = new TempDirectory();
-            var options = new SentryOptions {CacheDirectoryPath = cacheDirectory.Path};
+            var options = new SentryOptions
+            {
+                DiagnosticLogger = _logger,
+                CacheDirectoryPath = cacheDirectory.Path
+            };
 
             var innerTransport = Substitute.For<ITransport>();
             var isFailing = true;
@@ -186,7 +211,11 @@ namespace Sentry.Tests.Internals.Http
         {
             // Arrange
             using var cacheDirectory = new TempDirectory();
-            var options = new SentryOptions { CacheDirectoryPath = cacheDirectory.Path };
+            var options = new SentryOptions
+            {
+                DiagnosticLogger = _logger,
+                CacheDirectoryPath = cacheDirectory.Path
+            };
 
             var exception = new HttpRequestException(null, new SocketException());
             var receivedException = new Exception();

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -10,6 +10,7 @@ using Sentry.Internal.Http;
 using Sentry.Protocol.Envelopes;
 using Sentry.Testing;
 using Xunit;
+using Xunit.Abstractions;
 using static Sentry.Internal.Constants;
 using static Sentry.Protocol.Constants;
 using static Sentry.DsnSamples;
@@ -19,6 +20,13 @@ namespace Sentry.Tests
     [Collection(nameof(SentrySdkCollection))]
     public class SentrySdkTests : SentrySdkTestFixture
     {
+        private readonly IDiagnosticLogger _logger;
+
+        public SentrySdkTests(ITestOutputHelper testOutputHelper)
+        {
+            _logger = new TestOutputDiagnosticLogger(testOutputHelper);
+        }
+
         [Fact]
         public void IsEnabled_StartsOfFalse()
         {
@@ -213,6 +221,7 @@ namespace Sentry.Tests
                 var initialInnerTransport = new FakeFailingTransport();
                 await using var initialTransport = new CachingTransport(initialInnerTransport, new SentryOptions
                 {
+                    DiagnosticLogger = _logger,
                     Dsn = ValidDsnWithoutSecret,
                     CacheDirectoryPath = cacheDirectory.Path
                 });
@@ -232,6 +241,7 @@ namespace Sentry.Tests
             using var _ = SentrySdk.Init(o =>
             {
                 o.Dsn = ValidDsnWithoutSecret;
+                o.DiagnosticLogger = _logger;
                 o.CacheDirectoryPath = cacheDirectory.Path;
                 o.CacheFlushTimeout = TimeSpan.FromSeconds(30);
                 o.CreateHttpClientHandler = () => new FakeHttpClientHandler();


### PR DESCRIPTION
In some tests we use a fake/mocked logger so we might need to add an `AggregateDiagnosticLogger` abstraction to accommodate those. Anyway, this is a prototype.

Closes #612 