### PR TITLE
Add ReportAssembliesMode in favor of ReportAssemblies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Implement pause & resume session ([#1069](https://github.com/getsentry/sentry-dotnet/pull/1069))
 - Add auto session tracking ([#1068](https://github.com/getsentry/sentry-dotnet/pull/1068))
+- Add ReportAssembliesMode in favor of ReportAssemblies ([#1079](https://github.com/getsentry/sentry-dotnet/pull/1079))
 
 ## 3.6.0-alpha.2
 

--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -301,7 +301,9 @@ namespace Serilog
 
             if (reportAssemblies.HasValue)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 sentrySerilogOptions.ReportAssemblies = reportAssemblies.Value;
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             if (deduplicateMode.HasValue)

--- a/src/Sentry/Reflection/AssemblyExtensions.cs
+++ b/src/Sentry/Reflection/AssemblyExtensions.cs
@@ -22,11 +22,24 @@ namespace Sentry.Reflection
         {
             var asmName = asm.GetName();
             var name = asmName.Name;
-            var version =
-                asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
-                ?? asmName?.Version?.ToString();
+            var asmVersion = string.Empty;
 
-            return new SdkVersion {Name = name, Version = version};
+            // Note: on full .NET FX, checking the AssemblyInformationalVersionAttribute could throw an exception, therefore
+            // this method uses a try/catch to make sure this method always returns a value
+            try
+            {
+                asmVersion = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+            }
+            catch
+            {
+            }
+
+            if (string.IsNullOrWhiteSpace(asmVersion))
+            {
+                asmVersion = asmName?.Version?.ToString();
+            }
+
+            return new SdkVersion {Name = name, Version = asmVersion };
         }
     }
 }

--- a/src/Sentry/Reflection/AssemblyExtensions.cs
+++ b/src/Sentry/Reflection/AssemblyExtensions.cs
@@ -22,7 +22,7 @@ namespace Sentry.Reflection
         {
             var asmName = asm.GetName();
             var name = asmName.Name;
-            var asmVersion = string.Empty;
+            string? asmVersion = null;
 
             // Note: on full .NET FX, checking the AssemblyInformationalVersionAttribute could throw an exception, therefore
             // this method uses a try/catch to make sure this method always returns a value
@@ -34,7 +34,11 @@ namespace Sentry.Reflection
             {
             }
 
-            if (string.IsNullOrWhiteSpace(asmVersion))
+            // Note: even though the informational version could be "invalid" (e.g. string.Empty), it should
+            // be used for versioning and the software should not fallback to the assembly version string.
+            //
+            // See https://github.com/getsentry/sentry-dotnet/pull/1079#issuecomment-866992216
+            if (asmVersion is null)
             {
                 asmVersion = asmName?.Version?.ToString();
             }

--- a/src/Sentry/ReportAssembliesMode.cs
+++ b/src/Sentry/ReportAssembliesMode.cs
@@ -1,0 +1,24 @@
+namespace Sentry
+{
+    /// <summary>
+    /// Possible modes for reporting the assemblies.
+    /// </summary>
+    public enum ReportAssembliesMode
+    {
+        /// <summary>
+        /// Don't report any assemblies.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Report assemblies and use the assembly version to determine the version.
+        /// </summary>
+        Version,
+
+        /// <summary>
+        /// Report assemblies and prefer the informational assembly version to determine the version. If
+        /// the informational assembly version is not available, fall back to the assembly version.
+        /// </summary>
+        InformationalVersion
+    }
+}

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -372,7 +372,18 @@ namespace Sentry
         /// <summary>
         /// Whether or not to include referenced assemblies in each event sent to sentry. Defaults to <see langword="true"/>.
         /// </summary>
-        public bool ReportAssemblies { get; set; } = true;
+        [Obsolete("Use ReportAssembliesMode instead", error : false)]
+        public bool ReportAssemblies
+        {
+            // Note: note marking this as error to prevent breaking changes, but this is now a wrapper around ReportAssembliesMode
+            get { return ReportAssembliesMode != ReportAssembliesMode.None; }
+            set { ReportAssembliesMode = value ? ReportAssembliesMode.Version : ReportAssembliesMode.None; }
+        }
+
+        /// <summary>
+        /// What mode to use for reporting referenced assemblies in each event sent to sentry. Defaults to <see cref="ReportAssembliesMode.Version"/>.
+        /// </summary>
+        public ReportAssembliesMode ReportAssembliesMode { get; set; } = ReportAssembliesMode.Version;
 
         /// <summary>
         /// What modes to use for event automatic deduplication

--- a/test/Sentry.Serilog.Tests/SentrySerilogSinkExtensionsTests.cs
+++ b/test/Sentry.Serilog.Tests/SentrySerilogSinkExtensionsTests.cs
@@ -88,7 +88,9 @@ namespace Sentry.Serilog.Tests
             // Compare individual properties
             Assert.Equal(_fixture.SendDefaultPii, sut.SendDefaultPii);
             Assert.Equal(_fixture.DecompressionMethods, sut.DecompressionMethods);
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Equal(_fixture.ReportAssemblies, sut.ReportAssemblies);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Equal(_fixture.SampleRate, sut.SampleRate);
         }
 
@@ -125,7 +127,9 @@ namespace Sentry.Serilog.Tests
             Assert.Equal(_fixture.RequestBodyCompressionBuffered, sut.RequestBodyCompressionBuffered);
             Assert.Equal(_fixture.Debug, sut.Debug);
             Assert.Equal(_fixture.DiagnosticLevel, sut.DiagnosticLevel);
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Equal(_fixture.ReportAssemblies, sut.ReportAssemblies);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Equal(_fixture.DeduplicateMode, sut.DeduplicateMode);
             Assert.Equal(_fixture.InitializeSdk, sut.InitializeSdk);
             Assert.Equal(_fixture.MinimumEventLevel, sut.MinimumEventLevel);

--- a/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
@@ -312,12 +312,51 @@ namespace Sentry.Tests.Internals
         [Fact]
         public void Process_Modules_IsEmpty_WhenSpecified()
         {
+            // Note: this property is obsolete, test is kept for backwards compatibility check
+#pragma warning disable CS0618 // Type or member is obsolete
             _fixture.SentryOptions.ReportAssemblies = false;
+#pragma warning restore CS0618 // Type or member is obsolete
+
             var sut = _fixture.GetSut();
             var evt = new SentryEvent();
             _ = sut.Process(evt);
 
             Assert.Empty(evt.Modules);
+        }
+
+        [Fact]
+        public void Process_Modules_ReportAssembliesMode_None()
+        {
+            _fixture.SentryOptions.ReportAssembliesMode = ReportAssembliesMode.None;
+            var sut = _fixture.GetSut();
+            var evt = new SentryEvent();
+            _ = sut.Process(evt);
+
+            Assert.Empty(evt.Modules);
+        }
+
+        [Fact]
+        public void Process_Modules_ReportAssembliesMode_Version()
+        {
+            _fixture.SentryOptions.ReportAssembliesMode = ReportAssembliesMode.Version;
+            var sut = _fixture.GetSut();
+            var evt = new SentryEvent();
+            _ = sut.Process(evt);
+
+            // Don't allow any assembly with a + (sha commit is added to informational version)
+            Assert.DoesNotContain(evt.Modules, x => x.Value.Contains("+"));
+        }
+
+        [Fact]
+        public void Process_Modules_ReportAssembliesMode_InformationalVersion()
+        {
+            _fixture.SentryOptions.ReportAssembliesMode = ReportAssembliesMode.InformationalVersion;
+            var sut = _fixture.GetSut();
+            var evt = new SentryEvent();
+            _ = sut.Process(evt);
+
+            // Ensure at least 1 assembly with a + (sha commit is added to informational version)
+            Assert.Contains(evt.Modules, x => x.Value.Contains("+"));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1072

Introduces the InformationalVersionAttribute in favor of ReportAssemblies, covered by unit tests.

A few additional changes:

1. Added additional null check for assemblies
2. Moved retrieving the informational version attribute to try/catch since it was failing on the unit tests for NET461

Technically the GetName() can be optimized inside the foreach loop (only needed when value =  in the MainSentryEventProcessor, but wasn't sure if it was worth less-readable code vs this optimization. Let me know if you would like this to be changed. For now this value is also used to determine whether an assembly should be checked / added at all.

Looking forward to your review. Have a great day!