### PR TITLE
Fix logger call in BackgroundWorker that caused a formatting exception in runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `IHub.ResumeSession()`: don't start a new session if pause wasn't called or if there is no active session ([#1089](https://github.com/getsentry/sentry-dotnet/pull/1089))
+- Fix logger call in BackgroundWorker that caused a formatting exception in runtime ([#1092](https://github.com/getsentry/sentry-dotnet/pull/1092))
 
 ## 3.6.0
 

--- a/src/Sentry/Internal/BackgroundWorker.cs
+++ b/src/Sentry/Internal/BackgroundWorker.cs
@@ -145,7 +145,7 @@ namespace Sentry.Internal
                         catch (Exception exception)
                         {
                             _options.DiagnosticLogger?.LogError(
-                                "Error while processing event {1}: {0}. #{2} in queue.",
+                                "Error while processing envelope (event ID: '{0}'). #{1} in queue.",
                                 exception,
                                 envelope.TryGetEventId(),
                                 _queue.Count


### PR DESCRIPTION
Fixes #1090 

I'm not sure if the intention was to ever the log the exception as part of the message at all, but I don't think it is, so I removed it from the list of formatting placeholders. It's still included in the log entry itself though.

If we _do_ want the exception to be formatted inside the message as well, then we need to look into #699.