### PR TITLE
Use delegate for transaction name

### DIFF
--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -28,9 +28,9 @@ namespace Sentry.AspNetCore.Extensions
                 return legacyFormat;
             }
 
-            var sentryRouteName = context.Features.Get<ITransactionNameProvider>();
+            var sentryRouteName = context.Features.Get<TransactionNameProvider>();
 
-            return sentryRouteName?.GetRouteName(context);
+            return sentryRouteName?.Invoke(context);
         }
 
         // Internal for testing.

--- a/src/Sentry.AspNetCore/ITransactionNameProvider.cs
+++ b/src/Sentry.AspNetCore/ITransactionNameProvider.cs
@@ -5,13 +5,7 @@ namespace Sentry.AspNetCore;
 /// <summary>
 /// Provides the strategy to define the name of a transaction based on the <see cref="HttpContext"/>.
 /// </summary>
-public interface ITransactionNameProvider
-{
-    /// <summary>
-    /// The strategy to define the name of a transaction based on the <see cref="HttpContext"/>.
-    /// </summary>
-    /// <remarks>
-    /// The SDK can name transactions automatically when using MVC or Endpoint Routing. In other cases, like when serving static files, it fallback to Unknown Route. This hook allows custom code to define a transaction name given a <see cref="HttpContext"/>.
-    /// </remarks>
-    string? GetRouteName(HttpContext context);
-}
+/// <remarks>
+/// The SDK can name transactions automatically when using MVC or Endpoint Routing. In other cases, like when serving static files, it fallback to Unknown Route. This hook allows custom code to define a transaction name given a <see cref="HttpContext"/>.
+/// </remarks>
+public delegate string? TransactionNameProvider(HttpContext context);

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
@@ -50,7 +50,7 @@ public class SentryAspNetCoreOptions : SentryLoggingOptions
     /// <remarks>
     /// The SDK can name transactions automatically when using MVC or Endpoint Routing. In other cases, like when serving static files, it will fallback to Unknown Route. This hook allows custom code to define a transaction name given a <see cref="HttpContext"/>.
     /// </remarks>
-    public ITransactionNameProvider? TransactionNameProvider { get; set; }
+    public TransactionNameProvider? TransactionNameProvider { get; set; }
 
     /// <summary>
     /// Controls whether the casing of the standard (Production, Development and Staging) environment name supplied by <see cref="Microsoft.AspNetCore.Hosting.IHostingEnvironment" />

--- a/src/Sentry.Google.Cloud.Functions/SentryStartup.cs
+++ b/src/Sentry.Google.Cloud.Functions/SentryStartup.cs
@@ -49,7 +49,8 @@ public class SentryStartup : FunctionsStartup
             options.FlushBeforeRequestCompleted = true;
             // K_SERVICE is where the name of the FAAS is stored.
             // It'll return null. if GCP Function is running locally.
-            options.TransactionNameProvider = _ => Environment.GetEnvironmentVariable("K_SERVICE");
+            var serviceName = Environment.GetEnvironmentVariable("K_SERVICE");
+            options.TransactionNameProvider = _ => serviceName;
         });
 
         logging.Services.AddSingleton<IConfigureOptions<SentryAspNetCoreOptions>, SentryAspNetCoreOptionsSetup>();

--- a/src/Sentry.Google.Cloud.Functions/SentryStartup.cs
+++ b/src/Sentry.Google.Cloud.Functions/SentryStartup.cs
@@ -47,7 +47,9 @@ public class SentryStartup : FunctionsStartup
         {
             // Make sure all events are flushed out
             options.FlushBeforeRequestCompleted = true;
-            options.TransactionNameProvider = new SentryGoogleCloudFunctionsRouteName();
+            // K_SERVICE is where the name of the FAAS is stored.
+            // It'll return null. if GCP Function is running locally.
+            options.TransactionNameProvider = _ => Environment.GetEnvironmentVariable("K_SERVICE");
         });
 
         logging.Services.AddSingleton<IConfigureOptions<SentryAspNetCoreOptions>, SentryAspNetCoreOptionsSetup>();
@@ -117,14 +119,5 @@ public class SentryStartup : FunctionsStartup
         {
             await _next(httpContext).ConfigureAwait(false);
         }
-    }
-
-    private class SentryGoogleCloudFunctionsRouteName : ITransactionNameProvider
-    {
-        private static readonly Lazy<string?> RouteName = new(() => Environment.GetEnvironmentVariable("K_SERVICE"));
-
-        // K_SERVICE is where the name of the FAAS is stored.
-        // It'll return null. if GCP Function is running locally.
-        public string? GetRouteName(HttpContext _) => RouteName.Value;
     }
 }

--- a/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
@@ -207,10 +207,9 @@ public class HttpContextExtensionsTests
     public void TryGetRouteTemplate_WithSentryRouteName_RouteName()
     {
         // Arrange
-        var sentryRouteName = Substitute.For<ITransactionNameProvider>();
-        var httpContext = Fixture.GetSut();
         var expectedName = "abc";
-        sentryRouteName.GetRouteName(httpContext).Returns(expectedName);
+        TransactionNameProvider sentryRouteName = _ => expectedName;
+        var httpContext = Fixture.GetSut();
         httpContext.Features.Set(sentryRouteName);
 
         // Act

--- a/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
@@ -327,13 +327,10 @@ public class SentryTracingMiddlewareTests
 
         var hub = new Hub(options, sentryClient);
 
-        var transactionNameProvider = Substitute.For<ITransactionNameProvider>();
-        transactionNameProvider.GetRouteName(Arg.Any<HttpContext>()).Returns(expectedName);
-
         var server = new TestServer(new WebHostBuilder()
             .UseSentry(aspNewOptions =>
             {
-                aspNewOptions.TransactionNameProvider = transactionNameProvider;
+                aspNewOptions.TransactionNameProvider = _ => expectedName;
             })
             .ConfigureServices(services =>
             {


### PR DESCRIPTION
what are peoples thoughts on using a delegate instead of an interface? it is less code for consumers and also more versatile since it can be defined inline 