### PR TITLE
ref: moved Sentry from namespace from Sentry.Protocol to Sentry (#643)

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
       - run: npx danger@10.5.2 ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@ docs/api/*
 docs/_site/*
 docs/docfx/*
 docs/docfx.zip
+/samples/Sentry.Samples.Aws.Lambda.AspNetCoreServer/Properties/launchSettings.json
 
 *.received.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
  
-* Ref moved SentryId from namespace Sentry.Protocol to Sentry (#643) @lucas-zimerman
+* Ref moved SentryId from namespace Sentry.Protocol to Sentry (#643) @lucas-zimerman ([#643](https://github.com/getsentry/sentry-dotnet/pull/644))
 * Ref renamed `CacheFlushTimeout` to `InitCacheFlushTimeout` (#638) @lucas-zimerman
 
 ## 3.0.0-alpha.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vNext
 
+* Ref moved SentryId from namespace Sentry.Protocol to Sentry (#643) @lucas-zimerman
 * Ref renamed `CacheFlushTimeout` to `InitCacheFlushTimeout` (#638) @lucas-zimerman
 
 ## 3.0.0-alpha.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
  
-* Ref moved SentryId from namespace Sentry.Protocol to Sentry (#643) @lucas-zimerman ([#643](https://github.com/getsentry/sentry-dotnet/pull/644))
+* Ref moved SentryId from namespace Sentry.Protocol to Sentry (#643) @lucas-zimerman ([#644](https://github.com/getsentry/sentry-dotnet/pull/644))
 * Ref renamed `CacheFlushTimeout` to `InitCacheFlushTimeout` (#638) @lucas-zimerman
 
 ## 3.0.0-alpha.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
  
-* Ref moved SentryId from namespace Sentry.Protocol to Sentry (#643) @lucas-zimerman ([#644](https://github.com/getsentry/sentry-dotnet/pull/644))
+* Ref moved SentryId from namespace Sentry.Protocol to Sentry (#643) @lucas-zimerman
 * Ref renamed `CacheFlushTimeout` to `InitCacheFlushTimeout` (#638) @lucas-zimerman
 
 ## 3.0.0-alpha.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## vNext
-
+ 
 * Ref moved SentryId from namespace Sentry.Protocol to Sentry (#643) @lucas-zimerman
 * Ref renamed `CacheFlushTimeout` to `InitCacheFlushTimeout` (#638) @lucas-zimerman
 

--- a/samples/Sentry.Samples.ME.Logging/Program.cs
+++ b/samples/Sentry.Samples.ME.Logging/Program.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Sentry;
 using Sentry.Extensions.Logging;
-using Sentry.Protocol;
 
 internal class Program
 {

--- a/samples/Sentry.Samples.Serilog/Program.cs
+++ b/samples/Sentry.Samples.Serilog/Program.cs
@@ -1,5 +1,4 @@
 using System;
-using Sentry;
 using Serilog;
 using Serilog.Context;
 using Serilog.Events;

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Options;
 using Sentry.Extensions.Logging;
 using Sentry.Internal;
-using Microsoft.Extensions.Hosting;
 #if NETSTANDARD2_0
 using IHostingEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
 #else

--- a/src/Sentry.Extensions.Logging/MelDiagnosticLogger.cs
+++ b/src/Sentry.Extensions.Logging/MelDiagnosticLogger.cs
@@ -1,7 +1,6 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Sentry.Extensibility;
-using Sentry.Protocol;
 
 namespace Sentry.Extensions.Logging
 {

--- a/src/Sentry.Log4Net/LevelMapping.cs
+++ b/src/Sentry.Log4Net/LevelMapping.cs
@@ -1,5 +1,4 @@
 using log4net.Core;
-using Sentry.Protocol;
 
 namespace Sentry.Log4Net
 {

--- a/src/Sentry.NLog/ConfigurationExtensions.cs
+++ b/src/Sentry.NLog/ConfigurationExtensions.cs
@@ -2,8 +2,6 @@ using System;
 using NLog.Config;
 using NLog.Layouts;
 using NLog.Targets;
-
-using Sentry;
 using Sentry.NLog;
 
 // ReSharper disable once CheckNamespace

--- a/src/Sentry.NLog/NLogDiagnosticLogger.cs
+++ b/src/Sentry.NLog/NLogDiagnosticLogger.cs
@@ -1,6 +1,5 @@
 using System;
 using Sentry.Extensibility;
-using Sentry.Protocol;
 
 using NLog.Common;
 using Sentry.Infrastructure;

--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -4,8 +4,6 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using Sentry;
-using Sentry.Internal;
-using Sentry.Protocol;
 using Sentry.Serilog;
 using Serilog.Configuration;
 using Serilog.Events;

--- a/src/Sentry/Extensibility/DiagnosticLoggerExtensions.cs
+++ b/src/Sentry/Extensibility/DiagnosticLoggerExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using Sentry.Protocol;
 
 namespace Sentry.Extensibility
 {

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Sentry.Protocol;
 
 namespace Sentry.Extensibility
 {

--- a/src/Sentry/Extensibility/IDiagnosticLogger.cs
+++ b/src/Sentry/Extensibility/IDiagnosticLogger.cs
@@ -1,5 +1,4 @@
 using System;
-using Sentry.Protocol;
 
 namespace Sentry.Extensibility
 {

--- a/src/Sentry/IHub.cs
+++ b/src/Sentry/IHub.cs
@@ -1,5 +1,3 @@
-using Sentry.Protocol;
-
 namespace Sentry
 {
     /// <summary>

--- a/src/Sentry/ISentryClient.cs
+++ b/src/Sentry/ISentryClient.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Sentry.Protocol;
 
 namespace Sentry
 {

--- a/src/Sentry/Infrastructure/ConsoleDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/ConsoleDiagnosticLogger.cs
@@ -1,6 +1,5 @@
 using System;
 using Sentry.Extensibility;
-using Sentry.Protocol;
 
 namespace Sentry.Infrastructure
 {

--- a/src/Sentry/Infrastructure/DebugDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/DebugDiagnosticLogger.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using Sentry.Extensibility;
-using Sentry.Protocol;
 
 namespace Sentry.Infrastructure
 {

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Sentry.Extensibility;
 using Sentry.Integrations;
-using Sentry.Protocol;
 
 namespace Sentry.Internal
 {

--- a/src/Sentry/PlatformAbstractions/Runtime.cs
+++ b/src/Sentry/PlatformAbstractions/Runtime.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Sentry.PlatformAbstractions
 {
     /// <summary>

--- a/src/Sentry/Protocol/SentryId.cs
+++ b/src/Sentry/Protocol/SentryId.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Text.Json;
+using Sentry.Protocol;
 
-namespace Sentry.Protocol
+namespace Sentry
 {
     /// <summary>
     /// The identifier of an event in Sentry.

--- a/src/Sentry/SentryClientExtensions.cs
+++ b/src/Sentry/SentryClientExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel;
-using Sentry.Protocol;
 
 namespace Sentry
 {

--- a/test/Sentry.AspNetCore.Grpc.Tests/IntegrationTests.cs
+++ b/test/Sentry.AspNetCore.Grpc.Tests/IntegrationTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Grpc.Core;
-using Sentry.AspNetCore.Tests;
 using Xunit;
 
 namespace Sentry.AspNetCore.Grpc.Tests

--- a/test/Sentry.AspNetCore.Grpc.Tests/SentryCoreDependentCollection.cs
+++ b/test/Sentry.AspNetCore.Grpc.Tests/SentryCoreDependentCollection.cs
@@ -1,4 +1,3 @@
-using Sentry.AspNetCore.Tests;
 using Xunit;
 
 namespace Sentry.AspNetCore.Grpc.Tests

--- a/test/Sentry.AspNetCore.Tests/MiddlewareLoggerIntegration.cs
+++ b/test/Sentry.AspNetCore.Tests/MiddlewareLoggerIntegration.cs
@@ -13,7 +13,6 @@ using NSubstitute;
 using Sentry.Extensions.Logging;
 using Sentry.Infrastructure;
 using Sentry.Internal;
-using Sentry.Protocol;
 using Xunit;
 
 namespace Sentry.AspNetCore.Tests

--- a/test/Sentry.Extensions.Logging.Tests/MelDiagnosticLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/MelDiagnosticLoggerTests.cs
@@ -1,7 +1,6 @@
 using System;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using Sentry.Protocol;
 using Xunit;
 
 namespace Sentry.Extensions.Logging.Tests

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerFactoryExtensionsTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerFactoryExtensionsTests.cs
@@ -2,8 +2,6 @@ using System;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Sentry.Extensibility;
-using Sentry.Internal;
-using Sentry.Protocol;
 using Xunit;
 
 namespace Sentry.Extensions.Logging.Tests

--- a/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
+++ b/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
@@ -2,7 +2,6 @@ using System;
 using log4net;
 using log4net.Core;
 using NSubstitute;
-using Sentry.Protocol;
 using Sentry.Reflection;
 using Xunit;
 

--- a/test/Sentry.NLog.Tests/NLogDiagnosticLoggerTest.cs
+++ b/test/Sentry.NLog.Tests/NLogDiagnosticLoggerTest.cs
@@ -1,5 +1,4 @@
 using System;
-using Sentry.Protocol;
 using NLog;
 using NLog.Common;
 using Xunit;

--- a/test/Sentry.Tests/Internals/BackgroundWorkerTests.cs
+++ b/test/Sentry.Tests/Internals/BackgroundWorkerTests.cs
@@ -6,7 +6,6 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Sentry.Extensibility;
 using Sentry.Internal;
-using Sentry.Protocol;
 using Sentry.Protocol.Envelopes;
 using Xunit;
 

--- a/test/Sentry.Tests/Internals/DefaultSentryHttpClientFactoryTests.cs
+++ b/test/Sentry.Tests/Internals/DefaultSentryHttpClientFactoryTests.cs
@@ -1,7 +1,5 @@
-using System;
 using System.IO.Compression;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using NSubstitute;
 using Sentry.Internal.Http;

--- a/test/Sentry.Tests/Protocol/Context/DeviceTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/DeviceTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Sentry.Tests.Protocol;
 using Xunit;
 
 // ReSharper disable once CheckNamespace

--- a/test/Sentry.Tests/Protocol/Context/GpuTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/GpuTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Sentry.Tests.Protocol;
 using Xunit;
 
 // ReSharper disable once CheckNamespace

--- a/test/Sentry.Tests/Protocol/Context/OperatingSystemTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/OperatingSystemTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Sentry.Tests.Protocol;
 using Xunit;
 
 // ReSharper disable once CheckNamespace

--- a/test/Sentry.Tests/Protocol/Context/RuntimeTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/RuntimeTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Sentry.Tests.Protocol;
 using Xunit;
 
 // ReSharper disable once CheckNamespace

--- a/test/Sentry.Tests/Protocol/Exceptions/MechanismTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/MechanismTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Sentry.Tests.Protocol;
 using Xunit;
 
 // ReSharper disable once CheckNamespace

--- a/test/Sentry.Tests/Protocol/SentryIdTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryIdTests.cs
@@ -1,5 +1,4 @@
 using System;
-using Sentry.Protocol;
 using Xunit;
 
 namespace Sentry.Tests.Protocol

--- a/test/Sentry.Tests/SentryClientExtensionsTests.cs
+++ b/test/Sentry.Tests/SentryClientExtensionsTests.cs
@@ -1,6 +1,5 @@
 using System;
 using NSubstitute;
-using Sentry.Protocol;
 using Xunit;
 
 namespace Sentry.Tests

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -5,10 +5,8 @@ using System.Threading.Tasks;
 using NSubstitute;
 using Sentry.Extensibility;
 using Sentry.Internal;
-using Sentry.Protocol;
 using Sentry.Protocol.Envelopes;
 using VerifyXunit;
-using VerifyTests;
 using Xunit;
 
 namespace Sentry.Tests


### PR DESCRIPTION
With that, the user is not required to use the Sentry.Protocol namespace only for calling the user feedback feature.
closes #643.