### PR TITLE
changelog format craft auto

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -2,7 +2,7 @@ minVersion: '0.13.2'
 github:
   owner: getsentry
   repo: sentry-dotnet
-changelogPolicy: simple
+changelogPolicy: auto
 statusProvider:
   name: github
 artifactProvider:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## vNext
+## Unreleased
+
+### Changes
 
 - Fix DI issues in ASP.NET Core + SentryHttpMessageHandlerBuilderFilter (#789) @Tyrrrz
 - Fix incorrect NRT on SpanContext.ctor (#788) @Tyrrrz


### PR DESCRIPTION
Please lets start using:

## Unreleased

### Changes


The sub heading is for the changelog generation in the nuget package that requires that. So unless there's a workaround, lets keep it. Unless we can split into `### Bug fixes` and `### Features`

And use `Unreleased` (and not anything else) so that I can use craft's `auto` mode


#skip-changelog