### PR TITLE
Fix EF Core garbage collected messages and ordering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- Fix EF Core garbage collected messages and ordering ([#1368](https://github.com/getsentry/sentry-dotnet/pull/1368))
 - Update X-Sentry-Auth header to include correct sdk name and version ([#1333](https://github.com/getsentry/sentry-dotnet/pull/1333))
 
 ## 3.12.0

--- a/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentryEFCoreListener.cs
+++ b/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentryEFCoreListener.cs
@@ -1,3 +1,8 @@
+#if NETCOREAPP3_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Threading;
+#endif
 using Sentry.Extensibility;
 
 namespace Sentry.Internals.DiagnosticSource

--- a/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentryEFCoreListener.cs
+++ b/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentryEFCoreListener.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
 using Sentry.Extensibility;
 
 namespace Sentry.Internals.DiagnosticSource

--- a/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentryEFCoreListener.cs
+++ b/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentryEFCoreListener.cs
@@ -72,7 +72,7 @@ namespace Sentry.Internals.DiagnosticSource
                 {
                     return;
                 }
-                                
+
                 if (GetSpanBucket(type) is not { } asyncLocalSpan)
                 {
                     return;

--- a/test/Sentry.DiagnosticSource.Tests/SentryEFCoreListenerTests.cs
+++ b/test/Sentry.DiagnosticSource.Tests/SentryEFCoreListenerTests.cs
@@ -322,7 +322,7 @@ public class SentryEFCoreListenerTests
 
 
     [Theory]
-    [InlineData(EFCommandExecuted)] 
+    [InlineData(EFCommandExecuted)]
     [InlineData(EFConnectionClosed)]
     [InlineData(EFQueryCompiled)]
     public void OnNext_TakeSpanWithoutSpan_ShowsGarbageCollectorError(string operation)

--- a/test/Sentry.DiagnosticSource.Tests/SentryEFCoreListenerTests.cs
+++ b/test/Sentry.DiagnosticSource.Tests/SentryEFCoreListenerTests.cs
@@ -338,7 +338,6 @@ public class SentryEFCoreListenerTests
         _fixture.Options.DiagnosticLogger.Received(1).Log(Arg.Is(SentryLevel.Warning), Arg.Is("Trying to close a span that was already garbage collected. {0}"), null, Arg.Any<object[]>());
     }
 
-
     [Fact]
     public void FilterNewLineValue_StringWithNewLine_SubStringAfterNewLine()
     {

--- a/test/Sentry.DiagnosticSource.Tests/SentryEFCoreListenerTests.cs
+++ b/test/Sentry.DiagnosticSource.Tests/SentryEFCoreListenerTests.cs
@@ -229,6 +229,7 @@ public class SentryEFCoreListenerTests
         Assert.Equal(_fixture.Tracer.SpanId, compilerSpan.ParentSpanId);
         Assert.Equal(_fixture.Tracer.SpanId, connectionSpan.ParentSpanId);
         Assert.Equal(connectionSpan.SpanId, commandSpan.ParentSpanId);
+        _fixture.Options.DiagnosticLogger.Received(0).Log(Arg.Is(SentryLevel.Warning), Arg.Is("Trying to close a span that was already garbage collected. {0}"), null, Arg.Any<object[]>());
     }
 
     [Fact]
@@ -318,6 +319,25 @@ public class SentryEFCoreListenerTests
         // Assert
         Assert.False(exceptionReceived);
     }
+
+
+    [Theory]
+    [InlineData(EFCommandExecuted)] 
+    [InlineData(EFConnectionClosed)]
+    [InlineData(EFQueryCompiled)]
+    public void OnNext_TakeSpanWithoutSpan_ShowsGarbageCollectorError(string operation)
+    {
+        // Arrange
+        var hub = _fixture.Hub;
+        var interceptor = new SentryEFCoreListener(hub, _fixture.Options);
+
+        // Act
+        interceptor.OnNext(new(operation, "ef Junk\r\nSELECT * FROM ..."));
+
+        // Assert
+        _fixture.Options.DiagnosticLogger.Received(1).Log(Arg.Is(SentryLevel.Warning), Arg.Is("Trying to close a span that was already garbage collected. {0}"), null, Arg.Any<object[]>());
+    }
+
 
     [Fact]
     public void FilterNewLineValue_StringWithNewLine_SubStringAfterNewLine()


### PR DESCRIPTION
- Don't show the message the spam was garbage collected when it wasn't.
- Fix spams grouping (connection/query compiler spams being created on the main transaction and execution spams being created to parent spam)