### PR TITLE
Added SentryAspNetCoreOptions.AdjustStandardEnvironmentNameCasing to …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - Use SentryId for ISession.Id ([#1052](https://github.com/getsentry/sentry-dotnet/pull/1052))
+- Added SentryAspNetCoreOptions.AdjustStandardEnvironmentNameCasing to control whether to transform the environment name to lower case or to keep it as is. [#1057](https://github.com/getsentry/sentry-dotnet/pull/1057)
 
 ## 3.6.0-alpha.1
 

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
@@ -40,7 +40,7 @@ namespace Sentry.AspNetCore
         public TimeSpan FlushTimeout { get; set; } = TimeSpan.FromSeconds(2);
 
         /// <summary>
-        /// Controls whether the casing of the standard (Production, Development and Staging) environment name supplied by <see cref="Microsoft.AspNetCore.Hosting.HostingEnvironment" />
+        /// Controls whether the casing of the standard (Production, Development and Staging) environment name supplied by <see cref="Microsoft.AspNetCore.Hosting.IHostingEnvironment" />
         /// is adjusted when setting the Sentry environment. Defaults to true.
         /// </summary>
         /// <remarks>

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
@@ -40,11 +40,11 @@ namespace Sentry.AspNetCore
         public TimeSpan FlushTimeout { get; set; } = TimeSpan.FromSeconds(2);
 
         /// <summary>
-        /// Controls whether the case of the standard (Production, Development and Staging) EnvironmentName supplied by HostingEnvironment
+        /// Controls whether the casing of the standard (Production, Development and Staging) environment name supplied by <see cref="Microsoft.AspNetCore.Hosting.HostingEnvironment" />
         /// is adjusted when setting the Sentry environment. Defaults to true.
         /// </summary>
         /// <remarks>
-        /// The default .NET Core EnvironmentNames include Production, Development and Staging (note Pascal casing), whereas sentry prefers
+        /// The default .NET Core environment names include Production, Development and Staging (note Pascal casing), whereas Sentry prefers
         /// to have its environment setting be all lower case.
         /// </remarks>
         public bool AdjustStandardEnvironmentNameCasing { get; set; } = true;

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
@@ -40,6 +40,16 @@ namespace Sentry.AspNetCore
         public TimeSpan FlushTimeout { get; set; } = TimeSpan.FromSeconds(2);
 
         /// <summary>
+        /// Controls whether the case of the standard (Production, Development and Staging) EnvironmentName supplied by HostingEnvironment
+        /// is adjusted when setting the Sentry environment. Defaults to true.
+        /// </summary>
+        /// <remarks>
+        /// The default .NET Core EnvironmentNames include Production, Development and Staging (note Pascal casing), whereas sentry prefers
+        /// to have its environment setting be all lower case.
+        /// </remarks>
+        public bool AdjustStandardEnvironmentNameCasing { get; set; } = true;
+
+        /// <summary>
         /// Creates a new instance of <see cref="SentryAspNetCoreOptions"/>.
         /// </summary>
         public SentryAspNetCoreOptions()

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
@@ -38,31 +38,39 @@ namespace Sentry.AspNetCore
                 }
                 else
                 {
-                    // NOTE: Sentry prefers to have its environment setting to be all lower case.
-                    //       .NET Core sets the ENV variable to 'Production' (upper case P) or
-                    //       'Development' (upper case D) which conflicts with the Sentry recommendation.
-                    //       As such, we'll be kind and override those values, here ... if applicable.
-                    // Assumption: The Hosting Environment is always set.
-                    //             If not set by a developer, then the framework will auto set it.
-                    //             Alternatively, developers might set this to a CUSTOM value, which we
-                    //             need to respect (especially the case-sensitivity).
-                    //             REF: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/environments
+                    if (options.AdjustStandardEnvironmentNameCasing)
+                    {
+                        // NOTE: Sentry prefers to have its environment setting to be all lower case.
+                        //       .NET Core sets the ENV variable to 'Production' (upper case P),
+                        //       'Development' (upper case D) or 'Staging' (upper case S) which conflicts with
+                        //       the Sentry recommendation. As such, we'll be kind and override those values,
+                        //       here ... if applicable.
+                        // Assumption: The Hosting Environment is always set.
+                        //             If not set by a developer, then the framework will auto set it.
+                        //             Alternatively, developers might set this to a CUSTOM value, which we
+                        //             need to respect (especially the case-sensitivity).
+                        //             REF: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/environments
 
-                    if (_hostingEnvironment.IsProduction())
-                    {
-                        options.Environment = Internal.Constants.ProductionEnvironmentSetting;
-                    }
-                    else if (_hostingEnvironment.IsStaging())
-                    {
-                        options.Environment = Internal.Constants.StagingEnvironmentSetting;
-                    }
-                    else if (_hostingEnvironment.IsDevelopment())
-                    {
-                        options.Environment = Internal.Constants.DevelopmentEnvironmentSetting;
+                        if (_hostingEnvironment.IsProduction())
+                        {
+                            options.Environment = Internal.Constants.ProductionEnvironmentSetting;
+                        }
+                        else if (_hostingEnvironment.IsStaging())
+                        {
+                            options.Environment = Internal.Constants.StagingEnvironmentSetting;
+                        }
+                        else if (_hostingEnvironment.IsDevelopment())
+                        {
+                            options.Environment = Internal.Constants.DevelopmentEnvironmentSetting;
+                        }
+                        else
+                        {
+                            // Use the value set by the developer.
+                            options.Environment = _hostingEnvironment.EnvironmentName;
+                        }
                     }
                     else
                     {
-                        // Use the value set by the developer.
                         options.Environment = _hostingEnvironment.EnvironmentName;
                     }
                 }

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
@@ -38,39 +38,37 @@ namespace Sentry.AspNetCore
                 }
                 else
                 {
-                    if (options.AdjustStandardEnvironmentNameCasing)
-                    {
-                        // NOTE: Sentry prefers to have its environment setting to be all lower case.
-                        //       .NET Core sets the ENV variable to 'Production' (upper case P),
-                        //       'Development' (upper case D) or 'Staging' (upper case S) which conflicts with
-                        //       the Sentry recommendation. As such, we'll be kind and override those values,
-                        //       here ... if applicable.
-                        // Assumption: The Hosting Environment is always set.
-                        //             If not set by a developer, then the framework will auto set it.
-                        //             Alternatively, developers might set this to a CUSTOM value, which we
-                        //             need to respect (especially the case-sensitivity).
-                        //             REF: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/environments
+                    // NOTE: Sentry prefers to have its environment setting to be all lower case.
+                    //       .NET Core sets the ENV variable to 'Production' (upper case P),
+                    //       'Development' (upper case D) or 'Staging' (upper case S) which conflicts with
+                    //       the Sentry recommendation. As such, we'll be kind and override those values,
+                    //       here ... if applicable.
+                    // Assumption: The Hosting Environment is always set.
+                    //             If not set by a developer, then the framework will auto set it.
+                    //             Alternatively, developers might set this to a CUSTOM value, which we
+                    //             need to respect (especially the case-sensitivity).
+                    //             REF: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/environments
 
-                        if (_hostingEnvironment.IsProduction())
-                        {
-                            options.Environment = Internal.Constants.ProductionEnvironmentSetting;
-                        }
-                        else if (_hostingEnvironment.IsStaging())
-                        {
-                            options.Environment = Internal.Constants.StagingEnvironmentSetting;
-                        }
-                        else if (_hostingEnvironment.IsDevelopment())
-                        {
-                            options.Environment = Internal.Constants.DevelopmentEnvironmentSetting;
-                        }
-                        else
-                        {
-                            // Use the value set by the developer.
-                            options.Environment = _hostingEnvironment.EnvironmentName;
-                        }
+                    if (!options.AdjustStandardEnvironmentNameCasing)
+                    {
+                        // Use the value set by the developer.
+                        options.Environment = _hostingEnvironment.EnvironmentName;
+                    }
+                    else if (_hostingEnvironment.IsProduction())
+                    {
+                        options.Environment = Internal.Constants.ProductionEnvironmentSetting;
+                    }
+                    else if (_hostingEnvironment.IsStaging())
+                    {
+                        options.Environment = Internal.Constants.StagingEnvironmentSetting;
+                    }
+                    else if (_hostingEnvironment.IsDevelopment())
+                    {
+                        options.Environment = Internal.Constants.DevelopmentEnvironmentSetting;
                     }
                     else
                     {
+                        // Use the value set by the developer.
                         options.Environment = _hostingEnvironment.EnvironmentName;
                     }
                 }

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
@@ -36,7 +36,7 @@ namespace Sentry.AspNetCore
                     // Sentry specific environment takes precedence #92.
                     options.Environment = locatedEnvironment;
                 }
-                else
+                else if (options.AdjustStandardEnvironmentNameCasing)
                 {
                     // NOTE: Sentry prefers to have its environment setting to be all lower case.
                     //       .NET Core sets the ENV variable to 'Production' (upper case P),
@@ -49,12 +49,7 @@ namespace Sentry.AspNetCore
                     //             need to respect (especially the case-sensitivity).
                     //             REF: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/environments
 
-                    if (!options.AdjustStandardEnvironmentNameCasing)
-                    {
-                        // Use the value set by the developer.
-                        options.Environment = _hostingEnvironment.EnvironmentName;
-                    }
-                    else if (_hostingEnvironment.IsProduction())
+                    if (_hostingEnvironment.IsProduction())
                     {
                         options.Environment = Internal.Constants.ProductionEnvironmentSetting;
                     }
@@ -71,6 +66,10 @@ namespace Sentry.AspNetCore
                         // Use the value set by the developer.
                         options.Environment = _hostingEnvironment.EnvironmentName;
                     }
+                }
+                else
+                {
+                    options.Environment = _hostingEnvironment.EnvironmentName;
                 }
             }
 

