### PR TITLE
Integrate trace headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - Add support for dynamic transaction sampling. (#753) @Tyrrrz
+- Integrate trace headers. (#758) @Tyrrrz
 
 ## 3.0.0-beta.0
 

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -65,7 +65,7 @@ namespace Sentry.Extensibility
         /// <summary>
         /// Returns null.
         /// </summary>
-        public SentryTraceHeader? GetSentryTrace() => null;
+        public SentryTraceHeader? GetTraceHeader() => null;
 
         /// <summary>
         /// No-Op.

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -82,7 +82,7 @@ namespace Sentry.Extensibility
         /// <summary>
         /// No-Op.
         /// </summary>
-        public void CaptureTransaction(Transaction transaction)
+        public void CaptureTransaction(ITransaction transaction)
         {
         }
 

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -153,7 +153,7 @@ namespace Sentry.Extensibility
         /// </summary>
         [DebuggerStepThrough]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void CaptureTransaction(Transaction transaction)
+        public void CaptureTransaction(ITransaction transaction)
             => SentrySdk.CaptureTransaction(transaction);
 
         /// <summary>

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -84,7 +84,7 @@ namespace Sentry.Extensibility
         /// Forwards the call to <see cref="SentrySdk"/>.
         /// </summary>
         [DebuggerStepThrough]
-        public SentryTraceHeader? GetSentryTrace()
+        public SentryTraceHeader? GetTraceHeader()
             => SentrySdk.GetTraceHeader();
 
         /// <summary>

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -43,6 +43,27 @@ namespace Sentry
         }
 
         /// <summary>
+        /// Starts a transaction from the specified trace header.
+        /// </summary>
+        public static ITransaction StartTransaction(
+            this IHub hub,
+            string name,
+            string operation,
+            SentryTraceHeader traceHeader)
+        {
+            var context = new TransactionContext(
+                // SpanId from the header becomes ParentSpanId on this transaction
+                traceHeader.SpanId,
+                traceHeader.TraceId,
+                name,
+                operation,
+                traceHeader.IsSampled
+            );
+
+            return hub.StartTransaction(context);
+        }
+
+        /// <summary>
         /// Adds a breadcrumb to the current scope.
         /// </summary>
         /// <param name="hub">The Hub which holds the scope stack.</param>

--- a/src/Sentry/IHub.cs
+++ b/src/Sentry/IHub.cs
@@ -31,8 +31,8 @@ namespace Sentry
         );
 
         /// <summary>
-        /// Gets the sentry trace header.
+        /// Gets the Sentry trace header for the last active span.
         /// </summary>
-        SentryTraceHeader? GetSentryTrace();
+        SentryTraceHeader? GetTraceHeader();
     }
 }

--- a/src/Sentry/ISentryClient.cs
+++ b/src/Sentry/ISentryClient.cs
@@ -31,8 +31,12 @@ namespace Sentry
         /// <summary>
         /// Captures a transaction.
         /// </summary>
+        /// <remarks>
+        /// Note: this method is not meant to be called from user code!
+        /// Instead, call <see cref="ISpan.Finish"/> on the transaction reference.
+        /// </remarks>
         /// <param name="transaction">The transaction.</param>
-        void CaptureTransaction(Transaction transaction);
+        void CaptureTransaction(ITransaction transaction);
 
         /// <summary>
         /// Flushes events queued up.

--- a/src/Sentry/ISentryClient.cs
+++ b/src/Sentry/ISentryClient.cs
@@ -32,8 +32,8 @@ namespace Sentry
         /// Captures a transaction.
         /// </summary>
         /// <remarks>
-        /// Note: this method is not meant to be called from user code!
-        /// Instead, call <see cref="ISpan.Finish"/> on the transaction reference.
+        /// Note: this method is NOT meant to be called from user code!
+        /// Instead, call <see cref="ISpan.Finish"/> on the transaction.
         /// </remarks>
         /// <param name="transaction">The transaction.</param>
         void CaptureTransaction(ITransaction transaction);

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -158,6 +158,7 @@ namespace Sentry.Internal
 
         public SentryTraceHeader? GetSentryTrace()
         {
+            // TODO:
             var (currentScope, _) = ScopeManager.GetCurrent();
             return currentScope.Transaction?.GetTraceHeader();
         }

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -191,11 +191,20 @@ namespace Sentry.Internal
             }
         }
 
