### PR TITLE
Fix references to removed code from configuration

### DIFF
--- a/samples/Sentry.Samples.AspNetCore5.Mvc/appsettings.json
+++ b/samples/Sentry.Samples.AspNetCore5.Mvc/appsettings.json
@@ -2,13 +2,13 @@
   "Sentry": {
     // The DSN can also be set via environment variable
     "Dsn": "https://80aed643f81249d4bed3e30687b310ab@o447951.ingest.sentry.io/5428537",
-    // Opt-in for payload submission
-    "IncludeRequestPayload": true,
     // Sends Cookies, User Id when one is logged on and user IP address to sentry. It's turned off by default.
     "SendDefaultPii": true,
+    // Opt-in for payload submission
+    "MaxRequestBodySize": "Always",
     // Whether to add System.Diagnostics.Activity data to the event::
     // For more: https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md
-    "MaxRequestBodySize": "Always",
+    "IncludeActivityData": true,
     // Record any message with this level or higher as a breadcrumb (default is Information)
     "MinimumBreadcrumbLevel": "Information",
     // Don't only keep Warnings as Breadcrumb but actually send an event


### PR DESCRIPTION
on samples/Sentry.Samples.AspNetCore5.Mvc/appsettings.json
IncludeActivityData was mistakenly replaced by MaxRequestBodySize where IncludeRequestPayload should be the correct item to be replaced by MaxRequestBodySize.

This PR fixes this issue.

Close #906.

#skip-changelog