### PR TITLE
Make debug diagnostic logger obsolete and add Trace diagnostic logger.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Make debug diagnostic logger obsolete and add Trace diagnostic logger ([#1048](https://github.com/getsentry/sentry-dotnet/pull/1048))
+- Introduce TraceDiagnosticLogger and obsolete DebugDiagnosticLogger ([#1048](https://github.com/getsentry/sentry-dotnet/pull/1048))
 
 ## 3.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Make debug diagnostic logger obsolete and add Trace diagnostic logger ([#1048](https://github.com/getsentry/sentry-dotnet/pull/1048))
+
 ## 3.5.0
 
 ### Features

--- a/src/Sentry.AspNet/SentryAspNetOptionsExtensions.cs
+++ b/src/Sentry.AspNet/SentryAspNetOptionsExtensions.cs
@@ -22,7 +22,7 @@ namespace Sentry.AspNet
 
             var eventProcessor = new SystemWebRequestEventProcessor(payloadExtractor, options);
 
-            options.DiagnosticLogger ??= new DebugDiagnosticLogger(options.DiagnosticLevel);
+            options.DiagnosticLogger ??= new TraceDiagnosticLogger(options.DiagnosticLevel);
             options.Release ??= SystemWebVersionLocator.GetCurrent();
             options.AddEventProcessor(eventProcessor);
         }

--- a/src/Sentry/Infrastructure/DebugDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/DebugDiagnosticLogger.cs
@@ -10,6 +10,7 @@ namespace Sentry.Infrastructure
     /// <remarks>
     /// Logger available when compiled in Debug mode. It's useful when debugging apps running under IIS which have no output to Console logger.
     /// </remarks>
+    [Obsolete("Logger doesn't work outside of Sentry SDK. Please use TraceDiagnosticLogger instead")]
     public class DebugDiagnosticLogger : IDiagnosticLogger
     {
         private readonly SentryLevel _minimalLevel;

--- a/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
@@ -33,8 +33,12 @@ namespace Sentry.Infrastructure
             {
                 for (var i = 0; i < Trace.Listeners.Count; i++)
                 {
-                    Trace.Listeners[i].WriteLine($@"{logLevel,7}: {string.Format(message, args)}
-{exception}");
+                    var listener = Trace.Listeners[i];
+                    listener.WriteLine($"{logLevel,7}: {string.Format(message, args)}");
+                    if (exception != null)
+                    {
+                        listener.WriteLine(exception);
+                    }
                 }
             }
             catch (ArgumentOutOfRangeException)

--- a/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Sentry.Extensibility;
 namespace Sentry.Infrastructure
@@ -28,13 +29,18 @@ namespace Sentry.Infrastructure
         /// </summary>
         public void Log(SentryLevel logLevel, string message, Exception? exception = null, params object?[] args)
         {
-            lock (Trace.Listeners)
+            try
             {
-                for (int index = 0; index < Trace.Listeners.Count; index++)
+                for (var i = 0; i < Trace.Listeners.Count; i++)
                 {
-                    Trace.Listeners[index].Write($@"{logLevel,7}: {string.Format(message, args)}
+                    Trace.Listeners[i].WriteLine($@"{logLevel,7}: {string.Format(message, args)}
 {exception}");
                 }
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // Trace.Listeners is a public mutable static property and listeners can be removed
+                // from anywhere at anytime.
             }
         }
     }

--- a/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Diagnostics;
+using Sentry.Extensibility;
+using System.Linq;
+
+namespace Sentry.Infrastructure
+{
+    /// <summary>
+    /// Trace logger used by the SDK to report its internal logging.
+    /// </summary>
+    /// <remarks>
+    /// Logger available when hooked to an IDE. It's useful when debugging apps running under IIS which have no output to Console logger.
+    /// </remarks>
+    public class TraceDiagnosticLogger : IDiagnosticLogger
+    {
+        private readonly SentryLevel _minimalLevel;
+
+        private Lazy<TraceListener?> _traceListener = new Lazy<TraceListener?>(() => GetFirstOrDefaultListener());
+
+        /// <summary>
+        /// Get the first TraceListener, usually it's the process debug output.
+        /// </summary>
+        /// <returns>The first TraceListener, if available</returns>
+        private static TraceListener? GetFirstOrDefaultListener()
+        {
+            var listeners = Trace.Listeners;
+            return listeners.Count > 0 ? listeners[0] : null;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="TraceDiagnosticLogger"/>.
+        /// </summary>
+        public TraceDiagnosticLogger(SentryLevel minimalLevel) => _minimalLevel = minimalLevel;
+
+        /// <summary>
+        /// Whether the logger is enabled to the defined level.
+        /// </summary>
+        public bool IsEnabled(SentryLevel level) => level >= _minimalLevel && _traceListener.Value != null;
+
+        /// <summary>
+        /// Log message with level, exception and parameters.
+        /// </summary>
+        public void Log(SentryLevel logLevel, string message, Exception? exception = null, params object?[] args)
+            => _traceListener.Value?.Write($@"{logLevel,7}: {string.Format(message, args)}
+{exception}");
+    }
+}

--- a/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Diagnostics;
 using Sentry.Extensibility;
-using System.Linq;
-
 namespace Sentry.Infrastructure
 {
     /// <summary>
@@ -15,18 +13,6 @@ namespace Sentry.Infrastructure
     {
         private readonly SentryLevel _minimalLevel;
 
-        private Lazy<TraceListener?> _traceListener = new Lazy<TraceListener?>(() => GetFirstOrDefaultListener());
-
-        /// <summary>
-        /// Get the first TraceListener, usually it's the process debug output.
-        /// </summary>
-        /// <returns>The first TraceListener, if available</returns>
-        private static TraceListener? GetFirstOrDefaultListener()
-        {
-            var listeners = Trace.Listeners;
-            return listeners.Count > 0 ? listeners[0] : null;
-        }
-
         /// <summary>
         /// Creates a new instance of <see cref="TraceDiagnosticLogger"/>.
         /// </summary>
@@ -35,13 +21,13 @@ namespace Sentry.Infrastructure
         /// <summary>
         /// Whether the logger is enabled to the defined level.
         /// </summary>
-        public bool IsEnabled(SentryLevel level) => level >= _minimalLevel && _traceListener.Value != null;
+        public bool IsEnabled(SentryLevel level) => level >= _minimalLevel;
 
         /// <summary>
         /// Log message with level, exception and parameters.
         /// </summary>
         public void Log(SentryLevel logLevel, string message, Exception? exception = null, params object?[] args)
-            => _traceListener.Value?.Write($@"{logLevel,7}: {string.Format(message, args)}
+            => Trace.Write($@"{logLevel,7}: {string.Format(message, args)}
 {exception}");
     }
 }

--- a/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
@@ -27,7 +27,16 @@ namespace Sentry.Infrastructure
         /// Log message with level, exception and parameters.
         /// </summary>
         public void Log(SentryLevel logLevel, string message, Exception? exception = null, params object?[] args)
-            => Trace.Write($@"{logLevel,7}: {string.Format(message, args)}
+        {
+            lock (Trace.Listeners)
+            {
+                for (int index = 0; index < Trace.Listeners.Count; index++)
+                {
+                    Trace.Listeners[index].Write($@"{logLevel,7}: {string.Format(message, args)}
 {exception}");
+                    System.Threading.Thread.Sleep(10000);
+                }
+            }
+        }
     }
 }

--- a/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
@@ -34,7 +34,6 @@ namespace Sentry.Infrastructure
                 {
                     Trace.Listeners[index].Write($@"{logLevel,7}: {string.Format(message, args)}
 {exception}");
-                    System.Threading.Thread.Sleep(10000);
                 }
             }
         }

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Sentry</RootNamespace>
     <Description>Official SDK for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
     <NoWarn Condition="$(TargetFramework) == 'netstandard2.0'">$(NoWarn);RS0017</NoWarn>
-    <DefineConstants>$(AdditionalConstants);TRACE</DefineConstants>
+    <DefineConstants>$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
 
   <!-- Ben.Demystifier -->

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Sentry</RootNamespace>
     <Description>Official SDK for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
     <NoWarn Condition="$(TargetFramework) == 'netstandard2.0'">$(NoWarn);RS0017</NoWarn>
-    <DefineConstants>$(AdditionalConstants)</DefineConstants>
+    <DefineConstants>$(AdditionalConstants);TRACE</DefineConstants>
   </PropertyGroup>
 
   <!-- Ben.Demystifier -->


### PR DESCRIPTION
 DebugDiagnosticLogger only works with projects inside Sentry.NET.snl since Release builds remove the Debug code, making it useless to the end-user.
Another approach is to use Trace as a replacement, it's not as simple as the good old DebugDiagnosticLogger but it should work just fine even in Release mode.

Close #1040.

It would be great if I could simply use Trace.Write but it seems like the compiler gets rid of it if not called from the current process.

EDIT: Validated on
* .NET 5 Console
* .NET Core with IIS 
* .NET Native UWP