-        public void CaptureTransaction(Transaction transaction)
+        public void CaptureTransaction(ITransaction transaction)
         {
             try
             {
                 _ownedClient.CaptureTransaction(transaction);
+
+                // Clear the transaction from the scope
+                ScopeManager.WithScope(scope =>
+                {
+                    if (scope.Transaction == transaction)
+                    {
+                        scope.Transaction = null;
+                    }
+                });
             }
             catch (Exception e)
             {

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -156,11 +156,10 @@ namespace Sentry.Internal
             return transaction;
         }
 
-        public SentryTraceHeader? GetSentryTrace()
+        public SentryTraceHeader? GetTraceHeader()
         {
-            // TODO:
             var (currentScope, _) = ScopeManager.GetCurrent();
-            return currentScope.Transaction?.GetTraceHeader();
+            return currentScope.GetSpan()?.GetTraceHeader();
         }
 
         public SentryId CaptureEvent(SentryEvent evt, Scope? scope = null)

--- a/src/Sentry/Protocol/Envelopes/Envelope.cs
+++ b/src/Sentry/Protocol/Envelopes/Envelope.cs
@@ -115,7 +115,7 @@ namespace Sentry.Protocol.Envelopes
         /// <summary>
         /// Creates an envelope that contains a single transaction.
         /// </summary>
-        public static Envelope FromTransaction(Transaction transaction)
+        public static Envelope FromTransaction(ITransaction transaction)
         {
             var header = new Dictionary<string, object?>(StringComparer.Ordinal)
             {

--- a/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
@@ -144,14 +144,14 @@ namespace Sentry.Protocol.Envelopes
         /// <summary>
         /// Creates an envelope item from transaction.
         /// </summary>
-        public static EnvelopeItem FromTransaction(Transaction transaction)
+        public static EnvelopeItem FromTransaction(ITransaction transaction)
         {
             var header = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
                 [TypeKey] = TypeValueTransaction
             };
 
-            return new EnvelopeItem(header, new JsonSerializable(transaction));
+            return new EnvelopeItem(header, new JsonSerializable((IJsonSerializable)transaction));
         }
 
         /// <summary>

--- a/src/Sentry/Protocol/IJsonSerializable.cs
+++ b/src/Sentry/Protocol/IJsonSerializable.cs
@@ -13,6 +13,10 @@ namespace Sentry.Protocol
         /// <summary>
         /// Writes the object as JSON.
         /// </summary>
+        /// <remarks>
+        /// Note: this method is meant only for internal use and is exposed due to a language limitation.
+        /// Avoid relying on this method in user code.
+        /// </remarks>
         void WriteTo(Utf8JsonWriter writer);
     }
 

--- a/src/Sentry/Protocol/ISpan.cs
+++ b/src/Sentry/Protocol/ISpan.cs
@@ -36,6 +36,11 @@ namespace Sentry.Protocol
         DateTimeOffset? EndTimestamp { get; }
 
         /// <summary>
+        /// Whether the span is finished.
+        /// </summary>
+        bool IsFinished { get; }
+
+        /// <summary>
         /// Starts a child span.
         /// </summary>
         ISpan StartChild(string operation);
@@ -44,6 +49,11 @@ namespace Sentry.Protocol
         /// Finishes the span.
         /// </summary>
         void Finish();
+
+        /// <summary>
+        /// Get Sentry trace header.
+        /// </summary>
+        SentryTraceHeader GetTraceHeader();
     }
 
     /// <summary>

--- a/src/Sentry/Protocol/ITransaction.cs
+++ b/src/Sentry/Protocol/ITransaction.cs
@@ -24,8 +24,8 @@ namespace Sentry.Protocol
         IReadOnlyCollection<ISpan> Spans { get; }
 
         /// <summary>
-        /// Get Sentry trace header.
+        /// Gets the last active (not finished) span in this transaction.
         /// </summary>
-        SentryTraceHeader GetTraceHeader();
+        ISpan? GetLastActiveSpan();
     }
 }

--- a/src/Sentry/Protocol/SentryTraceHeader.cs
+++ b/src/Sentry/Protocol/SentryTraceHeader.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace Sentry.Protocol
 {
@@ -82,5 +84,26 @@ namespace Sentry.Protocol
 
             return new SentryTraceHeader(traceId, spanId, isSampled);
         }
+
+        /// <summary>
+        /// Parses <see cref="SentryTraceHeader"/> from HTTP headers.
+        /// </summary>
+        public static SentryTraceHeader Parse(HttpHeaders headers)
+        {
+            if (!headers.TryGetValues(HeaderName, out var values) ||
+                !(values?.FirstOrDefault() is { } headerValue))
+            {
+                // TODO: we probably need a TryParse for this as it's gonna be common
+                throw new InvalidOperationException("Sentry trace header is not set.");
+            }
+
+            return Parse(headerValue);
+        }
+
+        /// <summary>
+        /// Parses <see cref="SentryTraceHeader"/> from an HTTP response.
+        /// </summary>
+        public static SentryTraceHeader Parse(HttpResponseMessage response) =>
+            Parse(response.Headers);
     }
 }

--- a/src/Sentry/Protocol/SentryTraceHeader.cs
+++ b/src/Sentry/Protocol/SentryTraceHeader.cs
@@ -38,26 +38,27 @@ namespace Sentry.Protocol
         }
 
         /// <summary>
-        /// Injects trace information into the headers of the specified HTTP request.
+        /// Injects trace information into HTTP headers.
         /// </summary>
-        public void Inject(HttpRequestMessage request)
+        public void Inject(HttpHeaders headers)
         {
             var headerValue = ToString();
 
-            request.Headers.Remove(HeaderName);
-            request.Headers.Add(HeaderName, headerValue);
+            headers.Remove(HeaderName);
+            headers.Add(HeaderName, headerValue);
         }
+
+        /// <summary>
+        /// Injects trace information into the headers of the specified HTTP request.
+        /// </summary>
+        public void Inject(HttpRequestMessage request) =>
+            Inject(request.Headers);
 
         /// <summary>
         /// Injects trace information into the default headers of the specified HTTP client.
         /// </summary>
-        public void Inject(HttpClient client)
-        {
-            var headerValue = ToString();
-
-            client.DefaultRequestHeaders.Remove(HeaderName);
-            client.DefaultRequestHeaders.Add(HeaderName, headerValue);
-        }
+        public void Inject(HttpClient client) =>
+            Inject(client.DefaultRequestHeaders);
 
         /// <inheritdoc />
         public override string ToString() => IsSampled is {} isSampled

