### PR TITLE
fix: incorrect order when getting the last active span.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `IHub.ResumeSession()`: don't start a new session if pause wasn't called or if there is no active session ([#1089](https://github.com/getsentry/sentry-dotnet/pull/1089))
+- Fixed incorrect order when getting the last active span ([#1094](https://github.com/getsentry/sentry-dotnet/pull/1094))
 
 ## 3.6.0
 

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -253,7 +253,9 @@ namespace Sentry
             Finish(exception, SpanStatusConverter.FromException(exception));
 
         /// <inheritdoc />
-        public ISpan? GetLastActiveSpan() => Spans.OrderByDescending(x => x.StartTimestamp).FirstOrDefault(s => !s.IsFinished);
+        public ISpan? GetLastActiveSpan() => 
+            // We need to sort by timestamp because the order of ConcurrentBag<T> is not deterministic
+            Spans.OrderByDescending(x => x.StartTimestamp).FirstOrDefault(s => !s.IsFinished);
 
         /// <inheritdoc />
         public SentryTraceHeader GetTraceHeader() => new(

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -253,7 +253,7 @@ namespace Sentry
             Finish(exception, SpanStatusConverter.FromException(exception));
 
         /// <inheritdoc />
-        public ISpan? GetLastActiveSpan() => Spans.LastOrDefault(s => !s.IsFinished);
+        public ISpan? GetLastActiveSpan() => Spans.OrderBy(x => x.StartTimestamp).LastOrDefault(s => !s.IsFinished);
 
         /// <inheritdoc />
         public SentryTraceHeader GetTraceHeader() => new(

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -253,7 +253,7 @@ namespace Sentry
             Finish(exception, SpanStatusConverter.FromException(exception));
 
         /// <inheritdoc />
-        public ISpan? GetLastActiveSpan() => Spans.OrderBy(x => x.StartTimestamp).LastOrDefault(s => !s.IsFinished);
+        public ISpan? GetLastActiveSpan() => Spans.OrderByDescending(x => x.StartTimestamp).FirstOrDefault(s => !s.IsFinished);
 
         /// <inheritdoc />
         public SentryTraceHeader GetTraceHeader() => new(


### PR DESCRIPTION
Here is an active span order issue.

when I started multi active span in the same transaction, the span tree in sentry ui was not what I expected.
For example, it should be:

```text
--- http.server
      |
      --- controller span
            |
            --- service span
                  |
                  --- repository span
```

but what I got was:
```text
--- http.server
      |
      --- controller span
            |
            --- service span
            |
            --- repository span
```            
Here is the actual screenshot:
![image](https://user-images.githubusercontent.com/15326381/123921282-6dd84800-d9b9-11eb-9835-7df1dd24f06c.png)

I've traced the source code, and found this issue was cause by `TransactionTrace.GetLastActiveSpan()`.
The `TransactionTrace` stored the ongoing span in the `ConcurrentBag<ISpan>`, it worked fine!
But the default order of `ConcurrentBag` is just like FILO, if I put several active spans sequentially, the result would like as following table:

 SpanName | IsFinished | StartTime 
--------------|--------|------
repository span | false | 2021/6/30 00:00:02 |
service span | false | 2021/6/30 00:00:01 | 
controller span | false | 2021/6/30 00:00:00 |

It could be solved by reordering the span.
```csharp
# before
public ISpan? GetLastActiveSpan() => Spans.LastOrDefault(s => !s.IsFinished);

# after
public ISpan? GetLastActiveSpan() => Spans.OrderBy(s => s.StartTimestamp).LastOrDefault(s => !s.IsFinished);
```