### PR TITLE
Fix tracing middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix tracing middleware (#813) @Tyrrrz
+
 ## 3.0.5
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Changes
+
 - Fix tracing middleware (#813) @Tyrrrz
 
 ## 3.0.5

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -14,6 +14,7 @@ namespace Sentry.AspNetCore
     internal class SentryTracingMiddleware
     {
         private const string UnknownRouteTransactionName = "Unknown Route";
+        private const string OperationName = "http.server";
 
         private readonly RequestDelegate _next;
         private readonly Func<IHub> _getHub;
@@ -72,12 +73,12 @@ namespace Sentry.AspNetCore
                 var transaction = traceHeader is not null
                     ? hub.StartTransaction(
                         transactionName,
-                        "http.server",
+                        OperationName,
                         traceHeader
                     )
                     : hub.StartTransaction(
                         transactionName,
-                        "http.server"
+                        OperationName
                     );
 
                 _options.DiagnosticLogger?.LogInfo(

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -125,6 +125,7 @@ namespace Sentry.AspNetCore
                         // try to get the transaction name again.
                         if (context.TryGetTransactionName() is { } transactionName)
                         {
+                            _options.DiagnosticLogger?.LogDebug("Found transaction name after request pipeline executed: {0}.", transactionName);
                             transaction.Name = transactionName;
                         }
 

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -125,6 +125,15 @@ namespace Sentry.AspNetCore
                     // try to get the transaction name again.
                     if (context.TryGetTransactionName() is { } transactionName)
                     {
+                        if (!string.Equals(transaction.Name, transactionName, StringComparison.Ordinal))
+                        {
+                            _options.DiagnosticLogger?.LogDebug(
+                                "Updated transaction name from '{0}' to '{1}' after request pipeline executed.",
+                                transaction.Name,
+                                transactionName
+                            );
+                        }
+
                         transaction.Name = transactionName;
                     }
 

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -130,7 +130,7 @@ namespace Sentry.AspNetCore
                         if (!string.Equals(transaction.Name, transactionName, StringComparison.Ordinal))
                         {
                             _options.DiagnosticLogger?.LogDebug(
-                                "Updated transaction name from '{0}' to '{1}' after request pipeline executed.",
+                                "Changed transaction name from '{0}' to '{1}' after request pipeline executed.",
                                 transaction.Name,
                                 transactionName
                             );

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -38,7 +38,7 @@ namespace Sentry.AspNetCore
                 return null;
             }
 
-            _options.DiagnosticLogger?.LogInfo("Received Sentry trace header '{0}'.", value);
+            _options.DiagnosticLogger?.LogDebug("Received Sentry trace header '{0}'.", value);
 
             try
             {

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -13,7 +13,7 @@ namespace Sentry.AspNetCore
     /// </summary>
     internal class SentryTracingMiddleware
     {
-        private const string UnknownRouteTransactionName = "Unknown route";
+        private const string UnknownRouteTransactionName = "Unknown Route";
 
         private readonly RequestDelegate _next;
         private readonly Func<IHub> _getHub;

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -111,6 +111,8 @@ namespace Sentry.AspNetCore
 
             var transaction = TryStartTransaction(context);
 
+            // Expose the transaction on the scope so that the user
+            // can retrieve it and start child spans off of it.
             hub.ConfigureScope(scope => scope.Transaction = transaction);
 
             try


### PR DESCRIPTION
This should fix the following issues:

- Pipeline shortcircuit when `SentryTracingMiddleware` fails.
- `Failure to ConfigureScopeAsync` error due to attempt to configure local scope. Not exactly sure why it was caused in #805 but I assume it was that. @bruno-garcia can you check if my usage of `PushAndLockScope()` is valid here?
- `Unknown route` appearing in `TransactionSamplingContext`. Now it will attempt to get a name first, so there is a chance something useful will be available to the user.

Fixes #805