### PR TITLE
Revert "Suppress LazyInitializer.EnsureInitialized warning (#1322)"

### DIFF
--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -7,8 +7,6 @@
     <ImplicitUsings>false</ImplicitUsings>
     <Description>Official SDK for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
     <NoWarn Condition="$(TargetFramework) == 'netstandard2.0'">$(NoWarn);RS0017</NoWarn>
-    <!-- TODO: remove the below NoWarn PR merged https://github.com/benaadams/Ben.Demystifier/pull/182-->
-    <NoWarn>$(NoWarn);CS8621</NoWarn>
     <DefineConstants>$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
This reverts commit d2e8d0bd60b363067c65c805ac3e5945fc54083b.

Since the upstream PR has been merged

fixes https://github.com/getsentry/sentry-dotnet/issues/1323

#skip-changelog
