### PR TITLE
Sync transaction and transaction name on scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Limit attachment size (#705)
 - Separate tracing middleware (#737)
+- Sync transaction and transaction name on scope (#740)
 
 ## 3.0.0-alpha.10
 

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -140,7 +140,7 @@ namespace Sentry.Tests
             scope.TransactionName = null;
 
             // Assert
-            scope.TransactionName.Should().BeEmpty();
+            scope.TransactionName.Should().BeNullOrEmpty();
             scope.TransactionName.Should().Be(scope.Transaction?.Name);
         }
 


### PR DESCRIPTION
Currently, `Scope.Transaction` and `Scope.TransactionName` are completely separate. This is apparently incorrect, so this PR addresses that.

For context, check the discussion on this issue: https://github.com/getsentry/develop/issues/246

Note: still pending an answer to https://github.com/getsentry/develop/issues/246#issuecomment-761172858