### PR TITLE
Add support for Serilog.Formatting.ITextFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Serilog: Add support for Serilog.Formatting.ITextFormatter ([#998](https://github.com/getsentry/sentry-dotnet/pull/998))
+
 ## 3.3.5-beta.0
 
 ### Features

--- a/samples/Sentry.Samples.Serilog/Program.cs
+++ b/samples/Sentry.Samples.Serilog/Program.cs
@@ -2,6 +2,7 @@ using System;
 using Serilog;
 using Serilog.Context;
 using Serilog.Events;
+using Serilog.Formatting.Display;
 
 internal static class Program
 {
@@ -20,12 +21,16 @@ internal static class Program
                 o.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
                 o.AttachStacktrace = true;
                 o.SendDefaultPii = true; // send PII like the username of the user logged in to the device
+                // Optional Serilog text formatter used to format LogEvent to string. If TextFormatter is set, FormatProvider is ignored.
+                o.TextFormatter = new MessageTemplateTextFormatter("[{MyTaskId}] {Message}", null);
                 // Other configuration
             })
             .CreateLogger();
 
         try
         {
+            // The following property is used in the TextFormatter to format the log message.
+            using (LogContext.PushProperty("MyTaskId", 42))
             // The following anonymous object gets serialized and sent with log messages
             using (LogContext.PushProperty("inventory", new
             {
@@ -41,6 +46,9 @@ internal static class Program
                 // Minimum Breadcrumb level is set to Debug so the following message is stored in memory
                 // and sent with following events of the same Scope
                 Log.Debug("Debug message stored as breadcrumb.");
+
+                // Breadcrumb with a different context property value will be formatted with a different prefix.
+                Log.ForContext("MyTaskId", 65).Debug("Message with a different MyTaskId");
 
                 // Sends an event and stores the message as a breadcrumb too, to be sent with any upcoming events.
                 Log.Error("Some event that includes the previous breadcrumbs");

--- a/src/Sentry.Serilog/SentrySerilogOptions.cs
+++ b/src/Sentry.Serilog/SentrySerilogOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using Sentry.Protocol;
 using Serilog.Events;
+using Serilog.Formatting;
 
 namespace Sentry.Serilog
 {
@@ -39,5 +40,10 @@ namespace Sentry.Serilog
         /// Optional <see cref="IFormatProvider"/>
         /// </summary>
         public IFormatProvider? FormatProvider { get; set; }
+
+        /// <summary>
+        /// Optional <see cref="ITextFormatter"/>
+        /// </summary>
+        public ITextFormatter? TextFormatter { get; set; }
     }
 }

--- a/src/Sentry.Serilog/SentrySink.cs
+++ b/src/Sentry.Serilog/SentrySink.cs
@@ -77,17 +77,7 @@ namespace Sentry.Serilog
 
             var exception = logEvent.Exception;
             var template = logEvent.MessageTemplate.Text;
-            string formatted;
-            if (_options.TextFormatter is { } formatter)
-            {
-                using var stringWriter = new StringWriter(new StringBuilder());
-                formatter.Format(logEvent, stringWriter);
-                formatted = stringWriter.ToString();
-            }
-            else
-            {
-                formatted = logEvent.RenderMessage(_options.FormatProvider);
-            }
+            var formatted = FormatLogEvent(logEvent);
 
             if (logEvent.Level >= _options.MinimumEventLevel)
             {
@@ -140,6 +130,20 @@ namespace Sentry.Serilog
                     context,
                     data: data,
                     level: logEvent.Level.ToBreadcrumbLevel());
+            }
+        }
+
+        private string FormatLogEvent(LogEvent logEvent)
+        {
+            if (_options.TextFormatter is { } formatter)
+            {
+                using var stringWriter = new StringWriter();
+                formatter.Format(logEvent, stringWriter);
+                return stringWriter.ToString();
+            }
+            else
+            {
+                return logEvent.RenderMessage(_options.FormatProvider);
             }
         }
 

--- a/src/Sentry.Serilog/SentrySink.cs
+++ b/src/Sentry.Serilog/SentrySink.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using Sentry.Extensibility;
 using Sentry.Infrastructure;
 using Sentry.Protocol;
@@ -74,8 +76,18 @@ namespace Sentry.Serilog
             }
 
             var exception = logEvent.Exception;
-            var formatted = logEvent.RenderMessage(_options.FormatProvider);
             var template = logEvent.MessageTemplate.Text;
+            string formatted;
+            if (_options.TextFormatter is null)
+            {
+                formatted = logEvent.RenderMessage(_options.FormatProvider);
+            }
+            else
+            {
+                var stringWriter = new StringWriter(new StringBuilder());
+                _options.TextFormatter.Format(logEvent, stringWriter);
+                formatted = stringWriter.ToString();
+            }
 
             if (logEvent.Level >= _options.MinimumEventLevel)
             {

--- a/src/Sentry.Serilog/SentrySink.cs
+++ b/src/Sentry.Serilog/SentrySink.cs
@@ -78,15 +78,15 @@ namespace Sentry.Serilog
             var exception = logEvent.Exception;
             var template = logEvent.MessageTemplate.Text;
             string formatted;
-            if (_options.TextFormatter is null)
+            if (_options.TextFormatter is { } formatter)
             {
-                formatted = logEvent.RenderMessage(_options.FormatProvider);
+                using var stringWriter = new StringWriter(new StringBuilder());
+                formatter.Format(logEvent, stringWriter);
+                formatted = stringWriter.ToString();
             }
             else
             {
-                var stringWriter = new StringWriter(new StringBuilder());
-                _options.TextFormatter.Format(logEvent, stringWriter);
-                formatted = stringWriter.ToString();
+                formatted = logEvent.RenderMessage(_options.FormatProvider);
             }
 
             if (logEvent.Level >= _options.MinimumEventLevel)

--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -219,7 +219,7 @@ namespace Serilog
                 sentrySerilogOptions.FormatProvider = formatProvider;
             }
 
-            if(textFormatter != null)
+            if (textFormatter != null)
             {
                 sentrySerilogOptions.TextFormatter = textFormatter;
             }

--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -7,6 +7,7 @@ using Sentry;
 using Sentry.Serilog;
 using Serilog.Configuration;
 using Serilog.Events;
+using Serilog.Formatting;
 
 // ReSharper disable once CheckNamespace - Discoverability
 namespace Serilog
@@ -24,6 +25,7 @@ namespace Serilog
         /// <param name="minimumEventLevel">Minimum log level to send an event. <seealso cref="SentrySerilogOptions.MinimumEventLevel"/></param>
         /// <param name="minimumBreadcrumbLevel">Minimum log level to record a breadcrumb. <seealso cref="SentrySerilogOptions.MinimumBreadcrumbLevel"/></param>
         /// <param name="formatProvider">The Serilog format provider. <seealso cref="IFormatProvider"/></param>
+        /// <param name="textFormatter">The Serilog text formatter. <seealso cref="ITextFormatter"/></param>
         /// <param name="sendDefaultPii">Whether to include default Personal Identifiable information. <seealso cref="SentryOptions.SendDefaultPii"/></param>
         /// <param name="isEnvironmentUser">Whether to report the <see cref="System.Environment.UserName"/> as the User affected in the event. <seealso cref="SentryOptions.IsEnvironmentUser"/></param>
         /// <param name="serverName">Gets or sets the name of the server running the application. <seealso cref="SentryOptions.ServerName"/></param>
@@ -94,6 +96,7 @@ namespace Serilog
             LogEventLevel minimumBreadcrumbLevel = LogEventLevel.Information,
             LogEventLevel minimumEventLevel = LogEventLevel.Error,
             IFormatProvider? formatProvider = null,
+            ITextFormatter? textFormatter = null,
             bool? sendDefaultPii = null,
             bool? isEnvironmentUser = null,
             string? serverName = null,
@@ -119,6 +122,7 @@ namespace Serilog
                 minimumEventLevel,
                 minimumBreadcrumbLevel,
                 formatProvider,
+                textFormatter,
                 sendDefaultPii,
                 isEnvironmentUser,
                 serverName,
@@ -148,6 +152,7 @@ namespace Serilog
         /// <param name="minimumEventLevel">Minimum log level to send an event. <seealso cref="SentrySerilogOptions.MinimumEventLevel"/></param>
         /// <param name="minimumBreadcrumbLevel">Minimum log level to record a breadcrumb. <seealso cref="SentrySerilogOptions.MinimumBreadcrumbLevel"/></param>
         /// <param name="formatProvider">The Serilog format provider. <seealso cref="IFormatProvider"/></param>
+        /// <param name="textFormatter">The Serilog text formatter. <seealso cref="ITextFormatter"/></param>
         /// <param name="sendDefaultPii">Whether to include default Personal Identifiable information. <seealso cref="SentryOptions.SendDefaultPii"/></param>
         /// <param name="isEnvironmentUser">Whether to report the <see cref="System.Environment.UserName"/> as the User affected in the event. <seealso cref="SentryOptions.IsEnvironmentUser"/></param>
         /// <param name="serverName">Gets or sets the name of the server running the application. <seealso cref="SentryOptions.ServerName"/></param>
@@ -173,6 +178,7 @@ namespace Serilog
             LogEventLevel? minimumEventLevel = null,
             LogEventLevel? minimumBreadcrumbLevel = null,
             IFormatProvider? formatProvider = null,
+            ITextFormatter? textFormatter = null,
             bool? sendDefaultPii = null,
             bool? isEnvironmentUser = null,
             string? serverName = null,
@@ -211,6 +217,11 @@ namespace Serilog
             if (formatProvider != null)
             {
                 sentrySerilogOptions.FormatProvider = formatProvider;
+            }
+
+            if(textFormatter != null)
+            {
+                sentrySerilogOptions.TextFormatter = textFormatter;
             }
 
             if (sendDefaultPii.HasValue)

--- a/test/Sentry.Serilog.Tests/SentrySerilogSinkExtensionsTests.cs
+++ b/test/Sentry.Serilog.Tests/SentrySerilogSinkExtensionsTests.cs
@@ -98,7 +98,7 @@ namespace Sentry.Serilog.Tests
             var sut = _fixture.GetSut();
 
             SentrySinkExtensions.ConfigureSentrySerilogOptions(sut, _fixture.Dsn, _fixture.MinimumEventLevel,
-                _fixture.MinimumBreadcrumbLevel, null,_fixture.SendDefaultPii,
+                _fixture.MinimumBreadcrumbLevel, null, null, _fixture.SendDefaultPii,
                 _fixture.IsEnvironmentUser, _fixture.ServerName, _fixture.AttachStackTrace, _fixture.MaxBreadcrumbs,
                 _fixture.SampleRate, _fixture.Release, _fixture.Environment,  _fixture.MaxQueueItems,
                 _fixture.ShutdownTimeout, _fixture.DecompressionMethods, _fixture.RequestBodyCompressionLevel,


### PR DESCRIPTION
This feature is needed because sometimes a identifier of some kind (example: user id, task id) is added via `Serilog.ILogger.ForContext()` so it's not visible in the log message body.
Currently there's no option to control how sentry formats received log events.
Most Serilog sinks that output texts have a `Serilog.Formatting.ITextFormatter formatter` or `string outputTemplate` argument so additional information can be added to the result log text.

This pull request is adding more arguments to public methods thus should be considered as a breaking change.