### PR TITLE
Only include latest release notes on NuGet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.0.0-alpha.11
 
+### Changed
+
 - Limit attachment size (#705)
 - Separate tracing middleware (#737)
 
@@ -45,7 +47,7 @@
 * Bump Microsoft.Bcl.AsyncInterfaces to 5.0.0 #618
 * Bump `Microsoft.Bcl.AsyncInterfaces` to 5.0.0 #618
 * `DefaultTags` moved from `SentryLoggingOptions` to `SentryOptions` (#637) @PureKrome
-* `Sentry.Serilog` can accept DefaultTags (#637) @PureKrome 
+* `Sentry.Serilog` can accept DefaultTags (#637) @PureKrome
 
 ## 3.0.0-alpha.5
 
@@ -104,9 +106,9 @@ We'd love to get feedback.
 
 ## 2.2.0-alpha
 
-Add nullable reference types support (Sentry, Sentry.Protocol) (#509) 
-fix: Use ASP.NET Core endpoint FQDN (#485) 
-feat: Add integration to TaskScheduler.UnobservedTaskException (#481) 
+Add nullable reference types support (Sentry, Sentry.Protocol) (#509)
+fix: Use ASP.NET Core endpoint FQDN (#485)
+feat: Add integration to TaskScheduler.UnobservedTaskException (#481)
 
 ## 2.1.6
 
@@ -151,13 +153,13 @@ build(deps): bump Microsoft.Extensions.Configuration.Json (#467) @dependabot-pre
 * SentryScopeManager - Fixed clone of Stack so it does not reverse order (#420) @snakefoot
 * build(deps): bump Serilog.AspNetCore from 2.1.1 to 3.2.0 (#411) @dependabot-preview
 * Removed dependency on System.Collections.Immutable (#405) @snakefoot
-* Fix Sentry.Microsoft.Logging Filter now drops also breadcrumbs (#440) 
+* Fix Sentry.Microsoft.Logging Filter now drops also breadcrumbs (#440)
 
 ## 2.1.2-beta5
 
-Fix Background worker dispose logs error message (#408) 
-Fix sentry serilog extension method collapsing (#406) 
-Fix Sentry.Samples.NLog so NLog.config is valid (#404) 
+Fix Background worker dispose logs error message (#408)
+Fix sentry serilog extension method collapsing (#406)
+Fix Sentry.Samples.NLog so NLog.config is valid (#404)
 
 Thanks @snakefoot and @JimHume for the fixes
 
@@ -179,10 +181,10 @@ Fixed ASP.NET System.Web catch HttpException to prevent the request processor fr
 ## 2.1.1
 
 Bug fix:  Don't overwrite server name set via configuration with machine name on ASP.NET Core #372
- 
+
 ## 2.1.0
 
-* Set score url to fully constructed url #367 Thanks @christopher-taormina-zocdoc 
+* Set score url to fully constructed url #367 Thanks @christopher-taormina-zocdoc
 * Don't dedupe from inner exception #363 - Note this might change groupings. It's opt-in.
 * Expose FlushAsync to intellisense #362
 * Protocol monorepo #325 - new protocol version whenever there's a new SDK release
@@ -204,10 +206,10 @@ Removed `-beta` from dependencies.
 
 ## 2.0.0
 
-* SentryTarget - GetTagsFromLogEvent with null check (#326) 
+* SentryTarget - GetTagsFromLogEvent with null check (#326)
 * handled process corrupted (#328)
 * sourcelink GA (#330)
-* Adds ability to specify user values via NLog configuration (#336) 
+* Adds ability to specify user values via NLog configuration (#336)
 * Add option to ASP.NET Core to flush events after response complete (#288)
 * Fixed race on `BackgroundWorker`  (#293)
 * Exclude `Sentry.` frames from InApp (#272)
@@ -215,23 +217,23 @@ Removed `-beta` from dependencies.
 * Logging on body not extracted (#246)
 * Add support to DefaultTags for ASP.NET Core and M.E.Logging (#268)
 * Don't use ValueTuple (#263)
-* All public members were documented: #252 
+* All public members were documented: #252
 * Use EnableBuffering to keep request payload around: #250
-* Serilog default levels: #237 
+* Serilog default levels: #237
 * Removed dev dependency from external dependencies 4d92ab0
 * Use new `Sentry.Protocol` 836fb07e
 * Use new `Sentry.PlatformAbsrtractions` #226
-* Debug logging for ASP.NET Classic #209 
+* Debug logging for ASP.NET Classic #209
 * Reading request body throws on ASP.NET Core 3 (#324)
-* NLog: null check contextProp.Value during IncludeEventDataOnBreadcrumbs (#323) 
-* JsonSerializerSettings - ReferenceLoopHandling.Ignore (#312) 
-* Fixed error when reading request body affects collecting other request data (#299) 
-* `Microsoft.Extensions.Logging` `ConfigureScope` invocation. #208, #210, #224 Thanks @dbraillon 
-* `Sentry.Serilog` Verbose level. #213, #217. Thanks @kanadaj 
+* NLog: null check contextProp.Value during IncludeEventDataOnBreadcrumbs (#323)
+* JsonSerializerSettings - ReferenceLoopHandling.Ignore (#312)
+* Fixed error when reading request body affects collecting other request data (#299)
+* `Microsoft.Extensions.Logging` `ConfigureScope` invocation. #208, #210, #224 Thanks @dbraillon
+* `Sentry.Serilog` Verbose level. #213, #217. Thanks @kanadaj
 * AppDomain.ProcessExit will close the SDK: #242
 * Adds PublicApiAnalyzers to public projects: #234
 * NLog: Utilizes Flush functionality in NLog target: #228
-* NLog: Set the logger via the log event info in SentryTarget.Write, #227 
+* NLog: Set the logger via the log event info in SentryTarget.Write, #227
 * Multi-target .NET Core 3.0 (#308)
 
 Major version bumped due to these breaking changes:
@@ -243,18 +245,18 @@ Major version bumped due to these breaking changes:
 
 ## 2.0.0-beta8
 
-* SentryTarget - GetTagsFromLogEvent with null check (#326) 
+* SentryTarget - GetTagsFromLogEvent with null check (#326)
 * handled process corrupted (#328)
 * sourcelink GA (#330)
-* Adds ability to specify user values via NLog configuration (#336) 
+* Adds ability to specify user values via NLog configuration (#336)
 
 ## 2.0.0-beta7
 
 Fixes:
 
 * Reading request body throws on ASP.NET Core 3 (#324)
-* NLog: null check contextProp.Value during IncludeEventDataOnBreadcrumbs (#323) 
-* JsonSerializerSettings - ReferenceLoopHandling.Ignore (#312) 
+* NLog: null check contextProp.Value during IncludeEventDataOnBreadcrumbs (#323)
+* JsonSerializerSettings - ReferenceLoopHandling.Ignore (#312)
 
 Features:
 
@@ -262,7 +264,7 @@ Features:
 
 ## 2.0.0-beta6
 
-* Fixed error when reading request body affects collecting other request data (#299) 
+* Fixed error when reading request body affects collecting other request data (#299)
 
 ## 2.0.0-beta5
 
@@ -279,16 +281,16 @@ Features:
 
 ## 2.0.0-beta3
 
-* All public members were documented: #252 
+* All public members were documented: #252
 * Use EnableBuffering to keep request payload around: #250
-* Serilog default levels: #237 
+* Serilog default levels: #237
 
 Thanks @josh-degraw for:
 
 * AppDomain.ProcessExit will close the SDK: #242
 * Adds PublicApiAnalyzers to public projects: #234
 * NLog: Utilizes Flush functionality in NLog target: #228
-* NLog: Set the logger via the log event info in SentryTarget.Write, #227 
+* NLog: Set the logger via the log event info in SentryTarget.Write, #227
 
 ## 2.0.0-beta2
 
@@ -313,12 +315,12 @@ Other Features:
 
 Fixes:
 
-* `Microsoft.Extensions.Logging` `ConfigureScope` invocation. #208, #210, #224 Thanks @dbraillon 
-* `Sentry.Serilog` Verbose level. #213, #217. Thanks @kanadaj 
+* `Microsoft.Extensions.Logging` `ConfigureScope` invocation. #208, #210, #224 Thanks @dbraillon
+* `Sentry.Serilog` Verbose level. #213, #217. Thanks @kanadaj
 
 ## 1.2.1-beta
 
-Fixes and improvements to the NLog integration: #207 by @josh-degraw 
+Fixes and improvements to the NLog integration: #207 by @josh-degraw
 
 ## 1.2.0
 
@@ -344,7 +346,7 @@ Bug fix: Don't override user  #199
 ## 1.1.3-beta3
 
 * First NLog integration release #188 (Thanks @josh-degraw)
-* Extensible stack trace #184 (Thanks @pengweiqhca) 
+* Extensible stack trace #184 (Thanks @pengweiqhca)
 
 ## 1.1.3-beta2
 
@@ -409,7 +411,7 @@ Thanks to our growing list of [contributors](https://github.com/getsentry/sentry
 
 ## 1.0.1-beta5
 
-* Added `net461` target to Serilog package #148 
+* Added `net461` target to Serilog package #148
 
 ## 1.0.1-beta4
 
@@ -526,7 +528,7 @@ Features and improvements:
 
 * `SentrySdk.LastEventId` to get scoped id
 * `BeforeBreadcrumb` to allow dropping or modifying a breadcrumb
-* Event processors on scope #58 
+* Event processors on scope #58
 * Event processor as `Func<SentryEvent,SentryEvent>`
 
 Bug fixes:
@@ -576,18 +578,18 @@ Download it directly below from GitHub or using NuGet:
 
 Features:
 
-* Support buffered gzip request #73 
+* Support buffered gzip request #73
 * Reduced dependencies from the ASP.NET Core integraiton
 * InAppExclude configurable #75
-* Duplicate event detects inner exceptions #76 
+* Duplicate event detects inner exceptions #76
 * HttpClientHandler configuration callback #72
 * Event sampling opt-in
 * ASP.NET Core sends server name
 
 Bug fixes:
 
-* On-prem without chuncked support for gzip #71 
-* Exception.Data key is not string #77 
+* On-prem without chuncked support for gzip #71
+* Exception.Data key is not string #77
 
 ##### [Watch on youtube](https://www.youtube.com/watch?v=xK6a1goK_w0) how to use the ASP.NET Core integration.
 
@@ -612,9 +614,9 @@ Features:
 
 Bug fixes:
 
-* `Init` pushes the first scope #55, #54 
+* `Init` pushes the first scope #55, #54
 * `Exception.Data` copied to `SentryEvent.Data` while storing the index of originating error.
-* Demangling code ensures Function name available #64 
+* Demangling code ensures Function name available #64
 * ASP.NET Core integration throws when Serilog added #65, #68, #67
 
 Improvements to [the docs](https://getsentry.github.io/sentry-dotnet) like:
@@ -697,7 +699,7 @@ Main features:
 * Captures unhandled exceptions in the middleware pipeline
 * Captures exceptions handled by the framework `UseExceptionHandler` and Error page display.
 * Captures process-wide unhandled exceptions (AppDomain)
-* Captures logger.Error or logger.Critical 
+* Captures logger.Error or logger.Critical
 * When an event is sent, data from the current request augments the event.
 * Sends information about the server running the app (OS, Runtime, etc)
 * Informational logs written by the app or framework augment events sent to Sentry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 * Bump Microsoft.Bcl.AsyncInterfaces to 5.0.0 #618
 * Bump `Microsoft.Bcl.AsyncInterfaces` to 5.0.0 #618
 * `DefaultTags` moved from `SentryLoggingOptions` to `SentryOptions` (#637) @PureKrome
-* `Sentry.Serilog` can accept DefaultTags (#637) @PureKrome
+* `Sentry.Serilog` can accept DefaultTags (#637) @PureKrome 
 
 ## 3.0.0-alpha.5
 
@@ -106,9 +106,9 @@ We'd love to get feedback.
 
 ## 2.2.0-alpha
 
-Add nullable reference types support (Sentry, Sentry.Protocol) (#509)
-fix: Use ASP.NET Core endpoint FQDN (#485)
-feat: Add integration to TaskScheduler.UnobservedTaskException (#481)
+Add nullable reference types support (Sentry, Sentry.Protocol) (#509) 
+fix: Use ASP.NET Core endpoint FQDN (#485) 
+feat: Add integration to TaskScheduler.UnobservedTaskException (#481) 
 
 ## 2.1.6
 
@@ -153,13 +153,13 @@ build(deps): bump Microsoft.Extensions.Configuration.Json (#467) @dependabot-pre
 * SentryScopeManager - Fixed clone of Stack so it does not reverse order (#420) @snakefoot
 * build(deps): bump Serilog.AspNetCore from 2.1.1 to 3.2.0 (#411) @dependabot-preview
 * Removed dependency on System.Collections.Immutable (#405) @snakefoot
-* Fix Sentry.Microsoft.Logging Filter now drops also breadcrumbs (#440)
+* Fix Sentry.Microsoft.Logging Filter now drops also breadcrumbs (#440) 
 
 ## 2.1.2-beta5
 
-Fix Background worker dispose logs error message (#408)
-Fix sentry serilog extension method collapsing (#406)
-Fix Sentry.Samples.NLog so NLog.config is valid (#404)
+Fix Background worker dispose logs error message (#408) 
+Fix sentry serilog extension method collapsing (#406) 
+Fix Sentry.Samples.NLog so NLog.config is valid (#404) 
 
 Thanks @snakefoot and @JimHume for the fixes
 
@@ -181,10 +181,10 @@ Fixed ASP.NET System.Web catch HttpException to prevent the request processor fr
 ## 2.1.1
 
 Bug fix:  Don't overwrite server name set via configuration with machine name on ASP.NET Core #372
-
+ 
 ## 2.1.0
 
-* Set score url to fully constructed url #367 Thanks @christopher-taormina-zocdoc
+* Set score url to fully constructed url #367 Thanks @christopher-taormina-zocdoc 
 * Don't dedupe from inner exception #363 - Note this might change groupings. It's opt-in.
 * Expose FlushAsync to intellisense #362
 * Protocol monorepo #325 - new protocol version whenever there's a new SDK release
@@ -206,10 +206,10 @@ Removed `-beta` from dependencies.
 
 ## 2.0.0
 
-* SentryTarget - GetTagsFromLogEvent with null check (#326)
+* SentryTarget - GetTagsFromLogEvent with null check (#326) 
 * handled process corrupted (#328)
 * sourcelink GA (#330)
-* Adds ability to specify user values via NLog configuration (#336)
+* Adds ability to specify user values via NLog configuration (#336) 
 * Add option to ASP.NET Core to flush events after response complete (#288)
 * Fixed race on `BackgroundWorker`  (#293)
 * Exclude `Sentry.` frames from InApp (#272)
@@ -217,23 +217,23 @@ Removed `-beta` from dependencies.
 * Logging on body not extracted (#246)
 * Add support to DefaultTags for ASP.NET Core and M.E.Logging (#268)
 * Don't use ValueTuple (#263)
-* All public members were documented: #252
+* All public members were documented: #252 
 * Use EnableBuffering to keep request payload around: #250
-* Serilog default levels: #237
+* Serilog default levels: #237 
 * Removed dev dependency from external dependencies 4d92ab0
 * Use new `Sentry.Protocol` 836fb07e
 * Use new `Sentry.PlatformAbsrtractions` #226
-* Debug logging for ASP.NET Classic #209
+* Debug logging for ASP.NET Classic #209 
 * Reading request body throws on ASP.NET Core 3 (#324)
-* NLog: null check contextProp.Value during IncludeEventDataOnBreadcrumbs (#323)
-* JsonSerializerSettings - ReferenceLoopHandling.Ignore (#312)
-* Fixed error when reading request body affects collecting other request data (#299)
-* `Microsoft.Extensions.Logging` `ConfigureScope` invocation. #208, #210, #224 Thanks @dbraillon
-* `Sentry.Serilog` Verbose level. #213, #217. Thanks @kanadaj
+* NLog: null check contextProp.Value during IncludeEventDataOnBreadcrumbs (#323) 
+* JsonSerializerSettings - ReferenceLoopHandling.Ignore (#312) 
+* Fixed error when reading request body affects collecting other request data (#299) 
+* `Microsoft.Extensions.Logging` `ConfigureScope` invocation. #208, #210, #224 Thanks @dbraillon 
+* `Sentry.Serilog` Verbose level. #213, #217. Thanks @kanadaj 
 * AppDomain.ProcessExit will close the SDK: #242
 * Adds PublicApiAnalyzers to public projects: #234
 * NLog: Utilizes Flush functionality in NLog target: #228
-* NLog: Set the logger via the log event info in SentryTarget.Write, #227
+* NLog: Set the logger via the log event info in SentryTarget.Write, #227 
 * Multi-target .NET Core 3.0 (#308)
 
 Major version bumped due to these breaking changes:
@@ -245,18 +245,18 @@ Major version bumped due to these breaking changes:
 
 ## 2.0.0-beta8
 
-* SentryTarget - GetTagsFromLogEvent with null check (#326)
+* SentryTarget - GetTagsFromLogEvent with null check (#326) 
 * handled process corrupted (#328)
 * sourcelink GA (#330)
-* Adds ability to specify user values via NLog configuration (#336)
+* Adds ability to specify user values via NLog configuration (#336) 
 
 ## 2.0.0-beta7
 
 Fixes:
 
 * Reading request body throws on ASP.NET Core 3 (#324)
-* NLog: null check contextProp.Value during IncludeEventDataOnBreadcrumbs (#323)
-* JsonSerializerSettings - ReferenceLoopHandling.Ignore (#312)
+* NLog: null check contextProp.Value during IncludeEventDataOnBreadcrumbs (#323) 
+* JsonSerializerSettings - ReferenceLoopHandling.Ignore (#312) 
 
 Features:
 
@@ -264,7 +264,7 @@ Features:
 
 ## 2.0.0-beta6
 
-* Fixed error when reading request body affects collecting other request data (#299)
+* Fixed error when reading request body affects collecting other request data (#299) 
 
 ## 2.0.0-beta5
 
@@ -281,16 +281,16 @@ Features:
 
 ## 2.0.0-beta3
 
-* All public members were documented: #252
+* All public members were documented: #252 
 * Use EnableBuffering to keep request payload around: #250
-* Serilog default levels: #237
+* Serilog default levels: #237 
 
 Thanks @josh-degraw for:
 
 * AppDomain.ProcessExit will close the SDK: #242
 * Adds PublicApiAnalyzers to public projects: #234
 * NLog: Utilizes Flush functionality in NLog target: #228
-* NLog: Set the logger via the log event info in SentryTarget.Write, #227
+* NLog: Set the logger via the log event info in SentryTarget.Write, #227 
 
 ## 2.0.0-beta2
 
@@ -315,12 +315,12 @@ Other Features:
 
 Fixes:
 
-* `Microsoft.Extensions.Logging` `ConfigureScope` invocation. #208, #210, #224 Thanks @dbraillon
-* `Sentry.Serilog` Verbose level. #213, #217. Thanks @kanadaj
+* `Microsoft.Extensions.Logging` `ConfigureScope` invocation. #208, #210, #224 Thanks @dbraillon 
+* `Sentry.Serilog` Verbose level. #213, #217. Thanks @kanadaj 
 
 ## 1.2.1-beta
 
-Fixes and improvements to the NLog integration: #207 by @josh-degraw
+Fixes and improvements to the NLog integration: #207 by @josh-degraw 
 
 ## 1.2.0
 
@@ -346,7 +346,7 @@ Bug fix: Don't override user  #199
 ## 1.1.3-beta3
 
 * First NLog integration release #188 (Thanks @josh-degraw)
-* Extensible stack trace #184 (Thanks @pengweiqhca)
+* Extensible stack trace #184 (Thanks @pengweiqhca) 
 
 ## 1.1.3-beta2
 
@@ -411,7 +411,7 @@ Thanks to our growing list of [contributors](https://github.com/getsentry/sentry
 
 ## 1.0.1-beta5
 
-* Added `net461` target to Serilog package #148
+* Added `net461` target to Serilog package #148 
 
 ## 1.0.1-beta4
 
@@ -528,7 +528,7 @@ Features and improvements:
 
 * `SentrySdk.LastEventId` to get scoped id
 * `BeforeBreadcrumb` to allow dropping or modifying a breadcrumb
-* Event processors on scope #58
+* Event processors on scope #58 
 * Event processor as `Func<SentryEvent,SentryEvent>`
 
 Bug fixes:
@@ -578,18 +578,18 @@ Download it directly below from GitHub or using NuGet:
 
 Features:
 
-* Support buffered gzip request #73
+* Support buffered gzip request #73 
 * Reduced dependencies from the ASP.NET Core integraiton
 * InAppExclude configurable #75
-* Duplicate event detects inner exceptions #76
+* Duplicate event detects inner exceptions #76 
 * HttpClientHandler configuration callback #72
 * Event sampling opt-in
 * ASP.NET Core sends server name
 
 Bug fixes:
 
-* On-prem without chuncked support for gzip #71
-* Exception.Data key is not string #77
+* On-prem without chuncked support for gzip #71 
+* Exception.Data key is not string #77 
 
 ##### [Watch on youtube](https://www.youtube.com/watch?v=xK6a1goK_w0) how to use the ASP.NET Core integration.
 
@@ -614,9 +614,9 @@ Features:
 
 Bug fixes:
 
-* `Init` pushes the first scope #55, #54
+* `Init` pushes the first scope #55, #54 
 * `Exception.Data` copied to `SentryEvent.Data` while storing the index of originating error.
-* Demangling code ensures Function name available #64
+* Demangling code ensures Function name available #64 
 * ASP.NET Core integration throws when Serilog added #65, #68, #67
 
 Improvements to [the docs](https://getsentry.github.io/sentry-dotnet) like:
@@ -699,7 +699,7 @@ Main features:
 * Captures unhandled exceptions in the middleware pipeline
 * Captures exceptions handled by the framework `UseExceptionHandler` and Error page display.
 * Captures process-wide unhandled exceptions (AppDomain)
-* Captures logger.Error or logger.Critical
+* Captures logger.Error or logger.Critical 
 * When an event is sent, data from the current request augments the event.
 * Sends information about the server running the app (OS, Runtime, etc)
 * Informational logs written by the app or framework augment events sent to Sentry

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!--Automatic upward search ends when first file found. From here we need to manually import parent props/targets
         https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build -->
-  <Import Project="..\Directory.Build.props" />
+  <Import Project="..\Directory.Build.props"/>
 
   <PropertyGroup>
     <!--Generate xml docs for all projects under 'src'-->
@@ -23,8 +23,6 @@
     <PackageProjectUrl>https://sentry.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
-    <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/../../CHANGELOG.md"))</PackageReleaseNotes>
-
     <!-- Prop required by Microsoft.SourceLink.GitHub -->
     <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -42,23 +40,33 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <ChangelogFile>$(SolutionDir)/CHANGELOG.md</ChangelogFile>
+    <AppendToReleaseNotesProperty>
+      <![CDATA[-->
+      See full changelog at https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md]]>
+    </AppendToReleaseNotesProperty>
+    <VersionRegex>^## (.+)</VersionRegex>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="../../.assets/sentry-nuget.png" Pack="true" PackagePath=""/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0" PrivateAssets="All" Condition="'$(Configuration)' != 'Release'" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0" PrivateAssets="All" Condition="'$(Configuration)' != 'Release'"/>
   </ItemGroup>
 
   <ItemGroup>
-<!--    To uncomment when Sentry.Protocol is added in-->
-<!--    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="2.9.3" PrivateAssets="All" />-->
+    <!--    To uncomment when Sentry.Protocol is added in-->
+    <!--    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="2.9.3" PrivateAssets="All" />-->
 
     <!-- To add files to the PublicAPI.Unshipped file, use a VS quick action. Once shipped, move to PublicAPI.Shipped.txt -->
-    <None Remove="PublicAPI.Shipped.txt" />
+    <None Remove="PublicAPI.Shipped.txt"/>
     <None Remove="PublicAPI.Unshipped.txt"/>
-    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
-    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Shipped.txt"/>
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolves #742.

This PR uses an MSBuild task from https://github.com/sillsdev/SIL.BuildTasks. A caveat to using this would be that it follows the conventions of https://keepachangelog.com/en/1.0.0/.