### PR TITLE
Hub.IsEnabled set to false when Hub disposed

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @bruno-garcia
+*       @bruno-garcia @tyrrrz

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -249,6 +249,11 @@ namespace Sentry.Internal
         {
             _options.DiagnosticLogger?.LogInfo("Disposing the Hub.");
 
+            if (Interlocked.Exchange(ref _isEnabled, 0) != 1)
+            {
+                return;
+            }
+
             if (_integrations?.Length > 0)
             {
                 foreach (var integration in _integrations)
@@ -260,7 +265,6 @@ namespace Sentry.Internal
                 }
             }
 
-            Interlocked.Exchange(ref _isEnabled, 0);
             (_ownedClient as IDisposable)?.Dispose();
             _rootScope.Dispose();
             ScopeManager.Dispose();

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Sentry.Extensibility;
 using Sentry.Integrations;
@@ -19,7 +20,8 @@ namespace Sentry.Internal
 
         internal SentryScopeManager ScopeManager { get; }
 
-        public bool IsEnabled => true;
+        private int _isEnabled = 1;
+        public bool IsEnabled => _isEnabled == 1;
 
         internal Hub(ISentryClient client, SentryOptions options)
         {
@@ -258,6 +260,7 @@ namespace Sentry.Internal
                 }
             }
 
+            Interlocked.Exchange(ref _isEnabled, 0);
             (_ownedClient as IDisposable)?.Dispose();
             _rootScope.Dispose();
             ScopeManager.Dispose();

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -640,10 +640,8 @@ namespace NotSentry.Tests
             hub.WithScope(scope => scope.Transaction.Should().BeNull());
         }
 
-        [Theory]
-        [InlineData(1)]
-        [InlineData(2)]
-        public void Dispose_IsEnabled_SetToFalse(int disposeCount)
+        [Fact]
+        public void Dispose_IsEnabled_SetToFalse()
         {
             // Arrange
             var hub = new Hub(new SentryOptions
@@ -651,14 +649,30 @@ namespace NotSentry.Tests
                 Dsn = DsnSamples.ValidDsnWithSecret
             });
 
+            hub.IsEnabled.Should().BeTrue();
+
             // Act
-            for (var i = 0; i < disposeCount; i++)
-            {
-                hub.Dispose();
-            }
+            hub.Dispose();
 
             // Assert
             hub.IsEnabled.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Dispose_CalledSecondTime_ClientDisposedOnce()
+        {
+            var client = Substitute.For<ISentryClient, IDisposable>();
+            var hub = new Hub(client, new SentryOptions
+            {
+                Dsn = DsnSamples.ValidDsnWithSecret
+            });
+
+            // Act
+            hub.Dispose();
+            hub.Dispose();
+
+            // Assert
+            (client as IDisposable).Received(1).Dispose();
         }
     }
 }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -639,5 +639,26 @@ namespace NotSentry.Tests
             // Assert
             hub.WithScope(scope => scope.Transaction.Should().BeNull());
         }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void Dispose_IsEnabled_SetToFalse(int disposeCount)
+        {
+            // Arrange
+            var hub = new Hub(new SentryOptions
+            {
+                Dsn = DsnSamples.ValidDsnWithSecret
+            });
+
+            // Act
+            for (var i = 0; i < disposeCount; i++)
+            {
+                hub.Dispose();
+            }
+
+            // Assert
+            hub.IsEnabled.Should().BeFalse();
+        }
     }
 }


### PR DESCRIPTION
`Hub.IsEnabled` is set to `false` when `Hub.Dispose()` is called. Related to https://github.com/getsentry/sentry-unity/issues/193 bug.