### PR TITLE
Adjust paramer type in AddBreadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Adjust parameter type in `AddBreadcrumb` to use `IReadOnlyDictionary<...>` instead of `Dictionary<...>` ([#1000](https://github.com/getsentry/sentry-dotnet/pull/1000))
+
 ### Features
 
 - Serilog: Add support for Serilog.Formatting.ITextFormatter ([#998](https://github.com/getsentry/sentry-dotnet/pull/998))

--- a/src/Sentry/IHasBreadcrumbs.cs
+++ b/src/Sentry/IHasBreadcrumbs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -85,7 +85,7 @@ namespace Sentry
             string message,
             string? category = null,
             string? type = null,
-            Dictionary<string, string>? data = null,
+            IReadOnlyDictionary<string, string>? data = null,
             BreadcrumbLevel level = default)
         {
             // Not to throw on code that ignores nullability warnings.


### PR DESCRIPTION
Always better to use a concrete type, also it's now consistent with the other extension method.