### PR TITLE
Fix GCP Tests on .NET 6

### DIFF
--- a/test/Sentry.Google.Cloud.Functions.Tests/Sentry.Google.Cloud.Functions.Tests.csproj
+++ b/test/Sentry.Google.Cloud.Functions.Tests/Sentry.Google.Cloud.Functions.Tests.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
-    <!-- Tests are failing on net6.0-->
-    <!-- <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>-->
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Sentry.Google.Cloud.Functions.Tests/SentryStartupTests.cs
+++ b/test/Sentry.Google.Cloud.Functions.Tests/SentryStartupTests.cs
@@ -25,11 +25,16 @@ namespace Sentry.Google.Cloud.Functions.Tests
 
         public SentryStartupTests()
         {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>())
+                .Build();
+
             WebHostBuilderContext = new WebHostBuilderContext
             {
-                Configuration = Substitute.For<IConfiguration>(),
+                Configuration = configuration,
                 HostingEnvironment = HostingEnvironment
             };
+
             LoggingBuilder = new TestLoggingBuilder();
             LoggingBuilder.Services.AddSingleton(HostingEnvironment);
 


### PR DESCRIPTION
This fixes the weird behavior with .NET 6.0. 
The main issue was some anomaly with Nsubstitute and IConfiguration, replacing it with a real constructor fixed the issue.

#skip-changelog.

```txt
  Failed Sentry.Google.Cloud.Functions.Tests.SentryStartupTests.ConfigureLogging_ModifiesReleaseLocatorAndReadsKRevisionEnvVar_AppendsToRelease [107 ms]
  Error Message:
   System.InvalidOperationException : Failed to convert configuration value at '' to type 'System.Boolean'.
---- System.FormatException :  is not a valid value for Boolean.
-------- System.FormatException : String '' was not recognized as a valid Boolean.
  Stack Trace:
     at Microsoft.Extensions.Configuration.ConfigurationBinder.BindInstance(Type type, Object instance, IConfiguration config, BinderOptions options)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.GetPropertyValue(PropertyInfo property, Object instance, IConfiguration config, BinderOptions options)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.BindProperty(PropertyInfo property, Object instance, IConfiguration config, BinderOptions options)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.BindNonScalar(IConfiguration configuration, Object instance, BinderOptions options)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.BindInstance(Type type, Object instance, IConfiguration config, BinderOptions options)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.Bind(IConfiguration configuration, Object instance, Action`1 configureOptions)
   at Microsoft.Extensions.Options.NamedConfigureFromConfigurationOptions`1.<>c__DisplayClass1_0.<.ctor>b__0(TOptions options)
   at Microsoft.Extensions.Options.ConfigureNamedOptions`1.Configure(String name, TOptions options)
   at Microsoft.Extensions.Options.OptionsFactory`1.Create(String name)
   at Microsoft.Extensions.Options.UnnamedOptionsManager`1.get_Value()
   at Sentry.Google.Cloud.Functions.Tests.SentryStartupTests.<>c__DisplayClass14_0.<ConfigureLogging_ModifiesReleaseLocatorAndReadsKRevisionEnvVar_AppendsToRelease>b__0() in /Users/runner/work/sentry-dotnet/sentry-dotnet/test/Sentry.Google.Cloud.Functions.Tests/SentryStartupTests.cs:line 54
   at Sentry.Testing.EnvironmentVariableGuard.WithVariable(String key, String value, Action action) in /Users/runner/work/sentry-dotnet/sentry-dotnet/test/Sentry.Testing/EnvironmentVariableGuard.cs:line 17
   at Sentry.Google.Cloud.Functions.Tests.SentryStartupTests.ConfigureLogging_ModifiesReleaseLocatorAndReadsKRevisionEnvVar_AppendsToRelease() in /Users/runner/work/sentry-dotnet/sentry-dotnet/test/Sentry.Google.Cloud.Functions.Tests/SentryStartupTests.cs:line 47
----- Inner Stack Trace -----
   at System.ComponentModel.BooleanConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   at System.ComponentModel.TypeConverter.ConvertFromInvariantString(String text)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.TryConvertValue(Type type, String value, String path, Object& result, Exception& error)
----- Inner Stack Trace -----
   at System.Boolean.Parse(ReadOnlySpan`1 value)
   at System.Boolean.Parse(String value)
   at System.ComponentModel.BooleanConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)

```