### PR TITLE
Fix: Use fallback if RoutePattern is MVC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Use fallback if route pattern is MVC ([#1188](https://github.com/getsentry/sentry-dotnet/pull/1188))
+
 ## 3.9.1
 
 ### Fixes

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -16,7 +16,7 @@ namespace Sentry.AspNetCore.Extensions
             var endpoint = context.Features.Get<IEndpointFeature?>()?.Endpoint as RouteEndpoint;
             var routePattern = endpoint?.RoutePattern.RawText;
 
-            // Skip route pattern and use legacy Mvc route e.g.
+            // Skip route pattern if it resembles to a MVC route or null  e.g.
             // {controller=Home}/{action=Index}/{id?}
             if (!string.IsNullOrWhiteSpace(routePattern) &&
                 routePattern.StartsWith("{controller=") is false)

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -16,7 +16,10 @@ namespace Sentry.AspNetCore.Extensions
             var endpoint = context.Features.Get<IEndpointFeature?>()?.Endpoint as RouteEndpoint;
             var routePattern = endpoint?.RoutePattern.RawText;
 
-            if (!string.IsNullOrWhiteSpace(routePattern))
+            // Skip route pattern and use legacy Mvc route e.g.
+            // {controller=Home}/{action=Index}/{id?}
+            if (!string.IsNullOrWhiteSpace(routePattern) &&
+                routePattern.StartsWith("{controller=") is false)
             {
                 return routePattern;
             }

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -22,7 +22,7 @@ namespace Sentry.AspNetCore.Extensions
             {
                 // Skip route pattern if it resembles to a MVC route or null  e.g.
                 // {controller=Home}/{action=Index}/{id?}
-                return RouteHasMvcParameters(routePattern) ? ReplaceMcvParameters(routePattern, context) : routePattern;
+                return RouteHasMvcParameters(routePattern) ? ReplaceMvcParameters(routePattern, context) : routePattern;
             }
 #endif
 
@@ -48,7 +48,7 @@ namespace Sentry.AspNetCore.Extensions
         }
 
         // Internal for testing.
-        internal static string ReplaceMcvParameters(string route, HttpContext? context)
+        internal static string ReplaceMvcParameters(string route, HttpContext? context)
         {
             // Return RouteData or Null, marking the HttpContext as nullable since the output doesn't
             // shows the nullable output.
@@ -75,6 +75,7 @@ namespace Sentry.AspNetCore.Extensions
         // Internal for testing.
         internal static bool RouteHasMvcParameters(string route)
             => route.Contains("{controller=") || route.Contains("{action=") || route.Contains("{area=");
+
         public static string? TryGetTransactionName(this HttpContext context)
         {
             var route = context.TryGetRouteTemplate();

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -12,7 +12,7 @@ namespace Sentry.AspNetCore.Extensions
     {
         public static string? TryGetRouteTemplate(this HttpContext context)
         {
-            
+
 #if !NETSTANDARD2_0 // endpoint routing is only supported after ASP.NET Core 3.0
             // Requires .UseRouting()/.UseEndpoints()
             var endpoint = context.Features.Get<IEndpointFeature?>()?.Endpoint as RouteEndpoint;

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -22,7 +22,9 @@ namespace Sentry.AspNetCore.Extensions
             {
                 // Skip route pattern if it resembles to a MVC route or null  e.g.
                 // {controller=Home}/{action=Index}/{id?}
-                return RouteHasMvcParameters(routePattern) ? ReplaceMvcParameters(routePattern, context) : routePattern;
+                return RouteHasMvcParameters(routePattern) 
+                    ? ReplaceMvcParameters(routePattern, context)
+                    : routePattern;
             }
 #endif
 

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -22,7 +22,7 @@ namespace Sentry.AspNetCore.Extensions
             {
                 // Skip route pattern if it resembles to a MVC route or null  e.g.
                 // {controller=Home}/{action=Index}/{id?}
-                return RouteHasMvcParameters(routePattern) 
+                return RouteHasMvcParameters(routePattern)
                     ? ReplaceMvcParameters(routePattern, context)
                     : routePattern;
             }

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -22,7 +22,7 @@ namespace Sentry.AspNetCore.Extensions
             {
                 // Skip route pattern if it resembles to a MVC route or null  e.g.
                 // {controller=Home}/{action=Index}/{id?}
-                return routePattern.StartsWith('{') ? ReplaceMcvParameters(routePattern, context) : routePattern;
+                return RouteHasMvcParameters(routePattern) ? ReplaceMcvParameters(routePattern, context) : routePattern;
             }
 #endif
 
@@ -72,6 +72,9 @@ namespace Sentry.AspNetCore.Extensions
             return route;
         }
 
+        // Internal for testing.
+        internal static bool RouteHasMvcParameters(string route)
+            => route.Contains("{controller=") || route.Contains("{action=") || route.Contains("{area=");
         public static string? TryGetTransactionName(this HttpContext context)
         {
             var route = context.TryGetRouteTemplate();

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -56,17 +56,17 @@ namespace Sentry.AspNetCore.Extensions
 
             if (routeData?.Values["controller"]?.ToString() is { } controller)
             {
-                route = Regex.Replace(route, "\\{controller=[^\\}]+\\}", controller);
+                route = Regex.Replace(route, "{controller=[^}]+}", controller);
             }
 
             if (routeData?.Values["action"]?.ToString() is { } action)
             {
-                route = Regex.Replace(route, "\\{action=[^\\}]+\\}", action);
+                route = Regex.Replace(route, "{action=[^}]+}", action);
             }
 
             if (routeData?.Values["area"]?.ToString() is { } area)
             {
-                route = Regex.Replace(route, "\\{area=[^\\}]+\\}", area);
+                route = Regex.Replace(route, "{area=[^}]+}", area);
             }
 
             return route;

--- a/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
@@ -1,0 +1,43 @@
+#if !NETCOREAPP2_1
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Sentry.AspNetCore.Extensions;
+using Xunit;
+
+namespace Sentry.AspNetCore.Tests.Extensions
+{
+    public class HttpContextExtensionsTests
+    {
+        private static void AddRouteValuesIfNotNull(RouteValueDictionary route, string key, string value)
+        {
+            if (value is not null)
+            {
+                route.Add(key, value);
+            }
+        }
+
+        [Theory]
+        [InlineData("{area=MyArea}/{controller=Home}/{action=Index}/{id?}", "theArea/house/about/{id?}", "house", "about", "theArea")]
+        [InlineData("{area=MyArea}/{controller=Home}/{action=Index}/{id?}", "{area=MyArea}/house/about/{id?}", "house", "about", null)]
+        [InlineData("{controller=Home}/{action=Index}/{id?}", "house/about/{id?}", "house", "about", null)]
+        [InlineData("{controller=Home}/{action=Index}", "house/about", "house", "about", null)]
+        [InlineData("{controller=Home}/{id?}", "house/{id?}", "house", "about", null)]
+        [InlineData("{action=Index}/{id?}", "about/{id?}", null, "about", null)]
+        [InlineData("not/mvc/", "not/mvc/", "house", "about", "area")]
+        public void ReplaceMcvParameters_ParsedParameters(string routeInput, string assertOutput, string context, string action, string area)
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext();
+            AddRouteValuesIfNotNull(httpContext.Request.RouteValues, "controller", context);
+            AddRouteValuesIfNotNull(httpContext.Request.RouteValues, "action", action);
+            AddRouteValuesIfNotNull(httpContext.Request.RouteValues, "area", area);
+
+        // Act
+        var filteredRoute = HttpContextExtensions.ReplaceMcvParameters(routeInput, httpContext);
+
+            // Assert
+            Assert.Equal(assertOutput, filteredRoute);
+        }
+
+    }
+}

--- a/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
@@ -1,3 +1,4 @@
+#if !NETCOREAPP2_1
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Sentry.AspNetCore.Extensions;
@@ -7,7 +8,6 @@ namespace Sentry.AspNetCore.Tests.Extensions
 {
     public class HttpContextExtensionsTests
     {
-#if !NETCOREAPP2_1
         private static void AddRouteValuesIfNotNull(RouteValueDictionary route, string key, string value)
         {
             if (value is not null)
@@ -35,7 +35,7 @@ namespace Sentry.AspNetCore.Tests.Extensions
             AddRouteValuesIfNotNull(httpContext.Request.RouteValues, "area", area);
 
             // Act
-            var filteredRoute = HttpContextExtensions.ReplaceMcvParameters(routeInput, httpContext);
+            var filteredRoute = HttpContextExtensions.ReplaceMvcParameters(routeInput, httpContext);
 
             // Assert
             Assert.Equal(assertOutput, filteredRoute);
@@ -67,6 +67,6 @@ namespace Sentry.AspNetCore.Tests.Extensions
             // Assert
             Assert.False(HttpContextExtensions.RouteHasMvcParameters(route));
         }
-#endif
     }
 }
+#endif

--- a/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
@@ -32,8 +32,8 @@ namespace Sentry.AspNetCore.Tests.Extensions
             AddRouteValuesIfNotNull(httpContext.Request.RouteValues, "action", action);
             AddRouteValuesIfNotNull(httpContext.Request.RouteValues, "area", area);
 
-        // Act
-        var filteredRoute = HttpContextExtensions.ReplaceMcvParameters(routeInput, httpContext);
+            // Act
+            var filteredRoute = HttpContextExtensions.ReplaceMcvParameters(routeInput, httpContext);
 
             // Assert
             Assert.Equal(assertOutput, filteredRoute);

--- a/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
@@ -1,4 +1,3 @@
-#if !NETCOREAPP2_1
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Sentry.AspNetCore.Extensions;

--- a/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
@@ -7,6 +7,7 @@ namespace Sentry.AspNetCore.Tests.Extensions
 {
     public class HttpContextExtensionsTests
     {
+#if !NETCOREAPP2_1
         private static void AddRouteValuesIfNotNull(RouteValueDictionary route, string key, string value)
         {
             if (value is not null)
@@ -37,6 +38,6 @@ namespace Sentry.AspNetCore.Tests.Extensions
             // Assert
             Assert.Equal(assertOutput, filteredRoute);
         }
-
+#endif
     }
 }

--- a/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
@@ -19,11 +19,13 @@ namespace Sentry.AspNetCore.Tests.Extensions
         [Theory]
         [InlineData("{area=MyArea}/{controller=Home}/{action=Index}/{id?}", "theArea/house/about/{id?}", "house", "about", "theArea")]
         [InlineData("{area=MyArea}/{controller=Home}/{action=Index}/{id?}", "{area=MyArea}/house/about/{id?}", "house", "about", null)]
+        [InlineData("{area=}/{controller=}/{action=}/{id?}", "{area=}/{controller=}/{action=}/{id?}", "house", "about", "theArea")]
         [InlineData("{controller=Home}/{action=Index}/{id?}", "house/about/{id?}", "house", "about", null)]
         [InlineData("{controller=Home}/{action=Index}", "house/about", "house", "about", null)]
         [InlineData("{controller=Home}/{id?}", "house/{id?}", "house", "about", null)]
         [InlineData("{action=Index}/{id?}", "about/{id?}", null, "about", null)]
         [InlineData("not/mvc/", "not/mvc/", "house", "about", "area")]
+        [InlineData("not/mvc/{controller}/{action}/{area}", "not/mvc/{controller}/{action}/{area}", "house", "about", "area")]
         public void ReplaceMcvParameters_ParsedParameters(string routeInput, string assertOutput, string context, string action, string area)
         {
             // Arrange
@@ -37,6 +39,33 @@ namespace Sentry.AspNetCore.Tests.Extensions
 
             // Assert
             Assert.Equal(assertOutput, filteredRoute);
+        }
+
+        [Theory]
+        [InlineData("{area=MyArea}/{controller=Home}/{action=Index}/{id?}")]
+        [InlineData("{controller=Home}/{action=Index}/{id?}")]
+        [InlineData("{controller=Home}/{id?}")]
+        [InlineData("abc/{controller=}/")]
+        [InlineData("{action=Index}/{id?}")]
+        [InlineData("{area=Index}/{id?}")]
+        public void RouteHasMvcParameters_RouteWithMvcParameters_True(string route)
+        {
+            // Assert
+            Assert.True(HttpContextExtensions.RouteHasMvcParameters(route));
+        }
+
+        [Theory]
+        [InlineData("test/{area}")]
+        [InlineData("test/{action}")]
+        [InlineData("test/{controller}")]
+        [InlineData("area/test")]
+        [InlineData("/area/test")]
+        [InlineData("/")]
+        [InlineData("")]
+        public void RouteHasMvcParameters_RouteWithoutMvcParameters_False(string route)
+        {
+            // Assert
+            Assert.False(HttpContextExtensions.RouteHasMvcParameters(route));
         }
 #endif
     }


### PR DESCRIPTION
Despite a context feature having a RouteEndpoint, it doesn't mean we can use the RawText value of the RoutePattern since it may result in a default route for different paths.
For a simple fix, I opted to just use the fallback to get the MVC route since we didn't have any proper data of the Route Template on the given Endpoint.

Additionally, that the SDK is creating transactions for items like loading a CSS file, thus results in Unknown Routes. If desired, we could use context.Request.Path.Value as a last fallback for cases like that.

Sample:
![image](https://user-images.githubusercontent.com/8229322/132744944-1d165b34-18ee-498f-a417-c33b838ed5ef.png)

Also, the issue can be easily reproduced on the sample Sentry.Samples.AspNetCore.Mvc

Close #1189.