### PR TITLE
Group unknown routes

### DIFF
--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -40,12 +40,24 @@ namespace Sentry.AspNetCore.Extensions
             return null;
         }
 
-        public static string GetTransactionName(this HttpContext context)
+        /// <summary>
+        /// Get the route template of the current path, or the path string itself if there is no route template
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="usesPathName">Returns true if we return the path name instead of a route template</param>
+        /// <returns></returns>
+        public static string GetTransactionName(this HttpContext context, out bool usesPathName)
         {
             // Try to get the route template or fallback to the request path
 
+            usesPathName = false;
             var method = context.Request.Method.ToUpperInvariant();
-            var route = context.TryGetRouteTemplate() ?? context.Request.Path;
+            var route = context.TryGetRouteTemplate();
+            if (route == null)
+            {
+                usesPathName = true;
+                route = context.Request.Path;
+            }
 
             return $"{method} {route}";
         }

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -44,20 +44,13 @@ namespace Sentry.AspNetCore.Extensions
         /// Get the route template of the current path, or the path string itself if there is no route template
         /// </summary>
         /// <param name="context"></param>
-        /// <param name="usesPathName">Returns true if we return the path name instead of a route template</param>
         /// <returns></returns>
-        public static string GetTransactionName(this HttpContext context, out bool usesPathName)
+        public static string GetTransactionName(this HttpContext context)
         {
             // Try to get the route template or fallback to the request path
 
-            usesPathName = false;
             var method = context.Request.Method.ToUpperInvariant();
-            var route = context.TryGetRouteTemplate();
-            if (route == null)
-            {
-                usesPathName = true;
-                route = context.Request.Path;
-            }
+            var route = context.TryGetRouteTemplate() ?? "Unknown Route";
 
             return $"{method} {route}";
         }

--- a/src/Sentry.AspNetCore/ScopeExtensions.cs
+++ b/src/Sentry.AspNetCore/ScopeExtensions.cs
@@ -88,7 +88,7 @@ namespace Sentry.AspNetCore
                     scope.SetTag("route.area", area);
                 }
 
-                scope.TransactionName = context.GetTransactionName(out _);
+                scope.TransactionName = context.GetTransactionName();
             }
             catch(Exception e)
             {

--- a/src/Sentry.AspNetCore/ScopeExtensions.cs
+++ b/src/Sentry.AspNetCore/ScopeExtensions.cs
@@ -88,7 +88,7 @@ namespace Sentry.AspNetCore
                     scope.SetTag("route.area", area);
                 }
 
-                scope.TransactionName = context.GetTransactionName();
+                scope.TransactionName = context.GetTransactionName(out _);
             }
             catch(Exception e)
             {

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -34,7 +34,7 @@ namespace Sentry.AspNetCore
             }
 
             var transaction = hub.StartTransaction(
-                context.GetTransactionName(),
+                context.GetTransactionName(out var usesPathName),
                 "http.server"
             );
 
@@ -44,6 +44,11 @@ namespace Sentry.AspNetCore
             }
             finally
             {
+                // TODO: Add a config flag to optionally also include 401 and 403 in case those take precedence over routing. Maybe a list?
+                if (context.Response.StatusCode == 404 && usesPathName)
+                {
+                    transaction.Name = "Unknown Route";
+                }
                 transaction.Finish(
                     GetSpanStatusFromCode(context.Response.StatusCode)
                 );

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -44,6 +44,7 @@ namespace Sentry.AspNetCore
             }
             finally
             {
+                // We get the transaction name here since the MVC middleware might modify the route
                 transaction.Name = context.GetTransactionName();
 
                 transaction.Finish(

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -34,7 +34,7 @@ namespace Sentry.AspNetCore
             }
 
             var transaction = hub.StartTransaction(
-                context.GetTransactionName(out var usesPathName),
+                "Unknown Route",
                 "http.server"
             );
 
@@ -44,11 +44,8 @@ namespace Sentry.AspNetCore
             }
             finally
             {
-                // TODO: Add a config flag to optionally also include 401 and 403 in case those take precedence over routing. Maybe a list?
-                if (context.Response.StatusCode == 404 && usesPathName)
-                {
-                    transaction.Name = "Unknown Route";
-                }
+                transaction.Name = context.GetTransactionName();
+
                 transaction.Finish(
                     GetSpanStatusFromCode(context.Response.StatusCode)
                 );


### PR DESCRIPTION
Creates a grouping for "Unknown Route" instead of using the path name for 404 responses.

Also exposes an `out` bool on `GetTransactionName` to make this simpler.

_#skip-changelog_