### PR TITLE
Add auto session tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - ASP.NET Core: Option `AdjustStandardEnvironmentNameCasing` to opt-out from lower casing env name. [#1057](https://github.com/getsentry/sentry-dotnet/pull/1057)
 - Sessions: Improve exception check in `CaptureEvent(...)` for the purpose of reporting errors in session ([#1058](https://github.com/getsentry/sentry-dotnet/pull/1058))
 - Introduce TraceDiagnosticLogger and obsolete DebugDiagnosticLogger ([#1048](https://github.com/getsentry/sentry-dotnet/pull/1048))
-- Add auto session tracking([#1068](https://github.com/getsentry/sentry-dotnet/pull/1068))
+- Add auto session tracking ([#1068](https://github.com/getsentry/sentry-dotnet/pull/1068))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - ASP.NET Core: Option `AdjustStandardEnvironmentNameCasing` to opt-out from lower casing env name. [#1057](https://github.com/getsentry/sentry-dotnet/pull/1057)
 - Sessions: Improve exception check in `CaptureEvent(...)` for the purpose of reporting errors in session ([#1058](https://github.com/getsentry/sentry-dotnet/pull/1058))
 - Introduce TraceDiagnosticLogger and obsolete DebugDiagnosticLogger ([#1048](https://github.com/getsentry/sentry-dotnet/pull/1048))
+- Add auto session tracking([#1068](https://github.com/getsentry/sentry-dotnet/pull/1068))
 
 ### Fixes
 

--- a/src/Sentry/Integrations/AutoSessionTrackingIntegration.cs
+++ b/src/Sentry/Integrations/AutoSessionTrackingIntegration.cs
@@ -1,0 +1,26 @@
+﻿using Sentry.Internal;
+
+namespace Sentry.Integrations
+{
+    internal class AutoSessionTrackingIntegration : IInternalSdkIntegration
+    {
+        private bool _isSessionStarted;
+
+        public void Register(IHub hub, SentryOptions options)
+        {
+            if (options.AutoSessionTracking)
+            {
+                hub.StartSession();
+                _isSessionStarted = true;
+            }
+        }
+
+        public void Unregister(IHub hub)
+        {
+            if (_isSessionStarted)
+            {
+                hub.EndSession();
+            }
+        }
+    }
+}

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -482,10 +482,10 @@ namespace Sentry
         /// end the session when it's closed.
         /// </summary>
         /// <remarks>
-        /// This is enabled by default, but may be disabled by certain integrations in case
-        /// they provide a better mechanism for automatically tracking sessions.
+        /// Note: this is disabled by default in the current version, but may be become
+        /// enabled by default in a future major update.
         /// </remarks>
-        public bool AutoSessionTracking { get; set; } = true;
+        public bool AutoSessionTracking { get; set; } = false;
 
         /// <summary>
         /// Creates a new instance of <see cref="SentryOptions"/>

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -478,6 +478,16 @@ namespace Sentry
         public StartupTimeDetectionMode DetectStartupTime { get; set; } = StartupTimeDetectionMode.Best;
 
         /// <summary>
+        /// Whether the SDK should start a session automatically when it's initialized and
+        /// end the session when it's closed.
+        /// </summary>
+        /// <remarks>
+        /// This is enabled by default, but may be disabled by certain integrations in case
+        /// they provide a better mechanism for automatically tracking sessions.
+        /// </remarks>
+        public bool AutoSessionTracking { get; set; } = true;
+
+        /// <summary>
         /// Creates a new instance of <see cref="SentryOptions"/>
         /// </summary>
         public SentryOptions()
@@ -501,9 +511,9 @@ namespace Sentry
             ISentryStackTraceFactory SentryStackTraceFactoryAccessor() => SentryStackTraceFactory;
 
             EventProcessors = new ISentryEventProcessor[] {
-                    // de-dupe to be the first to run
-                    new DuplicateEventDetectionEventProcessor(this),
-                    new MainSentryEventProcessor(this, SentryStackTraceFactoryAccessor),
+                // De-dupe to be the first to run
+                new DuplicateEventDetectionEventProcessor(this),
+                new MainSentryEventProcessor(this, SentryStackTraceFactoryAccessor)
             };
 
             ExceptionProcessors = new ISentryEventExceptionProcessor[] {
@@ -511,6 +521,8 @@ namespace Sentry
             };
 
             Integrations = new ISdkIntegration[] {
+                // Auto-session tracking to be the first to run
+                new AutoSessionTrackingIntegration(),
                 new AppDomainUnhandledExceptionIntegration(),
                 new AppDomainProcessExitIntegration(),
                 new TaskUnobservedTaskExceptionIntegration(),


### PR DESCRIPTION
Related to #1054
Implemented through `ISdkIntegration`.

Tests omitted.

Note the issue says:

> Add an option: EnableAutoSessionTracking with default false until our next major, where we'll flip the default to true.

Should we do that? I added it as `true` by default because I thought that was the consensus.