### PR TITLE
experimental wpf integration

### DIFF
--- a/Sentry.sln
+++ b/Sentry.sln
@@ -125,6 +125,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.EntityFramework.Test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.EntityFramework", "samples\Sentry.Samples.EntityFramework\Sentry.Samples.EntityFramework.csproj", "{8E4BA4C7-413C-4668-8F41-32F484FFB7AA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.Wpf", "samples\Sentry.Samples.Wpf\Sentry.Samples.Wpf.csproj", "{0A73AAD2-F705-4A64-8214-C49739E0FF07}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -271,6 +273,10 @@ Global
 		{8E4BA4C7-413C-4668-8F41-32F484FFB7AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8E4BA4C7-413C-4668-8F41-32F484FFB7AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8E4BA4C7-413C-4668-8F41-32F484FFB7AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A73AAD2-F705-4A64-8214-C49739E0FF07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A73AAD2-F705-4A64-8214-C49739E0FF07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A73AAD2-F705-4A64-8214-C49739E0FF07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A73AAD2-F705-4A64-8214-C49739E0FF07}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -314,6 +320,7 @@ Global
 		{8B38F62E-0DD5-486F-96F5-2025AFB9B491} = {AF6AF4C7-8AA2-4D59-8064-2D79560904EB}
 		{840B220E-68EC-4ECB-AEA1-67B0151F17FC} = {83263231-1A2A-4733-B759-EEFF14E8C5D5}
 		{8E4BA4C7-413C-4668-8F41-32F484FFB7AA} = {77454495-55EE-4B40-A089-71B9E8F82E89}
+		{0A73AAD2-F705-4A64-8214-C49739E0FF07} = {77454495-55EE-4B40-A089-71B9E8F82E89}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0C652B1A-DF72-4EE5-A98B-194FE2C054F6}

--- a/samples/Sentry.Samples.Wpf/App.xaml
+++ b/samples/Sentry.Samples.Wpf/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="Sentry.Samples.Wpf.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Sentry.Samples.Wpf"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/samples/Sentry.Samples.Wpf/App.xaml.cs
+++ b/samples/Sentry.Samples.Wpf/App.xaml.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Navigation;
+using Sentry.Protocol;
+
+namespace Sentry.Samples.Wpf
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+        public App()
+        {
+            // TODO: Should be part of Sentry.Wpf and hook automatically
+            DispatcherUnhandledException += (sender, e) =>
+            {
+                if (e.Exception is Exception ex)
+                {
+                    ex.Data[Mechanism.HandledKey] = e.Handled;
+                    ex.Data[Mechanism.MechanismKey] = "App.DispatcherUnhandledException";
+                    _ = SentrySdk.CaptureException(ex);
+                }
+
+                if (!e.Handled)
+                {
+                    // Unhandled will crash the app so flush the queue:
+                    SentrySdk.FlushAsync(TimeSpan.FromSeconds(2)).GetAwaiter().GetResult();
+                }
+            };
+
+            SentrySdk.Init(o =>
+            {
+                o.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+                // TODO: Should print to VS debug window (similar to Sentry for ASP.NET)
+                o.Debug = true;
+                // TODO: Doesn't support multiple instances of the process on the same directory yet
+                o.CacheDirectoryPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                // For testing, set to 100% transactions for performance monitoring.
+                o.TracesSampleRate = 1.0;
+            });
+        }
+
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            SentrySdk.AddBreadcrumb("OnStartup", "app.lifecycle");
+            SentrySdk.ConfigureScope(s => s.Transaction = SentrySdk.StartTransaction("Startup", "app.start"));
+            base.OnStartup(e);
+        }
+
+        protected override void OnNavigating(NavigatingCancelEventArgs e)
+        {
+            SentrySdk.AddBreadcrumb("NavigatingCancelEventArgs",
+                "navigation",
+                data: new Dictionary<string, string>
+            {
+                {"url", e.Uri.ToString()}
+            });
+            base.OnNavigating(e);
+        }
+
+        protected override void OnFragmentNavigation(FragmentNavigationEventArgs e)
+        {
+            SentrySdk.AddBreadcrumb("OnFragmentNavigation",
+                "navigation",
+                data: new Dictionary<string, string>
+            {
+                {"fragment", e.Fragment},
+                {"handled", e.Handled.ToString()}
+            });
+            base.OnFragmentNavigation(e);
+        }
+
+        protected override void OnExit(ExitEventArgs e)
+        {
+            base.OnExit(e);
+            SentrySdk.Close();
+        }
+    }
+}

--- a/samples/Sentry.Samples.Wpf/AssemblyInfo.cs
+++ b/samples/Sentry.Samples.Wpf/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+    //(used if a resource is not found in the page,
+    // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+    //(used if a resource is not found in the page,
+    // app, or any theme specific resource dictionaries)
+)]

--- a/samples/Sentry.Samples.Wpf/MainWindow.xaml
+++ b/samples/Sentry.Samples.Wpf/MainWindow.xaml
@@ -1,0 +1,12 @@
+﻿<Window x:Class="Sentry.Samples.Wpf.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Sentry.Samples.Wpf"
+        mc:Ignorable="d"
+        Title="MainWindow" Height="450" Width="800">
+    <Grid>
+        <Button Click="ButtonBase_OnClick"></Button>
+    </Grid>
+</Window>

--- a/samples/Sentry.Samples.Wpf/MainWindow.xaml.cs
+++ b/samples/Sentry.Samples.Wpf/MainWindow.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Windows;
+
+namespace Sentry.Samples.Wpf
+{
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml
+    /// </summary>
+    public partial class MainWindow : Window
+    {
+        public MainWindow() => InitializeComponent();
+
+        private ISpan _initSpan;
+
+        public override void BeginInit()
+        {
+            _initSpan = SentrySdk.GetSpan()?.StartChild("BeginInit");
+            base.BeginInit();
+        }
+
+        public override void EndInit()
+        {
+            base.EndInit();
+            _initSpan?.Finish();
+            // Is this the API to close the current transaction bound to the scope? Maybe we need to revisit this..
+            SentrySdk.ConfigureScope(s => s.Transaction?.Finish());
+        }
+
+        private void ButtonBase_OnClick(object sender, RoutedEventArgs e)
+            => throw new InvalidOperationException("This button shall not be pressed!");
+    }
+}

--- a/samples/Sentry.Samples.Wpf/Sentry.Samples.Wpf.csproj
+++ b/samples/Sentry.Samples.Wpf/Sentry.Samples.Wpf.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>WinExe</OutputType>
+        <TargetFramework>netcoreapp3.1-windows</TargetFramework>
+        <UseWPF>true</UseWPF>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Starting from a sample to see what hooks we need.
The goal is to create a new package `Sentry.Wpf` that already hooks to `DispatcherUnhandledException`. Additionally it would set up offline caching by default, and create some transactions out of the box.

Once #1013 is done it can also emit release health stats out of the box.