### PR TITLE
Add useful contextual data to TransactionSamplingContext in ASP.NET Core integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add StartupTime and Device.BootTime (#887) @lucas-zimerman
 - Link events to currently active span (#909) @Tyrrrz
+- Add useful contextual data to TransactionSamplingContext in ASP.NET Core integration (#910) @Tyrrrz
 
 ## 3.2.0
 

--- a/samples/Sentry.Samples.AspNetCore5.Mvc/Program.cs
+++ b/samples/Sentry.Samples.AspNetCore5.Mvc/Program.cs
@@ -1,5 +1,7 @@
+using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Sentry.AspNetCore;
 using Sentry.Extensibility;
 
 namespace Sentry.Samples.AspNetCore5.Mvc
@@ -20,6 +22,16 @@ namespace Sentry.Samples.AspNetCore5.Mvc
                         o.Debug = true;
                         o.MaxRequestBodySize = RequestSize.Always;
                         o.Dsn = "https://80aed643f81249d4bed3e30687b310ab@o447951.ingest.sentry.io/5428537";
+                        o.TracesSampler = ctx =>
+                        {
+                            if (string.Equals(ctx.TryGetHttpRoute(), "/Home/Privacy", StringComparison.Ordinal))
+                            {
+                                // Collect fewer traces for this page
+                                return 0.3;
+                            }
+
+                            return 1;
+                        };
                     });
                     webBuilder.UseStartup<Startup>();
                 });

