### PR TITLE
Add packages System.Memory and System.Buffers

### DIFF
--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -33,6 +33,8 @@
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 
   <!-- Prefer bundled version of System.Text.Json to avoid extra dependencies -->


### PR DESCRIPTION
Reason: https://github.com/getsentry/sentry-dotnet/issues/931

Adding both packages mitigates the above error.

Related issue: https://github.com/mono/mono/issues/20805

By adding the package, the app that I was testing stopped throwing errors when serializing, it seems like both libraries are not included or are missing some fields required by Sentry, forcing it to update fixed the reference issue.

Close #931.

#skip-changelog