### PR TITLE
Fix: Disable Ben.Demystifier for UWP by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+- Fix UWP not registering exceptions (#???) @lucas-zimerman
 - Fix tracing middleware (#813) @Tyrrrz
 
 ## 3.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-- Fix UWP not registering exceptions (#???) @lucas-zimerman
+- Fix UWP not registering exceptions (#821) @lucas-zimerman
 - Fix tracing middleware (#813) @Tyrrrz
 
 ## 3.0.5

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -446,8 +446,9 @@ namespace Sentry
         /// </summary>
         public SentryOptions()
         {
-            // from 3.0.0 uses Enhanced (Ben.Demystifier) by default which is a breaking change.
-            StackTraceMode = StackTraceMode.Enhanced;
+            // from 3.0.0 uses Enhanced (Ben.Demystifier) by default which is a breaking change
+            // unless you are using .NET Native which isn't compatible with Ben.Demystifier.
+            StackTraceMode = Runtime.Current.Name == ".NET Native" ? StackTraceMode.Original : StackTraceMode.Enhanced;
 
             EventProcessorsProviders = new Func<IEnumerable<ISentryEventProcessor>>[] {
                 () => EventProcessors ?? Enumerable.Empty<ISentryEventProcessor>()


### PR DESCRIPTION
Ben Demystifier doesn't support .NET Native so we have to disable it for the UWP platform by default.

See benaadams/Ben.Demystifier#51 for more information.