### PR TITLE
Separate tracing middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - Limit attachment size (#705)
+- Separate tracing middleware (#737)
 
 ## 3.0.0-alpha.10
 

--- a/samples/Sentry.Samples.AspNetCore.Basic/Program.cs
+++ b/samples/Sentry.Samples.AspNetCore.Basic/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
+using Sentry.AspNetCore;
 
 namespace Sentry.Samples.AspNetCore.Basic
 {
@@ -32,6 +33,10 @@ namespace Sentry.Samples.AspNetCore.Basic
                     // An example ASP.NET Core middleware that throws an
                     // exception when serving a request to path: /throw
                     app.UseRouting();
+
+                    // Enable Sentry performance monitoring
+                    app.UseSentryTracing();
+
                     app.UseEndpoints(endpoints =>
                     {
                         // Reported events will be grouped by route pattern

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Sentry.AspNetCore.Extensions;
+using Sentry.Protocol;
+
+namespace Sentry.AspNetCore
+{
+    /// <summary>
+    /// Sentry tracing middleware for ASP.NET Core
+    /// </summary>
+    public class SentryTracingMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly Func<IHub> _hubAccessor;
+
+        public SentryTracingMiddleware(RequestDelegate next, Func<IHub> hubAccessor)
+        {
+            _next = next;
+            _hubAccessor = hubAccessor;
+        }
+
+        /// <summary>
+        /// Handles the <see cref="HttpContext"/>.
+        /// </summary>
+        public async Task InvokeAsync(HttpContext context)
+        {
+            var hub = _hubAccessor();
+            if (!hub.IsEnabled)
+            {
+                await _next(context).ConfigureAwait(false);
+                return;
+            }
+
+            var transaction = hub.CreateTransaction(
+                context.GetTransactionName(),
+                "http.server"
+            );
+
+            try
+            {
+                await _next(context).ConfigureAwait(false);
+            }
+            finally
+            {
+                transaction.Finish(
+                    GetSpanStatusFromCode(context.Response.StatusCode)
+                );
+            }
+        }
+
+        private static SpanStatus GetSpanStatusFromCode(int statusCode) => statusCode switch
+        {
+            < 400 => SpanStatus.Ok,
+            400 => SpanStatus.InvalidArgument,
+            401 => SpanStatus.Unauthenticated,
+            403 => SpanStatus.PermissionDenied,
+            404 => SpanStatus.NotFound,
+            409 => SpanStatus.AlreadyExists,
+            429 => SpanStatus.ResourceExhausted,
+            499 => SpanStatus.Cancelled,
+            < 500 => SpanStatus.InvalidArgument,
+            500 => SpanStatus.InternalError,
+            501 => SpanStatus.Unimplemented,
+            503 => SpanStatus.Unavailable,
+            504 => SpanStatus.DeadlineExceeded,
+            < 600 => SpanStatus.InternalError,
+            _ => SpanStatus.UnknownError
+        };
+    }
+
+    /// <summary>
+    /// Extensions for enabling <see cref="SentryTracingMiddleware"/>.
+    /// </summary>
+    public static class SentryTracingMiddlewareExtensions
+    {
+        /// <summary>
+        /// Adds Sentry's tracing middleware to the pipeline.
+        /// Make sure to place this middleware after <code>UseRouting(...)</code>.
+        /// </summary>
+        public static IApplicationBuilder UseSentryTracing(this IApplicationBuilder builder)
+        {
+            builder.UseMiddleware<SentryTracingMiddleware>();
+            return builder;
+        }
+    }
+}

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -10,7 +10,7 @@ namespace Sentry.AspNetCore
     /// <summary>
     /// Sentry tracing middleware for ASP.NET Core
     /// </summary>
-    public class SentryTracingMiddleware
+    internal class SentryTracingMiddleware
     {
         private readonly RequestDelegate _next;
         private readonly Func<IHub> _hubAccessor;

--- a/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
@@ -1,0 +1,68 @@
+﻿#if !NETCOREAPP2_1
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NSubstitute;
+using Sentry.Protocol;
+using Xunit;
+
+namespace Sentry.AspNetCore.Tests
+{
+    public class SentryTracingMiddlewareTests
+    {
+        [Fact]
+        public async Task Transactions_are_grouped_by_route()
+        {
+            // Arrange
+            var sentryClient = Substitute.For<ISentryClient>();
+
+            var hub = new Internal.Hub(sentryClient, new SentryOptions
+            {
+                Dsn = DsnSamples.ValidDsnWithoutSecret
+            });
+
+            var server = new TestServer(new WebHostBuilder()
+                .UseSentry()
+                .ConfigureServices(services =>
+                {
+                    services.AddRouting();
+
+                    services.RemoveAll(typeof(Func<IHub>));
+                    services.AddSingleton<Func<IHub>>(() => hub);
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseSentryTracing();
+
+                    app.UseEndpoints(routes =>
+                    {
+                        routes.Map("/person/{id}", async ctx =>
+                        {
+                            var id = ctx.GetRouteValue("id") as string;
+                            await ctx.Response.WriteAsync($"Person #{id}");
+                        });
+                    });
+                })
+            );
+
+            var client = server.CreateClient();
+
+            // Act
+            await client.GetStringAsync("/person/13");
+            await client.GetStringAsync("/person/69");
+
+            // Assert
+            sentryClient.Received(2).CaptureTransaction(
+                Arg.Is<Transaction>(transaction => transaction.Name == "GET /person/{id}")
+            );
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Separated tracing into its own middleware.

The user needs to add `UseSentryTracing()` after `UseRouting()` so that it has access to routing. If they add it before, it will instead use the request path for transaction name, which is still better than not working at all.

Closes #708