### PR TITLE
make JsonSerializerOptions a static field

### DIFF
--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -9,15 +9,9 @@ namespace Sentry.Internal.Extensions
 {
     internal static class JsonExtensions
     {
-        private static JsonSerializerOptions? _serializerOption;
-        /// <summary>
-        /// The Json options with a preset of rules that will remove dangerous and problematic
-        /// data from the serialized object.
-        /// </summary>
-        public static JsonSerializerOptions? SerializerOption => _serializerOption ??= new JsonSerializerOptions
-        {
-            Converters = { new SentryJsonConverter() }
-        };
+        // The Json options with a preset of rules that will remove dangerous and problematic
+        // data from the serialized object.
+        private static JsonSerializerOptions serializerOption = new() {Converters = {new SentryJsonConverter()}};
 
         public static void Deconstruct(this JsonProperty jsonProperty, out string name, out JsonElement value)
         {
@@ -286,7 +280,7 @@ namespace Sentry.Internal.Extensions
             }
             else
             {
-                JsonSerializer.Serialize(writer, value, SerializerOption);
+                JsonSerializer.Serialize(writer, value, serializerOption);
             }
         }
 

--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -11,7 +11,7 @@ namespace Sentry.Internal.Extensions
     {
         // The Json options with a preset of rules that will remove dangerous and problematic
         // data from the serialized object.
-        private static JsonSerializerOptions serializerOption = new() {Converters = {new SentryJsonConverter()}};
+        private static JsonSerializerOptions serializerOption = new() { Converters = { new SentryJsonConverter() } };
 
         public static void Deconstruct(this JsonProperty jsonProperty, out string name, out JsonElement value)
         {


### PR DESCRIPTION
The prop `JsonExtensions.SerializerOption`:

* is not used outside the class so can be a field
* the null check is redundant since nothing else sets it so can be set in the static constructor
* can never be null

#skip-changelog