--- a/src/Sentry/Protocol/SentryTraceHeader.cs
+++ b/src/Sentry/Protocol/SentryTraceHeader.cs
@@ -84,26 +84,5 @@ namespace Sentry.Protocol
 
             return new SentryTraceHeader(traceId, spanId, isSampled);
         }
-
-        /// <summary>
-        /// Parses <see cref="SentryTraceHeader"/> from HTTP headers.
-        /// </summary>
-        public static SentryTraceHeader Parse(HttpHeaders headers)
-        {
-            if (!headers.TryGetValues(HeaderName, out var values) ||
-                !(values?.FirstOrDefault() is { } headerValue))
-            {
-                // TODO: we probably need a TryParse for this as it's gonna be common
-                throw new InvalidOperationException("Sentry trace header is not set.");
-            }
-
-            return Parse(headerValue);
-        }
-
-        /// <summary>
-        /// Parses <see cref="SentryTraceHeader"/> from an HTTP response.
-        /// </summary>
-        public static SentryTraceHeader Parse(HttpResponseMessage response) =>
-            Parse(response.Headers);
     }
 }

--- a/src/Sentry/Protocol/SentryTraceHeader.cs
+++ b/src/Sentry/Protocol/SentryTraceHeader.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
 
 namespace Sentry.Protocol
 {
@@ -10,7 +7,7 @@ namespace Sentry.Protocol
     /// </summary>
     public class SentryTraceHeader
     {
-        private const string HeaderName = "sentry-trace";
+        internal const string HttpHeaderName = "sentry-trace";
 
         /// <summary>
         /// Trace ID.
@@ -36,29 +33,6 @@ namespace Sentry.Protocol
             SpanId = spanSpanId;
             IsSampled = isSampled;
         }
-
-        /// <summary>
-        /// Injects trace information into HTTP headers.
-        /// </summary>
-        public void Inject(HttpHeaders headers)
-        {
-            var headerValue = ToString();
-
-            headers.Remove(HeaderName);
-            headers.Add(HeaderName, headerValue);
-        }
-
-        /// <summary>
-        /// Injects trace information into the headers of the specified HTTP request.
-        /// </summary>
-        public void Inject(HttpRequestMessage request) =>
-            Inject(request.Headers);
-
-        /// <summary>
-        /// Injects trace information into the default headers of the specified HTTP client.
-        /// </summary>
-        public void Inject(HttpClient client) =>
-            Inject(client.DefaultRequestHeaders);
 
         /// <inheritdoc />
         public override string ToString() => IsSampled is {} isSampled

--- a/src/Sentry/Protocol/Span.cs
+++ b/src/Sentry/Protocol/Span.cs
@@ -33,6 +33,9 @@ namespace Sentry.Protocol
         /// <inheritdoc />
         public DateTimeOffset? EndTimestamp { get; private set; }
 
+        /// <inheritdoc />
+        public bool IsFinished => EndTimestamp is not null;
+
         /// <inheritdoc cref="ISpan.Operation" />
         public string Operation { get; set; }
 
@@ -85,6 +88,13 @@ namespace Sentry.Protocol
 
         /// <inheritdoc />
         public void Finish() => EndTimestamp = DateTimeOffset.UtcNow;
+
+        /// <inheritdoc />
+        public SentryTraceHeader GetTraceHeader() => new(
+            TraceId,
+            SpanId,
+            IsSampled
+        );
 
         /// <inheritdoc />
         public void WriteTo(Utf8JsonWriter writer)

--- a/src/Sentry/Protocol/Transaction.cs
+++ b/src/Sentry/Protocol/Transaction.cs
@@ -65,10 +65,10 @@ namespace Sentry.Protocol
         public string Name { get; set; }
 
         /// <inheritdoc />
-        public DateTimeOffset StartTimestamp { get; private set; } = DateTimeOffset.UtcNow;
+        public DateTimeOffset StartTimestamp { get; internal set; } = DateTimeOffset.UtcNow;
 
         /// <inheritdoc />
-        public DateTimeOffset? EndTimestamp { get; private set; }
+        public DateTimeOffset? EndTimestamp { get; internal set; }
 
         /// <inheritdoc cref="ISpan.Operation" />
         public string Operation

--- a/src/Sentry/Protocol/Transaction.cs
+++ b/src/Sentry/Protocol/Transaction.cs
@@ -170,6 +170,9 @@ namespace Sentry.Protocol
         /// <inheritdoc />
         public IReadOnlyCollection<ISpan> Spans => _spansLazy.Value;
 
+        /// <inheritdoc />
+        public bool IsFinished => EndTimestamp is not null;
+
         // This constructor is used for deserialization purposes.
         // It's required because some of the fields are mapped on 'contexts.trace'.
         // When deserializing, we don't parse those fields explicitly, but
@@ -250,6 +253,9 @@ namespace Sentry.Protocol
             // Client decides whether to discard this transaction based on sampling
             _client.CaptureTransaction(this);
         }
+
+        /// <inheritdoc />
+        public ISpan? GetLastActiveSpan() => Spans.LastOrDefault(s => !s.IsFinished);
 
         /// <inheritdoc />
         public SentryTraceHeader GetTraceHeader() => new(

--- a/src/Sentry/Protocol/TransactionContext.cs
+++ b/src/Sentry/Protocol/TransactionContext.cs
@@ -29,11 +29,12 @@
         /// Initializes an instance of <see cref="TransactionContext"/>.
         /// </summary>
         public TransactionContext(
+            SpanId? parentSpanId,
+            SentryId traceId,
             string name,
             string operation,
-            string description,
             bool? isSampled)
-            : this(SpanId.Create(), null, SentryId.Create(), name, operation, description, null, isSampled)
+            : this(SpanId.Create(), parentSpanId, traceId, name, operation, "", null, isSampled)
         {
         }
 
@@ -44,7 +45,7 @@
             string name,
             string operation,
             bool? isSampled)
