### PR TITLE
Fix: Avoid replacing the Transaction Name by null or empty

### DIFF
--- a/src/Sentry.AspNetCore/ScopeExtensions.cs
+++ b/src/Sentry.AspNetCore/ScopeExtensions.cs
@@ -87,7 +87,14 @@ namespace Sentry.AspNetCore
                     scope.SetTag("route.area", area);
                 }
 
-                scope.TransactionName = context.TryGetTransactionName();
+                // TransactionName refers to Transaction.Name, so skip this code if Transaction is null.
+                if (scope.Transaction != null &&
+                    scope.TransactionName is SentryTracingMiddleware.UnknownRouteTransactionName or null)
+                {
+                    scope.TransactionName =
+                        context.TryGetTransactionName()
+                        ?? SentryTracingMiddleware.UnknownRouteTransactionName;
+                }
             }
             catch (Exception e)
             {

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -14,7 +14,7 @@ namespace Sentry.AspNetCore
     /// </summary>
     internal class SentryTracingMiddleware
     {
-        private const string UnknownRouteTransactionName = "Unknown Route";
+        internal const string UnknownRouteTransactionName = "Unknown Route";
         private const string OperationName = "http.server";
 
         private readonly RequestDelegate _next;


### PR DESCRIPTION
This fix does two issues:
- Avoid calling TryGetTransactionName if you don't have a transaction or if it Transaction.Name is already set.
- Avoid replacing the Transaction Name with null.

The second fix is important since transactions with null or Empty names get dropped.
https://github.com/getsentry/sentry-dotnet/blob/74312a4684e96babdfa555df2013fcc7c2ff9291/src/Sentry/SentryClient.cs#L120-L127

