### PR TITLE
Aspnet Test Cleanup

### DIFF
--- a/src/Sentry.AspNet/Internal/SystemWebVersionLocator.cs
+++ b/src/Sentry.AspNet/Internal/SystemWebVersionLocator.cs
@@ -12,6 +12,11 @@ internal static class SystemWebVersionLocator
             return release;
         }
 
+        return Resolve(context);
+    }
+
+    internal static string? Resolve(HttpContext context)
+    {
         if (context.ApplicationInstance?.GetType() is { } type)
         {
             // Usually the type is ASP.global_asax and the BaseType is the Web Application.

--- a/test/Sentry.AspNet.Tests/ApiApprovalTests.cs
+++ b/test/Sentry.AspNet.Tests/ApiApprovalTests.cs
@@ -1,6 +1,5 @@
+using Sentry.AspNet;
 using Sentry.Tests;
-
-namespace Sentry.AspNet.Tests;
 
 [UsesVerify]
 public class ApiApprovalTests

--- a/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
@@ -4,9 +4,14 @@ public static class HttpContextBuilder
 {
     public static HttpContext Build(int responseStatusCode = 200)
     {
-        return new HttpContext(new HttpRequest("test", "http://test/the/path", null), new HttpResponse(TextWriter.Null)
+        return new HttpContext(
+            new HttpRequest("test", "http://test/the/path", null),
+            new HttpResponse(TextWriter.Null)
+            {
+                StatusCode = responseStatusCode
+            })
         {
-            StatusCode = responseStatusCode
-        });
+            ApplicationInstance = new HttpApplication()
+        };
     }
 }

--- a/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
@@ -4,7 +4,7 @@ public static class HttpContextBuilder
 {
     public static HttpContext Build(int responseStatusCode = 200)
     {
-        return new HttpContext(new HttpRequest("test", "http://test/the/path", null), new HttpResponse(new StringWriter())
+        return new HttpContext(new HttpRequest("test", "http://test/the/path", null), new HttpResponse(TextWriter.Null)
         {
             StatusCode = responseStatusCode
         });

--- a/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
@@ -1,0 +1,12 @@
+using System.Web;
+
+public static class HttpContextBuilder
+{
+    public static HttpContext Build(int responseStatusCode = 200)
+    {
+        return new HttpContext(new HttpRequest("test", "http://test/the/path", null), new HttpResponse(new StringWriter())
+        {
+            StatusCode = responseStatusCode
+        });
+    }
+}

--- a/test/Sentry.AspNet.Tests/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextExtensionsTests.cs
@@ -39,12 +39,15 @@ public class HttpContextExtensionsTests
     public void FinishSentryTransaction_FinishesTransaction()
     {
         // Arrange
-        using var _ = SentrySdk.UseHub(new Sentry.Internal.Hub(
-            new SentryOptions { Dsn = "https://d4d82fc1c2c4032a83f3a29aa3a3aff@fake-sentry.io:65535/2147483647" },
+        using var _ = SentrySdk.UseHub(new Hub(
+            new SentryOptions
+            {
+                Dsn = "https://d4d82fc1c2c4032a83f3a29aa3a3aff@fake-sentry.io:65535/2147483647"
+            },
             Substitute.For<ISentryClient>()
         ));
 
-        var context =HttpContextBuilder.Build(404);
+        var context = HttpContextBuilder.Build(404);
 
         // Act
         var transaction = context.StartSentryTransaction();

--- a/test/Sentry.AspNet.Tests/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextExtensionsTests.cs
@@ -1,6 +1,4 @@
-using System.Web;
-
-namespace Sentry.AspNet.Tests;
+using Sentry.AspNet;
 
 public class HttpContextExtensionsTests
 {
@@ -8,18 +6,13 @@ public class HttpContextExtensionsTests
     public void StartSentryTransaction_CreatesValidTransaction()
     {
         // Arrange
-        var context = new HttpContext(
-            new HttpRequest("foo", "https://localhost/person/13", "details=true")
-            {
-                RequestType = "GET"
-            },
-            new HttpResponse(TextWriter.Null));
+        var context = HttpContextBuilder.Build();
 
         // Act
         var transaction = context.StartSentryTransaction();
 
         // Assert
-        transaction.Name.Should().Be("GET /person/13");
+        transaction.Name.Should().Be("GET /the/path");
         transaction.Operation.Should().Be("http.server");
     }
 
@@ -27,17 +20,12 @@ public class HttpContextExtensionsTests
     public void StartSentryTransaction_BindsToScope()
     {
         // Arrange
-        using var _ = SentrySdk.UseHub(new Sentry.Internal.Hub(
+        using var _ = SentrySdk.UseHub(new Hub(
             new SentryOptions { Dsn = "https://d4d82fc1c2c4032a83f3a29aa3a3aff@fake-sentry.io:65535/2147483647" },
             Substitute.For<ISentryClient>()
         ));
 
-        var context = new HttpContext(
-            new HttpRequest("foo", "https://localhost/person/13", "details=true")
-            {
-                RequestType = "GET"
-            },
-            new HttpResponse(TextWriter.Null));
+        var context = HttpContextBuilder.Build();
 
         // Act
         var transaction = context.StartSentryTransaction();
@@ -56,15 +44,7 @@ public class HttpContextExtensionsTests
             Substitute.For<ISentryClient>()
         ));
 
-        var context = new HttpContext(
-            new HttpRequest("foo", "https://localhost/person/13", "details=true")
-            {
-                RequestType = "GET"
-            },
-            new HttpResponse(TextWriter.Null)
-            {
-                StatusCode = 404
-            });
+        var context =HttpContextBuilder.Build(404);
 
         // Act
         var transaction = context.StartSentryTransaction();

--- a/test/Sentry.AspNet.Tests/HttpContextTest.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextTest.cs
@@ -1,0 +1,23 @@
+using System.Web;
+
+public abstract class HttpContextTest :
+    IDisposable
+{
+    private HttpContext _context;
+
+    protected HttpContextTest()
+    {
+        HttpContext.Current = Context = HttpContextBuilder.Build();
+    }
+
+    public HttpContext Context
+    {
+        get => _context;
+        set => HttpContext.Current = _context = value;
+    }
+
+    public void Dispose()
+    {
+        HttpContext.Current = null;
+    }
+}

--- a/test/Sentry.AspNet.Tests/Internal/SentryScopeManagerTests.cs
+++ b/test/Sentry.AspNet.Tests/Internal/SentryScopeManagerTests.cs
@@ -1,7 +1,5 @@
 using Sentry.AspNet.Internal;
 
-namespace Sentry.AspNet.Tests.Internal;
-
 public class SentryScopeManagerTests
 {
     private class Fixture

--- a/test/Sentry.AspNet.Tests/Internal/SystemWebRequestEventProcessorTests.cs
+++ b/test/Sentry.AspNet.Tests/Internal/SystemWebRequestEventProcessorTests.cs
@@ -1,8 +1,6 @@
 using System.Web;
 using Sentry.AspNet.Internal;
 
-namespace Sentry.AspNet.Tests.Internal;
-
 public class SystemWebRequestEventProcessorTests
 {
     private class Fixture
@@ -15,7 +13,7 @@ public class SystemWebRequestEventProcessorTests
         public Fixture()
         {
             _ = RequestPayloadExtractor.ExtractPayload(Arg.Any<IHttpRequest>()).Returns(MockBody);
-            HttpContext = new HttpContext(new HttpRequest("test", "http://test", null), new HttpResponse(new StringWriter()));
+            HttpContext = HttpContextBuilder.Build();
         }
 
         public SystemWebRequestEventProcessor GetSut()

--- a/test/Sentry.AspNet.Tests/Internal/SystemWebRequestEventProcessorTests.cs
+++ b/test/Sentry.AspNet.Tests/Internal/SystemWebRequestEventProcessorTests.cs
@@ -1,24 +1,21 @@
-using System.Web;
 using Sentry.AspNet.Internal;
 
-public class SystemWebRequestEventProcessorTests
+public class SystemWebRequestEventProcessorTests :
+    HttpContextTest
 {
     private class Fixture
     {
         public IRequestPayloadExtractor RequestPayloadExtractor { get; set; } = Substitute.For<IRequestPayloadExtractor>();
         public SentryOptions SentryOptions { get; set; } = new();
         public object MockBody { get; set; } = new();
-        public HttpContext HttpContext { get; set; }
 
         public Fixture()
         {
             _ = RequestPayloadExtractor.ExtractPayload(Arg.Any<IHttpRequest>()).Returns(MockBody);
-            HttpContext = HttpContextBuilder.Build();
         }
 
         public SystemWebRequestEventProcessor GetSut()
         {
-            HttpContext.Current = HttpContext;
             return new SystemWebRequestEventProcessor(RequestPayloadExtractor, SentryOptions);
         }
     }
@@ -50,7 +47,7 @@ public class SystemWebRequestEventProcessorTests
     [Fact]
     public void Process_NoHttpContext_NoRequestData()
     {
-        _fixture.HttpContext = null;
+        Context = null;
         var expected = new SentryEvent();
 
         var sut = _fixture.GetSut();

--- a/test/Sentry.AspNet.Tests/Internal/SystemWebVersionLocatorTests.cs
+++ b/test/Sentry.AspNet.Tests/Internal/SystemWebVersionLocatorTests.cs
@@ -1,36 +1,15 @@
-using System.Reflection;
 using System.Web;
 using Sentry.AspNet.Internal;
 
-public class SystemWebVersionLocatorTests
+public class SystemWebVersionLocatorTests :
+    HttpContextTest
 {
-    private class Fixture
-    {
-        public HttpContext HttpContext { get; set; }
-
-        public Fixture()
-        {
-            HttpContext = HttpContextBuilder.Build();
-        }
-
-        public Assembly GetSut()
-        {
-            HttpContext.Current = HttpContext;
-            HttpContext.Current.ApplicationInstance = new HttpApplication();
-            return HttpContext.Current.ApplicationInstance.GetType().Assembly;
-        }
-    }
-
-    private readonly Fixture _fixture = new();
-
     [Fact]
     public void GetCurrent_GetEntryAssemblyNull_HttpApplicationAssembly()
     {
-        _fixture.HttpContext.ApplicationInstance = new HttpApplication();
-        var sut = _fixture.GetSut();
-        var expected = ApplicationVersionLocator.GetCurrent(sut);
+        var expected = ApplicationVersionLocator.GetCurrent(typeof(HttpApplication).Assembly);
 
-        var actual = SystemWebVersionLocator.Resolve((string)null, _fixture.HttpContext);
+        var actual = SystemWebVersionLocator.Resolve((string)null, Context);
 
         Assert.Equal(expected, actual);
     }
@@ -38,9 +17,9 @@ public class SystemWebVersionLocatorTests
     [Fact]
     public void GetCurrent_GetEntryAssemblySet_HttpApplicationAssembly()
     {
-        var expected = ApplicationVersionLocator.GetCurrent();
+        var expected = ApplicationVersionLocator.GetCurrent(typeof(HttpApplication).Assembly);
 
-        var actual = SystemWebVersionLocator.Resolve(new SentryOptions(), _fixture.HttpContext);
+        var actual = SystemWebVersionLocator.Resolve(new SentryOptions(), Context);
 
         Assert.Equal(expected, actual);
     }

--- a/test/Sentry.AspNet.Tests/Internal/SystemWebVersionLocatorTests.cs
+++ b/test/Sentry.AspNet.Tests/Internal/SystemWebVersionLocatorTests.cs
@@ -2,8 +2,6 @@ using System.Reflection;
 using System.Web;
 using Sentry.AspNet.Internal;
 
-namespace Sentry.AspNet.Tests.Internal;
-
 public class SystemWebVersionLocatorTests
 {
     private class Fixture
@@ -12,7 +10,7 @@ public class SystemWebVersionLocatorTests
 
         public Fixture()
         {
-            HttpContext = new HttpContext(new HttpRequest("test", "http://test", null), new HttpResponse(new StringWriter()));
+            HttpContext = HttpContextBuilder.Build();
         }
 
         public Assembly GetSut()

--- a/test/Sentry.AspNet.Tests/Internal/SystemWebVersionLocatorTests.cs
+++ b/test/Sentry.AspNet.Tests/Internal/SystemWebVersionLocatorTests.cs
@@ -15,11 +15,11 @@ public class SystemWebVersionLocatorTests :
     }
 
     [Fact]
-    public void GetCurrent_GetEntryAssemblySet_HttpApplicationAssembly()
+    public void HttpApplicationAssembly_VersionParsing()
     {
         var expected = ApplicationVersionLocator.GetCurrent(typeof(HttpApplication).Assembly);
 
-        var actual = SystemWebVersionLocator.Resolve(new SentryOptions(), Context);
+        var actual = SystemWebVersionLocator.Resolve(Context);
 
         Assert.Equal(expected, actual);
     }

--- a/test/Sentry.AspNet.Tests/SentryAspNetOptionsExtensionsTests.cs
+++ b/test/Sentry.AspNet.Tests/SentryAspNetOptionsExtensionsTests.cs
@@ -1,6 +1,5 @@
+using Sentry.AspNet;
 using Sentry.AspNet.Internal;
-
-namespace Sentry.AspNet.Tests;
 
 public class SentryAspNetOptionsExtensionsTests
 {

--- a/test/Sentry.AspNet.Tests/SentryAspNetOptionsExtensionsTests.cs
+++ b/test/Sentry.AspNet.Tests/SentryAspNetOptionsExtensionsTests.cs
@@ -1,7 +1,8 @@
 using Sentry.AspNet;
 using Sentry.AspNet.Internal;
 
-public class SentryAspNetOptionsExtensionsTests
+public class SentryAspNetOptionsExtensionsTests :
+    HttpContextTest
 {
     [Fact]
     public void AddAspNet_EventProcessorsContainBodyExtractor()

--- a/test/Sentry.AspNet.Tests/SentryHttpServerUtilityExtensionsTests.cs
+++ b/test/Sentry.AspNet.Tests/SentryHttpServerUtilityExtensionsTests.cs
@@ -1,6 +1,4 @@
-using System.Web;
-
-namespace Sentry.AspNet.Tests;
+using Sentry.AspNet;
 
 public class SentryHttpServerUtilityExtensionsTests
 {
@@ -27,7 +25,7 @@ public class SentryHttpServerUtilityExtensionsTests
         var hub = _fixture.GetSut();
         var exception = new Exception();
 
-        var context = new HttpContext(new HttpRequest("", "http://test", null), new HttpResponse(new StringWriter()));
+        var context = HttpContextBuilder.Build();
         context.AddError(exception);
 
         // Act
@@ -45,7 +43,7 @@ public class SentryHttpServerUtilityExtensionsTests
     {
         // Arrange
         var hub = _fixture.GetSut();
-        var context = new HttpContext(new HttpRequest("", "http://test", null), new HttpResponse(new StringWriter()));
+        var context = HttpContextBuilder.Build();
 
         // Act
         var receivedId = context.Server.CaptureLastError(hub);


### PR DESCRIPTION
 * add a base test class for httpcontext.current manipulation
 * fixes order of execution bug with httpcontext.current: fixes #1424
 * Add a HttpContextBuilder for constructing HttpContext

#skip-changelog