### PR TITLE
Add CaptureLastError for ASP.NET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+## Features
+
+- Add CaptureLastError for ASP.NET ([#1411](https://github.com/getsentry/sentry-dotnet/pull/1411))
+
 ## 3.12.3
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Features
 
-- Add CaptureLastError for ASP.NET ([#1411](https://github.com/getsentry/sentry-dotnet/pull/1411))
+- Add CaptureLastError as an extension method to the Server class on ASP.NET ([#1411](https://github.com/getsentry/sentry-dotnet/pull/1411))
 
 ## 3.12.3
 

--- a/src/Sentry.AspNet/SentryHttpServerUtilityExtensions.cs
+++ b/src/Sentry.AspNet/SentryHttpServerUtilityExtensions.cs
@@ -1,0 +1,26 @@
+using System.Web;
+using Sentry.Protocol;
+
+namespace Sentry.AspNet;
+/// <summary>
+/// HttpServerUtility extensions.
+/// </summary>
+public static class SentryHttpServerUtilityExtensions
+{
+    /// <summary>
+    /// Caoture the last error from the given HttpServerUtility and send to Sentry.
+    /// </summary>
+    /// <param name="server">The HttpServerUtility that contains the last error.</param>
+    /// <param name="hub">(optional) The Hub that will capture the exception.</param>
+    /// <returns>A SentryId.</returns>
+    public static SentryId CaptureLastError(this HttpServerUtility server, IHub? hub = null)
+    {
+        if (server.GetLastError() is { } exception)
+        {
+            exception.Data[Mechanism.HandledKey] = false;
+            exception.Data[Mechanism.MechanismKey] = "HttpApplication.Application_Error";
+            return hub?.CaptureException(exception) ?? SentrySdk.CaptureException(exception);
+        }
+        return SentryId.Empty;
+    }
+}

--- a/src/Sentry.AspNet/SentryHttpServerUtilityExtensions.cs
+++ b/src/Sentry.AspNet/SentryHttpServerUtilityExtensions.cs
@@ -14,7 +14,7 @@ public static class SentryHttpServerUtilityExtensions
     /// <param name="hub">(optional) The Hub that will capture the exception.</param>
     /// <returns>A SentryId.</returns>
     public static SentryId CaptureLastError(this HttpServerUtility server) => server.CaptureLastError(HubAdapter.Instance);
-    
+
     // for testing
     internal static SentryId CaptureLastError(this HttpServerUtility server, IHub hub)
     {

--- a/src/Sentry.AspNet/SentryHttpServerUtilityExtensions.cs
+++ b/src/Sentry.AspNet/SentryHttpServerUtilityExtensions.cs
@@ -8,12 +8,15 @@ namespace Sentry.AspNet;
 public static class SentryHttpServerUtilityExtensions
 {
     /// <summary>
-    /// Caoture the last error from the given HttpServerUtility and send to Sentry.
+    /// Captures the last error from the given HttpServerUtility and sends it to Sentry.
     /// </summary>
     /// <param name="server">The HttpServerUtility that contains the last error.</param>
     /// <param name="hub">(optional) The Hub that will capture the exception.</param>
     /// <returns>A SentryId.</returns>
-    public static SentryId CaptureLastError(this HttpServerUtility server, IHub? hub = null)
+    public static SentryId CaptureLastError(this HttpServerUtility server) => server.CaptureLastError(HubAdapter.Instance);
+    
+    // for testing
+    internal static SentryId CaptureLastError(this HttpServerUtility server, IHub hub)
     {
         if (server.GetLastError() is { } exception)
         {

--- a/src/Sentry.AspNet/SentryHttpServerUtilityExtensions.cs
+++ b/src/Sentry.AspNet/SentryHttpServerUtilityExtensions.cs
@@ -1,7 +1,9 @@
 using System.Web;
+using Sentry.Extensibility;
 using Sentry.Protocol;
 
 namespace Sentry.AspNet;
+
 /// <summary>
 /// HttpServerUtility extensions.
 /// </summary>
@@ -11,7 +13,6 @@ public static class SentryHttpServerUtilityExtensions
     /// Captures the last error from the given HttpServerUtility and sends it to Sentry.
     /// </summary>
     /// <param name="server">The HttpServerUtility that contains the last error.</param>
-    /// <param name="hub">(optional) The Hub that will capture the exception.</param>
     /// <returns>A SentryId.</returns>
     public static SentryId CaptureLastError(this HttpServerUtility server) => server.CaptureLastError(HubAdapter.Instance);
 
@@ -22,7 +23,7 @@ public static class SentryHttpServerUtilityExtensions
         {
             exception.Data[Mechanism.HandledKey] = false;
             exception.Data[Mechanism.MechanismKey] = "HttpApplication.Application_Error";
-            return hub?.CaptureException(exception) ?? SentrySdk.CaptureException(exception);
+            return hub.CaptureException(exception);
         }
         return SentryId.Empty;
     }

--- a/test/Sentry.AspNet.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.AspNet.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -12,6 +12,6 @@ namespace Sentry.AspNet
     }
     public static class SentryHttpServerUtilityExtensions
     {
-        public static Sentry.SentryId CaptureLastError(this System.Web.HttpServerUtility server, Sentry.IHub? hub = null) { }
+        public static Sentry.SentryId CaptureLastError(this System.Web.HttpServerUtility server) { }
     }
 }

--- a/test/Sentry.AspNet.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.AspNet.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -10,4 +10,8 @@ namespace Sentry.AspNet
     {
         public static void AddAspNet(this Sentry.SentryOptions options, Sentry.Extensibility.RequestSize maxRequestBodySize = 0) { }
     }
+    public static class SentryHttpServerUtilityExtensions
+    {
+        public static Sentry.SentryId CaptureLastError(this System.Web.HttpServerUtility server, Sentry.IHub? hub = null) { }
+    }
 }

--- a/test/Sentry.AspNet.Tests/SentryHttpServerUtilityExtensionsTests.cs
+++ b/test/Sentry.AspNet.Tests/SentryHttpServerUtilityExtensionsTests.cs
@@ -1,6 +1,7 @@
 using System.Web;
 
 namespace Sentry.AspNet.Tests;
+
 public class SentryHttpServerUtilityExtensionsTests
 {
     private class Fixture
@@ -53,5 +54,4 @@ public class SentryHttpServerUtilityExtensionsTests
         hub.Received(0).CaptureEvent(Arg.Any<SentryEvent>());
         Assert.Equal(SentryId.Empty, receivedId);
     }
-
 }

--- a/test/Sentry.AspNet.Tests/SentryHttpServerUtilityExtensionsTests.cs
+++ b/test/Sentry.AspNet.Tests/SentryHttpServerUtilityExtensionsTests.cs
@@ -1,0 +1,42 @@
+using System.Web;
+
+namespace Sentry.AspNet.Tests;
+public class SentryHttpServerUtilityExtensionsTests
+{
+    [Fact]
+    public void CaptureLastError_WithError_UnhandledErrorCaptured()
+    {
+        // Arrange
+        var exception = new Exception();
+        var id = SentryId.Create();
+        var hub = Substitute.For<IHub>();
+        hub.CaptureException(Arg.Any<Exception>()).Returns(id);
+        var context = new HttpContext(new HttpRequest("", "http://test", null), new HttpResponse(new StringWriter()));
+        context.AddError(exception);
+
+        // Act
+        var receivedId = context.Server.CaptureLastError(hub);
+
+        // Assert
+        hub.Received(1).CaptureException(Arg.Is(exception));
+        Assert.False(exception.Data[Mechanism.HandledKey] as bool?);
+        Assert.Equal("HttpApplication.Application_Error", exception.Data[Mechanism.MechanismKey]);
+        Assert.Equal(id, receivedId);
+    }
+
+    [Fact]
+    public void CaptureLastError_WithoutError_DoNothing()
+    {
+        // Arrange
+        var hub = Substitute.For<IHub>();
+        var context = new HttpContext(new HttpRequest("", "http://test", null), new HttpResponse(new StringWriter()));
+
+        // Act
+        var receivedId = context.Server.CaptureLastError(hub);
+
+        // Assert
+        hub.Received(0).CaptureException(Arg.Any<Exception>());
+        Assert.Equal(SentryId.Empty, receivedId);
+    }
+
+}

--- a/test/Sentry.AspNet.Tests/SentryHttpServerUtilityExtensionsTests.cs
+++ b/test/Sentry.AspNet.Tests/SentryHttpServerUtilityExtensionsTests.cs
@@ -3,14 +3,29 @@ using System.Web;
 namespace Sentry.AspNet.Tests;
 public class SentryHttpServerUtilityExtensionsTests
 {
+    private class Fixture
+    {
+        public SentryId Id { get; set; }
+
+        public IHub GetSut()
+        {
+            Id = SentryId.Create();
+            var hub = Substitute.For<IHub>();
+            hub.IsEnabled.Returns(true);
+            hub.CaptureEvent(Arg.Any<SentryEvent>()).Returns(Id);
+            return hub;
+        }
+    }
+
+    private readonly Fixture _fixture = new();
+
     [Fact]
     public void CaptureLastError_WithError_UnhandledErrorCaptured()
     {
         // Arrange
+        var hub = _fixture.GetSut();
         var exception = new Exception();
-        var id = SentryId.Create();
-        var hub = Substitute.For<IHub>();
-        hub.CaptureException(Arg.Any<Exception>()).Returns(id);
+
         var context = new HttpContext(new HttpRequest("", "http://test", null), new HttpResponse(new StringWriter()));
         context.AddError(exception);
 
@@ -18,24 +33,24 @@ public class SentryHttpServerUtilityExtensionsTests
         var receivedId = context.Server.CaptureLastError(hub);
 
         // Assert
-        hub.Received(1).CaptureException(Arg.Is(exception));
+        hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(@event => @event.Exception == exception));
         Assert.False(exception.Data[Mechanism.HandledKey] as bool?);
         Assert.Equal("HttpApplication.Application_Error", exception.Data[Mechanism.MechanismKey]);
-        Assert.Equal(id, receivedId);
+        Assert.Equal(_fixture.Id, receivedId);
     }
 
     [Fact]
     public void CaptureLastError_WithoutError_DoNothing()
     {
         // Arrange
-        var hub = Substitute.For<IHub>();
+        var hub = _fixture.GetSut();
         var context = new HttpContext(new HttpRequest("", "http://test", null), new HttpResponse(new StringWriter()));
 
         // Act
         var receivedId = context.Server.CaptureLastError(hub);
 
         // Assert
-        hub.Received(0).CaptureException(Arg.Any<Exception>());
+        hub.Received(0).CaptureEvent(Arg.Any<SentryEvent>());
         Assert.Equal(SentryId.Empty, receivedId);
     }
 


### PR DESCRIPTION
Simplifies the process of capturing exceptions on ASP.NET. Additionally, it also flags the errors as unhandled.

Update #1411 once merged.