### PR TITLE
FIx: Add Sentry.Google.Cloud.Functions to craft.yml

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -15,3 +15,4 @@ targets:
       nuget:Sentry.Log4Net:
       nuget:Sentry.Serilog:
       nuget:Sentry.NLog:
+      nuget:Sentry.Google.Cloud.Functions

--- a/.craft.yml
+++ b/.craft.yml
@@ -15,4 +15,4 @@ targets:
       nuget:Sentry.Log4Net:
       nuget:Sentry.Serilog:
       nuget:Sentry.NLog:
-      nuget:Sentry.Google.Cloud.Functions
+      nuget:Sentry.Google.Cloud.Functions:


### PR DESCRIPTION
#skip-changelog.

for reference https://github.com/getsentry/sentry-release-registry/tree/master/packages/nuget/Sentry.Google.Cloud.Functions

Because of that, the `Google cloud functions` is not getting the version updated.