### PR TITLE
TryRecoverPersistedSession logs debug if file doesnt exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Don't log an error when attempting to recover a persisted session but none exists ([#1123](https://github.com/getsentry/sentry-dotnet/pull/1123))
+
 ## 3.8.0
 
 ### Fixes

--- a/src/Sentry/GlobalSessionManager.cs
+++ b/src/Sentry/GlobalSessionManager.cs
@@ -311,6 +311,15 @@ namespace Sentry
                     }
                 );
             }
+            catch (FileNotFoundException)
+            {
+                // Not a notable error
+                _options.DiagnosticLogger?.LogDebug(
+                    "Failed to recover persisted session from the file system '{0}' because the file doesn't exist."
+                );
+
+                return null;
+            }
             catch (Exception ex)
             {
                 _options.DiagnosticLogger?.LogError(

--- a/src/Sentry/GlobalSessionManager.cs
+++ b/src/Sentry/GlobalSessionManager.cs
@@ -315,7 +315,8 @@ namespace Sentry
             {
                 // Not a notable error
                 _options.DiagnosticLogger?.LogDebug(
-                    "Failed to recover persisted session from the file system '{0}' because the file doesn't exist."
+                    "Failed to recover persisted session from the file system '{0}' because the file doesn't exist.",
+                    filePath
                 );
 
                 return null;

--- a/src/Sentry/GlobalSessionManager.cs
+++ b/src/Sentry/GlobalSessionManager.cs
@@ -240,7 +240,6 @@ namespace Sentry
             var filePath = Path.Combine(_persistenceDirectoryPath, PersistedSessionFileName);
             try
             {
-
                 // Try to log the contents of the session file before we delete it
                 if (_options.DiagnosticLogger?.IsEnabled(SentryLevel.Debug) ?? false)
                 {
@@ -324,7 +323,7 @@ namespace Sentry
             catch (Exception ex)
             {
                 _options.DiagnosticLogger?.LogError(
-                    "Failed to recover persisted session from the file system '{0}'",
+                    "Failed to recover persisted session from the file system '{0}'.",
                     ex,
                     filePath
                 );


### PR DESCRIPTION
Log a debug entry instead of an error because it's an expected error (`TryRecoverPersistedSession()` is called every time a session is started for the first time, but a left over file will actually exist very rarely).