### PR TITLE
Add IsParentSampled to TransactionContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+- Add IsParentSampled to TransactionContext (#885) @Tyrrrz
+
 ## 3.1.0
 
 ### Features

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -51,13 +51,15 @@ namespace Sentry
             string operation,
             SentryTraceHeader traceHeader)
         {
+            var parentSpanId = traceHeader.SpanId;
+            var isParentSampled = traceHeader.IsSampled;
+
             var context = new TransactionContext(
-                // SpanId from the header becomes ParentSpanId on this transaction
-                traceHeader.SpanId,
+                parentSpanId,
                 traceHeader.TraceId,
                 name,
                 operation,
-                traceHeader.IsSampled
+                isParentSampled
             );
 
             return hub.StartTransaction(context);

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -108,7 +108,7 @@ namespace Sentry.Internal
         {
             var transaction = new Transaction(this, context);
 
-            // Dynamic sampling is ran regardless of whether a decision
+            // Tracing sampler callback runs regardless of whether a decision
             // has already been made, as it can be used to override it.
             if (_options.TracesSampler is { } tracesSampler)
             {

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -123,7 +123,7 @@ namespace Sentry.Internal
                 }
             }
 
-            // Static sampling is ran only if the sampling decision hasn't
+            // Random sampling runs only if the sampling decision hasn't
             // been made already.
             transaction.IsSampled ??= SynchronizedRandom.NextBool(_options.TracesSampleRate);
 

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -117,7 +117,7 @@ namespace Sentry.Internal
                     customSamplingContext
                 );
 
-                if (tracesSampler(samplingContext) is {} sampleRate)
+                if (tracesSampler(samplingContext) is { } sampleRate)
                 {
                     transaction.IsSampled = SynchronizedRandom.NextBool(sampleRate);
                 }

--- a/src/Sentry/Internal/SynchronizedRandom.cs
+++ b/src/Sentry/Internal/SynchronizedRandom.cs
@@ -13,5 +13,12 @@ namespace Sentry.Internal
                 return Random.NextDouble();
             }
         }
+
+        public static bool NextBool(double rate) => rate switch
+        {
+            >= 1 => true,
+            <= 0 => false,
+            _ => NextDouble() < rate
+        };
     }
 }

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -171,7 +171,7 @@ namespace Sentry
         {
             if (_options.SampleRate != null)
             {
-                if (SynchronizedRandom.NextDouble() > _options.SampleRate.Value)
+                if (!SynchronizedRandom.NextBool(_options.SampleRate.Value))
                 {
                     _options.DiagnosticLogger?.LogDebug("Event sampled.");
                     return SentryId.Empty;

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -421,7 +421,7 @@ namespace Sentry
         /// Default value is <code>0</code>, which means tracing is disabled.
         /// </summary>
         /// <remarks>
-        /// Static sampling rate is only applied to transactions that don't already
+        /// Random sampling rate is only applied to transactions that don't already
         /// have a sampling decision set by other means, such as through <see cref="TracesSampler"/>,
         /// by inheriting it from an incoming trace header, or by copying it from <see cref="TransactionContext"/>.
         /// </remarks>

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -411,7 +411,7 @@ namespace Sentry
         /// </remarks>
         public Dictionary<string, string> DefaultTags => _defaultTags ??= new Dictionary<string, string>();
 
-        private double _tracesSampleRate = 0.0;
+        private double _tracesSampleRate;
 
         /// <summary>
         /// Indicates the percentage of the tracing data that is collected.
@@ -420,6 +420,11 @@ namespace Sentry
         /// Values outside of this range are invalid.
         /// Default value is <code>0</code>, which means tracing is disabled.
         /// </summary>
+        /// <remarks>
+        /// Static sampling rate is only applied to transactions that don't already
+        /// have a sampling decision set by other means, such as through <see cref="TracesSampler"/>,
+        /// by inheriting it from an incoming trace header, or by copying it from <see cref="TransactionContext"/>.
+        /// </remarks>
         public double TracesSampleRate
         {
             get => _tracesSampleRate;
@@ -438,9 +443,14 @@ namespace Sentry
 
         /// <summary>
         /// Custom delegate that returns sample rate dynamically for a specific transaction context.
-        /// The delegate may also return <code>null</code> to fallback to default sample rate as
-        /// defined by the <see cref="TracesSampleRate"/> property.
         /// </summary>
+        /// <remarks>
+        /// Returning <code>null</code> signals that the sampler did not reach a sampling decision.
+        /// In such case, if the transaction already has a sampling decision (for example, if it's
+        /// started from a trace header) that decision is retained.
+        /// Otherwise sampling decision is determined by applying the static sampling rate
+        /// set in <see cref="TracesSampleRate"/>.
+        /// </remarks>
         public Func<TransactionSamplingContext, double?>? TracesSampler { get; set; }
 
         /// <summary>

--- a/src/Sentry/TransactionContext.cs
+++ b/src/Sentry/TransactionContext.cs
@@ -9,6 +9,11 @@
         public string Name { get; }
 
         /// <summary>
+        /// Whether the parent transaction of this transaction has been sampled.
+        /// </summary>
+        public bool? IsParentSampled { get; }
+
+        /// <summary>
         /// Initializes an instance of <see cref="TransactionContext"/>.
         /// </summary>
         public TransactionContext(
@@ -19,10 +24,12 @@
             string operation,
             string description,
             SpanStatus? status,
-            bool? isSampled)
+            bool? isSampled,
+            bool? isParentSampled)
             : base(spanId, parentSpanId, traceId, operation, description, status, isSampled)
         {
             Name = name;
+            IsParentSampled = isParentSampled;
         }
 
         /// <summary>
@@ -33,8 +40,8 @@
             SentryId traceId,
             string name,
             string operation,
-            bool? isSampled)
-            : this(SpanId.Create(), parentSpanId, traceId, name, operation, "", null, isSampled)
+            bool? isParentSampled)
+            : this(SpanId.Create(), parentSpanId, traceId, name, operation, "", null, null, isParentSampled)
         {
         }
 
@@ -45,7 +52,7 @@
             string name,
             string operation,
             bool? isSampled)
