### PR TITLE
Blazor Wasm JavaScript interop

### DIFF
--- a/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Pages/Thrower.razor
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Pages/Thrower.razor
@@ -1,14 +1,18 @@
 ﻿@page "/thrower"
 @using Microsoft.Extensions.Logging
 @inject ILogger<Thrower> Logger
+@inject IJSRuntime JS;
 
 <h1>Throw Exception</h1>
 
 <button class="btn btn-primary" @onclick="Throw">Throw</button>
 
+<button class="btn btn-primary" @onclick="ThrowFromJavaScript">Throw From JavaScript</button>
+<button class="btn btn-primary" @onclick="ThrowOnSetTimeout">Throw from setTimeout in JavaScript</button>
+
 @if (SentrySdk.LastEventId != SentryId.Empty)
 {
-<p>Event Id: @SentrySdk.LastEventId</p>
+    <p>Event Id: @SentrySdk.LastEventId</p>
 }
 
 @code {
@@ -23,4 +27,15 @@
         public static void DoSomething() => Thrower();
         private static void Thrower() => throw null;
     }
+
+    private async Task ThrowFromJavaScript()
+    {
+        await JS.InvokeAsync<string>("throwFromJavaScript", "from C#");
+    }
+
+    private async Task ThrowOnSetTimeout()
+    {
+        await JS.InvokeAsync<string>("throwOnSetTimeout", "from C#");
+    }
+
 }

--- a/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Sentry.Samples.AspNetCore.Blazor.Wasm.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Sentry.Samples.AspNetCore.Blazor.Wasm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/wwwroot/index.html
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/wwwroot/index.html
@@ -9,14 +9,35 @@
 </head>
 
 <body>
-<div id="app">Loading...</div>
+    <div id="app">Loading...</div>
 
-<div id="blazor-error-ui">
-    An unhandled error has occurred.
-    <a href="" class="reload">Reload</a>
-    <a class="dismiss">🗙</a>
-</div>
-<script src="_framework/blazor.webassembly.js"></script>
+<script src="https://browser.sentry-cdn.com/5.29.2/bundle.min.js"
+        integrity="sha384-ir4+BihBClNpjZk3UKgHTr0cwRhujAjy/M5VEGvcOzjhM1Db79GAg9xLxYn4uVK4"
+        crossorigin="anonymous"></script>
+<script type="text/javascript">
+    Sentry.init({
+        dsn: 'https://80aed643f81249d4bed3e30687b310ab@o447951.ingest.sentry.io/5428537',
+    });
+
+</script>
+
+        <div id="blazor-error-ui">
+        An unhandled error has occurred.
+        <a href="" class="reload">Reload</a>
+        <a class="dismiss">🗙</a>
+    </div>
+    <script type="text/javascript">
+        function throwFromJavaScript(caller) {
+            throw Error("Exceptional JavaScript function called by: " + caller);
+        }
+        function throwOnSetTimeout(caller) {
+            setTimeout(() => {
+                    throw Error("JavaScript error on setTimeout called by: " + caller);
+                },
+                1000);
+        }
+    </script>
+    <script src="_framework/blazor.webassembly.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Exceptions thrown in a C# to JavaScript calls get reported by the .NET SDK.

JavaScript code that isn't directly called by .NET Wasm doesn't get captured without the JavaScript SDK. `setTimeout` or a call from the DOM to a JS function for example.