### PR TITLE
fix nupkg readme

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,6 +22,7 @@
     <PackageIcon>sentry-nuget.png</PackageIcon>
     <PackageProjectUrl>https://sentry.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <!-- Prop required by Microsoft.SourceLink.GitHub -->
     <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
@@ -50,8 +51,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)/../.assets/sentry-nuget.png" Pack="true" PackagePath=""/>
-    <None Include="$(MSBuildThisFileDirectory)/../README.md" Pack="true" PackagePath=""/>
+    <None Include="$(MSBuildThisFileDirectory)../.assets/sentry-nuget.png" Pack="true" PackagePath=""/>
+    <None Include="$(MSBuildThisFileDirectory)../README.md" Pack="true" PackagePath=""/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
@Tyrrrz did this work for you when you added it?
Didn't show up on nuget.org

I added it [on another project](https://github.com/bruno-garcia/unoptimized-assembly-detector) and I assume this should do (didn't check here yet)

#skip-changelog