-            : this(name, operation, "", isSampled)
+            : this(null, SentryId.Create(), name, operation, isSampled)
         {
         }
 

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -382,5 +382,11 @@ namespace Sentry
                 }
             }
         }
+
+        /// <summary>
+        /// Gets the currently ongoing (not finished) span or <code>null</code> if none available.
+        /// This relies on the transactions being manually set on the scope via <see cref="Transaction"/>.
+        /// </summary>
+        public ISpan? GetSpan() => Transaction?.GetLastActiveSpan();
     }
 }

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -387,6 +387,6 @@ namespace Sentry
         /// Gets the currently ongoing (not finished) span or <code>null</code> if none available.
         /// This relies on the transactions being manually set on the scope via <see cref="Transaction"/>.
         /// </summary>
-        public ISpan? GetSpan() => Transaction?.GetLastActiveSpan();
+        public ISpan? GetSpan() => Transaction?.GetLastActiveSpan() ?? Transaction;
     }
 }

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -129,19 +129,23 @@ namespace Sentry
                 return;
             }
 
+            // Unfinished transaction can only happen if the user calls this method instead of
+            // transaction.Finish().
+            // We still send these transactions over, but warn the user not to do it.
             if (!transaction.IsFinished)
             {
                 _options.DiagnosticLogger?.LogWarning(
-                    "Transaction dropped because it's not finished. " +
-                    "You don't need to call hub.CaptureTransaction(...) directly. " +
-                    "Instead call transaction.Finish() to finalize and send the transaction to Sentry."
+                    "Sending a transaction which was not finished. " +
+                    "Please call transaction.Finish() instead of hub.CaptureTransaction(transaction) " +
+                    "to properly finalize the transaction and send it to Sentry."
                 );
-
-                return;
             }
 
             // Sampling decision MUST have been made at this point
-            Debug.Assert(transaction.IsSampled != null, "Attempt to capture transaction without sampling decision.");
+            Debug.Assert(
+                transaction.IsSampled != null,
+                "Attempt to capture transaction without sampling decision."
+            );
 
             if (transaction.IsSampled != true)
             {

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -129,6 +129,17 @@ namespace Sentry
                 return;
             }
 
+            if (!transaction.IsFinished)
+            {
+                _options.DiagnosticLogger?.LogWarning(
+                    "Transaction dropped because it's not finished. " +
+                    "Don't call hub.CaptureTransaction(...) directly. " +
+                    "Instead call transaction.Finish() to finalize and send the transaction to Sentry."
+                );
+
+                return;
+            }
+
             // Sampling decision MUST have been made at this point
             Debug.Assert(transaction.IsSampled != null, "Attempt to capture transaction without sampling decision.");
 

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -103,7 +103,7 @@ namespace Sentry
         }
 
         /// <inheritdoc />
