### PR TITLE
[DRAFT] Fix: Ignore DiagnosticSource Integration if no Sampling available.

### DIFF
--- a/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentryDiagnosticListenerIntegration.cs
+++ b/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentryDiagnosticListenerIntegration.cs
@@ -11,8 +11,16 @@ namespace Sentry.Internals.DiagnosticSource
 
         public void Register(IHub hub, SentryOptions options)
         {
-            _subscriber = new SentryDiagnosticSubscriber(hub, options);
-            _diagnosticListener = DiagnosticListener.AllListeners.Subscribe(_subscriber);
+            if (options.TracesSampleRate == 0)
+            {
+                options.DiagnosticLogger?.Log(SentryLevel.Info, "DiagnosticSource Integration is now disabled due to TracesSampleRate being set to zero.");
+                options.DisableDiagnosticSourceIntegration();
+            }
+            else
+            {
+                _subscriber = new SentryDiagnosticSubscriber(hub, options);
+                _diagnosticListener = DiagnosticListener.AllListeners.Subscribe(_subscriber);
+            }
         }
 
         public void Unregister(IHub hub)

--- a/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentryEFCoreListener.cs
+++ b/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentryEFCoreListener.cs
@@ -57,23 +57,36 @@ namespace Sentry.Internals.DiagnosticSource
 
         private ISpan? AddSpan(SentryEFSpanType type, string operation, string? description)
         {
-            if (_hub.GetSpan()?.StartChild(operation, description) is { } span &&
-                GetSpanBucket(type) is { } asyncLocalSpan)
+            ISpan? span = null;
+            _hub.ConfigureScope(scope =>
             {
-                asyncLocalSpan.Value = new WeakReference<ISpan>(span);
-                return span;
-            }
-            return null;
+                if (scope.Transaction?.IsSampled == true &&
+                    scope.GetSpan()?.StartChild(operation, description) is { } startedChild &&
+                    GetSpanBucket(type) is { } asyncLocalSpan)
+                {
+                    asyncLocalSpan.Value = new WeakReference<ISpan>(startedChild);
+                    span = startedChild;
+                }
+            });
+            return span;
         }
 
         private ISpan? TakeSpan(SentryEFSpanType type)
         {
-            if (GetSpanBucket(type)?.Value is { } reference && reference.TryGetTarget(out var span))
+            ISpan? span = null;
+            _hub.ConfigureScope(scope =>
             {
-                return span;
-            }
-            _options.DiagnosticLogger?.LogWarning("Trying to close a span that was already garbage collected. {0}", type);
-            return null;
+                if (scope.Transaction?.IsSampled == true)
+                {
+                    if (GetSpanBucket(type)?.Value is { } reference &&
+                        reference.TryGetTarget(out var startedSpan))
+                    {
+                        span = startedSpan;
+                    }
+                    _options.DiagnosticLogger?.LogWarning("Trying to close a span that was already garbage collected. {0}", type);
+                }
+            });
+            return span;
         }
 
         private AsyncLocal<WeakReference<ISpan>>? GetSpanBucket(SentryEFSpanType type)
@@ -105,7 +118,7 @@ namespace Sentry.Internals.DiagnosticSource
 
                 //Connection Span
                 //A transaction may or may not show a connection with it.
-                if (_logConnectionEnabled && value.Key == EFConnectionOpening)
+                else if (_logConnectionEnabled && value.Key == EFConnectionOpening)
                 {
                     AddSpan(SentryEFSpanType.Connection, "db.connection", null);
                 }

--- a/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentrySqlListener.cs
+++ b/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentrySqlListener.cs
@@ -77,26 +77,26 @@ namespace Sentry.Internals.DiagnosticSource
             return null;
         }
 
