### PR TITLE
fix: unhandled error crashed session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Exceptions from UnhandledExceptionIntegration were not marking sessions as crashed ([#1193](https://github.com/getsentry/sentry-dotnet/pull/1193))
+
 ## 3.9.1
 
 ### Fixes

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -304,15 +304,13 @@ namespace Sentry.Internal
 
                 actualScope.SessionUpdate = evt switch
                 {
-                    // TODO: Extract both branches as internal extension methods (IsCrashed and IsErrored):
-
                     // Event contains a terminal exception -> end session as crashed
-                    var e when e.SentryExceptions?.Any(x => !(x.Mechanism?.Handled ?? true)) ?? false =>
+                    var e when e.HasUnhandledException =>
                         _sessionManager.EndSession(SessionEndStatus.Crashed),
 
                     // Event contains a non-terminal exception -> report error
                     // (this might return null if the session has already reported errors before)
-                    var e when e.Exception is not null || e.SentryExceptions?.Any() == true =>
+                    var e when e.HasException =>
                         _sessionManager.ReportError(),
 
                     // Event doesn't contain any kind of exception -> no reason to attach session update

--- a/src/Sentry/SentryEvent.cs
+++ b/src/Sentry/SentryEvent.cs
@@ -167,8 +167,8 @@ namespace Sentry
         internal bool HasException => Exception is not null || SentryExceptions?.Any() == true;
 
         internal bool HasUnhandledException => (SentryExceptions?.Any(e => !(e.Mechanism?.Handled ?? true)) ?? false)
-                                                // Before event is processed by the client and SentryExceptions created.
-                                                // See: AppDomainUnhandledExceptionIntegration
+                                               // Before event is processed by the client and SentryExceptions created.
+                                               // See: AppDomainUnhandledExceptionIntegration
                                                || Exception?.Data[Mechanism.HandledKey] is false;
 
         /// <summary>

--- a/src/Sentry/SentryEvent.cs
+++ b/src/Sentry/SentryEvent.cs
@@ -164,6 +164,13 @@ namespace Sentry
         /// <inheritdoc />
         public IReadOnlyDictionary<string, string> Tags => _tags ??= new Dictionary<string, string>();
 
+        internal bool HasException => Exception is not null || SentryExceptions?.Any() == true;
+
+        internal bool HasUnhandledException => (SentryExceptions?.Any(e => !(e.Mechanism?.Handled ?? true)) ?? false)
+                                                // Before event is processed by the client and SentryExceptions created.
+                                                // See: AppDomainUnhandledExceptionIntegration
+                                               || Exception?.Data[Mechanism.HandledKey] is false;
+
         /// <summary>
         /// Creates a new instance of <see cref="T:Sentry.SentryEvent" />.
         /// </summary>


### PR DESCRIPTION
Exceptions from UnhandledExceptionIntegration were not marking sessions as crashed