-        public void CaptureTransaction(Transaction transaction)
+        public void CaptureTransaction(ITransaction transaction)
         {
             if (_disposed)
             {

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -133,7 +133,7 @@ namespace Sentry
             {
                 _options.DiagnosticLogger?.LogWarning(
                     "Transaction dropped because it's not finished. " +
-                    "Don't call hub.CaptureTransaction(...) directly. " +
+                    "You don't need to call hub.CaptureTransaction(...) directly. " +
                     "Instead call transaction.Finish() to finalize and send the transaction to Sentry."
                 );
 

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -135,7 +135,7 @@ namespace Sentry
             if (!transaction.IsFinished)
             {
                 _options.DiagnosticLogger?.LogWarning(
-                    "Sending a transaction which was not finished. " +
+                    "Capturing a transaction which has not been finished. " +
                     "Please call transaction.Finish() instead of hub.CaptureTransaction(transaction) " +
                     "to properly finalize the transaction and send it to Sentry."
                 );

--- a/src/Sentry/SentryHttpMessageHandler.cs
+++ b/src/Sentry/SentryHttpMessageHandler.cs
@@ -1,0 +1,72 @@
+﻿using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Sentry.Extensibility;
+using Sentry.Protocol;
+
+namespace Sentry
+{
+    /// <summary>
+    /// Special HTTP message handler that can be used to propagate Sentry headers and other contextual information.
+    /// </summary>
+    public class SentryHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpMessageInvoker _httpMessageInvoker;
+        private readonly IHub _hub;
+
+        private SentryHttpMessageHandler(HttpMessageInvoker httpMessageInvoker, IHub hub)
+        {
+            _httpMessageInvoker = httpMessageInvoker;
+            _hub = hub;
+        }
+
+        /// <summary>
+        /// Initializes an instance of <see cref="SentryHttpMessageHandler"/>.
+        /// </summary>
+        public SentryHttpMessageHandler(HttpMessageHandler innerHandler, IHub hub)
+            : this(new HttpMessageInvoker(innerHandler, false), hub) {}
+
+        /// <summary>
+        /// Initializes an instance of <see cref="SentryHttpMessageHandler"/>.
+        /// </summary>
+        public SentryHttpMessageHandler(HttpMessageHandler innerHandler)
+            : this(innerHandler, HubAdapter.Instance) {}
+
+        /// <summary>
+        /// Initializes an instance of <see cref="SentryHttpMessageHandler"/>.
+        /// </summary>
+        public SentryHttpMessageHandler(IHub hub)
+            : this(new HttpMessageInvoker(new HttpClientHandler(), true), hub) {}
+
+        /// <summary>
+        /// Initializes an instance of <see cref="SentryHttpMessageHandler"/>.
+        /// </summary>
+        public SentryHttpMessageHandler()
+            : this(HubAdapter.Instance) {}
+
+        /// <inheritdoc />
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            // Set trace header if it hasn't already been set
+            if (!request.Headers.Contains(SentryTraceHeader.HttpHeaderName) &&
+                _hub.GetTraceHeader() is {} traceHeader)
+            {
+                request.Headers.Add(
+                    SentryTraceHeader.HttpHeaderName,
+                    traceHeader.ToString()
+                );
+            }
+
+            return _httpMessageInvoker.SendAsync(request, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            _httpMessageInvoker.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -346,6 +346,13 @@ namespace Sentry
             => _hub.StartTransaction(name, operation, description);
 
         /// <summary>
+        /// Starts a transaction.
+        /// </summary>
+        [DebuggerStepThrough]
+        public static ITransaction StartTransaction(string name, string operation, SentryTraceHeader traceHeader)
+            => _hub.StartTransaction(name, operation, traceHeader);
+
+        /// <summary>
         /// Gets the Sentry trace header.
         /// </summary>
         [DebuggerStepThrough]

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -312,7 +312,7 @@ namespace Sentry
         /// Captures a transaction.
         /// </summary>
         [DebuggerStepThrough]
-        public static void CaptureTransaction(Transaction transaction)
+        public static void CaptureTransaction(ITransaction transaction)
             => _hub.CaptureTransaction(transaction);
 
         /// <summary>

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -357,6 +357,6 @@ namespace Sentry
         /// </summary>
         [DebuggerStepThrough]
         public static SentryTraceHeader? GetTraceHeader()
-            => _hub.GetSentryTrace();
+            => _hub.GetTraceHeader();
     }
 }

--- a/test/Sentry.Testing/HttpClientExtensions.cs
+++ b/test/Sentry.Testing/HttpClientExtensions.cs
@@ -38,17 +38,20 @@ namespace Sentry
             }
 
             // Content
-            var cloneContentStream = new MemoryStream();
-
-            await source.Content.CopyToAsync(cloneContentStream).ConfigureAwait(false);
-            cloneContentStream.Position = 0;
-
-            clone.Content = new StreamContent(cloneContentStream);
-
-            // Content headers
-            foreach (var (key, value) in source.Content.Headers)
+            if (source.Content != null)
             {
-                clone.Content.Headers.Add(key, value);
+                var cloneContentStream = new MemoryStream();
+
+                await source.Content.CopyToAsync(cloneContentStream).ConfigureAwait(false);
+                cloneContentStream.Position = 0;
+
+                clone.Content = new StreamContent(cloneContentStream);
+
+                // Content headers
+                foreach (var (key, value) in source.Content.Headers)
+                {
+                    clone.Content.Headers.Add(key, value);
+                }
             }
 
             return clone;

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -329,5 +329,31 @@ namespace NotSentry.Tests
             // Assert
             transaction.IsSampled.Should().BeFalse();
         }
+
+        [Fact]
+        public void GetTraceHeader_ReturnsHeaderForActiveSpan()
+        {
+            // Arrange
+            var hub = new Hub(new SentryOptions
+            {
+                Dsn = DsnSamples.ValidDsnWithSecret
+            });
+
+            var transaction = hub.StartTransaction("foo", "bar");
+
+            // Act
+            hub.WithScope(scope =>
+            {
+                scope.Transaction = transaction;
+
+                var header = hub.GetTraceHeader();
+
+                // Assert
+                header.Should().NotBeNull();
+                header?.SpanId.Should().Be(transaction.SpanId);
+                header?.TraceId.Should().Be(transaction.TraceId);
+                header?.IsSampled.Should().Be(transaction.IsSampled);
+            });
+        }
     }
 }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -355,5 +355,27 @@ namespace NotSentry.Tests
                 header?.IsSampled.Should().Be(transaction.IsSampled);
             });
         }
+
+        [Fact]
+        public void CaptureTransaction_AfterTransactionFinishes_ResetsTransactionOnScope()
+        {
+            // Arrange
+            var client = Substitute.For<ISentryClient>();
+
+            var hub = new Hub(client, new SentryOptions
+            {
+                Dsn = DsnSamples.ValidDsnWithSecret
+            });
+
+            var transaction = hub.StartTransaction("foo", "bar");
+
+            hub.WithScope(scope => scope.Transaction = transaction);
+
+            // Act
+            transaction.Finish();
+
+            // Assert
+            hub.WithScope(scope => scope.Transaction.Should().BeNull());
+        }
     }
 }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -163,6 +163,30 @@ namespace NotSentry.Tests
         }
 
         [Fact]
