### PR TITLE
Use System.Text.Json v5.0.2 to fix the CVE-2021-26701

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Use System.Text.Json v5.0.2 to fix the CVE-2021-26701 in the System.Text.Encodings.Web library ([#1075](https://github.com/getsentry/sentry-dotnet/issues/1075))
+
 ## 3.5.0
 
 ### Features

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -37,7 +37,7 @@
 
   <!-- Prefer bundled version of System.Text.Json to avoid extra dependencies -->
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) or '$(TargetFramework)' == 'net461'">
-    <PackageReference Include="System.Text.Json" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 
 </Project>

--- a/test/Sentry.Tests/Sentry.Tests.csproj
+++ b/test/Sentry.Tests/Sentry.Tests.csproj
@@ -34,7 +34,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <ProjectReference Update="../../src/Sentry/Sentry.csproj" SetTargetFramework="TargetFramework=netstandard2.1" />
     <!-- NET Core's built-in STJ is lower version which causes conflicts, so we have to explicitly reference it -->
-    <PackageReference Include="System.Text.Json" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
     <!-- Ben.Demystifier uses S.R.M v5 and also requires it via package reference when on nca3.x -->
     <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
The CVE-2021-26701 is in the System.Text.Encodings.Web library used by System.Text.Json.

See https://github.com/dotnet/runtime/issues/49377

Fixes #1705 #1706