### PR TITLE
fix: check crash callback for sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Unity Android support: check for native crashes before closing session as Abnormal ([#1222](https://github.com/getsentry/sentry-dotnet/pull/1222))
+
 ## 3.9.3
 
 ### Fixes

--- a/src/Sentry/Integrations/AppDomainProcessExitIntegration.cs
+++ b/src/Sentry/Integrations/AppDomainProcessExitIntegration.cs
@@ -1,4 +1,5 @@
 using System;
+using Sentry.Extensibility;
 using Sentry.Internal;
 
 namespace Sentry.Integrations
@@ -7,15 +8,15 @@ namespace Sentry.Integrations
     {
         private readonly IAppDomain _appDomain;
         private IHub? _hub;
+        private SentryOptions? _options;
 
         public AppDomainProcessExitIntegration(IAppDomain? appDomain = null)
-        {
-            _appDomain = appDomain ?? AppDomainAdapter.Instance;
-        }
+            => _appDomain = appDomain ?? AppDomainAdapter.Instance;
 
         public void Register(IHub hub, SentryOptions options)
         {
             _hub = hub;
+            _options = options;
             _appDomain.ProcessExit += HandleProcessExit;
         }
 
@@ -23,10 +24,12 @@ namespace Sentry.Integrations
         {
             _appDomain.ProcessExit -= HandleProcessExit;
             _hub = null;
+            _options = null;
         }
 
         internal void HandleProcessExit(object? sender, EventArgs e)
         {
+            _options?.DiagnosticLogger?.LogInfo("AppDomain process exited: Disposing SDK.");
             (_hub as IDisposable)?.Dispose();
         }
     }

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -183,9 +183,7 @@ namespace Sentry.Internal
                 }
                 catch (Exception ex)
                 {
-                    _options.DiagnosticLogger?.LogError(
-                        "Failed to recover persisted session.",
-                        ex);
+                    _options.DiagnosticLogger?.LogError("Failed to recover persisted session.", ex);
                 }
             }
 
@@ -200,9 +198,7 @@ namespace Sentry.Internal
             }
             catch (Exception ex)
             {
-                _options.DiagnosticLogger?.LogError(
-                    "Failed to start a session.",
-                    ex);
+                _options.DiagnosticLogger?.LogError("Failed to start a session.", ex);
             }
         }
 
@@ -216,9 +212,7 @@ namespace Sentry.Internal
                 }
                 catch (Exception ex)
                 {
-                    _options.DiagnosticLogger?.LogError(
-                        "Failed to pause a session.",
-                        ex);
+                    _options.DiagnosticLogger?.LogError("Failed to pause a session.", ex);
                 }
             }
         }
@@ -236,9 +230,7 @@ namespace Sentry.Internal
                 }
                 catch (Exception ex)
                 {
-                    _options.DiagnosticLogger?.LogError(
-                        "Failed to resume a session.",
-                        ex);
+                    _options.DiagnosticLogger?.LogError("Failed to resume a session.", ex);
                 }
             }
         }
@@ -255,9 +247,7 @@ namespace Sentry.Internal
             }
             catch (Exception ex)
             {
-                _options.DiagnosticLogger?.LogError(
-                    "Failed to end a session.",
-                    ex);
+                _options.DiagnosticLogger?.LogError("Failed to end a session.", ex);
             }
         }
 


### PR DESCRIPTION
Instead of assuming a previous session was healthy if it was on the background. First check with the optional callback used for native integrations.

In order to debug this I had to adjust some of the debug logs. In the process I fix their format inconsistencies.