### PR TITLE
BackgroundWorker: make types public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,10 @@
 
 ### Features
 
-- The implementation of the background worker can now be changed ([#1450](https://github.com/getsentry/sentry-dotnet/pull/1450))
-
-## 3.13.0
-
-## Features
-
 - Add the delegate TransactionNameProvider to allow the name definition from Unknown transactions on ASP.NET Core ([#1421](https://github.com/getsentry/sentry-dotnet/pull/1421))
 - SentrySDK.WithScope is now obsolete in favour of overloads of CaptureEvent, CaptureMessage, CaptureException ([#1412](https://github.com/getsentry/sentry-dotnet/pull/1412))
 - Add Sentry to global usings when ImplicitUsings is enabled (`<ImplicitUsings>true</ImplicitUsings>`) ([#1398](https://github.com/getsentry/sentry-dotnet/pull/1398))
+- The implementation of the background worker can now be changed ([#1450](https://github.com/getsentry/sentry-dotnet/pull/1450))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- The implementation of the background worker can now be changed ([#1450](https://github.com/getsentry/sentry-dotnet/pull/1450))
+
 ## 3.13.0
-
-### Various fixes & improvements
-
-- fix flakey memory test (#1430) by @SimonCropp
-- dispose of client should only flush (#1354) by @SimonCropp
-- Add CaptureLastError for ASP.NET (#1411) by @lucas-zimerman
-- add IsDynamicCode* to events (#1418) by @SimonCropp
-- Report ThreadPool stats (#1399) by @SimonCropp
 
 ## Features
 

--- a/src/Sentry/Envelopes/Envelope.cs
+++ b/src/Sentry/Envelopes/Envelope.cs
@@ -14,7 +14,7 @@ namespace Sentry.Protocol.Envelopes
     /// <summary>
     /// Envelope.
     /// </summary>
-    internal sealed class Envelope : ISerializable, IDisposable
+    public sealed class Envelope : ISerializable, IDisposable
     {
         private const string EventIdKey = "event_id";
 

--- a/src/Sentry/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Envelopes/EnvelopeItem.cs
@@ -13,7 +13,7 @@ namespace Sentry.Protocol.Envelopes
     /// <summary>
     /// Envelope item.
     /// </summary>
-    internal sealed class EnvelopeItem : ISerializable, IDisposable
+    public sealed class EnvelopeItem : ISerializable, IDisposable
     {
         private const string TypeKey = "type";
         private const string TypeValueEvent = "event";

--- a/src/Sentry/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Envelopes/EnvelopeItem.cs
@@ -58,6 +58,10 @@ namespace Sentry.Protocol.Envelopes
                 var value => Convert.ToInt64(value) // can be int, long, or another numeric type
             };
 
+        /// <summary>
+        /// Returns the file name or null if no name exists.
+        /// </summary>
+        /// <returns>The file name or null.</returns>
         public string? TryGetFileName() => Header.GetValueOrDefault(FileNameKey) as string;
 
         private async Task<MemoryStream> BufferPayloadAsync(IDiagnosticLogger? logger, CancellationToken cancellationToken = default)

--- a/src/Sentry/Envelopes/ISerializable.cs
+++ b/src/Sentry/Envelopes/ISerializable.cs
@@ -8,7 +8,7 @@ namespace Sentry.Protocol.Envelopes
     /// <summary>
     /// Represents a serializable entity.
     /// </summary>
-    internal interface ISerializable
+    public interface ISerializable
     {
         /// <summary>
         /// Serializes the object to a stream.

--- a/src/Sentry/Extensibility/IBackgroundWorker.cs
+++ b/src/Sentry/Extensibility/IBackgroundWorker.cs
@@ -7,7 +7,7 @@ namespace Sentry.Extensibility
     /// <summary>
     /// A worker that queues envelopes synchronously and flushes async.
     /// </summary>
-    internal interface IBackgroundWorker
+    public interface IBackgroundWorker
     {
         /// <summary>
         /// Attempts to queue the envelope with the worker.

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -83,7 +83,10 @@ namespace Sentry
 
         internal IExceptionFilter[]? ExceptionFilters { get; set; } = Array.Empty<IExceptionFilter>();
 
-        internal IBackgroundWorker? BackgroundWorker { get; set; }
+        /// <summary>
+        /// The worker used by the client and passes to the transport.
+        /// </summary>
+        public IBackgroundWorker? BackgroundWorker { get; set; }
 
         internal ISentryHttpClientFactory? SentryHttpClientFactory { get; set; }
 

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -84,7 +84,7 @@ namespace Sentry
         internal IExceptionFilter[]? ExceptionFilters { get; set; } = Array.Empty<IExceptionFilter>();
 
         /// <summary>
-        /// The worker used by the client and passes to the transport.
+        /// The worker used by the client to pass envelopes.
         /// </summary>
         public IBackgroundWorker? BackgroundWorker { get; set; }
 

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -443,6 +443,7 @@ namespace Sentry
         public bool AttachStacktrace { get; set; }
         public bool AutoSessionTracking { get; set; }
         public System.TimeSpan AutoSessionTrackingInterval { get; set; }
+        public Sentry.Extensibility.IBackgroundWorker? BackgroundWorker { get; set; }
         public System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?>? BeforeBreadcrumb { get; set; }
         public System.Func<Sentry.SentryEvent, Sentry.SentryEvent?>? BeforeSend { get; set; }
         public string? CacheDirectoryPath { get; set; }
@@ -981,6 +982,12 @@ namespace Sentry.Extensibility
             "nd CaptureException that provide a callback to a configurable scope.")]
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
     }
+    public interface IBackgroundWorker
+    {
+        int QueuedItems { get; }
+        bool EnqueueEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
+        System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
     public interface IDiagnosticLogger
     {
         bool IsEnabled(Sentry.SentryLevel level);
@@ -1303,6 +1310,44 @@ namespace Sentry.Protocol
         public Sentry.SentryId TraceId { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Trace FromJson(System.Text.Json.JsonElement json) { }
+    }
+}
+namespace Sentry.Protocol.Envelopes
+{
+    public sealed class Envelope : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public Envelope(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> items) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> Items { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public Sentry.SentryId? TryGetEventId() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.Envelope> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public string? TryGetFileName() { }
+        public long? TryGetLength() { }
+        public string? TryGetType() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.EnvelopeItem> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.Attachment attachment) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromEvent(Sentry.SentryEvent @event) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public interface ISerializable
+    {
+        System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default);
     }
 }
 namespace Sentry.Reflection

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -443,6 +443,7 @@ namespace Sentry
         public bool AttachStacktrace { get; set; }
         public bool AutoSessionTracking { get; set; }
         public System.TimeSpan AutoSessionTrackingInterval { get; set; }
+        public Sentry.Extensibility.IBackgroundWorker? BackgroundWorker { get; set; }
         public System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?>? BeforeBreadcrumb { get; set; }
         public System.Func<Sentry.SentryEvent, Sentry.SentryEvent?>? BeforeSend { get; set; }
         public string? CacheDirectoryPath { get; set; }
@@ -981,6 +982,12 @@ namespace Sentry.Extensibility
             "nd CaptureException that provide a callback to a configurable scope.")]
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
     }
+    public interface IBackgroundWorker
+    {
+        int QueuedItems { get; }
+        bool EnqueueEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
+        System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
     public interface IDiagnosticLogger
     {
         bool IsEnabled(Sentry.SentryLevel level);
@@ -1303,6 +1310,44 @@ namespace Sentry.Protocol
         public Sentry.SentryId TraceId { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Trace FromJson(System.Text.Json.JsonElement json) { }
+    }
+}
+namespace Sentry.Protocol.Envelopes
+{
+    public sealed class Envelope : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public Envelope(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> items) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> Items { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public Sentry.SentryId? TryGetEventId() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.Envelope> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public string? TryGetFileName() { }
+        public long? TryGetLength() { }
+        public string? TryGetType() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.EnvelopeItem> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.Attachment attachment) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromEvent(Sentry.SentryEvent @event) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public interface ISerializable
+    {
+        System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default);
     }
 }
 namespace Sentry.Reflection

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -443,6 +443,7 @@ namespace Sentry
         public bool AttachStacktrace { get; set; }
         public bool AutoSessionTracking { get; set; }
         public System.TimeSpan AutoSessionTrackingInterval { get; set; }
+        public Sentry.Extensibility.IBackgroundWorker? BackgroundWorker { get; set; }
         public System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?>? BeforeBreadcrumb { get; set; }
         public System.Func<Sentry.SentryEvent, Sentry.SentryEvent?>? BeforeSend { get; set; }
         public string? CacheDirectoryPath { get; set; }
@@ -981,6 +982,12 @@ namespace Sentry.Extensibility
             "nd CaptureException that provide a callback to a configurable scope.")]
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
     }
+    public interface IBackgroundWorker
+    {
+        int QueuedItems { get; }
+        bool EnqueueEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
+        System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
     public interface IDiagnosticLogger
     {
         bool IsEnabled(Sentry.SentryLevel level);
@@ -1303,6 +1310,44 @@ namespace Sentry.Protocol
         public Sentry.SentryId TraceId { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Trace FromJson(System.Text.Json.JsonElement json) { }
+    }
+}
+namespace Sentry.Protocol.Envelopes
+{
+    public sealed class Envelope : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public Envelope(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> items) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> Items { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public Sentry.SentryId? TryGetEventId() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.Envelope> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public string? TryGetFileName() { }
+        public long? TryGetLength() { }
+        public string? TryGetType() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.EnvelopeItem> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.Attachment attachment) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromEvent(Sentry.SentryEvent @event) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public interface ISerializable
+    {
+        System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default);
     }
 }
 namespace Sentry.Reflection

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -443,6 +443,7 @@ namespace Sentry
         public bool AttachStacktrace { get; set; }
         public bool AutoSessionTracking { get; set; }
         public System.TimeSpan AutoSessionTrackingInterval { get; set; }
+        public Sentry.Extensibility.IBackgroundWorker? BackgroundWorker { get; set; }
         public System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?>? BeforeBreadcrumb { get; set; }
         public System.Func<Sentry.SentryEvent, Sentry.SentryEvent?>? BeforeSend { get; set; }
         public string? CacheDirectoryPath { get; set; }
@@ -980,6 +981,12 @@ namespace Sentry.Extensibility
             "nd CaptureException that provide a callback to a configurable scope.")]
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
     }
+    public interface IBackgroundWorker
+    {
+        int QueuedItems { get; }
+        bool EnqueueEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
+        System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
     public interface IDiagnosticLogger
     {
         bool IsEnabled(Sentry.SentryLevel level);
@@ -1302,6 +1309,44 @@ namespace Sentry.Protocol
         public Sentry.SentryId TraceId { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Trace FromJson(System.Text.Json.JsonElement json) { }
+    }
+}
+namespace Sentry.Protocol.Envelopes
+{
+    public sealed class Envelope : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public Envelope(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> items) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> Items { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public Sentry.SentryId? TryGetEventId() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.Envelope> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public string? TryGetFileName() { }
+        public long? TryGetLength() { }
+        public string? TryGetType() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.EnvelopeItem> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.Attachment attachment) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromEvent(Sentry.SentryEvent @event) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public interface ISerializable
+    {
+        System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default);
     }
 }
 namespace Sentry.Reflection

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -443,6 +443,7 @@ namespace Sentry
         public bool AttachStacktrace { get; set; }
         public bool AutoSessionTracking { get; set; }
         public System.TimeSpan AutoSessionTrackingInterval { get; set; }
+        public Sentry.Extensibility.IBackgroundWorker? BackgroundWorker { get; set; }
         public System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?>? BeforeBreadcrumb { get; set; }
         public System.Func<Sentry.SentryEvent, Sentry.SentryEvent?>? BeforeSend { get; set; }
         public string? CacheDirectoryPath { get; set; }
@@ -980,6 +981,12 @@ namespace Sentry.Extensibility
             "nd CaptureException that provide a callback to a configurable scope.")]
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
     }
+    public interface IBackgroundWorker
+    {
+        int QueuedItems { get; }
+        bool EnqueueEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
+        System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
     public interface IDiagnosticLogger
     {
         bool IsEnabled(Sentry.SentryLevel level);
@@ -1302,6 +1309,44 @@ namespace Sentry.Protocol
         public Sentry.SentryId TraceId { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Trace FromJson(System.Text.Json.JsonElement json) { }
+    }
+}
+namespace Sentry.Protocol.Envelopes
+{
+    public sealed class Envelope : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public Envelope(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> items) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> Items { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public Sentry.SentryId? TryGetEventId() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.Envelope> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public string? TryGetFileName() { }
+        public long? TryGetLength() { }
+        public string? TryGetType() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.EnvelopeItem> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.Attachment attachment) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromEvent(Sentry.SentryEvent @event) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public interface ISerializable
+    {
+        System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default);
     }
 }
 namespace Sentry.Reflection

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -443,6 +443,7 @@ namespace Sentry
         public bool AttachStacktrace { get; set; }
         public bool AutoSessionTracking { get; set; }
         public System.TimeSpan AutoSessionTrackingInterval { get; set; }
+        public Sentry.Extensibility.IBackgroundWorker? BackgroundWorker { get; set; }
         public System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?>? BeforeBreadcrumb { get; set; }
         public System.Func<Sentry.SentryEvent, Sentry.SentryEvent?>? BeforeSend { get; set; }
         public string? CacheDirectoryPath { get; set; }
@@ -981,6 +982,12 @@ namespace Sentry.Extensibility
             "nd CaptureException that provide a callback to a configurable scope.")]
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
     }
