### PR TITLE
Replace Task default with Task.CompletedTask in tests

### DIFF
--- a/benchmarks/Sentry.Benchmarks/BackgroundWorkerFlushBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/BackgroundWorkerFlushBenchmarks.cs
@@ -13,7 +13,7 @@ namespace Sentry.Benchmarks
         private class FakeTransport : ITransport
         {
             public Task SendEnvelopeAsync(Envelope envelope, CancellationToken cancellationToken = default)
-                => default;
+                => Task.CompletedTask;
         }
 
         private IBackgroundWorker _backgroundWorker;

--- a/test/Sentry.Tests/Extensibility/HubAdapterTests.cs
+++ b/test/Sentry.Tests/Extensibility/HubAdapterTests.cs
@@ -74,7 +74,7 @@ namespace Sentry.Tests.Extensibility
         [Fact]
         public void ConfigureScopeAsync_MockInvoked()
         {
-            static Task Expected(Scope _) => default;
+            static Task Expected(Scope _) => Task.CompletedTask;
 
             _ = HubAdapter.Instance.ConfigureScopeAsync(Expected);
             _ = Hub.Received(1).ConfigureScopeAsync(Expected);

--- a/test/Sentry.Tests/Internals/SentryScopeManagerTests.cs
+++ b/test/Sentry.Tests/Internals/SentryScopeManagerTests.cs
@@ -127,7 +127,7 @@ namespace Sentry.Tests.Internals
             await sut.ConfigureScopeAsync(_ =>
             {
                 isInvoked = true;
-                return default;
+                return Task.CompletedTask;
             });
 
             Assert.True(isInvoked);

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -418,7 +418,7 @@ namespace Sentry.Tests
             await SentrySdk.ConfigureScopeAsync(_ =>
             {
                 invoked = true;
-                return default;
+                return Task.CompletedTask;
             });
             Assert.False(invoked);
         }


### PR DESCRIPTION
#skip-changelog.

noticed via updating Roslynator.Analyzers to Version 3.2.2 https://github.com/getsentry/sentry-dotnet/pull/1257