### PR TITLE
Add IsParentSampled to ITransactionContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+
+### Fixes
+
 - Add IsParentSampled to ITransactionContext ([#1128]https://github.com/getsentry/sentry-dotnet/pull/1128)
 
 ## 3.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add IsParentSampled to ITransactionContext ([#1128]https://github.com/getsentry/sentry-dotnet/pull/1128)
+
 ## 3.8.1
 
 ### Fixes

--- a/src/Sentry/ITransaction.cs
+++ b/src/Sentry/ITransaction.cs
@@ -14,6 +14,12 @@ namespace Sentry
         new string Name { get; set; }
 
         /// <summary>
+        /// Whether the parent transaction of this transaction has been sampled.
+        /// </summary>
+        // 'new' because it adds a setter
+        new bool? IsParentSampled { get; set; }
+
+        /// <summary>
         /// Flat list of spans within this transaction.
         /// </summary>
         IReadOnlyCollection<ISpan> Spans { get; }

--- a/src/Sentry/ITransactionContext.cs
+++ b/src/Sentry/ITransactionContext.cs
@@ -9,5 +9,10 @@
         /// Transaction name.
         /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// Whether the parent transaction of this transaction has been sampled.
+        /// </summary>
+        bool? IsParentSampled { get; }        
     }
 }

--- a/src/Sentry/Transaction.cs
+++ b/src/Sentry/Transaction.cs
@@ -49,6 +49,9 @@ namespace Sentry
         public string Name { get; private set; }
 
         /// <inheritdoc />
+        public bool? IsParentSampled { get; set; }
+
+        /// <inheritdoc />
         public string? Platform { get; set; } = Constants.Platform;
 
         /// <inheritdoc />

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -39,6 +39,9 @@ namespace Sentry
         /// <inheritdoc cref="ITransaction.Name" />
         public string Name { get; set; }
 
+        /// <inheritdoc cref="ITransaction.IsParentSampled" />
+        public bool? IsParentSampled { get; set; }
+
         /// <inheritdoc />
         public string? Platform { get; set; } = Constants.Platform;
 


### PR DESCRIPTION
IsParentSampled is currently on the concrete class but in none of the interfaces it implements.  Adding it to the ITransactionContext interface to make it available for use as described in the documentation here: https://docs.sentry.io/platforms/dotnet/guides/aspnet/configuration/sampling/