+    public interface IBackgroundWorker
+    {
+        int QueuedItems { get; }
+        bool EnqueueEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
+        System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
     public interface IDiagnosticLogger
     {
         bool IsEnabled(Sentry.SentryLevel level);
@@ -1303,6 +1310,44 @@ namespace Sentry.Protocol
         public Sentry.SentryId TraceId { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Trace FromJson(System.Text.Json.JsonElement json) { }
+    }
+}
+namespace Sentry.Protocol.Envelopes
+{
+    public sealed class Envelope : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public Envelope(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> items) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> Items { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public Sentry.SentryId? TryGetEventId() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.Envelope> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public string? TryGetFileName() { }
+        public long? TryGetLength() { }
+        public string? TryGetType() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.EnvelopeItem> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.Attachment attachment) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromEvent(Sentry.SentryEvent @event) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public interface ISerializable
+    {
+        System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default);
     }
 }
 namespace Sentry.Reflection

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -442,6 +442,7 @@ namespace Sentry
         public bool AttachStacktrace { get; set; }
         public bool AutoSessionTracking { get; set; }
         public System.TimeSpan AutoSessionTrackingInterval { get; set; }
+        public Sentry.Extensibility.IBackgroundWorker? BackgroundWorker { get; set; }
         public System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?>? BeforeBreadcrumb { get; set; }
         public System.Func<Sentry.SentryEvent, Sentry.SentryEvent?>? BeforeSend { get; set; }
         public string? CacheDirectoryPath { get; set; }