-        private void AddSpan(SentrySqlSpanType type, string operation, string? description, Guid operationId, Guid? connectionId = null)
+        private void AddSpan(SentrySqlSpanType type, string operation, KeyValuePair<string, object?> value)
         {
             _hub.ConfigureScope(scope =>
             {
-                if (scope.Transaction is { } transaction)
+                if (scope.Transaction is { } transaction && transaction.IsSampled == true)
                 {
                     if (type == SentrySqlSpanType.Connection &&
-                        transaction?.StartChild(operation, description) is { } connectionSpan)
+                        transaction?.StartChild(operation) is { } connectionSpan)
                     {
-                        SetOperationId(connectionSpan, operationId);
+                        SetOperationId(connectionSpan, value.GetProperty<Guid>(OperationKey));
                     }
-                    else if (type == SentrySqlSpanType.Execution && connectionId != null)
+                    else if (type == SentrySqlSpanType.Execution && value.GetProperty<Guid>(ConnectionKey) is { } connectionId)
                     {
                         var span = TryStartChild(
-                            TryGetConnectionSpan(scope, connectionId.Value) ?? transaction,
+                            TryGetConnectionSpan(scope, connectionId) ?? transaction,
                             operation,
-                            description);
+                            null);
                         if (span is not null)
                         {
-                            SetOperationId(span, operationId);
+                            SetOperationId(span, value.GetProperty<Guid>(OperationKey));
                             SetConnectionId(span, connectionId);
                         }
                     }
@@ -104,36 +104,59 @@ namespace Sentry.Internals.DiagnosticSource
             });
         }
 
