### PR TITLE
Set error status if http has exception and ok status.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Set error status to transaction if http has exception and ok status ([#1143](https://github.com/getsentry/sentry-dotnet/pull/1143))
+
 ## 3.8.3
 
 ### Features

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -157,6 +157,9 @@ namespace Sentry.AspNetCore
                     {
                         transaction.Finish(status);
                     }
+                    // Status code not yet changed to 500 but an exception does exist
+                    // so lets avoid passing the misleading 200 down and close only with
+                    // the exception instance that will be inferred as errored.
                     else if (status == SpanStatus.Ok)
                     {
                         transaction.Finish(exception);

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
@@ -156,6 +156,10 @@ namespace Sentry.AspNetCore
                     if (exception is null)
                     {
                         transaction.Finish(status);
+                    }
+                    else if (status == SpanStatus.Ok)
+                    {
+                        transaction.Finish(exception);
                     }
                     else
                     {

--- a/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP2_1
+#if !NETCOREAPP2_1
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -338,7 +338,8 @@ namespace Sentry.AspNetCore.Tests
             await client.GetAsync("/person/13");
 
             // Assert
-            Assert.True(hub.ExceptionToSpanMap.TryGetValue(exception, out _));
+            Assert.True(hub.ExceptionToSpanMap.TryGetValue(exception, out var span));
+            Assert.Equal(SpanStatus.InternalError, span.Status);
         }
     }
 }


### PR DESCRIPTION
InvokeAsync middleware doesn't receive the correct status code during an error, setting a transaction with an error as "OK", this PR sets the default status code based on the received Exception and if the status code is Ok.

Before
![image](https://user-images.githubusercontent.com/8229322/127033038-c34b2c81-4718-477f-90da-73b28712fe0b.png)

After
![image](https://user-images.githubusercontent.com/8229322/127033070-e6c4eed5-5816-4d86-85f0-ff3a039b6304.png)
