### PR TITLE
Fix CachingTransport throwing an exception can't move the files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - MaxCacheItems option to control files on disk (#846) @Tyrrrz
 - Move SentryHttpMessageHandlerBuilderFilter to Sentry.Extensions.Logging (#845) @Tyrrrz
 
+### Fixes
+
+- Fix CachingTransport throwing an exception when it can't move the files from the previous session (#871) @Tyrrrz
+
 ## 3.0.7
 
 ### Changes

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -58,20 +58,6 @@ namespace Sentry.Internal.Http
 
             _processingDirectoryPath = Path.Combine(_isolatedCacheDirectoryPath, "__processing");
 
-            // Processing directory may already contain some files left from previous session
-            // if the worker has been terminated unexpectedly.
-            // Move everything from that directory back to cache directory.
-            if (Directory.Exists(_processingDirectoryPath))
-            {
-                foreach (var filePath in Directory.EnumerateFiles(_processingDirectoryPath))
-                {
-                    File.Move(
-                        filePath,
-                        Path.Combine(_isolatedCacheDirectoryPath, Path.GetFileName(filePath))
-                    );
-                }
-            }
-
             _worker = Task.Run(CachedTransportBackgroundTask);
         }
 
@@ -79,6 +65,20 @@ namespace Sentry.Internal.Http
         {
             try
             {
+                // Processing directory may already contain some files left from previous session
+                // if the worker has been terminated unexpectedly.
+                // Move everything from that directory back to cache directory.
+                if (Directory.Exists(_processingDirectoryPath))
+                {
+                    foreach (var filePath in Directory.EnumerateFiles(_processingDirectoryPath))
+                    {
+                        File.Move(
+                            filePath,
+                            Path.Combine(_isolatedCacheDirectoryPath, Path.GetFileName(filePath))
+                        );
+                    }
+                }
+
                 while (!_workerCts.IsCancellationRequested)
                 {
                     try


### PR DESCRIPTION
Fixes #850

Copied the suggested solution. It won't thrown on exception, but will fail the background thread, which means that the cache won't be processed. Considering that the exception in the original issue signifies that we can't move files around, caching will likely be unusable anyway.

The exception from the background thread will be propagated when the `CachingTransport` is disposed.