### PR TITLE
Add fallback to Scope Stack from AspNet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Add fallback to Scope Stack from AspNet ([#1180](https://github.com/getsentry/sentry-dotnet/pull/1180))
+
 ## 3.9.0
 
 ### Features

--- a/src/Sentry.AspNet/Internal/HttpContextScopeStackContainer.cs
+++ b/src/Sentry.AspNet/Internal/HttpContextScopeStackContainer.cs
@@ -8,10 +8,30 @@ namespace Sentry.AspNet.Internal
     {
         private const string FieldName = "__SentryScopeStack";
 
+        //Internal for testing
+        internal KeyValuePair<Scope, ISentryClient>[]? FallbackStack;
+
         public KeyValuePair<Scope, ISentryClient>[]? Stack
         {
-            get => HttpContext.Current.Items[FieldName] as KeyValuePair<Scope, ISentryClient>[];
-            set => HttpContext.Current.Items[FieldName] = value;
+            get
+            {
+                if (HttpContext.Current is { } currentContext)
+                {
+                    return currentContext.Items[FieldName] as KeyValuePair<Scope, ISentryClient>[];
+                }
+                return FallbackStack;
+            }
+            set
+            {
+                if (HttpContext.Current is { } currentContext)
+                {
+                    currentContext.Items[FieldName] = value;
+                }
+                else
+                {
+                    FallbackStack = value;
+                }
+            }
         }
     }
 }

--- a/test/Sentry.AspNet.Tests/Internal/SentryScopeManagerTests.cs
+++ b/test/Sentry.AspNet.Tests/Internal/SentryScopeManagerTests.cs
@@ -1,0 +1,43 @@
+using NSubstitute;
+using Sentry.AspNet.Internal;
+using Sentry.Internal;
+using Xunit;
+
+namespace Sentry.AspNet.Tests.Internal
+{
+    public class SentryScopeManagerTests
+    {
+        private class Fixture
+        {
+            public SentryScopeManager GetSut() => new SentryScopeManager(
+                new HttpContextScopeStackContainer(),
+                new SentryOptions(),
+                Substitute.For<ISentryClient>());
+        }
+
+        private Fixture _fixture => new();
+
+        [Fact]
+        public void SetScopeStack_NoHttpContext_FallbackSet()
+        {
+            // Arrange
+            var scopeManager = _fixture.GetSut();
+
+            // Act
+            scopeManager.PushScope();
+
+            // Assert
+            Assert.NotNull(scopeManager.ScopeStackContainer.Stack);
+        }
+
+        [Fact]
+        public void GetScopeStack_NoHttpContext_Null()
+        {
+            // Arrange
+            var scopeManager = _fixture.GetSut();
+
+            // Assert
+            Assert.Null(scopeManager.ScopeStackContainer.Stack);
+        }
+    }
+}


### PR DESCRIPTION
This will stop the null reference exceptions when using the ASP.NET SDK  during any Scope interaction that happens before a HttpContext is created.

Close #1157.