### PR TITLE
Include staging in the environment naming rules from HostEnvironment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Report lowercase staging environment for ASP.NET Core ([#1046](https://github.com/getsentry/sentry-unity/pull/1046))
+
 ## 3.5.0
 
 ### Features

--- a/src/Sentry.AspNetCore/Constants.cs
+++ b/src/Sentry.AspNetCore/Constants.cs
@@ -4,19 +4,5 @@ namespace Sentry.AspNetCore
     {
         // See: https://github.com/getsentry/sentry-release-registry
         public const string SdkName = "sentry.dotnet.aspnetcore";
-
-        public static string ASPNETCoreProductionEnvironmentName =>
-#if NETSTANDARD2_0
-             "Production";
-#else
-             Microsoft.Extensions.Hosting.Environments.Production;
-#endif
-
-        public static string ASPNETCoreDevelopmentEnvironmentName =>
-#if NETSTANDARD2_0
-             "Development";
-#else
-             Microsoft.Extensions.Hosting.Environments.Development;
-#endif
     }
 }

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
@@ -4,8 +4,10 @@ using Microsoft.Extensions.Options;
 using Sentry.Extensions.Logging;
 using Sentry.Internal;
 #if NETSTANDARD2_0
+using Microsoft.AspNetCore.Hosting;
 using IHostingEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
 #else
+using Microsoft.Extensions.Hosting;
 using IHostingEnvironment = Microsoft.AspNetCore.Hosting.IWebHostEnvironment;
 #endif
 
@@ -36,7 +38,7 @@ namespace Sentry.AspNetCore
                 }
                 else
                 {
-                    // NOTE: Sentry prefers to have it's environment setting to be all lower case.
+                    // NOTE: Sentry prefers to have its environment setting to be all lower case.
                     //       .NET Core sets the ENV variable to 'Production' (upper case P) or
                     //       'Development' (upper case D) which conflicts with the Sentry recommendation.
                     //       As such, we'll be kind and override those values, here ... if applicable.
@@ -46,11 +48,15 @@ namespace Sentry.AspNetCore
                     //             need to respect (especially the case-sensitivity).
                     //             REF: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/environments
 
-                    if (_hostingEnvironment.EnvironmentName.Equals(Constants.ASPNETCoreProductionEnvironmentName))
+                    if (_hostingEnvironment.IsProduction())
                     {
                         options.Environment = Internal.Constants.ProductionEnvironmentSetting;
                     }
-                    else if (_hostingEnvironment.EnvironmentName.Equals(Constants.ASPNETCoreDevelopmentEnvironmentName))
+                    else if (_hostingEnvironment.IsStaging())
+                    {
+                        options.Environment = Internal.Constants.StagingEnvironmentSetting;
+                    }
+                    else if (_hostingEnvironment.IsDevelopment())
                     {
                         options.Environment = Internal.Constants.DevelopmentEnvironmentSetting;
                     }

--- a/src/Sentry/Internal/Constants.cs
+++ b/src/Sentry/Internal/Constants.cs
@@ -26,6 +26,8 @@ namespace Sentry.Internal
         /// <remarks>Best Sentry practice is to always try and have a value for this setting.</remarks>
         public const string ProductionEnvironmentSetting = "production";
 
+        public const string StagingEnvironmentSetting = "staging";
+
         public const string DevelopmentEnvironmentSetting = "development";
 
         public const string DebugEnvironmentSetting = "debug";

--- a/test/Sentry.AspNetCore.Tests/SentryAspNetCoreOptionsSetupTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryAspNetCoreOptionsSetupTests.cs
@@ -48,8 +48,11 @@ namespace Sentry.AspNetCore.Tests
         [InlineData("", "Production", "production")] // Custom - nothing set. ASPNET_ENVIRONMENT is default PROD.
         [InlineData(null, "Development", "development")] // Custom - nothing set. ASPNET_ENVIRONMENT is default DEV.
         [InlineData("", "Development", "development")] // Custom - nothing set. ASPNET_ENVIRONMENT is default DEV.
+        [InlineData(null, "Staging", "staging")] // Custom - nothing set. ASPNET_ENVIRONMENT is default DEV.
+        [InlineData("", "Staging", "staging")] // Custom - nothing set. ASPNET_ENVIRONMENT is default DEV.
         [InlineData(null, "production", "production")] // Custom - nothing set. ASPNET_ENVIRONMENT is custom (notice lowercase 'p').
         [InlineData(null, "development", "development")] // Custom - nothing set. ASPNET_ENVIRONMENT is custom (notice lowercase 'd').
+        [InlineData(null, "staging", "staging")] // Custom - nothing set. ASPNET_ENVIRONMENT is custom (notice lowercase 's').
         public void Filters_Environment_CustomOrASPNETEnvironment_Set(string environment, string hostingEnvironmentSetting, string expectedEnvironment)
         {
             // Arrange.


### PR DESCRIPTION
Continues on from where #551 / #554 left off with the environment naming. Like "Production" and "Development", the environment "Staging" is built into the framework. For consistency, I think it is important that all 3 of these built-in names perform the same way.

Additionally, I've switched to use the extension methods to check the environment names. Logically they would perform the same action but it is the "standard" way of checking the environments.