+        public void StartTransaction_FromTraceHeader_Works()
+        {
+            // Arrange
+            var hub = new Hub(new SentryOptions
+            {
+                Dsn = DsnSamples.ValidDsnWithSecret
+            });
+
+            var traceHeader = new SentryTraceHeader(
+                SentryId.Parse("75302ac48a024bde9a3b3734a82e36c8"),
+                SpanId.Parse("2000000000000000"),
+                true
+            );
+
+            // Act
+            var transaction = hub.StartTransaction("name", "operation", traceHeader);
+
+            // Assert
+            transaction.TraceId.Should().Be("75302ac48a024bde9a3b3734a82e36c8");
+            transaction.ParentSpanId.Should().Be(SpanId.Parse("2000000000000000"));
+            transaction.IsSampled.Should().BeTrue();
+        }
+
+        [Fact]
         public void StartTransaction_StaticSampling_SampledIn()
         {
             // Arrange

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -181,7 +181,7 @@ namespace NotSentry.Tests
             var transaction = hub.StartTransaction("name", "operation", traceHeader);
 
             // Assert
-            transaction.TraceId.Should().Be("75302ac48a024bde9a3b3734a82e36c8");
+            transaction.TraceId.Should().Be(SentryId.Parse("75302ac48a024bde9a3b3734a82e36c8"));
             transaction.ParentSpanId.Should().Be(SpanId.Parse("2000000000000000"));
             transaction.IsSampled.Should().BeTrue();
         }

--- a/test/Sentry.Tests/Protocol/SentryTraceHeaderTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryTraceHeaderTests.cs
@@ -1,0 +1,96 @@
+﻿using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sentry.Protocol;
+using Sentry.Testing;
+using Xunit;
+
+namespace Sentry.Tests.Protocol
+{
+    public class SentryTraceHeaderTests
+    {
+        [Fact]
+        public void Parse_WithoutSampled_Works()
+        {
+            // Arrange
+            const string headerValue = "75302ac48a024bde9a3b3734a82e36c8-1000000000000000";
+
+            // Act
+            var header = SentryTraceHeader.Parse(headerValue);
+
+            // Assert
+            header.TraceId.Should().Be(SentryId.Parse("75302ac48a024bde9a3b3734a82e36c8"));
+            header.SpanId.Should().Be(SpanId.Parse("1000000000000000"));
+            header.IsSampled.Should().BeNull();
+        }
+
+        [Fact]
+        public void Parse_WithSampledTrue_Works()
+        {
+            // Arrange
+            const string headerValue = "75302ac48a024bde9a3b3734a82e36c8-1000000000000000-1";
+
+            // Act
+            var header = SentryTraceHeader.Parse(headerValue);
+
+            // Assert
+            header.TraceId.Should().Be(SentryId.Parse("75302ac48a024bde9a3b3734a82e36c8"));
+            header.SpanId.Should().Be(SpanId.Parse("1000000000000000"));
+            header.IsSampled.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Parse_WithSampledFalse_Works()
+        {
+            // Arrange
+            const string headerValue = "75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0";
+
+            // Act
+            var header = SentryTraceHeader.Parse(headerValue);
+
+            // Assert
+            header.TraceId.Should().Be(SentryId.Parse("75302ac48a024bde9a3b3734a82e36c8"));
+            header.SpanId.Should().Be(SpanId.Parse("1000000000000000"));
+            header.IsSampled.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Inject_ToHttpRequest_Works()
+        {
+            // Arrange
+            using var request = new HttpRequestMessage();
+            var header = SentryTraceHeader.Parse("75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0");
+
+            // Act
+            header.Inject(request);
+
+            // Assert
+            request.Headers.Should().Contain(h =>
+                h.Key == "sentry-trace" &&
+                string.Concat(h.Value) == "75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0"
+            );
+        }
+
+        [Fact]
+        public async Task Inject_ToHttpClient_Works()
+        {
+            // Arrange
+            using var handler = new FakeHttpClientHandler();
+            using var client = new HttpClient(handler);
+            var header = SentryTraceHeader.Parse("75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0");
+
+            // Act
+            header.Inject(client);
+            await client.GetAsync("https://example.com");
+
+            using var request = handler.GetRequests().Single();
+
+            // Assert
+            request.Headers.Should().Contain(h =>
+                h.Key == "sentry-trace" &&
+                string.Concat(h.Value) == "75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0"
+            );
+        }
+    }
+}

--- a/test/Sentry.Tests/Protocol/SentryTraceHeaderTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryTraceHeaderTests.cs
@@ -1,10 +1,5 @@
-﻿using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Threading.Tasks;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Sentry.Protocol;
-using Sentry.Testing;
 using Xunit;
 
 namespace Sentry.Tests.Protocol
@@ -54,44 +49,6 @@ namespace Sentry.Tests.Protocol
             header.TraceId.Should().Be(SentryId.Parse("75302ac48a024bde9a3b3734a82e36c8"));
             header.SpanId.Should().Be(SpanId.Parse("1000000000000000"));
             header.IsSampled.Should().BeFalse();
-        }
-
-        [Fact]
-        public void Inject_ToHttpRequest_Works()
-        {
-            // Arrange
-            using var request = new HttpRequestMessage();
-            var header = SentryTraceHeader.Parse("75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0");
-
-            // Act
-            header.Inject(request);
-
-            // Assert
-            request.Headers.Should().Contain(h =>
-                h.Key == "sentry-trace" &&
-                string.Concat(h.Value) == "75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0"
-            );
-        }
-
-        [Fact]
-        public async Task Inject_ToHttpClient_Works()
-        {
-            // Arrange
-            using var handler = new FakeHttpClientHandler();
-            using var client = new HttpClient(handler);
-            var header = SentryTraceHeader.Parse("75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0");
-
-            // Act
-            header.Inject(client);
-            await client.GetAsync("https://example.com");
-
-            using var request = handler.GetRequests().Single();
-
-            // Assert
-            request.Headers.Should().Contain(h =>
-                h.Key == "sentry-trace" &&
-                string.Concat(h.Value) == "75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0"
-            );
         }
     }
 }

