### PR TITLE
Ref: Add instruction_addr  to SentryStackFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add instruction_addr to SentryStackFrame. (#744) @lucas-zimerman
+
 ## 3.0.0-alpha.11
 
 - Limit attachment size (#705)

--- a/src/Sentry/Protocol/Exceptions/SentryStackFrame.cs
+++ b/src/Sentry/Protocol/Exceptions/SentryStackFrame.cs
@@ -258,10 +258,9 @@ namespace Sentry.Protocol
             }
 
             // Instruction address
-            if (InstructionAddress is { } instructionAddress &&
-                Regex.IsMatch(instructionAddress, @"\A\b0[xX][0-9a-fA-F]+\b\Z"))
+            if (InstructionAddress is { } instructionAddress)
             {
-                writer.WriteString("instruction_addr", instructionAddress.ToLower());
+                writer.WriteString("instruction_addr", instructionAddress);
             }
 
             // Instruction offset

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
@@ -27,7 +27,7 @@ namespace Sentry.Tests.Protocol.Exceptions
                 ImageAddress = 3,
                 SymbolAddress = 4,
                 InstructionOffset = 5,
-                InstructionAddress = "0xFFFFFFFF"
+                InstructionAddress = "0xffffffff"
             };
 
             var actual = sut.ToJsonString();
@@ -56,19 +56,6 @@ namespace Sentry.Tests.Protocol.Exceptions
                 "}",
                 actual
             );
-        }
-
-        [Fact]
-        public void SerializeObject_InvalidInstructionAddressSet_SerializesValidObjectWithoutInstructionAddress()
-        {
-            var sut = new SentryStackFrame
-            {
-                InstructionAddress = "0xFFFFFFFGG"
-            };
-
-            var actual = sut.ToJsonString();
-
-            Assert.Equal("{}", actual);
         }
 
         [Fact]

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
@@ -27,6 +27,7 @@ namespace Sentry.Tests.Protocol.Exceptions
                 ImageAddress = 3,
                 SymbolAddress = 4,
                 InstructionOffset = 5,
+                InstructionAddress = "0xFFFFFFFF"
             };
 
             var actual = sut.ToJsonString();
@@ -50,10 +51,24 @@ namespace Sentry.Tests.Protocol.Exceptions
                 "\"platform\":\"Platform\"," +
                 "\"image_addr\":3," +
                 "\"symbol_addr\":4," +
+                "\"instruction_addr\":\"0xffffffff\"," +
                 "\"instruction_offset\":5" +
                 "}",
                 actual
             );
+        }
+
+        [Fact]
+        public void SerializeObject_InvalidInstructionAddressSet_SerializesValidObjectWithoutInstructionAddress()
+        {
+            var sut = new SentryStackFrame
+            {
+                InstructionAddress = "0xFFFFFFFGG"
+            };
+
+            var actual = sut.ToJsonString();
+
+            Assert.Equal("{}", actual);
         }
 
         [Fact]


### PR DESCRIPTION
https://develop.sentry.dev/sdk/event-payloads/stacktrace/
instruction_addr  was missing from SentryStackFrame and it's an important parameter for Native exceptions (allowing it to get symbolicated)