### PR TITLE
add release to options

### DIFF
--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -257,6 +257,7 @@ public class HubTests
         var hub = new Hub(new SentryOptions
         {
             Dsn = DsnSamples.ValidDsnWithSecret,
+            Release = "release"
         }, client);
 
         hub.StartSession();
@@ -369,6 +370,7 @@ public class HubTests
         var hub = new Hub(new SentryOptions
         {
             Dsn = DsnSamples.ValidDsnWithSecret,
+            Release = "release"
         }, client);
 
         hub.StartSession();
@@ -387,7 +389,11 @@ public class HubTests
         // Arrange
         var worker = Substitute.For<IBackgroundWorker>();
 
-        var options = new SentryOptions { Dsn = DsnSamples.ValidDsnWithSecret };
+        var options = new SentryOptions
+        {
+            Dsn = DsnSamples.ValidDsnWithSecret,
+            Release = "release"
+        };
         var client = new SentryClient(options, worker);
         var hub = new Hub(options, client);
 
@@ -418,7 +424,11 @@ public class HubTests
         // Arrange
         var worker = Substitute.For<IBackgroundWorker>();
 
-        var options = new SentryOptions { Dsn = DsnSamples.ValidDsnWithSecret };
+        var options = new SentryOptions
+        {
+            Dsn = DsnSamples.ValidDsnWithSecret,
+            Release = "release"
+        };
         var client = new SentryClient(options, worker);
         var hub = new Hub(options, client);
 
@@ -860,7 +870,8 @@ public class HubTests
 
         var hub = new Hub(new SentryOptions
         {
-            Dsn = DsnSamples.ValidDsnWithSecret
+            Dsn = DsnSamples.ValidDsnWithSecret,
+            Release = "release"
         }, client);
 
         // Act
@@ -878,7 +889,8 @@ public class HubTests
 
         var hub = new Hub(new SentryOptions
         {
-            Dsn = DsnSamples.ValidDsnWithSecret
+            Dsn = DsnSamples.ValidDsnWithSecret,
+            Release = "release"
         }, client);
 
         hub.StartSession();
@@ -900,7 +912,8 @@ public class HubTests
         _ = new Hub(new SentryOptions
         {
             Dsn = DsnSamples.ValidDsnWithSecret,
-            AutoSessionTracking = true
+            AutoSessionTracking = true,
+            Release = "release"
         }, client);
 
         // Assert
@@ -950,7 +963,8 @@ public class HubTests
         var hub = new Hub(new SentryOptions
         {
             Dsn = DsnSamples.ValidDsnWithSecret,
-            AutoSessionTracking = true
+            AutoSessionTracking = true,
+            Release = "release"
         }, client);
 
         // Act
@@ -992,7 +1006,8 @@ public class HubTests
         var options = new SentryOptions
         {
             Dsn = DsnSamples.ValidDsnWithSecret,
-            AutoSessionTrackingInterval = TimeSpan.FromMilliseconds(10)
+            AutoSessionTrackingInterval = TimeSpan.FromMilliseconds(10),
+            Release = "release"
         };
 
         var hub = new Hub(


### PR DESCRIPTION
fixes tests in r#. since R# test runner wont provide an entry assembly

#skip-changelog