### PR TITLE
re-enable testa AppDomain

### DIFF
--- a/test/xunit.runner.json
+++ b/test/xunit.runner.json
@@ -1,7 +1,5 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "appDomain": "denied",
-
   "// TODO:": "Re-enable parallelization (disabled due to test flakiness)",
   "parallelizeAssembly": false,
   "parallelizeTestCollections": false,


### PR DESCRIPTION
@lucas-zimerman so this fixes the CodDom load issue you mentioned. With `"appDomain": "denied",` mstest does not launch a new appdomain,  resulting in it not interrogating the binding redirects that are generated by the build. 

@bruno-garcia you [added this setting](https://github.com/getsentry/sentry-dotnet/commit/13a822004a281040be2050bd4a925e946c566194). do you remember why?

#skip-changelog