### PR TITLE
fix: Recover from broken context/attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Events no longer get dropped because of non-serializable contexts or attachments ([#1400](https://github.com/getsentry/sentry-dotnet/pull/1400))
 - Add MemoryInfo to sentry event ([#1337](https://github.com/getsentry/sentry-dotnet/pull/1337))
 
 ## 3.12.2

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- Workaround the fact that http doesnt exist in earlier frameworks -->
-    <Using Remove="System.Net.Http"/>
-    <Using Remove="System.Net.Http.Json"/>
-  </ItemGroup>
-</Project>

--- a/src/Sentry/Envelopes/Envelope.cs
+++ b/src/Sentry/Envelopes/Envelope.cs
@@ -132,12 +132,9 @@ namespace Sentry.Protocol.Envelopes
                     }
                     catch (Exception exception)
                     {
-                        if (logger is null)
-                        {
-                            throw;
-                        }
-
-                        logger.LogError("Failed to add attachment: {0}.", exception, attachment.FileName);
+                        // In the event of failing to add an attachment, we don't want to throw away a whole event
+                        // so we'll suppress issues here.
+                        logger?.LogError("Failed to add attachment: {0}.", exception, attachment.FileName);
                     }
                 }
             }

--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -287,13 +287,7 @@ namespace Sentry.Internal.Extensions
             }
             else
             {
-                using var stream = new MemoryStream();
-                var tempWriter = new Utf8JsonWriter(stream);
-                JsonSerializer.Serialize(tempWriter, value, SerializerOption);
-                tempWriter.Flush();
-                stream.Flush();
-                using var document = JsonDocument.Parse(stream);
-                document.RootElement.WriteTo(writer);
+                JsonSerializer.Serialize(writer, value, SerializerOption);
             }
         }
 
@@ -311,7 +305,8 @@ namespace Sentry.Internal.Extensions
             }
             catch (Exception e) when (logger != null)
             {
-                writer.WriteNullValue();
+                writer.WriteStartObject();
+                writer.WriteEndObject();
 
                 // The only location in the protocol we allow dynamic objects are Extra and Contexts
                 // In the event of an instance that can't be serialized, we don't want to throw away a whole event

--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -303,7 +303,7 @@ namespace Sentry.Internal.Extensions
             {
                 writer.WriteDynamicValue(value, logger);
             }
-            catch (Exception e) when (logger != null)
+            catch (Exception e)
             {
                 writer.WriteStartObject();
                 writer.WriteEndObject();
@@ -311,7 +311,7 @@ namespace Sentry.Internal.Extensions
                 // The only location in the protocol we allow dynamic objects are Extra and Contexts
                 // In the event of an instance that can't be serialized, we don't want to throw away a whole event
                 // so we'll suppress issues here.
-                logger.LogError("Failed to serialize object for property {0}", e, propertyName);
+                logger?.LogError("Failed to serialize object for property {0}", e, propertyName);
             }
         }
 

--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -287,14 +287,13 @@ namespace Sentry.Internal.Extensions
             }
             else
             {
-                using var tempStream = new MemoryStream();
-                var tempWriter = new Utf8JsonWriter(tempStream);
-
+                using var stream = new MemoryStream();
+                var tempWriter = new Utf8JsonWriter(stream);
                 JsonSerializer.Serialize(tempWriter, value, SerializerOption);
-
-                tempStream.Flush();
-                var a = tempStream.ToArray();
-                
+                tempWriter.Flush();
+                stream.Flush();
+                using var document = JsonDocument.Parse(stream);
+                document.RootElement.WriteTo(writer);
             }
         }
 

--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
 using Sentry.Extensibility;
@@ -286,7 +287,14 @@ namespace Sentry.Internal.Extensions
             }
             else
             {
-                JsonSerializer.Serialize(writer, value, SerializerOption);
+                using var tempStream = new MemoryStream();
+                var tempWriter = new Utf8JsonWriter(tempStream);
+
+                JsonSerializer.Serialize(tempWriter, value, SerializerOption);
+
+                tempStream.Flush();
+                var a = tempStream.ToArray();
+                
             }
         }
 
@@ -296,13 +304,16 @@ namespace Sentry.Internal.Extensions
             object? value,
             IDiagnosticLogger? logger)
         {
+            writer.WritePropertyName(propertyName);
+
             try
             {
-                writer.WritePropertyName(propertyName);
                 writer.WriteDynamicValue(value, logger);
             }
             catch (Exception e) when (logger != null)
             {
+                writer.WriteNullValue();
+
                 // The only location in the protocol we allow dynamic objects are Extra and Contexts
                 // In the event of an instance that can't be serialized, we don't want to throw away a whole event
                 // so we'll suppress issues here.

--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Text.Json;
 using Sentry.Extensibility;


### PR DESCRIPTION
To throw without a logger available means we lose the whole event with `options.Debug = false;`.