### PR TITLE
Increase codecov threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,11 @@
 coverage:
   status:
-    patch: false
     changes: false
+    project:
+      default:
+        threshold: 5%
+    patch:
+      default:
+        threshold: 5%
   ignore:
     - "test/**/*"


### PR DESCRIPTION
Closes #622

Not sure why `patch` was `false` previously. The codecov documentation doesn't show an example which sets that variable to `false`.

#skip-changelog