### PR TITLE
remove await using noise in test project

### DIFF
--- a/test/Sentry.Tests/Internals/PartialStreamTests.cs
+++ b/test/Sentry.Tests/Internals/PartialStreamTests.cs
@@ -8,18 +8,13 @@ public class PartialStreamTests
     public async Task PartialStream_WithOffsetAndLength_Length_ReturnsPartialLength()
     {
         // Arrange
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var originalStream = new MemoryStream();
+        using var originalStream = new MemoryStream();
         await originalStream.FillWithRandomBytesAsync(1024);
 
         const int offset = 10;
         const int length = 100;
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var partialStream = new PartialStream(originalStream, offset, length);
+
+        using var partialStream = new PartialStream(originalStream, offset, length);
 
         // Act & assert
         partialStream.Length.Should().Be(length);
@@ -29,24 +24,16 @@ public class PartialStreamTests
     public async Task PartialStream_WithOffsetAndLength_ReadToEnd_ReturnsOnlyDataInRange()
     {
         // Arrange
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var originalStream = new MemoryStream();
+        using var originalStream = new MemoryStream();
         await originalStream.FillWithRandomBytesAsync(1024);
 
         const int offset = 10;
         const int length = 100;
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var partialStream = new PartialStream(originalStream, offset, length);
+
+        using var partialStream = new PartialStream(originalStream, offset, length);
 
         // Act
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var outputStream = new MemoryStream();
+        using var outputStream = new MemoryStream();
         await partialStream.CopyToAsync(outputStream);
 
         // Assert
@@ -60,23 +47,15 @@ public class PartialStreamTests
     public async Task PartialStream_WithOffset_ReadToEnd_ReturnsOnlyDataInRange()
     {
         // Arrange
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var originalStream = new MemoryStream();
+        using var originalStream = new MemoryStream();
         await originalStream.FillWithRandomBytesAsync(1024);
 
         const int offset = 10;
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var partialStream = new PartialStream(originalStream, offset, null);
+
+        using var partialStream = new PartialStream(originalStream, offset, null);
 
         // Act
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var outputStream = new MemoryStream();
+        using var outputStream = new MemoryStream();
         await partialStream.CopyToAsync(outputStream);
 
         // Assert
@@ -90,28 +69,20 @@ public class PartialStreamTests
     public async Task PartialStream_WithOffsetAndLength_Seek_WorksCorrectly()
     {
         // Arrange
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var originalStream = new MemoryStream();
+        using var originalStream = new MemoryStream();
         await originalStream.FillWithRandomBytesAsync(1024);
 
         const int offset = 10;
         const int length = 100;
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var partialStream = new PartialStream(originalStream, offset, length);
+
+        using var partialStream = new PartialStream(originalStream, offset, length);
 
         // Act
         const int additionalOffset = 40;
         partialStream.Seek(additionalOffset, SeekOrigin.Begin);
 
         // Assert
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var outputStream = new MemoryStream();
+        using var outputStream = new MemoryStream();
         await partialStream.CopyToAsync(outputStream);
 
         var originalPortion = originalStream
@@ -127,18 +98,13 @@ public class PartialStreamTests
     public async Task PartialStream_WithOffsetAndLength_SettingInvalidPosition_Throws()
     {
         // Arrange
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var originalStream = new MemoryStream();
+        using var originalStream = new MemoryStream();
         await originalStream.FillWithRandomBytesAsync(1024);
 
         const int offset = 10;
         const int length = 100;
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var partialStream = new PartialStream(originalStream, offset, length);
+
+        using var partialStream = new PartialStream(originalStream, offset, length);
 
         // Act & assert
         Assert.Throws<InvalidOperationException>(() => partialStream.Position = 200);
@@ -148,27 +114,19 @@ public class PartialStreamTests
     public async Task PartialStream_WithOffsetAndLength_InnerPositionChanged_StillReadsCorrectly()
     {
         // Arrange
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var originalStream = new MemoryStream();
+        using var originalStream = new MemoryStream();
         await originalStream.FillWithRandomBytesAsync(1024);
 
         const int offset = 10;
         const int length = 100;
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var partialStream = new PartialStream(originalStream, offset, length);
+
+        using var partialStream = new PartialStream(originalStream, offset, length);
 
         // Act
         originalStream.Position = 1000;
 
         // Assert
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var outputStream = new MemoryStream();
+        using var outputStream = new MemoryStream();
         await partialStream.CopyToAsync(outputStream);
 
         var originalPortion = originalStream.ToArray().Skip(offset).Take(length).ToArray();

--- a/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
@@ -27,10 +27,7 @@ public class EnvelopeTests
     public async Task Deserialization_EnvelopeWithoutItems_Success()
     {
         // Arrange
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var input = "{\"event_id\":\"12c2d058d58442709aa2eca08bf20986\"}\n".ToMemoryStream();
+        using var input = "{\"event_id\":\"12c2d058d58442709aa2eca08bf20986\"}\n".ToMemoryStream();
 
         using var expectedEnvelope = new Envelope(
             new Dictionary<string, object> { ["event_id"] = "12c2d058d58442709aa2eca08bf20986" },
@@ -72,10 +69,7 @@ public class EnvelopeTests
     public async Task Deserialization_EnvelopeWithoutHeader_Success()
     {
         // Arrange
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var input = (
+        using var input = (
                 "{}\n" +
                 "{\"type\":\"fake\",\"length\":75}\n" +
                 "{\"started\": \"2020-02-07T14:16:00Z\",\"attrs\":{\"release\":\"sentry-test@1.0.0\"}}\n"
@@ -149,11 +143,7 @@ public class EnvelopeTests
     [Fact]
     public async Task Deserialization_EnvelopeWithTwoItems_Success()
     {
-        // Arrange
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var input = (
+        using var input = (
                 "{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"dsn\":\"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42\"}\n" +
                 "{\"type\":\"attachment\",\"length\":13,\"content_type\":\"text/plain\",\"filename\":\"hello.txt\"}\n" +
                 "\xef\xbb\xbfHello\r\n\n" +
@@ -242,10 +232,7 @@ public class EnvelopeTests
     public async Task Deserialization_EnvelopeWithTwoEmptyItems_Success()
     {
         // Arrange
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var input = (
+        using var input = (
                 "{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\"}\n" +
                 "{\"type\":\"attachment\",\"length\":0}\n" +
                 "\n" +
@@ -311,10 +298,7 @@ public class EnvelopeTests
     public async Task Deserialization_EnvelopeWithItemWithoutLength_Success()
     {
         // Arrange
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var input = (
+        using var input = (
                 "{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\"}\n" +
                 "{\"type\":\"attachment\"}\n" +
                 "helloworld\n"
@@ -372,10 +356,7 @@ public class EnvelopeTests
 
         using var envelope = Envelope.FromEvent(@event);
 
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var stream = new MemoryStream();
+        using var stream = new MemoryStream();
 
         // Act
         await envelope.SerializeAsync(stream);
@@ -412,10 +393,7 @@ public class EnvelopeTests
 
         using var envelope = Envelope.FromEvent(@event, new[] { attachment });
 
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var stream = new MemoryStream();
+        using var stream = new MemoryStream();
 
         // Act
         await envelope.SerializeAsync(stream);
@@ -452,10 +430,7 @@ public class EnvelopeTests
 
         using var envelope = Envelope.FromEvent(@event, new[] { attachment }, sessionUpdate);
 
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var stream = new MemoryStream();
+        using var stream = new MemoryStream();
 
         // Act
         await envelope.SerializeAsync(stream);
@@ -487,10 +462,7 @@ public class EnvelopeTests
 
         using var envelope = Envelope.FromUserFeedback(feedback);
 
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var stream = new MemoryStream();
+        using var stream = new MemoryStream();
 
         // Act
         await envelope.SerializeAsync(stream);
@@ -516,10 +488,7 @@ public class EnvelopeTests
 
         using var envelope = Envelope.FromSession(sessionUpdate);
 
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var stream = new MemoryStream();
+        using var stream = new MemoryStream();
 
         // Act
         await envelope.SerializeAsync(stream);
@@ -541,10 +510,7 @@ public class EnvelopeTests
     public async Task Deserialization_EmptyStream_Throws()
     {
         // Arrange
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var input = new MemoryStream();
+        using var input = new MemoryStream();
 
         // Act & assert
         await Assert.ThrowsAnyAsync<Exception>(
@@ -555,10 +521,7 @@ public class EnvelopeTests
     public async Task Deserialization_InvalidData_Throws()
     {
         // Arrange
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var input = new MemoryStream(new byte[1_000_000]); // all 0's
+        using var input = new MemoryStream(new byte[1_000_000]); // all 0's
 
         // Act & assert
         await Assert.ThrowsAnyAsync<Exception>(
@@ -569,10 +532,7 @@ public class EnvelopeTests
     public async Task Deserialization_MalformedData_Throws()
     {
         // Arrange
-#if !NET461 && !NETCOREAPP2_1
-        await
-#endif
-            using var input = "helloworld\n".ToMemoryStream();
+        using var input = "helloworld\n".ToMemoryStream();
 
         // Act & assert
         await Assert.ThrowsAnyAsync<Exception>(


### PR DESCRIPTION
before 

```
#if !NET461 && !NETCOREAPP2_1
        await
#endif
            using var originalStream = new MemoryStream();
```

after 
```
using var originalStream = new MemoryStream();
```

in tests there will be no noticeable perf impact. and the result is much easier to read

#skip-changelog