--- a/test/Sentry.Tests/Protocol/SentryTraceHeaderTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryTraceHeaderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -48,6 +49,22 @@ namespace Sentry.Tests.Protocol
 
             // Act
             var header = SentryTraceHeader.Parse(headerValue);
+
+            // Assert
+            header.TraceId.Should().Be(SentryId.Parse("75302ac48a024bde9a3b3734a82e36c8"));
+            header.SpanId.Should().Be(SpanId.Parse("1000000000000000"));
+            header.IsSampled.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Parse_FromResponse_Works()
+        {
+            // Arrange
+            using var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Headers.Add("sentry-trace", "75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0");
+
+            // Act
+            var header = SentryTraceHeader.Parse(response);
 
             // Assert
             header.TraceId.Should().Be(SentryId.Parse("75302ac48a024bde9a3b3734a82e36c8"));

--- a/test/Sentry.Tests/Protocol/SentryTraceHeaderTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryTraceHeaderTests.cs
@@ -57,22 +57,6 @@ namespace Sentry.Tests.Protocol
         }
 
         [Fact]
-        public void Parse_FromResponse_Works()
-        {
-            // Arrange
-            using var response = new HttpResponseMessage(HttpStatusCode.OK);
-            response.Headers.Add("sentry-trace", "75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0");
-
-            // Act
-            var header = SentryTraceHeader.Parse(response);
-
-            // Assert
-            header.TraceId.Should().Be(SentryId.Parse("75302ac48a024bde9a3b3734a82e36c8"));
-            header.SpanId.Should().Be(SpanId.Parse("1000000000000000"));
-            header.IsSampled.Should().BeFalse();
-        }
-
-        [Fact]
         public void Inject_ToHttpRequest_Works()
         {
             // Arrange

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -193,7 +193,7 @@ namespace Sentry.Tests
         }
 
         [Fact]
-        public void GetSpan_ActiveSpans_ReturnsTransaction()
+        public void GetSpan_ActiveSpans_ReturnsSpan()
         {
             // Arrange
             var scope = new Scope();

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -157,5 +157,58 @@ namespace Sentry.Tests
             scope.TransactionName.Should().Be("foo");
             scope.TransactionName.Should().Be(scope.Transaction?.Name);
         }
+
+        [Fact]
+        public void GetSpan_NoSpans_ReturnsTransaction()
+        {
+            // Arrange
+            var scope = new Scope();
+            var transaction = new Transaction(DisabledHub.Instance, "foo", "_");
+            scope.Transaction = transaction;
+
+            // Act
+            var span = scope.GetSpan();
+
+            // Assert
+            span.Should().Be(transaction);
+        }
+
+        [Fact]
+        public void GetSpan_FinishedSpans_ReturnsTransaction()
+        {
+            // Arrange
+            var scope = new Scope();
+
+            var transaction = new Transaction(DisabledHub.Instance, "foo", "_");
+            transaction.StartChild("123").Finish();
+            transaction.StartChild("456").Finish();
+
+            scope.Transaction = transaction;
+
+            // Act
+            var span = scope.GetSpan();
+
+            // Assert
+            span.Should().Be(transaction);
+        }
+
+        [Fact]
+        public void GetSpan_ActiveSpans_ReturnsTransaction()
+        {
+            // Arrange
+            var scope = new Scope();
+
+            var transaction = new Transaction(DisabledHub.Instance, "foo", "_");
+            var activeSpan = transaction.StartChild("123");
+            transaction.StartChild("456").Finish();
+
+            scope.Transaction = transaction;
+
+            // Act
+            var span = scope.GetSpan();
+
+            // Assert
+            span.Should().Be(activeSpan);
+        }
     }
 }

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -355,7 +355,7 @@ namespace Sentry.Tests
             )
             {
                 IsSampled = false,
-                EndTimestamp = DateTimeOffset.Now
+                EndTimestamp = DateTimeOffset.Now // finished
             });
 
             // Assert
@@ -377,7 +377,7 @@ namespace Sentry.Tests
                 )
                 {
                     IsSampled = true,
-                    EndTimestamp = DateTimeOffset.Now
+                    EndTimestamp = DateTimeOffset.Now // finished
                 }
             );
 
@@ -398,7 +398,7 @@ namespace Sentry.Tests
             )
             {
                 IsSampled = true,
-                EndTimestamp = DateTimeOffset.Now
+                EndTimestamp = DateTimeOffset.Now // finished
             };
 
             transaction.Contexts.Trace.SpanId = SpanId.Empty;
@@ -425,7 +425,7 @@ namespace Sentry.Tests
                 )
                 {
                     IsSampled = true,
-                    EndTimestamp = DateTimeOffset.Now
+                    EndTimestamp = DateTimeOffset.Now // finished
                 }
             );
 
@@ -448,7 +448,7 @@ namespace Sentry.Tests
                 )
                 {
                     IsSampled = true,
-                    EndTimestamp = DateTimeOffset.Now
+                    EndTimestamp = DateTimeOffset.Now // finished
                 }
             );
 
@@ -457,7 +457,7 @@ namespace Sentry.Tests
         }
 
         [Fact]
-        public void CaptureTransaction_NotFinished_Ignored()
+        public void CaptureTransaction_NotFinished_Sent()
         {
             // Arrange
             var sut = _fixture.GetSut();
@@ -476,7 +476,7 @@ namespace Sentry.Tests
             );
 
             // Assert
