### PR TITLE
remove redundant asserts in memory info

### DIFF
--- a/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
@@ -71,12 +71,6 @@ public class MainSentryEventProcessorTests
         Assert.NotEqual(0, memory.HighMemoryLoadThresholdBytes);
         Assert.NotEqual(0, memory.TotalAvailableMemoryBytes);
         Assert.NotEqual(0, memory.MemoryLoadBytes);
-#if NET5_0_OR_GREATER
-        Assert.NotEqual(0, memory.TotalCommittedBytes);
-        Assert.NotEqual(0, memory.PromotedBytes);
-        Assert.NotEqual(0, memory.PauseTimePercentage);
-        Assert.NotEmpty(memory.PauseDurations);
-#endif
     }
 #endif
 


### PR DESCRIPTION
given zero is valid

#skip-changelog

fixes #1414

