### PR TITLE
Reduced the logger noise from EF when not using Performance Monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Reduced the logger noise from EF when using Performance Monitoring ([#1441](https://github.com/getsentry/sentry-dotnet/pull/1441))
 - Create CachingTransport directories in constructor to avoid DirectoryNotFoundException ([#1432](https://github.com/getsentry/sentry-dotnet/pull/1432))
 
 ## 3.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- Reduced the logger noise from EF when using Performance Monitoring ([#1441](https://github.com/getsentry/sentry-dotnet/pull/1441))
+- Reduced the logger noise from EF when not using Performance Monitoring ([#1441](https://github.com/getsentry/sentry-dotnet/pull/1441))
 - Create CachingTransport directories in constructor to avoid DirectoryNotFoundException ([#1432](https://github.com/getsentry/sentry-dotnet/pull/1432))
 
 ## 3.13.0

--- a/src/Sentry.EntityFramework/DbInterceptionIntegration.cs
+++ b/src/Sentry.EntityFramework/DbInterceptionIntegration.cs
@@ -1,17 +1,34 @@
 using System.Data.Entity.Infrastructure.Interception;
+using Sentry.Extensibility;
 using Sentry.Integrations;
 
 namespace Sentry.EntityFramework;
 
 internal class DbInterceptionIntegration : ISdkIntegration
 {
-    private IDbInterceptor? _sqlInterceptor { get; set; }
+    // Internal for testing.
+    internal IDbInterceptor? SqlInterceptor { get; set; }
+
+    internal const string SampleRateDisabledMessage = "EF performance won't be collected because TracesSampleRate is set to 0.";
 
     public void Register(IHub hub, SentryOptions options)
     {
-        _sqlInterceptor = new SentryQueryPerformanceListener(hub, options);
-        DbInterception.Add(_sqlInterceptor);
+        if (options.TracesSampleRate == 0)
+        {
+            options.DiagnosticLogger?.LogInfo(SampleRateDisabledMessage);
+        }
+        else
+        {
+            SqlInterceptor = new SentryQueryPerformanceListener(hub, options);
+            DbInterception.Add(SqlInterceptor);
+        }
     }
 
-    public void Unregister() => DbInterception.Remove(_sqlInterceptor);
+    public void Unregister()
+    {
+        if (SqlInterceptor is { } interceptor)
+        {
+            DbInterception.Remove(interceptor);
+        }
+    }
 }

--- a/src/Sentry.EntityFramework/DbInterceptionIntegration.cs
+++ b/src/Sentry.EntityFramework/DbInterceptionIntegration.cs
@@ -7,7 +7,7 @@ namespace Sentry.EntityFramework;
 internal class DbInterceptionIntegration : ISdkIntegration
 {
     // Internal for testing.
-    internal IDbInterceptor? SqlInterceptor { get; set; }
+    internal IDbInterceptor? SqlInterceptor { get; private set; }
 
     internal const string SampleRateDisabledMessage = "EF performance won't be collected because TracesSampleRate is set to 0.";
 

--- a/src/Sentry.EntityFramework/SentryOptionsExtensions.cs
+++ b/src/Sentry.EntityFramework/SentryOptionsExtensions.cs
@@ -30,16 +30,8 @@ public static class SentryOptionsExtensions
                 .LogError("Failed to configure EF breadcrumbs. Make sure to init Sentry before EF.", e);
         }
 
-        if (sentryOptions.TracesSampleRate == 0)
-        {
-            sentryOptions.DiagnosticLogger?
-                .LogInfo("Database performance integration is now disabled due to TracesSampleRate being set to zero.");
-        }
-        else
-        {
-            DbIntegration = new DbInterceptionIntegration();
-            sentryOptions.AddIntegration(DbIntegration);
-        }
+        DbIntegration = new DbInterceptionIntegration();
+        sentryOptions.AddIntegration(DbIntegration);
 
         sentryOptions.AddExceptionProcessor(new DbEntityValidationExceptionProcessor());
         // DbConcurrencyExceptionProcessor is untested due to problems with testing it, so it might not be production ready

--- a/src/Sentry.EntityFramework/SentryOptionsExtensions.cs
+++ b/src/Sentry.EntityFramework/SentryOptionsExtensions.cs
@@ -30,8 +30,16 @@ public static class SentryOptionsExtensions
                 .LogError("Failed to configure EF breadcrumbs. Make sure to init Sentry before EF.", e);
         }
 
-        DbIntegration = new DbInterceptionIntegration();
-        sentryOptions.AddIntegration(DbIntegration);
+        if (sentryOptions.TracesSampleRate == 0)
+        {
+            sentryOptions.DiagnosticLogger?
+                .LogInfo("Database performance integration is now disabled due to TracesSampleRate being set to zero.");
+        }
+        else
+        {
+            DbIntegration = new DbInterceptionIntegration();
+            sentryOptions.AddIntegration(DbIntegration);
+        }
 
         sentryOptions.AddExceptionProcessor(new DbEntityValidationExceptionProcessor());
         // DbConcurrencyExceptionProcessor is untested due to problems with testing it, so it might not be production ready

--- a/src/Sentry.EntityFramework/SentryQueryPerformanceListener.cs
+++ b/src/Sentry.EntityFramework/SentryQueryPerformanceListener.cs
@@ -68,9 +68,9 @@ internal class SentryQueryPerformanceListener : IDbCommandInterceptor
                 span.Finish(interceptionContext.Exception);
             }
         }
-        else
+        else if (_hub.GetSpan() is { })
         {
-            _options.DiagnosticLogger?.LogWarning("Span with key {0} was not found on interceptionContext.", key);
+            _options.DiagnosticLogger?.LogDebug("Span with key {0} was not found on interceptionContext.", key);
         }
     }
 }

--- a/src/Sentry.EntityFramework/SentryQueryPerformanceListener.cs
+++ b/src/Sentry.EntityFramework/SentryQueryPerformanceListener.cs
@@ -68,7 +68,8 @@ internal class SentryQueryPerformanceListener : IDbCommandInterceptor
                 span.Finish(interceptionContext.Exception);
             }
         }
-        else if (_hub.GetSpan() is { })
+        //Only log if there was a transaction on the Hub.
+        else if (_options.DiagnosticLevel == SentryLevel.Debug && _hub.GetSpan() is { })
         {
             _options.DiagnosticLogger?.LogDebug("Span with key {0} was not found on interceptionContext.", key);
         }

--- a/test/Sentry.EntityFramework.Tests/DbInterceptionIntegrationTests.cs
+++ b/test/Sentry.EntityFramework.Tests/DbInterceptionIntegrationTests.cs
@@ -1,0 +1,28 @@
+using Sentry.Testing;
+
+namespace Sentry.EntityFramework.Tests
+{
+    public class DbInterceptionIntegrationTests
+    {
+        [Fact]
+        public void Register_TraceSAmpleRateZero_IntegrationNotRegistered()
+        {
+            // Arrange
+            var logger = Substitute.For<ITestOutputHelper>();
+            var options = new SentryOptions()
+            {
+                Debug = true,
+                DiagnosticLogger = new TestOutputDiagnosticLogger(logger, SentryLevel.Debug),
+                TracesSampleRate = 0
+            };
+            var integration = new DbInterceptionIntegration();
+
+            // Act
+            integration.Register(Substitute.For<IHub>(), options);
+
+            // Assert
+            logger.Received(1).WriteLine(Arg.Is<string>(message => message.Contains(DbInterceptionIntegration.SampleRateDisabledMessage)));
+            Assert.Null(integration.SqlInterceptor);
+        }
+    }
+}

--- a/test/Sentry.EntityFramework.Tests/SentryQueryPerformanceListenerTests.cs
+++ b/test/Sentry.EntityFramework.Tests/SentryQueryPerformanceListenerTests.cs
@@ -200,7 +200,7 @@ public class SentryQueryPerformanceListenerTests
     {
         // Arrange
         var integration = new DbInterceptionIntegration();
-        integration.Register(_fixture.Hub, new SentryOptions());
+        integration.Register(_fixture.Hub, new SentryOptions() { TracesSampleRate = 1 });
 
         // Act
         _ = _fixture.DbContext.TestTable.FirstOrDefault();

--- a/test/Sentry.EntityFramework.Tests/SentryQueryPerformanceListenerTests.cs
+++ b/test/Sentry.EntityFramework.Tests/SentryQueryPerformanceListenerTests.cs
@@ -227,7 +227,8 @@ public class SentryQueryPerformanceListenerTests
     public void Finish_NoActiveTransaction_LoggerNotCalled()
     {
         // Arrange
-        var integration = new DbInterceptionIntegration();
+        var hub = _fixture.Hub;
+        hub.GetSpan().Returns((_) => null);
         var logger = Substitute.For<ITestOutputHelper>();
 
         var options = new SentryOptions()
@@ -236,8 +237,7 @@ public class SentryQueryPerformanceListenerTests
             DiagnosticLogger = new TestOutputDiagnosticLogger(logger, SentryLevel.Debug)
         };
 
-        _fixture.Hub.GetSpan().Returns((_) => null);
-        var listener = new SentryQueryPerformanceListener(_fixture.Hub, options);
+        var listener = new SentryQueryPerformanceListener(hub, options);
 
         // Act
         listener.ScalarExecuted(Substitute.For<DbCommand>(), Substitute.For<DbCommandInterceptionContext<object>>());


### PR DESCRIPTION
- Database performance integration if SampleRate is zero
- lowered the logger level if the transaction was not found.

Fixes #1440