### PR TITLE
infer netfx version from min reg versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Infer netfx version from min reg versions ([#1346](https://github.com/getsentry/sentry-dotnet/pull/1346))
+
 ## 3.12.0
 
 ### Features

--- a/src/Sentry/PlatformAbstractions/FrameworkInfo.NetFx.cs
+++ b/src/Sentry/PlatformAbstractions/FrameworkInfo.NetFx.cs
@@ -12,6 +12,7 @@ namespace Sentry.PlatformAbstractions
     {
         internal const string NetFxNdpRegistryKey = @"SOFTWARE\Microsoft\NET Framework Setup\NDP\";
         internal const string NetFxNdpFullRegistryKey = @"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\";
+
         /// <summary>
         /// Get the latest Framework installation for the specified CLR
         /// </summary>
@@ -174,9 +175,57 @@ namespace Sentry.PlatformAbstractions
 
         internal static Version GetNetFxVersionFromRelease(int release)
         {
-            _ = NetFxReleaseVersionMap.TryGetValue(release, out var version);
-            _ = Version.TryParse(version, out var parsed);
-            return parsed;
+            if (release >= 528040)
+            {
+                return new Version(4, 8);
+            }
+
+            if (release >= 461808)
+            {
+                return new Version(4, 7, 2);
+            }
+
+            if (release >= 461308)
+            {
+                return new Version(4, 7, 1);
+            }
+
+            if (release >= 460798)
+            {
+                return new Version(4, 7);
+            }
+
+            if (release >= 394802)
+            {
+                return new Version(4, 6, 2);
+            }
+
+            if (release >= 394254)
+            {
+                return new Version(4, 6, 1);
+            }
+
+            if (release >= 393295)
+            {
+                return new Version(4, 6);
+            }
+
+            if (release >= 379893)
+            {
+                return new Version(4, 5, 2);
+            }
+
+            if (release >= 378675)
+            {
+                return new Version(4, 5, 1);
+            }
+
+            if (release >= 378389)
+            {
+                return new Version(4, 5);
+            }
+
+            throw new($"Unknown version for NetFx registry version: {release}");
         }
     }
 }

--- a/src/Sentry/PlatformAbstractions/FrameworkInfo.NetFx.cs
+++ b/src/Sentry/PlatformAbstractions/FrameworkInfo.NetFx.cs
@@ -173,6 +173,7 @@ namespace Sentry.PlatformAbstractions
             return ndpKey?.GetInt("Release");
         }
 
+        // https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#minimum-version
         internal static Version GetNetFxVersionFromRelease(int release)
         {
             if (release >= 528040)

--- a/src/Sentry/PlatformAbstractions/FrameworkInfo.cs
+++ b/src/Sentry/PlatformAbstractions/FrameworkInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Sentry.PlatformAbstractions
@@ -13,6 +14,7 @@ namespace Sentry.PlatformAbstractions
         /// The map between release number and version number
         /// </summary>
         /// <see href="https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed" />
+        [Obsolete("No longer required by sentry.")]
         public static IReadOnlyDictionary<int, string> NetFxReleaseVersionMap { get; }
             = new Dictionary<int, string>
             {

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1074,6 +1074,7 @@ namespace Sentry.PlatformAbstractions
 {
     public static class FrameworkInfo
     {
+        [System.Obsolete("No longer required by sentry.")]
         public static System.Collections.Generic.IReadOnlyDictionary<int, string> NetFxReleaseVersionMap { get; }
         public static System.Collections.Generic.IEnumerable<Sentry.PlatformAbstractions.FrameworkInstallation> GetInstallations() { }
         public static Sentry.PlatformAbstractions.FrameworkInstallation? GetLatest(int clr) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet2_1.verified.txt
@@ -1073,6 +1073,7 @@ namespace Sentry.PlatformAbstractions
 {
     public static class FrameworkInfo
     {
+        [System.Obsolete("No longer required by sentry.")]
         public static System.Collections.Generic.IReadOnlyDictionary<int, string> NetFxReleaseVersionMap { get; }
         public static System.Collections.Generic.IEnumerable<Sentry.PlatformAbstractions.FrameworkInstallation> GetInstallations() { }
         public static Sentry.PlatformAbstractions.FrameworkInstallation? GetLatest(int clr) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet3_0.verified.txt
@@ -1073,6 +1073,7 @@ namespace Sentry.PlatformAbstractions
 {
     public static class FrameworkInfo
     {
+        [System.Obsolete("No longer required by sentry.")]
         public static System.Collections.Generic.IReadOnlyDictionary<int, string> NetFxReleaseVersionMap { get; }
         public static System.Collections.Generic.IEnumerable<Sentry.PlatformAbstractions.FrameworkInstallation> GetInstallations() { }
         public static Sentry.PlatformAbstractions.FrameworkInstallation? GetLatest(int clr) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1073,6 +1073,7 @@ namespace Sentry.PlatformAbstractions
 {
     public static class FrameworkInfo
     {
+        [System.Obsolete("No longer required by sentry.")]
         public static System.Collections.Generic.IReadOnlyDictionary<int, string> NetFxReleaseVersionMap { get; }
         public static System.Collections.Generic.IEnumerable<Sentry.PlatformAbstractions.FrameworkInstallation> GetInstallations() { }
         public static Sentry.PlatformAbstractions.FrameworkInstallation? GetLatest(int clrVersion) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1074,6 +1074,7 @@ namespace Sentry.PlatformAbstractions
 {
     public static class FrameworkInfo
     {
+        [System.Obsolete("No longer required by sentry.")]
         public static System.Collections.Generic.IReadOnlyDictionary<int, string> NetFxReleaseVersionMap { get; }
         public static System.Collections.Generic.IEnumerable<Sentry.PlatformAbstractions.FrameworkInstallation> GetInstallations() { }
         public static Sentry.PlatformAbstractions.FrameworkInstallation? GetLatest(int clr) { }


### PR DESCRIPTION
For me SetReleaseAndVersionNetFx_OnNetFx_NonNullReleaseAndVersion was failing. This is dues to me having a newer net48 on my machine which has a reg key of 528449.

This PR changes the detection logic to infer by the [min versions](https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#minimum-version) instead of a hard coded dictionary, so it is more resilient moving forward