--- a/test/Sentry.AspNetCore.Tests/SentryAspNetCoreOptionsSetupTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryAspNetCoreOptionsSetupTests.cs
@@ -42,24 +42,18 @@ namespace Sentry.AspNetCore.Tests
         }
 
         [Theory]
-        [InlineData("foo", "Production", true, "foo")] // Custom - set. Adjust standard casing - true. Rest ignored.
-        [InlineData("Production", "Production", true, "Production")] // Custom - set. Adjust standard casing - true. Rest ignored. NOTE: Custom value _happens_ to be the common ASPNET_ENVIRONMENT PROD setting.
-        [InlineData(null, "Production", true, "production")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default PROD.
-        [InlineData("", "Production", true, "production")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default PROD.
-        [InlineData(null, "Development", true, "development")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default DEV.
-        [InlineData("", "Development", true, "development")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default DEV.
-        [InlineData(null, "Staging", true, "staging")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default STAGING.
-        [InlineData("", "Staging", true, "staging")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default STAGING.
-        [InlineData(null, "Production", false, "Production")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default PROD.
-        [InlineData("", "Production", false, "Production")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default PROD.
-        [InlineData(null, "Development", false, "Development")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default DEV.
-        [InlineData("", "Development", false, "Development")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default DEV.
-        [InlineData(null, "Staging", false, "Staging")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default STAGING.
-        [InlineData("", "Staging", false, "Staging")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default STAGING.
-        [InlineData(null, "production", true, "production")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is custom (notice lowercase 'p').
-        [InlineData(null, "development", true, "development")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is custom (notice lowercase 'd').
-        [InlineData(null, "staging", true, "staging")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is custom (notice lowercase 's').
-        public void Filters_Environment_CustomOrASPNETEnvironment_Set(string environment, string hostingEnvironmentSetting, bool adjustStandardEnvironmentNameCasingSetting, string expectedEnvironment)
+        [InlineData("foo", "Production", "foo")] // Custom - set. Rest ignored.
+        [InlineData("Production", "Production", "Production")] // Custom - set. Rest ignored. NOTE: Custom value _happens_ to be the common ASPNET_ENVIRONMENT PROD setting.
+        [InlineData(null, "Production", "production")] // Custom - nothing set. ASPNET_ENVIRONMENT is default PROD.
+        [InlineData("", "Production", "production")] // Custom - nothing set. ASPNET_ENVIRONMENT is default PROD.
+        [InlineData(null, "Development", "development")] // Custom - nothing set. ASPNET_ENVIRONMENT is default DEV.
+        [InlineData("", "Development", "development")] // Custom - nothing set. ASPNET_ENVIRONMENT is default DEV.
+        [InlineData(null, "Staging", "staging")] // Custom - nothing set. ASPNET_ENVIRONMENT is default STAGING.
+        [InlineData("", "Staging", "staging")] // Custom - nothing set. ASPNET_ENVIRONMENT is default STAGING.
+        [InlineData(null, "production", "production")] // Custom - nothing set. ASPNET_ENVIRONMENT is custom (notice lowercase 'p').
+        [InlineData(null, "development", "development")] // Custom - nothing set. ASPNET_ENVIRONMENT is custom (notice lowercase 'd').
+        [InlineData(null, "staging", "staging")] // Custom - nothing set. ASPNET_ENVIRONMENT is custom (notice lowercase 's').
+        public void Filters_Environment_CustomOrASPNETEnvironment_Set(string environment, string hostingEnvironmentSetting, string expectedEnvironment)
         {
             // Arrange.
             var hostingEnvironment = Substitute.For<IHostingEnvironment>();
@@ -70,6 +64,34 @@ namespace Sentry.AspNetCore.Tests
                 hostingEnvironment);
 
             //const string environment = "some environment";
+            _target.Environment = environment;
+
+            // Act.
+            sut.Configure(_target);
+
+            // Assert.
+            Assert.Equal(expectedEnvironment, _target.Environment);
+        }
+
+        [Theory]
+        [InlineData("Foo", "Production", true, "Foo")] // Custom - set. Don't modify.
+        [InlineData(null, "Foo", true, "Foo")] // Custom - nothing set. ASPNET_ENVIRONMENT is custom. Don't modify.
+        [InlineData(null, "Production", true, "production")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default PROD.
+        [InlineData(null, "Development", true, "development")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default DEV.
+        [InlineData(null, "Staging", true, "staging")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default STAGING.
+        [InlineData(null, "Production", false, "Production")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default PROD.
+        [InlineData(null, "Development", false, "Development")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default DEV.
+        [InlineData(null, "Staging", false, "Staging")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default STAGING.
+        public void Filters_Environment_AdjustStandardEnvironmentNameCasing_AffectsSentryEnvironment(string environment, string hostingEnvironmentSetting, bool adjustStandardEnvironmentNameCasingSetting, string expectedEnvironment)
+        {
+            // Arrange.
+            var hostingEnvironment = Substitute.For<IHostingEnvironment>();
+            hostingEnvironment.EnvironmentName = hostingEnvironmentSetting;
+
+            var sut = new SentryAspNetCoreOptionsSetup(
+                Substitute.For<ILoggerProviderConfiguration<SentryAspNetCoreLoggerProvider>>(),
+                hostingEnvironment);
+
             _target.Environment = environment;
             _target.AdjustStandardEnvironmentNameCasing = adjustStandardEnvironmentNameCasingSetting;
 

--- a/test/Sentry.AspNetCore.Tests/SentryAspNetCoreOptionsSetupTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryAspNetCoreOptionsSetupTests.cs
@@ -42,18 +42,24 @@ namespace Sentry.AspNetCore.Tests
         }
 
         [Theory]
-        [InlineData("foo", "Production", "foo")] // Custom - set. Rest ignored.
-        [InlineData("Production", "Production", "Production")] // Custom - set. Rest ignored. NOTE: Custom value _happens_ to be the common ASPNET_ENVIRONMENT PROD setting.
-        [InlineData(null, "Production", "production")] // Custom - nothing set. ASPNET_ENVIRONMENT is default PROD.
-        [InlineData("", "Production", "production")] // Custom - nothing set. ASPNET_ENVIRONMENT is default PROD.
-        [InlineData(null, "Development", "development")] // Custom - nothing set. ASPNET_ENVIRONMENT is default DEV.
-        [InlineData("", "Development", "development")] // Custom - nothing set. ASPNET_ENVIRONMENT is default DEV.
-        [InlineData(null, "Staging", "staging")] // Custom - nothing set. ASPNET_ENVIRONMENT is default DEV.
-        [InlineData("", "Staging", "staging")] // Custom - nothing set. ASPNET_ENVIRONMENT is default DEV.
-        [InlineData(null, "production", "production")] // Custom - nothing set. ASPNET_ENVIRONMENT is custom (notice lowercase 'p').
-        [InlineData(null, "development", "development")] // Custom - nothing set. ASPNET_ENVIRONMENT is custom (notice lowercase 'd').
-        [InlineData(null, "staging", "staging")] // Custom - nothing set. ASPNET_ENVIRONMENT is custom (notice lowercase 's').
-        public void Filters_Environment_CustomOrASPNETEnvironment_Set(string environment, string hostingEnvironmentSetting, string expectedEnvironment)
+        [InlineData("foo", "Production", true, "foo")] // Custom - set. Adjust standard casing - true. Rest ignored.
+        [InlineData("Production", "Production", true, "Production")] // Custom - set. Adjust standard casing - true. Rest ignored. NOTE: Custom value _happens_ to be the common ASPNET_ENVIRONMENT PROD setting.
+        [InlineData(null, "Production", true, "production")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default PROD.
+        [InlineData("", "Production", true, "production")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default PROD.
+        [InlineData(null, "Development", true, "development")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default DEV.
+        [InlineData("", "Development", true, "development")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default DEV.
+        [InlineData(null, "Staging", true, "staging")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default STAGING.
+        [InlineData("", "Staging", true, "staging")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is default STAGING.
+        [InlineData(null, "Production", false, "Production")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default PROD.
+        [InlineData("", "Production", false, "Production")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default PROD.
+        [InlineData(null, "Development", false, "Development")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default DEV.
+        [InlineData("", "Development", false, "Development")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default DEV.
+        [InlineData(null, "Staging", false, "Staging")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default STAGING.
+        [InlineData("", "Staging", false, "Staging")] // Custom - nothing set. Adjust standard casing - false. ASPNET_ENVIRONMENT is default STAGING.
+        [InlineData(null, "production", true, "production")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is custom (notice lowercase 'p').
+        [InlineData(null, "development", true, "development")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is custom (notice lowercase 'd').
+        [InlineData(null, "staging", true, "staging")] // Custom - nothing set. Adjust standard casing - true. ASPNET_ENVIRONMENT is custom (notice lowercase 's').
+        public void Filters_Environment_CustomOrASPNETEnvironment_Set(string environment, string hostingEnvironmentSetting, bool adjustStandardEnvironmentNameCasingSetting, string expectedEnvironment)
         {
             // Arrange.
             var hostingEnvironment = Substitute.For<IHostingEnvironment>();
@@ -65,6 +71,7 @@ namespace Sentry.AspNetCore.Tests
 
             //const string environment = "some environment";
             _target.Environment = environment;
+            _target.AdjustStandardEnvironmentNameCasing = adjustStandardEnvironmentNameCasingSetting;
 
             // Act.
             sut.Configure(_target);


### PR DESCRIPTION
…have sentry avoid modifying the case of the standard ASPNET_ENVIRONMENT names when determining the sentry environment.

Fixes #999.