### PR TITLE
Remove the `Evaluate` error from the breadcrumb list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix DI issues in ASP.NET Core + SentryHttpMessageHandlerBuilderFilter (#789) @Tyrrrz
 - Fix incorrect NRT on SpanContext.ctor (#788) @Tyrrrz
+- Remove the `Evaluate` error from the breadcrumb list (#790) @Tyrrrz
 
 ## 3.0.2
 

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -371,13 +371,11 @@ namespace Sentry
                 {
                     OnEvaluating?.Invoke(this, EventArgs.Empty);
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    AddBreadcrumb(
-                        new Breadcrumb(
-                            message: "Failed invoking event handler: " + e,
-                            level: BreadcrumbLevel.Error
-                        )
+                    Options.DiagnosticLogger?.LogError(
+                        "Failed invoking event handler.",
+                        ex
                     );
                 }
                 finally

--- a/test/Sentry.Testing/InMemoryDiagnosticLogger.cs
+++ b/test/Sentry.Testing/InMemoryDiagnosticLogger.cs
@@ -4,7 +4,7 @@ using Sentry.Extensibility;
 
 namespace Sentry.Testing
 {
-    public class AccumulativeDiagnosticLogger : IDiagnosticLogger
+    public class InMemoryDiagnosticLogger : IDiagnosticLogger
     {
         public List<Entry> Entries { get; } = new();
 

--- a/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
@@ -67,7 +67,7 @@ namespace Sentry.Tests.Internals.Http
             httpHandler.VerifiableSendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
                 .Returns(_ => SentryResponses.GetJsonErrorResponse(expectedCode, expectedMessage, expectedCauses));
 
-            var logger = new AccumulativeDiagnosticLogger();
+            var logger = new InMemoryDiagnosticLogger();
 
             var httpTransport = new HttpTransport(
                 new SentryOptions
@@ -108,7 +108,7 @@ namespace Sentry.Tests.Internals.Http
             _ = httpHandler.VerifiableSendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
                   .Returns(_ => SentryResponses.GetTextErrorResponse(expectedCode, expectedMessage));
 
-            var logger = new AccumulativeDiagnosticLogger();
+            var logger = new InMemoryDiagnosticLogger();
 
             var httpTransport = new HttpTransport(
                 new SentryOptions
@@ -147,7 +147,7 @@ namespace Sentry.Tests.Internals.Http
             httpHandler.VerifiableSendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
                 .Returns(_ => SentryResponses.GetJsonErrorResponse(expectedCode, null));
 
-            var logger = new AccumulativeDiagnosticLogger();
+            var logger = new InMemoryDiagnosticLogger();
 
             var httpTransport = new HttpTransport(
                 new SentryOptions
@@ -249,7 +249,7 @@ namespace Sentry.Tests.Internals.Http
                 new FakeHttpMessageHandler()
             );
 
-            var logger = new AccumulativeDiagnosticLogger();
+            var logger = new InMemoryDiagnosticLogger();
 
             var httpTransport = new HttpTransport(
                 new SentryOptions

--- a/test/Sentry.Tests/Protocol/ScopeExtensionsTests.cs
+++ b/test/Sentry.Tests/Protocol/ScopeExtensionsTests.cs
@@ -530,7 +530,7 @@ namespace Sentry.Tests.Protocol
         public async Task AddAttachment_FromStream_UnknownLength_IsDropped()
         {
             // Arrange
-            var logger = new AccumulativeDiagnosticLogger();
+            var logger = new InMemoryDiagnosticLogger();
             _fixture.ScopeOptions.DiagnosticLogger = logger;
             _fixture.ScopeOptions.Debug = true;
 

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -52,7 +52,7 @@ namespace Sentry.Tests
             scope.OnEvaluating += (_, _) => throw exception;
 
             // Act
-            _sut.Evaluate();
+            scope.Evaluate();
 
             // Assert
             logger.Entries.Should().Contain(entry =>

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -2,6 +2,7 @@ using System;
 using FluentAssertions;
 using Sentry.Extensibility;
 using Sentry.Protocol;
+using Sentry.Testing;
 using Xunit;
 
 namespace Sentry.Tests
@@ -36,20 +37,28 @@ namespace Sentry.Tests
         }
 
         [Fact]
-        public void OnEvaluate_EventHandlerThrows_ExceptionAsBreadcrumb()
+        public void OnEvaluate_EventHandlerThrows_LogsException()
         {
-            var expected = new InvalidOperationException("test");
+            // Arrange
+            var logger = new InMemoryDiagnosticLogger();
 
-            _sut.OnEvaluating += (_, _) => throw expected;
+            var scope = new Scope(new SentryOptions
+            {
+                DiagnosticLogger = logger,
+                Debug = true
+            });
+
+            var exception = new InvalidOperationException("test");
+            scope.OnEvaluating += (_, _) => throw exception;
+
+            // Act
             _sut.Evaluate();
 
-            var crumb = Assert.Single(_sut.Breadcrumbs);
-
-            Assert.Equal(BreadcrumbLevel.Error, crumb!.Level);
-
-            Assert.Equal(
-                "Failed invoking event handler: " + expected,
-                crumb.Message);
+            // Assert
+            logger.Entries.Should().Contain(entry =>
+                entry.Message == "Failed invoking event handler." &&
+                entry.Exception == exception
+            );
         }
 
         [Fact]


### PR DESCRIPTION
Closes #771
Closes #543
Closes #764