### PR TITLE
Use `DebugDiagnosticLogger` as the default logger for legacy ASP.NET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Adjust parameter type in `AddBreadcrumb` to use `IReadOnlyDictionary<...>` instead of `Dictionary<...>` ([#1000](https://github.com/getsentry/sentry-dotnet/pull/1000))
 - await dispose everywhere ([#1009](https://github.com/getsentry/sentry-dotnet/pull/1009))
+- Use `DebugDiagnosticLogger` as the default logger for legacy ASP.NET ([#1012](https://github.com/getsentry/sentry-dotnet/pull/1012))
 
 ### Features
 

--- a/src/Sentry.AspNet/SentryAspNetOptionsExtensions.cs
+++ b/src/Sentry.AspNet/SentryAspNetOptionsExtensions.cs
@@ -1,5 +1,6 @@
 using Sentry.AspNet.Internal;
 using Sentry.Extensibility;
+using Sentry.Infrastructure;
 
 namespace Sentry.AspNet
 {
@@ -21,6 +22,7 @@ namespace Sentry.AspNet
 
             var eventProcessor = new SystemWebRequestEventProcessor(payloadExtractor, options);
 
+            options.DiagnosticLogger ??= new DebugDiagnosticLogger(options.DiagnosticLevel);
             options.Release ??= SystemWebVersionLocator.GetCurrent();
             options.AddEventProcessor(eventProcessor);
         }


### PR DESCRIPTION
Closes #971