### PR TITLE
ref: Disable Mono StackTrace Factory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Disabled Mono StackTrace Factory. (#709) @lucas-zimerman
+
 ## 3.0.0-alpha.9
 
 - Handle non-json error response messages on HttpTransport. (#690) @lucas-zimerman

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -436,10 +436,7 @@ namespace Sentry
                 () => ExceptionProcessors ?? Enumerable.Empty<ISentryEventExceptionProcessor>()
             };
 
-            SentryStackTraceFactory = Runtime.Current.IsMono()
-                // Also true for IL2CPP
-                ? new MonoSentryStackTraceFactory(this)
-                : new SentryStackTraceFactory(this);
+            SentryStackTraceFactory = new SentryStackTraceFactory(this);
 
             ISentryStackTraceFactory SentryStackTraceFactoryAccessor() => SentryStackTraceFactory;
 

--- a/test/Sentry.Tests/SentryOptionsTests.cs
+++ b/test/Sentry.Tests/SentryOptionsTests.cs
@@ -1,8 +1,10 @@
+using System;
 using System.IO.Compression;
 using System.Net;
 #if NETFX
 using Sentry.Internal;
 using Sentry.PlatformAbstractions;
+using Xunit.Sdk;
 #endif
 using Xunit;
 
@@ -16,16 +18,14 @@ namespace Sentry.Tests
             var sut = new SentryOptions();
             Assert.Equal(~DecompressionMethods.None, sut.DecompressionMethods);
         }
-
         [Fact]
         public void RequestBodyCompressionLevel_ByDefault_Optimal()
         {
             var sut = new SentryOptions();
             Assert.Equal(CompressionLevel.Optimal, sut.RequestBodyCompressionLevel);
         }
-
 #if NETFX
-        [SkippableFact]
+        [SkippableFact(typeof(IsTypeException))]
         public void StackTraceFactory_RunningOnMono_HasMonoStackTraceFactory()
         {
             Skip.If(!RuntimeInfo.GetRuntime().IsMono());
@@ -34,7 +34,7 @@ namespace Sentry.Tests
             Assert.IsType<MonoSentryStackTraceFactory>(sut.SentryStackTraceFactory);
         }
 
-        [SkippableFact]
+        [SkippableFact(typeof(IsNotTypeException))]
         public void StackTraceFactory_NotRunningOnMono_NotMonoStackTraceFactory()
         {
             Skip.If(RuntimeInfo.GetRuntime().IsMono());


### PR DESCRIPTION
As discussed on Discord, the MonoStackTraceFactory lacks any Assembly information, generating a different grouping compared to the previous stable release (2.1.8).

In addition, since there's no assembly info, the SDK doesn't exclude the known frames that are not part of the user code.
To conclude, the current SentryStackTraceFactory produces richer information when running on mono compared to MonoStackTraceFactory, but it's only lacking the additional info for symbolicate the frames. But since this code wasn't implemented on the server-side, I feel like it's better, for now, to stick to the current StackTraceFactory for mono and in the future, once the symbolization code is ready, enhance the current StackTrace with the needed information.