-            _ = sut.Worker.DidNotReceive().EnqueueEnvelope(Arg.Any<Envelope>());
+            _ = sut.Worker.Received(1).EnqueueEnvelope(Arg.Any<Envelope>());
         }
 
         [Fact]

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -352,7 +352,11 @@ namespace Sentry.Tests
                 sut,
                 "test name",
                 "test operation"
-            ) {IsSampled = false});
+            )
+            {
+                IsSampled = false,
+                EndTimestamp = DateTimeOffset.Now
+            });
 
             // Assert
             _ = sut.Worker.DidNotReceive().EnqueueEnvelope(Arg.Any<Envelope>());
@@ -370,7 +374,11 @@ namespace Sentry.Tests
                     sut,
                     "test name",
                     "test operation"
-                ) {IsSampled = true}
+                )
+                {
+                    IsSampled = true,
+                    EndTimestamp = DateTimeOffset.Now
+                }
             );
 
             // Assert
@@ -387,7 +395,11 @@ namespace Sentry.Tests
                 sut,
                 "test name",
                 "test operation"
-            ) {IsSampled = true};
+            )
+            {
+                IsSampled = true,
+                EndTimestamp = DateTimeOffset.Now
+            };
 
             transaction.Contexts.Trace.SpanId = SpanId.Empty;
 
@@ -410,7 +422,11 @@ namespace Sentry.Tests
                     sut,
                     null!,
                     "test operation"
-                ) {IsSampled = true}
+                )
+                {
+                    IsSampled = true,
+                    EndTimestamp = DateTimeOffset.Now
+                }
             );
 
             // Assert
@@ -429,7 +445,34 @@ namespace Sentry.Tests
                     sut,
                     "test name",
                     null!
-                ) {IsSampled = true}
+                )
+                {
+                    IsSampled = true,
+                    EndTimestamp = DateTimeOffset.Now
+                }
+            );
+
+            // Assert
+            _ = sut.Worker.DidNotReceive().EnqueueEnvelope(Arg.Any<Envelope>());
+        }
+
+        [Fact]
+        public void CaptureTransaction_NotFinished_Ignored()
+        {
+            // Arrange
+            var sut = _fixture.GetSut();
+
+            // Act
+            sut.CaptureTransaction(
+                new Transaction(
+                    sut,
+                    "test name",
+                    null!
+                )
+                {
+                    IsSampled = true,
+                    EndTimestamp = null // not finished
+                }
             );
 
             // Assert

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -467,7 +467,7 @@ namespace Sentry.Tests
                 new Transaction(
                     sut,
                     "test name",
-                    null!
+                    "test operation"
                 )
                 {
                     IsSampled = true,

--- a/test/Sentry.Tests/SentryHttpMessageHandlerTests.cs
+++ b/test/Sentry.Tests/SentryHttpMessageHandlerTests.cs
@@ -36,5 +36,33 @@ namespace Sentry.Tests
                 string.Concat(h.Value) == "75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0"
             );
         }
+
+        [Fact]
+        public async Task SendAsync_SentryTraceHeaderAlreadySet_NotOverwritten()
+        {
+            // Arrange
+            var hub = Substitute.For<IHub>();
+
+            hub.GetTraceHeader().ReturnsForAnyArgs(
+                SentryTraceHeader.Parse("75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0")
+            );
+
+            using var innerHandler = new FakeHttpClientHandler();
+            using var sentryHandler = new SentryHttpMessageHandler(innerHandler, hub);
+            using var client = new HttpClient(sentryHandler);
+
+            client.DefaultRequestHeaders.Add("sentry-trace", "foobar");
+
+            // Act
+            await client.GetAsync("https://example.com");
+
+            using var request = innerHandler.GetRequests().Single();
+
+            // Assert
+            request.Headers.Should().Contain(h =>
+                h.Key == "sentry-trace" &&
+                string.Concat(h.Value) == "foobar"
+            );
+        }
     }
 }

--- a/test/Sentry.Tests/SentryHttpMessageHandlerTests.cs
+++ b/test/Sentry.Tests/SentryHttpMessageHandlerTests.cs
@@ -1,0 +1,40 @@
+﻿using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
+using Sentry.Protocol;
+using Sentry.Testing;
+using Xunit;
+
+namespace Sentry.Tests
+{
+    public class SentryHttpMessageHandlerTests
+    {
+        [Fact]
+        public async Task SendAsync_SentryTraceHeaderNotSet_SetsHeader()
+        {
+            // Arrange
+            var hub = Substitute.For<IHub>();
+
+            hub.GetTraceHeader().ReturnsForAnyArgs(
+                SentryTraceHeader.Parse("75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0")
+            );
+
+            using var innerHandler = new FakeHttpClientHandler();
+            using var sentryHandler = new SentryHttpMessageHandler(innerHandler, hub);
+            using var client = new HttpClient(sentryHandler);
+
+            // Act
+            await client.GetAsync("https://example.com");
+
+            using var request = innerHandler.GetRequests().Single();
+
+            // Assert
+            request.Headers.Should().Contain(h =>
+                h.Key == "sentry-trace" &&
+                string.Concat(h.Value) == "75302ac48a024bde9a3b3734a82e36c8-1000000000000000-0"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Related to #663 

Note, this doesn't include auto instrumentation for ASP.net Core, but only the core parts. Adding the instrumentation later would be easy once these are in (and won't be a breaking change).