### PR TITLE
Allow User with only IP address set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Features
+
+- Report user IP address for ASP.NET Core ([#1045](https://github.com/getsentry/sentry-unity/pull/1045))
 
 ### Fixes
 

--- a/src/Sentry.AspNetCore/DefaultUserFactory.cs
+++ b/src/Sentry.AspNetCore/DefaultUserFactory.cs
@@ -9,7 +9,7 @@ namespace Sentry.AspNetCore
         public User? Create(HttpContext context)
         {
             var principal = context.User;
-            if (principal == null)
+            if (principal is null)
             {
                 return null;
             }
@@ -36,20 +36,21 @@ namespace Sentry.AspNetCore
             // Identity.Name Reads the value of: ClaimsIdentity.NameClaimType which by default is ClaimTypes.Name
             // It can be changed by the application to read a different claim though:
             var name = principal.Identity?.Name;
-            if (name != null && username != name)
+            if (name is not null && username != name)
             {
                 username = name;
             }
 
-            // Don't create a user if all we have is his IP address
-            return email == null && id == null && username == null
+            var ipAddress = context.Connection?.RemoteIpAddress?.ToString();
+
+            return email is null && id is null && username is null && ipAddress is null
                 ? null
                 : new User
                 {
                     Id = id,
                     Email = email,
                     Username = username,
-                    IpAddress = context.Connection?.RemoteIpAddress?.ToString()
+                    IpAddress = ipAddress,
                 };
         }
     }

--- a/src/Sentry.AspNetCore/DefaultUserFactory.cs
+++ b/src/Sentry.AspNetCore/DefaultUserFactory.cs
@@ -36,7 +36,7 @@ namespace Sentry.AspNetCore
             // Identity.Name Reads the value of: ClaimsIdentity.NameClaimType which by default is ClaimTypes.Name
             // It can be changed by the application to read a different claim though:
             var name = principal.Identity?.Name;
-            if (name is not null && username is not name)
+            if (name is not null && username != name)
             {
                 username = name;
             }

--- a/src/Sentry.AspNetCore/DefaultUserFactory.cs
+++ b/src/Sentry.AspNetCore/DefaultUserFactory.cs
@@ -36,7 +36,7 @@ namespace Sentry.AspNetCore
             // Identity.Name Reads the value of: ClaimsIdentity.NameClaimType which by default is ClaimTypes.Name
             // It can be changed by the application to read a different claim though:
             var name = principal.Identity?.Name;
-            if (name is not null && username != name)
+            if (name is not null && username is not name)
             {
                 username = name;
             }

--- a/test/Sentry.AspNetCore.Tests/DefaultUserFactoryTests.cs
+++ b/test/Sentry.AspNetCore.Tests/DefaultUserFactoryTests.cs
@@ -69,11 +69,12 @@ namespace Sentry.AspNetCore.Tests
         }
 
         [Fact]
-        public void Create_NoClaimsNoIdentity_Null()
+        public void Create_NoClaimsNoIdentity_IpAddress()
         {
             _ = HttpContext.User.Identity.ReturnsNull();
             _ = HttpContext.User.Claims.Returns(Enumerable.Empty<Claim>());
-            Assert.Null(_sut.Create(HttpContext));
+            var actual = _sut.Create(HttpContext);
+            Assert.Equal(IPAddress.IPv6Loopback.ToString(), actual?.IpAddress);
         }
 
         [Fact]


### PR DESCRIPTION
Currently the `DefaultUserFactory` requires `HttpContext.User.Identity` or `HttpContext.User.Claims` to be set in order to create the User object. If they're not set, the IP address of the web client isn't used and eventually gets overridden with `{{auto}}` which isn't a desirable default behaviour for ASP.NET Core as the server ip will be reported as the user IP.

This PR allows User to be created also if the client IP address is the only property available and this will result in a more desirable default behaviour for ASP.NET Core apps as client address should (almost?) always be set.