### PR TITLE
Replaced HttpClient Stream by LengthlessStream for attachment test.

### DIFF
--- a/test/Sentry.Testing/LengthlessStream.cs
+++ b/test/Sentry.Testing/LengthlessStream.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+
+namespace Sentry.Testing
+{
+    public class LengthlessStream : Stream
+    {
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => throw new NotSupportedException();
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) { }
+
+        public override void Write(byte[] buffer, int offset, int count) { }
+    }
+}

--- a/test/Sentry.Tests/Protocol/ScopeExtensionsTests.cs
+++ b/test/Sentry.Tests/Protocol/ScopeExtensionsTests.cs
@@ -527,15 +527,15 @@ namespace Sentry.Tests.Protocol
         }
 
         [Fact]
-        public async Task AddAttachment_FromStream_UnknownLength_IsDropped()
+        public void AddAttachment_FromStream_UnknownLength_IsDropped()
         {
             // Arrange
             var logger = new InMemoryDiagnosticLogger();
             _fixture.ScopeOptions.DiagnosticLogger = logger;
             _fixture.ScopeOptions.Debug = true;
 
-            // HTTP streams don't have length
-            using var stream = await new HttpClient().GetStreamAsync("https://example.com");
+            // Stream without length, similar to HTTP streams.
+            var stream = new LengthlessStream();
 
             var scope = _fixture.GetSut();
 


### PR DESCRIPTION
Replaced HTTP stream with an abstract stream with similar behaviour.
Close #966.
#skip-changelog.