### PR TITLE
fix minor warnings

### DIFF
--- a/src/Sentry/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Envelopes/EnvelopeItem.cs
@@ -68,7 +68,7 @@ namespace Sentry.Protocol.Envelopes
             return buffer;
         }
 
-        private async Task SerializeHeaderAsync(
+        private static async Task SerializeHeaderAsync(
             Stream stream,
             IReadOnlyDictionary<string, object?> header,
             CancellationToken cancellationToken = default)

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -53,10 +53,10 @@ namespace Sentry.Internal.Http
 
             _processingDirectoryPath = Path.Combine(_isolatedCacheDirectoryPath, "__processing");
 
-            _worker = Task.Run(CachedTransportBackgroundTask);
+            _worker = Task.Run(CachedTransportBackgroundTaskAsync);
         }
 
-        private async Task CachedTransportBackgroundTask()
+        private async Task CachedTransportBackgroundTaskAsync()
         {
             try
             {


### PR DESCRIPTION
#skip-changelog

 * add a missing `Async` suffix
 * Make a method static

Both non-public