--- a/src/Sentry.AspNetCore/SamplingExtensions.cs
+++ b/src/Sentry.AspNetCore/SamplingExtensions.cs
@@ -2,6 +2,9 @@
 
 namespace Sentry.AspNetCore
 {
+    /// <summary>
+    /// Methods to extract ASP.NET Core specific data from <see cref="TransactionSamplingContext"/>.
+    /// </summary>
     public static class SamplingExtensions
     {
         internal const string KeyForHttpRoute = "__HttpRoute";

--- a/src/Sentry.AspNetCore/SamplingExtensions.cs
+++ b/src/Sentry.AspNetCore/SamplingExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+
+namespace Sentry.AspNetCore
+{
+    public static class SamplingExtensions
+    {
+        internal const string KeyForHttpRoute = "__HttpRoute";
+        internal const string KeyForHttpPath = "__HttpPath";
+
+        /// <summary>
+        /// Gets the HTTP route associated with the transaction.
+        /// </summary>
+        /// <remarks>
+        /// This method extracts data from <see cref="TransactionSamplingContext.CustomSamplingContext"/>
+        /// which is populated by Sentry's ASP.NET Core integration.
+        /// </remarks>
+        public static string? TryGetHttpRoute(this TransactionSamplingContext samplingContext) =>
+            samplingContext.CustomSamplingContext.GetValueOrDefault(KeyForHttpRoute) as string;
+
+        /// <summary>
+        /// Gets the HTTP path associated with the transaction.
+        /// </summary>
+        /// <remarks>
+        /// This method extracts data from <see cref="TransactionSamplingContext.CustomSamplingContext"/>
+        /// which is populated by Sentry's ASP.NET Core integration.
+        /// </remarks>
+        public static string? TryGetHttpPath(this TransactionSamplingContext samplingContext) =>
+            samplingContext.CustomSamplingContext.GetValueOrDefault(KeyForHttpPath) as string;
+    }
+}

--- a/src/Sentry.AspNetCore/SamplingExtensions.cs
+++ b/src/Sentry.AspNetCore/SamplingExtensions.cs
@@ -7,8 +7,20 @@ namespace Sentry.AspNetCore
     /// </summary>
     public static class SamplingExtensions
     {
+        internal const string KeyForHttpMethod = "__HttpMethod";
         internal const string KeyForHttpRoute = "__HttpRoute";
         internal const string KeyForHttpPath = "__HttpPath";
+
+        /// <summary>
+        /// Gets the HTTP method associated with the transaction.
+        /// May return null if the value has not been set by the integration.
+        /// </summary>
+        /// <remarks>
+        /// This method extracts data from <see cref="TransactionSamplingContext.CustomSamplingContext"/>
+        /// which is populated by Sentry's ASP.NET Core integration.
+        /// </remarks>
+        public static string? TryGetHttpMethod(this TransactionSamplingContext samplingContext) =>
+            samplingContext.CustomSamplingContext.GetValueOrDefault(KeyForHttpMethod) as string;
 
         /// <summary>
         /// Gets the HTTP route associated with the transaction.

--- a/src/Sentry.AspNetCore/SamplingExtensions.cs
+++ b/src/Sentry.AspNetCore/SamplingExtensions.cs
@@ -12,6 +12,7 @@ namespace Sentry.AspNetCore
 
         /// <summary>
         /// Gets the HTTP route associated with the transaction.
+        /// May return null if the value has not been set by the integration.
         /// </summary>
         /// <remarks>
         /// This method extracts data from <see cref="TransactionSamplingContext.CustomSamplingContext"/>
@@ -22,6 +23,7 @@ namespace Sentry.AspNetCore
 
         /// <summary>
         /// Gets the HTTP path associated with the transaction.
+        /// May return null if the value has not been set by the integration.
         /// </summary>
         /// <remarks>
         /// This method extracts data from <see cref="TransactionSamplingContext.CustomSamplingContext"/>

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -77,6 +77,7 @@ namespace Sentry.AspNetCore
 
                 var customSamplingContext = new Dictionary<string, object?>(StringComparer.Ordinal)
                 {
+                    [SamplingExtensions.KeyForHttpMethod] = context.Request.Method,
                     [SamplingExtensions.KeyForHttpRoute] = context.TryGetRouteTemplate(),
                     [SamplingExtensions.KeyForHttpPath] = context.Request.Path.Value
                 };

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -48,21 +48,8 @@ namespace Sentry
             this IHub hub,
             string name,
             string operation,
-            SentryTraceHeader traceHeader)
-        {
-            var parentSpanId = traceHeader.SpanId;
-            var isParentSampled = traceHeader.IsSampled;
-
-            var context = new TransactionContext(
-                parentSpanId,
-                traceHeader.TraceId,
-                name,
-                operation,
-                isParentSampled
-            );
-
-            return hub.StartTransaction(context);
-        }
+            SentryTraceHeader traceHeader) =>
+            hub.StartTransaction(new TransactionContext(name, operation, traceHeader));
 
         /// <summary>
         /// Adds a breadcrumb to the current scope.

--- a/src/Sentry/TransactionContext.cs
+++ b/src/Sentry/TransactionContext.cs
@@ -59,8 +59,19 @@
         /// <summary>
         /// Initializes an instance of <see cref="TransactionContext"/>.
         /// </summary>
+        public TransactionContext(
+            string name,
+            string operation,
+            SentryTraceHeader traceHeader)
+            : this(traceHeader.SpanId, traceHeader.TraceId, name, operation, traceHeader.IsSampled)
+        {
+        }
+
+        /// <summary>
+        /// Initializes an instance of <see cref="TransactionContext"/>.
+        /// </summary>
         public TransactionContext(string name, string operation)
-            : this(name, operation, null)
+            : this(name, operation, (bool?) null)
         {
         }
     }

--- a/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
@@ -280,6 +280,7 @@ namespace Sentry.AspNetCore.Tests
 
             // Assert
             samplingContext.Should().NotBeNull();
+            samplingContext.TryGetHttpMethod().Should().Be("GET");
             samplingContext.TryGetHttpRoute().Should().Be("/person/{id}");
             samplingContext.TryGetHttpPath().Should().Be("/person/13");
         }


### PR DESCRIPTION
Closes #814 

I added only request path and route name, because those were the most commonly requested ones. If there are any other suggestions, I'm all ears.

It's also possible to add the whole `HttpContext`, however it becomes unusable once it's disposed. Given that the sampling should occur while the request is still underway, it may be fine, but I'm still weary of putting too much rather than too little in this case. Thoughts?