### PR TITLE
Option to disable  TaskUnobservedTaskException Capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Adding TaskUnobservedTaskExceptionIntegration to default integrations and method to remove it @FilipNemec
+- Adding TaskUnobservedTaskExceptionIntegration to default integrations and method to remove it (#870) @FilipNemec
 - Add AddSentryTag and AddSentryContext Extensions for exception class (#834) @lucas-zimerman
 - Associate span exceptions with event exceptions (#848) @Tyrrrz
 - MaxCacheItems option to control files on disk (#846) @Tyrrrz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Adding TaskUnobservedTaskExceptionIntegration to default integrations and method to remove it @FilipNemec
 - Add AddSentryTag and AddSentryContext Extensions for exception class (#834) @lucas-zimerman
 - Associate span exceptions with event exceptions (#848) @Tyrrrz
 - MaxCacheItems option to control files on disk (#846) @Tyrrrz

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -495,6 +495,7 @@ namespace Sentry
             Integrations = new ISdkIntegration[] {
                 new AppDomainUnhandledExceptionIntegration(),
                 new AppDomainProcessExitIntegration(),
+                new TaskUnobservedTaskExceptionIntegration(),
 #if NETFX
                 new NetFxInstallationsIntegration(),
 #endif

--- a/src/Sentry/SentryOptionsExtensions.cs
+++ b/src/Sentry/SentryOptionsExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading.Tasks;
 using Sentry.Extensibility;
 using Sentry.Infrastructure;
 using Sentry.Integrations;
@@ -37,6 +38,13 @@ namespace Sentry
         /// <param name="options">The SentryOptions to remove the integration from.</param>
         public static void DisableAppDomainUnhandledExceptionCapture(this SentryOptions options) =>
             options.RemoveIntegration<AppDomainUnhandledExceptionIntegration>();
+
+        /// <summary>
+        /// Disables the capture of errors through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </summary>
+        /// <param name="options">The SentryOptions to remove the integration from.</param>
+        public static void DisableTaskUnobservedTaskExceptionCapture(this SentryOptions options) =>
+            options.RemoveIntegration<TaskUnobservedTaskExceptionIntegration>();
 
 #if NETFX
         /// <summary>

--- a/test/Sentry.Tests/SentryOptionsExtensionsTests.cs
+++ b/test/Sentry.Tests/SentryOptionsExtensionsTests.cs
@@ -44,6 +44,14 @@ namespace Sentry.Tests
         }
 
         [Fact]
+        public void DisableTaskUnobservedTaskExceptionCapture_TaskUnobservedTaskExceptionIntegration()
+        {
+            Sut.DisableTaskUnobservedTaskExceptionCapture();
+            Assert.DoesNotContain(Sut.Integrations!,
+                p => p.GetType() == typeof(TaskUnobservedTaskExceptionIntegration));
+        }
+
+        [Fact]
         public void AddIntegration_StoredInOptions()
         {
             var expected = Substitute.For<ISdkIntegration>();

--- a/test/Sentry.Tests/SentryOptionsExtensionsTests.cs
+++ b/test/Sentry.Tests/SentryOptionsExtensionsTests.cs
@@ -261,6 +261,18 @@ namespace Sentry.Tests
             Assert.Contains(Sut.Integrations!, i => i.GetType() == typeof(AppDomainUnhandledExceptionIntegration));
         }
 
+        [Fact]
+        public void Integrations_Includes_AppDomainProcessExitIntegration()
+        {
+            Assert.Contains(Sut.Integrations!, i => i.GetType() == typeof(AppDomainProcessExitIntegration));
+        }
+
+        [Fact]
+        public void Integrations_Includes_TaskUnobservedTaskExceptionIntegration()
+        {
+            Assert.Contains(Sut.Integrations!, i => i.GetType() == typeof(TaskUnobservedTaskExceptionIntegration));
+        }
+
         [Theory]
         [InlineData("Microsoft.")]
         [InlineData("System.")]


### PR DESCRIPTION
Option to disable  TaskUnobservedTaskException Capture thorigh SentryOptions method DisableTaskUnobservedTaskExceptionCapture. This option will enable that sentry doesn't receive TaskUnobservedTaskException automatically. 