### PR TITLE
Improve transaction instrumentation on ASP.NET Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Integrate trace headers. (#758) @Tyrrrz
 - Renamed Option `DiagnosticsLevel` to `DiagnosticLevel` (#759) @bruno-garcia
 - Add additional data to transactions (#763) @Tyrrrz
+- Improve transaction instrumentation on ASP.NET Core (#766) @Tyrrrz
 
 ## 3.0.0-beta.0
 

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -11,7 +11,7 @@ namespace Sentry.AspNetCore.Extensions
     {
         public static string? TryGetRouteTemplate(this HttpContext context)
         {
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 // endpoint routing is only supported after ASP.NET Core 3.0
             // Requires .UseRouting()/.UseEndpoints()
             var endpoint = context.Features.Get<IEndpointFeature?>()?.Endpoint as RouteEndpoint;
             var routePattern = endpoint?.RoutePattern.RawText;
@@ -22,8 +22,11 @@ namespace Sentry.AspNetCore.Extensions
             }
 #endif
 
-            // Requires legacy .UseMvc()
-            var routeData = context.Features.Get<IRoutingFeature?>()?.RouteData;
+            // Fallback for legacy .UseMvc().
+            // Uses context.Features.Get<IRoutingFeature?>() under the hood and CAN be null,
+            // despite the annotations claiming otherwise.
+            var routeData = context.GetRouteData();
+
             var controller = routeData?.Values["controller"]?.ToString();
             var action = routeData?.Values["action"]?.ToString();
             var area = routeData?.Values["area"]?.ToString();


### PR DESCRIPTION
Closes #761 
Closes #760

@kanadaj 

>Things needed:
>1.  Bind the transaction in the middleware on creation
>2.  A GetCurrentTransaction() on IHub or ISentryClient
>3. Possibly a StartSpan() helper method to avoid fiddling with the transaction
>4. Either make CaptureTransaction() internal, or change the parameter type to ITransaction for consistency with public APIs.

1. is done in this PR
2. `Scope.GetSpan()` was added a few PRs ago which should return the last active (not finished) span (or transaction) on the current scope
3. this is not part of the spec, but I think `Scope.GetSpan().StartChild()` should be equivalent to that
4. done in previous PR