### PR TITLE
CheckEolTargetFramework=false also for netcore2.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
 
   <!-- We're aware it's out of support but this is a library and it doesn't require nca3.1.  -->
   <!-- there's no reason to cause friction to a consumer that for some reason is stuck on an unsupported version. -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <PropertyGroup>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 


### PR DESCRIPTION
 * remove some warnings about 2.1 being EOL
 * Not point limiting it to netcoreapp3.0 since i assume we dont care about when fw become obsolete, and will instead make explicit decisions as to when to remove support for each one

#skip-changelog