-        private ISpan? GetSpan(SentrySqlSpanType type, Guid? operationId = null, Guid? connectionId = null)
+        private ISpan? GetSpan(SentrySqlSpanType type, KeyValuePair<string, object?> value)
         {
             ISpan? span = null;
             _hub.ConfigureScope(scope =>
             {
-                if (type == SentrySqlSpanType.Execution &&
-                    operationId is { } queryId &&
-                    TryGetQuerySpan(scope, queryId) is { } querySpan)
+                if (scope.Transaction?.IsSampled != true)
                 {
-                    span = querySpan;
+                    return;
+                }
 
-                    if (span.ParentSpanId == scope.Transaction?.SpanId &&
-                        TryGetConnectionId(span) is { } spanConnectionId &&
-                        spanConnectionId is Guid spanConnectionGuid &&
-                        span is SpanTracer executionTracer &&
-                        TryGetConnectionSpan(scope, spanConnectionGuid) is { } spanConnectionRef)
+                if (type == SentrySqlSpanType.Execution)
+                {
+                    var operationId = value.GetProperty<Guid>(OperationKey);
+                    if (TryGetQuerySpan(scope, operationId) is { } querySpan)
                     {
-                        // Connection Span exist but wasn't set as the parent of the current Span.
-                        executionTracer.ParentSpanId = spanConnectionRef.SpanId;
+                        span = querySpan;
+
+                        if (span.ParentSpanId == scope.Transaction?.SpanId &&
+                            TryGetConnectionId(span) is { } spanConnectionId &&
+                            spanConnectionId is Guid spanConnectionGuid &&
+                            span is SpanTracer executionTracer &&
+                            TryGetConnectionSpan(scope, spanConnectionGuid) is { } spanConnectionRef)
+                        {
+                            // Connection Span exist but wasn't set as the parent of the current Span.
+                            executionTracer.ParentSpanId = spanConnectionRef.SpanId;
+                        }
+                    }
+                    else
+                    {
+                        _options.DiagnosticLogger?.LogWarning("Trying to get a span of type {0} with operation id {1}, but it was not found.",
+                            type,
+                            operationId);
                     }
                 }
-                else if (type == SentrySqlSpanType.Connection &&
-                    connectionId is { } id &&
+                else if ((value.Key == SqlMicrosoftWriteConnectionCloseAfterCommand ||
+                          value.Key == SqlDataWriteConnectionCloseAfterCommand) &&
+                    value.GetProperty<Guid>(ConnectionKey) is { } id &&
                     TryGetConnectionSpan(scope, id) is { } connectionSpan)
                 {
                     span = connectionSpan;
                 }
+                else if ((value.Key is SqlMicrosoftWriteTransactionCommitAfter ||
+                          value.Key is SqlDataWriteTransactionCommitAfter) &&
+                    value.GetSubProperty<Guid>("Connection", "ClientConnectionId") is { } commitId &&
+                    TryGetConnectionSpan(scope, commitId) is { } commitSpan)
+                {
+                    span = commitSpan;
+                }
                 else
                 {
-                    _options.DiagnosticLogger?.LogWarning("Trying to get a span of type {0} with operation id {1}, but it was not found.", type, operationId);
+                    _options.DiagnosticLogger?.LogWarning("Trying to get a span of type {0} with operation id {1}, but it was not found.",
+                        type,
+                        value.GetProperty<Guid>(OperationKey));
                 }
             });
             return span;
@@ -174,16 +197,16 @@ namespace Sentry.Internals.DiagnosticSource
                 // Query.
                 if (value.Key == SqlMicrosoftBeforeExecuteCommand || value.Key == SqlDataBeforeExecuteCommand)
                 {
-                    AddSpan(SentrySqlSpanType.Execution, "db.query", null, value.GetProperty<Guid>(OperationKey), value.GetProperty<Guid>(ConnectionKey));
+                    AddSpan(SentrySqlSpanType.Execution, "db.query", value);
                 }
                 else if ((value.Key == SqlMicrosoftAfterExecuteCommand || value.Key == SqlDataAfterExecuteCommand) &&
-                    GetSpan(SentrySqlSpanType.Execution, value.GetProperty<Guid>(OperationKey)) is { } commandSpan)
+                    GetSpan(SentrySqlSpanType.Execution, value) is { } commandSpan)
                 {
                     commandSpan.Description = value.GetSubProperty<string>("Command", "CommandText");
                     commandSpan.Finish(SpanStatus.Ok);
                 }
                 else if ((value.Key == SqlMicrosoftWriteCommandError || value.Key == SqlDataWriteCommandError) &&
-                    GetSpan(SentrySqlSpanType.Execution, value.GetProperty<Guid>(OperationKey)) is { } errorSpan)
+                    GetSpan(SentrySqlSpanType.Execution, value) is { } errorSpan)
                 {
                     errorSpan.Description = value.GetSubProperty<string>("Command", "CommandText");
                     errorSpan.Finish(SpanStatus.InternalError);
@@ -192,7 +215,7 @@ namespace Sentry.Internals.DiagnosticSource
                 // Connection.
                 else if (value.Key == SqlMicrosoftWriteConnectionOpenBeforeCommand || value.Key == SqlDataWriteConnectionOpenBeforeCommand)
                 {
-                    AddSpan(SentrySqlSpanType.Connection, "db.connection", null, value.GetProperty<Guid>(OperationKey));
+                    AddSpan(SentrySqlSpanType.Connection, "db.connection", value);
                 }
                 else if (value.Key == SqlMicrosoftWriteConnectionOpenAfterCommand || value.Key == SqlDataWriteConnectionOpenAfterCommand)
                 {
@@ -200,13 +223,13 @@ namespace Sentry.Internals.DiagnosticSource
                 }
                 else if ((value.Key == SqlMicrosoftWriteConnectionCloseAfterCommand ||
                           value.Key == SqlDataWriteConnectionCloseAfterCommand) &&
-                    GetSpan(SentrySqlSpanType.Connection, null, value.GetProperty<Guid>(ConnectionKey)) is { } connectionSpan)
+                    GetSpan(SentrySqlSpanType.Connection, value) is { } connectionSpan)
                 {
                     TrySetConnectionStatistics(connectionSpan, value);
                     connectionSpan.Finish(SpanStatus.Ok);
                 }
                 else if ((value.Key is SqlMicrosoftWriteTransactionCommitAfter || value.Key is SqlDataWriteTransactionCommitAfter) &&
-                    GetSpan(SentrySqlSpanType.Connection, null, value.GetSubProperty<Guid>("Connection", "ClientConnectionId")) is { } connectionSpan2)
+                    GetSpan(SentrySqlSpanType.Connection, value) is { } connectionSpan2)
                 {
                     // If some query makes changes to the Database data, CloseAfterCommand event will not be invoked,
                     // instead, TransactionCommitAfter is invoked.

--- a/test/Sentry.DiagnosticSource.Tests/Integration/SQLite/SentryDiagnosticListenerTests.cs
+++ b/test/Sentry.DiagnosticSource.Tests/Integration/SQLite/SentryDiagnosticListenerTests.cs
@@ -24,7 +24,10 @@ namespace Sentry.DiagnosticSource.Tests.Integration.SQLite
             internal SentryScopeManager ScopeManager { get; }
             public Fixture()
             {
-                var options = new SentryOptions();
+                var options = new SentryOptions()
+                {
+                    TracesSampleRate = 1.0
+                };
                 ScopeManager = new SentryScopeManager(
                     new AsyncLocalScopeStackContainer(),
                     options,


### PR DESCRIPTION
This PR solves two use cases.

- The integration was being enabled despite TracesSampleRate being set to zero.
- Spans were being created for Transactions that weren't going to be sent to Sentry.

The first issue is solved by disabling the integration during the application's startup if found that TracesSampleRate is set to zero.

The latter is fixed by not trying to retrieve/create a span if the current transaction is not being sampled.