### PR TITLE
DRAFT: use GetEntryAssembly() or Assembly.GetExecutingAssembly()

### DIFF
--- a/test/Sentry.Tests/Internals/ReleaseLocatorTests.cs
+++ b/test/Sentry.Tests/Internals/ReleaseLocatorTests.cs
@@ -24,18 +24,10 @@ namespace Sentry.Tests.Internals
                 });
         }
 
-
-#if NET461
-        [SkippableFact]
-#else
         [Fact]
-#endif
         public void ResolveFromEnvironment_WithoutEnvironmentVariable_VersionOfEntryAssembly()
         {
-#if NET461
-            Skip.If(Runtime.Current.IsMono(), "GetEntryAssembly returning null on Mono.");
-#endif
-            var ass = Assembly.GetEntryAssembly();
+            var ass = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly() ;
 
             EnvironmentVariableGuard.WithVariable(
                 Sentry.Internal.Constants.ReleaseEnvironmentVariable,

--- a/test/Sentry.Tests/Internals/ReleaseLocatorTests.cs
+++ b/test/Sentry.Tests/Internals/ReleaseLocatorTests.cs
@@ -27,7 +27,7 @@ namespace Sentry.Tests.Internals
         [Fact]
         public void ResolveFromEnvironment_WithoutEnvironmentVariable_VersionOfEntryAssembly()
         {
-            var ass = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly() ;
+            var ass = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
 
             EnvironmentVariableGuard.WithVariable(
                 Sentry.Internal.Constants.ReleaseEnvironmentVariable,


### PR DESCRIPTION
In the r# test runner on VS2022 GetEntryAssembly returns null

fixes a null ref when i run tests.

But now it causes a null to be returned from `ReleaseLocator.LocateFromEnvironment()`. So need to debug into that

#skip-changelog