@@ -980,6 +981,12 @@ namespace Sentry.Extensibility
             "nd CaptureException that provide a callback to a configurable scope.")]
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
     }
+    public interface IBackgroundWorker
+    {
+        int QueuedItems { get; }
+        bool EnqueueEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
+        System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
     public interface IDiagnosticLogger
     {
         bool IsEnabled(Sentry.SentryLevel level);
@@ -1303,6 +1310,44 @@ namespace Sentry.Protocol
         public Sentry.SentryId TraceId { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Trace FromJson(System.Text.Json.JsonElement json) { }
+    }
+}
+namespace Sentry.Protocol.Envelopes
+{
+    public sealed class Envelope : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public Envelope(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> items) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> Items { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public Sentry.SentryId? TryGetEventId() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.Envelope> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public string? TryGetFileName() { }
+        public long? TryGetLength() { }
+        public string? TryGetType() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.EnvelopeItem> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.Attachment attachment) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromEvent(Sentry.SentryEvent @event) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public interface ISerializable
+    {
+        System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default);
     }
 }
 namespace Sentry.Reflection

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -443,6 +443,7 @@ namespace Sentry
         public bool AttachStacktrace { get; set; }
         public bool AutoSessionTracking { get; set; }
         public System.TimeSpan AutoSessionTrackingInterval { get; set; }
