### PR TITLE
Tests updated to NSubstitute 4

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/test/Sentry.AspNetCore.Grpc.Tests/Sentry.AspNetCore.Grpc.Tests.csproj
+++ b/test/Sentry.AspNetCore.Grpc.Tests/Sentry.AspNetCore.Grpc.Tests.csproj
@@ -5,19 +5,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.33.1"/>
-    <PackageReference Include="Grpc.Net.Client" Version="2.33.1"/>
-    <PackageReference Include="Grpc.Tools" Version="2.33.1" PrivateAssets="All"/>
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.33.1" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.33.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.33.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Sentry.AspNetCore.Grpc\Sentry.AspNetCore.Grpc.csproj"/>
-    <ProjectReference Include="..\Sentry.AspNetCore.Tests\Sentry.AspNetCore.Tests.csproj"/>
-    <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj"/>
+    <ProjectReference Include="..\..\src\Sentry.AspNetCore.Grpc\Sentry.AspNetCore.Grpc.csproj" />
+    <ProjectReference Include="..\Sentry.AspNetCore.Tests\Sentry.AspNetCore.Tests.csproj" />
+    <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <Protobuf Include="Proto\tests.proto" GrpcServices="Both"/>
+    <Protobuf Include="Proto\tests.proto" GrpcServices="Both" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.AspNetCore.Tests/BaseRequestPayloadExtractorTests.cs
+++ b/test/Sentry.AspNetCore.Tests/BaseRequestPayloadExtractorTests.cs
@@ -12,7 +12,7 @@ namespace Sentry.AspNetCore.Tests
         protected class Fixture
         {
             public HttpRequest HttpRequestCore { get; set; } = Substitute.For<HttpRequest>();
-            public IHttpRequest HttpRequest { get; set; } 
+            public IHttpRequest HttpRequest { get; set; }
             public Stream Stream { get; set; } = Substitute.For<Stream>();
 
             public Fixture()
@@ -63,7 +63,7 @@ namespace Sentry.AspNetCore.Tests
 
             Assert.Null(sut.ExtractPayload(TestFixture.HttpRequest));
 
-            TestFixture.Stream.DidNotReceive().Position = Arg.Any<int>();
+            TestFixture.Stream.DidNotReceive().Position = Arg.Any<long>();
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace Sentry.AspNetCore.Tests
 
             Assert.Null(sut.ExtractPayload(TestFixture.HttpRequest));
 
-            TestFixture.Stream.DidNotReceive().Position = Arg.Any<int>();
+            TestFixture.Stream.DidNotReceive().Position = Arg.Any<long>();
         }
     }
 }

--- a/test/Sentry.AspNetCore.Tests/FormRequestPayloadExtractorTests.cs
+++ b/test/Sentry.AspNetCore.Tests/FormRequestPayloadExtractorTests.cs
@@ -42,7 +42,7 @@ namespace Sentry.AspNetCore.Tests
 
             Assert.Null(sut.ExtractPayload(TestFixture.HttpRequest));
 
-            TestFixture.Stream.DidNotReceive().Position = Arg.Any<int>();
+            TestFixture.Stream.DidNotReceive().Position = Arg.Any<long>();
         }
     }
 }

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
@@ -380,15 +380,6 @@ namespace Sentry.Extensions.Logging.Tests
                     default,
                     default);
 
-            // The below test is the original one, but for some reason NSubstitute 4 refuses to use the Arg.Any() parameters even though they should be correct and therefore throws an error
-            // _fixture.Hub.DidNotReceive()
-            //     .AddBreadcrumb(
-            //         _fixture.Clock,
-            //         Arg.Any<string>(),
-            //         _fixture.CategoryName,
-            //         BreadcrumbType,
-            //         null,
-            //         Arg.Any<BreadcrumbLevel>());
         }
 
         [Fact]

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
@@ -398,15 +398,6 @@ namespace Sentry.Extensions.Logging.Tests
                     default,
                     default);
 
-            // The below test is the original one, but for some reason NSubstitute 4 refuses to use the Arg.Any() parameters even though they should be correct and therefore throws an error
-            // _fixture.Hub.DidNotReceive()
-            //     .AddBreadcrumb(
-            //         _fixture.Clock,
-            //         Arg.Any<string>(),
-            //         _fixture.CategoryName,
-            //         BreadcrumbType,
-            //         null,
-            //         Arg.Any<BreadcrumbLevel>());
         }
 
         [Fact]

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
@@ -370,14 +370,25 @@ namespace Sentry.Extensions.Logging.Tests
 
             sut.LogDebug("anything");
 
-            _fixture.Hub.DidNotReceive()
+
+            _fixture.Hub.DidNotReceiveWithAnyArgs()
                 .AddBreadcrumb(
-                    _fixture.Clock,
-                    Arg.Any<string>(),
-                    _fixture.CategoryName,
-                    BreadcrumbType,
-                    null,
-                    Arg.Any<BreadcrumbLevel>());
+                    default,
+                    string.Empty,
+                    default,
+                    default,
+                    default,
+                    default);
+
+            // The below test is the original one, but for some reason NSubstitute 4 refuses to use the Arg.Any() parameters even though they should be correct and therefore throws an error
+            // _fixture.Hub.DidNotReceive()
+            //     .AddBreadcrumb(
+            //         _fixture.Clock,
+            //         Arg.Any<string>(),
+            //         _fixture.CategoryName,
+            //         BreadcrumbType,
+            //         null,
+            //         Arg.Any<BreadcrumbLevel>());
         }
 
         [Fact]
@@ -387,14 +398,24 @@ namespace Sentry.Extensions.Logging.Tests
 
             sut.LogTrace("anything");
 
-            _fixture.Hub.DidNotReceive()
+            _fixture.Hub.DidNotReceiveWithAnyArgs()
                 .AddBreadcrumb(
-                    _fixture.Clock,
-                    Arg.Any<string>(),
-                    _fixture.CategoryName,
-                    BreadcrumbType,
-                    null,
-                    Arg.Any<BreadcrumbLevel>());
+                    default,
+                    string.Empty,
+                    default,
+                    default,
+                    default,
+                    default);
+
+            // The below test is the original one, but for some reason NSubstitute 4 refuses to use the Arg.Any() parameters even though they should be correct and therefore throws an error
+            // _fixture.Hub.DidNotReceive()
+            //     .AddBreadcrumb(
+            //         _fixture.Clock,
+            //         Arg.Any<string>(),
+            //         _fixture.CategoryName,
+            //         BreadcrumbType,
+            //         null,
+            //         Arg.Any<BreadcrumbLevel>());
         }
 
         [Fact]


### PR DESCRIPTION
All tests now work with NSubstitute 4.2.2 instead of 3.x. 

`LogDebug_DefaultOptions_DoesNotRecordsBreadcrumbs` and `LogTrace_DefaultOptions_DoesNotRecordsBreadcrumbs` have had their `Args.Any<>()` replaced with `DidNotReceiveWithAnyArgs()` since this is a stricter condition anyway and the old version doesn't seem to work regardless of what I've tried.

#skip-changelog