-            : this(null, SentryId.Create(), name, operation, isSampled)
+            : this(SpanId.Create(), null, SentryId.Create(), name, operation, "", null, isSampled, null)
         {
         }
 

--- a/src/Sentry/TransactionContext.cs
+++ b/src/Sentry/TransactionContext.cs
@@ -41,7 +41,7 @@
             string name,
             string operation,
             bool? isParentSampled)
-            : this(SpanId.Create(), parentSpanId, traceId, name, operation, "", null, null, isParentSampled)
+            : this(SpanId.Create(), parentSpanId, traceId, name, operation, "", null, isParentSampled, isParentSampled)
         {
         }
 

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -432,6 +432,32 @@ namespace NotSentry.Tests
         }
 
         [Fact]
+        public void StartTransaction_DynamicSampling_CanRejectTransactionStartedFromHeader()
+        {
+            // Arrange
+            var hub = new Hub(new SentryOptions
+            {
+                Dsn = DsnSamples.ValidDsnWithSecret,
+                TracesSampler = _ => 0,
+                TracesSampleRate = 0
+            });
+
+            var traceHeader = new SentryTraceHeader(
+                SentryId.Parse("75302ac48a024bde9a3b3734a82e36c8"),
+                SpanId.Parse("2000000000000000"),
+                true
+            );
+
+            // Act
+            var transaction = hub.StartTransaction("foo", "bar", traceHeader);
+
+            // Assert
+            transaction.TraceId.Should().Be(SentryId.Parse("75302ac48a024bde9a3b3734a82e36c8"));
+            transaction.ParentSpanId.Should().Be(SpanId.Parse("2000000000000000"));
+            transaction.IsSampled.Should().BeFalse();
+        }
+
+        [Fact]
         public void GetTraceHeader_ReturnsHeaderForActiveSpan()
         {
             // Arrange


### PR DESCRIPTION
Closes #882 

Please validate the logic I implemented:

- Sampling callback ALWAYS runs and has access to `transactionContext.IsParentSampled` that allows it to reject transactions started from header.
- Sampling callback may return `null` which just means it didn't make any decision. If the decision has already been made before it (via header) then it stays, otherwise random sampling is applied. This also means that returning `null` on transactions started from header will not fall back to random sampling, but instead will retain their sampling decision (docs need to be updated).
- Random sampling is applied ONLY if no sampling decision has been made yet, either via header or by sampler callback.
- With `tracesSampler = null`, transactions started from header will always inherit sampling of their parent regardless of static sampling (even if `tracesSampleRate = 0.0`).
- With `tracesSampler = _ => 0`, ALL transactions will be sampled out, including local ones and those started from header.