+        public Sentry.Extensibility.IBackgroundWorker? BackgroundWorker { get; set; }
         public System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?>? BeforeBreadcrumb { get; set; }
         public System.Func<Sentry.SentryEvent, Sentry.SentryEvent?>? BeforeSend { get; set; }
         public string? CacheDirectoryPath { get; set; }
@@ -981,6 +982,12 @@ namespace Sentry.Extensibility
             "nd CaptureException that provide a callback to a configurable scope.")]
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
     }
+    public interface IBackgroundWorker
+    {
+        int QueuedItems { get; }
+        bool EnqueueEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
+        System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
     public interface IDiagnosticLogger
     {
         bool IsEnabled(Sentry.SentryLevel level);
@@ -1303,6 +1310,44 @@ namespace Sentry.Protocol
         public Sentry.SentryId TraceId { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Trace FromJson(System.Text.Json.JsonElement json) { }
+    }
+}
+namespace Sentry.Protocol.Envelopes
+{
+    public sealed class Envelope : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public Envelope(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> items) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> Items { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public Sentry.SentryId? TryGetEventId() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.Envelope> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public string? TryGetFileName() { }
+        public long? TryGetLength() { }
+        public string? TryGetType() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.EnvelopeItem> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.Attachment attachment) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromEvent(Sentry.SentryEvent @event) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public interface ISerializable
+    {
+        System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default);
     }
 }
 namespace Sentry.Reflection

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -443,6 +443,7 @@ namespace Sentry
         public bool AttachStacktrace { get; set; }
         public bool AutoSessionTracking { get; set; }
         public System.TimeSpan AutoSessionTrackingInterval { get; set; }
