### PR TITLE
fix flaky test on .NET 461

### DIFF
--- a/test/Sentry.Tests/GlobalSessionManagerTests.cs
+++ b/test/Sentry.Tests/GlobalSessionManagerTests.cs
@@ -311,7 +311,11 @@ public class GlobalSessionManagerTests
         });
         persistedSessionUpdate!.IsInitial.Should().BeFalse();
         persistedSessionUpdate!.Timestamp.Should().BeAfter(sessionUpdate!.Timestamp);
-        persistedSessionUpdate!.Duration.Should().BeGreaterThan(sessionUpdate!.Duration);
+        persistedSessionUpdate!.Duration.Should().BeGreaterThan(sessionUpdate!.Duration,
+            "Ok what broke: duration ticks is even? {0}, what about {1} and {2}",
+            persistedSessionUpdate!.Duration.Ticks == sessionUpdate!.Duration.Ticks,
+            persistedSessionUpdate!.Duration,
+            sessionUpdate!.Duration);
         persistedSessionUpdate!.SequenceNumber.Should().Be(sessionUpdate!.SequenceNumber + 1);
     }
 

--- a/test/Sentry.Tests/GlobalSessionManagerTests.cs
+++ b/test/Sentry.Tests/GlobalSessionManagerTests.cs
@@ -314,8 +314,8 @@ public class GlobalSessionManagerTests
         });
         persistedSessionUpdate!.IsInitial.Should().BeFalse();
         persistedSessionUpdate!.Timestamp.Should().BeAfter(sessionUpdate!.Timestamp);
-        persistedSessionUpdate!.SequenceNumber.Should().Be(sessionUpdate!.SequenceNumber + 1);
         persistedSessionUpdate!.Duration.Should().BeGreaterThan(sessionUpdate!.Duration);
+        persistedSessionUpdate!.SequenceNumber.Should().Be(sessionUpdate!.SequenceNumber + 1);
     }
 
     [Fact]

--- a/test/Sentry.Tests/GlobalSessionManagerTests.cs
+++ b/test/Sentry.Tests/GlobalSessionManagerTests.cs
@@ -303,11 +303,11 @@ public class GlobalSessionManagerTests
         var sessionUpdate = sut.StartSession();
 
         // Act
-        var persistedSessionUpdate = sut.TryRecoverPersistedSession();
+        var persistedSessionUpdate = sut.TryRecoverPersistedSession()!;
 
         // Assert
         sessionUpdate.Should().NotBeNull();
-        persistedSessionUpdate!.EndStatus.Should().Be(SessionEndStatus.Abnormal);
+        persistedSessionUpdate.EndStatus.Should().Be(SessionEndStatus.Abnormal);
         persistedSessionUpdate.Should().NotBeNull();
         persistedSessionUpdate.Should().BeEquivalentTo(sessionUpdate, o =>
         {
@@ -319,10 +319,10 @@ public class GlobalSessionManagerTests
 
             return o;
         });
-        persistedSessionUpdate!.IsInitial.Should().BeFalse();
-        persistedSessionUpdate!.Timestamp.Should().BeAfter(sessionUpdate!.Timestamp);
-        persistedSessionUpdate!.Duration.Should().BeGreaterThan(sessionUpdate!.Duration);
-        persistedSessionUpdate!.SequenceNumber.Should().Be(sessionUpdate!.SequenceNumber + 1);
+        persistedSessionUpdate.IsInitial.Should().BeFalse();
+        persistedSessionUpdate.Timestamp.Should().BeAfter(sessionUpdate!.Timestamp);
+        persistedSessionUpdate.Duration.Should().BeGreaterThan(sessionUpdate!.Duration);
+        persistedSessionUpdate.SequenceNumber.Should().Be(sessionUpdate!.SequenceNumber + 1);
     }
 
     [Fact]

--- a/test/Sentry.Tests/GlobalSessionManagerTests.cs
+++ b/test/Sentry.Tests/GlobalSessionManagerTests.cs
@@ -293,11 +293,11 @@ public class GlobalSessionManagerTests
         // Arrange
         var sut = _fixture.GetSut();
 
-        var time = DateTimeOffset.Now;
+        var timeOffset = DateTimeOffset.Now;
         _fixture.Clock.GetUtcNow().Returns((_) =>
         {
-            time = time.AddSeconds(1);
-            return time;
+            timeOffset = timeOffset.AddSeconds(1);
+            return timeOffset;
         });
 
         var sessionUpdate = sut.StartSession();

--- a/test/Sentry.Tests/GlobalSessionManagerTests.cs
+++ b/test/Sentry.Tests/GlobalSessionManagerTests.cs
@@ -293,8 +293,15 @@ public class GlobalSessionManagerTests
         // Arrange
         var sut = _fixture.GetSut();
 
+        var time = DateTimeOffset.Now;
+        _fixture.Clock.GetUtcNow().Returns((_) =>
+        {
+            time = time.AddSeconds(1);
+            return time;
+        });
+
         var sessionUpdate = sut.StartSession();
-        _fixture.Clock.GetUtcNow().Returns(DateTimeOffset.Now.AddSeconds(1));
+
         // Act
         var persistedSessionUpdate = sut.TryRecoverPersistedSession();
 


### PR DESCRIPTION
`var persistedSessionUpdate = sut.TryRecoverPersistedSession();` could run in less than a tick, the fix fixes the time flow, by not rellying on UtcNow.

#skip-changelog.