### PR TITLE
move to LangVersion>9

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>3.9.3</Version>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>9</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../.assets/Sentry.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
this will prevent people, who are using vs2022, from committing code that wont build for people still on VS2019. 
We can make an explicit decision to move to LangVersion>10 in the future

#skip-changelog