+        public Sentry.Extensibility.IBackgroundWorker? BackgroundWorker { get; set; }
         public System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?>? BeforeBreadcrumb { get; set; }
         public System.Func<Sentry.SentryEvent, Sentry.SentryEvent?>? BeforeSend { get; set; }
         public string? CacheDirectoryPath { get; set; }
@@ -981,6 +982,12 @@ namespace Sentry.Extensibility
             "nd CaptureException that provide a callback to a configurable scope.")]
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
     }
+    public interface IBackgroundWorker
+    {
+        int QueuedItems { get; }
+        bool EnqueueEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
+        System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
     public interface IDiagnosticLogger
     {
         bool IsEnabled(Sentry.SentryLevel level);
@@ -1303,6 +1310,44 @@ namespace Sentry.Protocol
         public Sentry.SentryId TraceId { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Trace FromJson(System.Text.Json.JsonElement json) { }
+    }
+}
+namespace Sentry.Protocol.Envelopes
+{
+    public sealed class Envelope : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public Envelope(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> items) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> Items { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public Sentry.SentryId? TryGetEventId() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.Envelope> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public string? TryGetFileName() { }
+        public long? TryGetLength() { }
+        public string? TryGetType() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.EnvelopeItem> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.Attachment attachment) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromEvent(Sentry.SentryEvent @event) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public interface ISerializable
+    {
+        System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default);
     }
 }
 namespace Sentry.Reflection


### PR DESCRIPTION
Following the experiment to add WebGL to Unity, we learned that we need to change the BackgroundWorker implementation.

See also: https://github.com/getsentry/sentry-dotnet/pull/1207/