### PR TITLE
Fix max breadcrumbs limit when MaxBreadcrumbs is zero or lower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+## Fixes
+
+- Fix max breadcrumbs limit when MaxBreadcrumbs is zero or lower ([#1145](https://github.com/getsentry/sentry-dotnet/pull/1145))
+
 ## 3.8.3
 
 ### Features

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -226,9 +226,12 @@ namespace Sentry
                 }
             }
 
-            var overflow = Breadcrumbs.Count - Options.MaxBreadcrumbs + 1;
-
-            if (overflow > 0)
+            if (Options.MaxBreadcrumbs <= 0)
+            {
+                //Always drop the breadcrumb.
+                return;
+            }
+            else if (Breadcrumbs.Count - Options.MaxBreadcrumbs + 1 > 0)
             {
                 _breadcrumbs.TryDequeue(out _);
             }

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -254,5 +254,30 @@ namespace Sentry.Tests
             //Assert
             scope.Attachments.Should().BeEmpty();
         }
+
+        [Theory]
+        [InlineData(0, -2, 0)]
+        [InlineData(0, -1, 0)]
+        [InlineData(0,  0, 0)]
+        [InlineData(0,  1, 1)]
+        [InlineData(0,  2, 1)]
+        [InlineData(1,  2, 2)]
+        [InlineData(2,  2, 2)]
+        public void AddBreadcrumb__AddBreadcrumb_RespectLimits(int initialCount, int maxBreadcrumbs, int expectedCount)
+        {
+            //Arrange
+            var scope = new Scope(new SentryOptions() { MaxBreadcrumbs = maxBreadcrumbs });
+
+            for (int i = 0; i < initialCount; i++)
+            {
+                scope.AddBreadcrumb(new Breadcrumb());
+            }
+
+            //Act
+            scope.AddBreadcrumb(new Breadcrumb());
+
+            //Assert
+            Assert.Equal(expectedCount, scope.Breadcrumbs.Count);
+        }
     }
 }


### PR DESCRIPTION
Previously, it didn't matter the MaxBreadcrumb value, it would always be able to insert at least one breadcrumb because `_breadcrumbs.Enqueue(breadcrumb);` was out of any validation.

Close #1110.
