### PR TITLE
Inject changelog into release notes

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,7 +23,7 @@
     <PackageProjectUrl>https://sentry.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
-    <PackageReleaseNotes>Can be found at: https://github.com/getsentry/sentry-dotnet/releases</PackageReleaseNotes>
+    <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/../../CHANGELOG.md"))</PackageReleaseNotes>
 
     <!-- Prop required by Microsoft.SourceLink.GitHub -->
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->


### PR DESCRIPTION
Nuspec looks like this:

![image](https://user-images.githubusercontent.com/1935960/103103835-8ba0ab00-462c-11eb-9a55-15b8cf8d7ae1.png)


_#skip-changelog_