### PR TITLE
Retrieve CurrentVersion for Asp Net applications.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Retrieve CurrentVersion for Asp Net applications (#884) @lucas-zimerman
+- Retrieve CurrentVersion for ASP.NET applications (#884) @lucas-zimerman
 
 ## 3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unchanged
+
+### Fixes
+
+- Retrieve CurrentVersion for Asp Net applications (#884) @lucas-zimerman
+
 ## 3.1.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unchanged
+## Unreleased
 
 ### Fixes
 

--- a/src/Sentry.AspNet/Internal/SystemWebVersionLocator.cs
+++ b/src/Sentry.AspNet/Internal/SystemWebVersionLocator.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Reflection;
+using System.Web;
+using Sentry.Internal;
+
+namespace Sentry.AspNet.Internal
+{
+    internal static class SystemWebVersionLocator
+    {
+        internal static string? GetCurrent()
+        {
+            if (ReleaseLocator.GetCurrent() is string release)
+            {
+                return release;
+            }
+            else if (HttpContext.Current?.ApplicationInstance?.GetType() is Type type)
+            {
+                while (type != null && type.Namespace == "ASP")
+                {
+                    type = type.BaseType;
+                }
+                if (type?.Assembly is Assembly assembly)
+                {
+                    return ApplicationVersionLocator.GetCurrent(assembly);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/Sentry.AspNet/Internal/SystemWebVersionLocator.cs
+++ b/src/Sentry.AspNet/Internal/SystemWebVersionLocator.cs
@@ -9,19 +9,20 @@ namespace Sentry.AspNet.Internal
     {
         public static string? GetCurrent() => GetCurrent(ReleaseLocator.GetCurrent());
         internal static string? GetCurrent(string? release)
+
         {
             if (release != null)
             {
                 return release;
             }
-            else if (HttpContext.Current?.ApplicationInstance?.GetType() is Type type)
+            else if (HttpContext.Current?.ApplicationInstance?.GetType() is { } type)
             {
                 //Usually the type is ASP.global_asax and the BaseType is the Web Application.
                 while (type != null && type.Namespace == "ASP")
                 {
                     type = type.BaseType;
                 }
-                if (type?.Assembly is Assembly assembly)
+                if (type?.Assembly is { } assembly)
                 {
                     return ApplicationVersionLocator.GetCurrent(assembly);
                 }

--- a/src/Sentry.AspNet/Internal/SystemWebVersionLocator.cs
+++ b/src/Sentry.AspNet/Internal/SystemWebVersionLocator.cs
@@ -7,14 +7,16 @@ namespace Sentry.AspNet.Internal
 {
     internal static class SystemWebVersionLocator
     {
-        internal static string? GetCurrent()
+        public static string? GetCurrent() => GetCurrent(ReleaseLocator.GetCurrent());
+        internal static string? GetCurrent(string? release)
         {
-            if (ReleaseLocator.GetCurrent() is string release)
+            if (release != null)
             {
                 return release;
             }
             else if (HttpContext.Current?.ApplicationInstance?.GetType() is Type type)
             {
+                //Usually the type is ASP.global_asax and the BaseType is the Web Application.
                 while (type != null && type.Namespace == "ASP")
                 {
                     type = type.BaseType;

--- a/src/Sentry.AspNet/SentryAspNetOptionsExtensions.cs
+++ b/src/Sentry.AspNet/SentryAspNetOptionsExtensions.cs
@@ -21,6 +21,7 @@ namespace Sentry.AspNet
 
             var eventProcessor = new SystemWebRequestEventProcessor(payloadExtractor, options);
 
+            options.Release ??= SystemWebVersionLocator.GetCurrent();
             options.AddEventProcessor(eventProcessor);
         }
     }

--- a/test/Sentry.AspNet.Tests/Internal/SystemWebVersionLocatorTests.cs
+++ b/test/Sentry.AspNet.Tests/Internal/SystemWebVersionLocatorTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using NSubstitute;
+using Sentry.AspNet.Internal;
+using Sentry.Extensibility;
+using Sentry.Internal;
+using Xunit;
+
+namespace Sentry.AspNet.Tests.Internal
+{
+    public class SystemWebVersionLocatorTests
+    {
+        private class Fixture
+        {
+            public HttpContext HttpContext { get; set; }
+
+            public Fixture()
+            {
+                HttpContext = new HttpContext(new HttpRequest("test", "http://test", null), new HttpResponse(new StringWriter()));
+            }
+
+            public Assembly GetSut()
+            {
+                HttpContext.Current = HttpContext;
+                HttpContext.Current.ApplicationInstance = new HttpApplication();
+                return HttpContext.Current.ApplicationInstance.GetType().Assembly;
+            }
+        }
+
+        private readonly Fixture _fixture = new();
+
+        [Fact]
+        public void GetCurrent_GetEntryAssemblyNull_HttpApplicationAssembly()
+        {
+            _fixture.HttpContext.ApplicationInstance = new HttpApplication();
+            var sut = _fixture.GetSut();
+            var expected = ApplicationVersionLocator.GetCurrent(sut);
+
+            var actual = SystemWebVersionLocator.GetCurrent(null);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetCurrent_GetEntryAssemblySet_HttpApplicationAssembly()
+        {
+            var expected = ApplicationVersionLocator.GetCurrent();
+
+            var actual = SystemWebVersionLocator.GetCurrent();
+
+            Assert.Equal(expected, actual);
+        }
+
+    }
+}


### PR DESCRIPTION
Based on: https://stackoverflow.com/a/6754205/14731950

The additional code sets the correct Assembly release version to Sentry Events.
This code is required because Asp.Net applications seem to be returning null to Assembly.GetEntryAssembly().

Draft PR because I need to figure out how to test it without a Sample server app.

Closes #883