### PR TITLE
break ci on missing artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
           uses: actions/upload-artifact@v2
           with:
             name: ${{ github.sha }}
+            if-no-files-found: error
             path: |
               ${{ github.workspace }}/src/**/Release/*.nupkg
 


### PR DESCRIPTION
default is warning

Example: A build that was successful, now fails with:

![image](https://user-images.githubusercontent.com/1633368/145738880-022b1d2a-34be-4772-adef-a68d17e32679.png)

#skip-changelog
