### PR TITLE
Fix incorrect sdk name in envelope header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Reduced the logger noise from EF when not using Performance Monitoring ([#1441](https://github.com/getsentry/sentry-dotnet/pull/1441))
 - Create CachingTransport directories in constructor to avoid DirectoryNotFoundException ([#1432](https://github.com/getsentry/sentry-dotnet/pull/1432))
 - UnobservedTaskException is now considered as Unhandled ([#1447](https://github.com/getsentry/sentry-dotnet/pull/1447))
+- Fix incorrect sdk name in envelope header ([#1474](https://github.com/getsentry/sentry-dotnet/pull/1474))
 
 ## 3.13.0
 

--- a/src/Sentry/Internal/ApplicationVersionLocator.cs
+++ b/src/Sentry/Internal/ApplicationVersionLocator.cs
@@ -14,18 +14,22 @@ namespace Sentry.Internal
                 return null;
             }
 
-            var nameAndVersion = asm.GetNameAndVersion();
-
-            if (string.IsNullOrWhiteSpace(nameAndVersion.Name) ||
-                string.IsNullOrWhiteSpace(nameAndVersion.Version))
+            var name = asm.GetName().Name;
+            var version = asm.GetVersion();
+            if (string.IsNullOrWhiteSpace(name) ||
+                string.IsNullOrWhiteSpace(version))
             {
                 return null;
             }
 
             // Don't add name prefix if it's already set by the user
-            return !nameAndVersion.Version.Contains('@')
-                ? $"{nameAndVersion.Name}@{nameAndVersion.Version}"
-                : nameAndVersion.Version;
+            if (version.Contains('@'))
+            {
+                return version;
+            }
+
+            return $"{name}@{version}";
+
         }
     }
 }

--- a/src/Sentry/Internal/MainSentryEventProcessor.cs
+++ b/src/Sentry/Internal/MainSentryEventProcessor.cs
@@ -131,7 +131,7 @@ namespace Sentry.Internal
                     var asmVersion = _options.ReportAssembliesMode switch
                     {
                         ReportAssembliesMode.Version => asmName.Version?.ToString() ?? string.Empty,
-                        ReportAssembliesMode.InformationalVersion => assembly.GetNameAndVersion().Version ?? string.Empty,
+                        ReportAssembliesMode.InformationalVersion => assembly.GetVersion() ?? string.Empty,
                         _ => throw new ArgumentOutOfRangeException(
                             $"Report assemblies mode '{_options.ReportAssembliesMode}' is not yet supported")
                     };

--- a/src/Sentry/Reflection/AssemblyExtensions.cs
+++ b/src/Sentry/Reflection/AssemblyExtensions.cs
@@ -20,16 +20,13 @@ namespace Sentry.Reflection
         /// <returns>The SdkVersion.</returns>
         public static SdkVersion GetNameAndVersion(this Assembly asm)
         {
-            var asmVersion = GetVersion(asm);
+            var asmName = asm.GetName();
+            var name = asmName.Name;
+            string? asmVersion = null;
 
-            return new SdkVersion { Name = "sentry.dotnet", Version = asmVersion };
-        }
-
-        private static string? GetVersion(Assembly asm)
-        {
             try
             {
-                return asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+                asmVersion = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
             }
             catch
             {
@@ -41,7 +38,9 @@ namespace Sentry.Reflection
             // be used for versioning and the software should not fallback to the assembly version string.
             // See https://github.com/getsentry/sentry-dotnet/pull/1079#issuecomment-866992216
             // TODO: Lets change this in a new major to return the Version as fallback
-            return  asm.GetName().Version?.ToString();
+            asmVersion ??= asmName.Version?.ToString();
+
+            return new SdkVersion { Name = name, Version = asmVersion };
         }
     }
 }

--- a/src/Sentry/Reflection/AssemblyExtensions.cs
+++ b/src/Sentry/Reflection/AssemblyExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.Reflection;
 
@@ -7,6 +8,7 @@ namespace Sentry.Reflection
     /// Extension methods to <see cref="Assembly"/>.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Should not be public. This method will be removed in version 4.")]
     public static class AssemblyExtensions
     {
         /// <summary>
@@ -20,13 +22,22 @@ namespace Sentry.Reflection
         /// <returns>The SdkVersion.</returns>
         public static SdkVersion GetNameAndVersion(this Assembly asm)
         {
-            var asmName = asm.GetName();
-            var name = asmName.Name;
-            string? asmVersion = null;
+            return new SdkVersion
+            {
+                Name =  asm.GetName().Name,
+                Version = asm.GetVersion()
+            };
+        }
 
+        internal static string? GetVersion(this Assembly assembly)
+        {
             try
             {
-                asmVersion = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+                var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+                if (informationalVersion != null)
+                {
+                    return informationalVersion;
+                }
             }
             catch
             {
@@ -38,9 +49,7 @@ namespace Sentry.Reflection
             // be used for versioning and the software should not fallback to the assembly version string.
             // See https://github.com/getsentry/sentry-dotnet/pull/1079#issuecomment-866992216
             // TODO: Lets change this in a new major to return the Version as fallback
-            asmVersion ??= asmName.Version?.ToString();
-
-            return new SdkVersion { Name = name, Version = asmVersion };
+            return assembly.GetName().Version?.ToString();
         }
     }
 }

--- a/src/Sentry/Reflection/AssemblyExtensions.cs
+++ b/src/Sentry/Reflection/AssemblyExtensions.cs
@@ -24,7 +24,7 @@ namespace Sentry.Reflection
         {
             return new SdkVersion
             {
-                Name =  asm.GetName().Name,
+                Name = asm.GetName().Name,
                 Version = asm.GetVersion()
             };
         }

--- a/src/Sentry/Reflection/AssemblyExtensions.cs
+++ b/src/Sentry/Reflection/AssemblyExtensions.cs
@@ -20,13 +20,16 @@ namespace Sentry.Reflection
         /// <returns>The SdkVersion.</returns>
         public static SdkVersion GetNameAndVersion(this Assembly asm)
         {
-            var asmName = asm.GetName();
-            var name = asmName.Name;
-            string? asmVersion = null;
+            var asmVersion = GetVersion(asm);
 
+            return new SdkVersion { Name = "sentry.dotnet", Version = asmVersion };
+        }
+
+        private static string? GetVersion(Assembly asm)
+        {
             try
             {
-                asmVersion = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+                return asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
             }
             catch
             {
@@ -38,9 +41,7 @@ namespace Sentry.Reflection
             // be used for versioning and the software should not fallback to the assembly version string.
             // See https://github.com/getsentry/sentry-dotnet/pull/1079#issuecomment-866992216
             // TODO: Lets change this in a new major to return the Version as fallback
-            asmVersion ??= asmName.Version?.ToString();
-
-            return new SdkVersion { Name = name, Version = asmVersion };
+            return  asm.GetName().Version?.ToString();
         }
     }
 }

--- a/src/Sentry/SdkVersion.cs
+++ b/src/Sentry/SdkVersion.cs
@@ -19,7 +19,7 @@ namespace Sentry
         private static readonly Lazy<SdkVersion> InstanceLazy = new(
             () => new SdkVersion
             {
-                Name =  "sentry.dotnet",
+                Name = "sentry.dotnet",
                 Version = typeof(ISentryClient).Assembly.GetVersion()
             });
 

--- a/src/Sentry/SdkVersion.cs
+++ b/src/Sentry/SdkVersion.cs
@@ -17,7 +17,11 @@ namespace Sentry
     public sealed class SdkVersion : IJsonSerializable
     {
         private static readonly Lazy<SdkVersion> InstanceLazy = new(
-            () => typeof(ISentryClient).Assembly.GetNameAndVersion());
+            () => new SdkVersion
+            {
+                Name =  "sentry.dotnet",
+                Version = typeof(ISentryClient).Assembly.GetVersion()
+            });
 
         internal static SdkVersion Instance => InstanceLazy.Value;
 

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1352,6 +1352,7 @@ namespace Sentry.Protocol.Envelopes
 }
 namespace Sentry.Reflection
 {
+    [System.Obsolete("Should not be public. This method will be removed in version 4.")]
     public static class AssemblyExtensions
     {
         public static Sentry.SdkVersion GetNameAndVersion(this System.Reflection.Assembly asm) { }

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1352,6 +1352,7 @@ namespace Sentry.Protocol.Envelopes
 }
 namespace Sentry.Reflection
 {
+    [System.Obsolete("Should not be public. This method will be removed in version 4.")]
     public static class AssemblyExtensions
     {
         public static Sentry.SdkVersion GetNameAndVersion(this System.Reflection.Assembly asm) { }

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1352,6 +1352,7 @@ namespace Sentry.Protocol.Envelopes
 }
 namespace Sentry.Reflection
 {
+    [System.Obsolete("Should not be public. This method will be removed in version 4.")]
     public static class AssemblyExtensions
     {
         public static Sentry.SdkVersion GetNameAndVersion(this System.Reflection.Assembly asm) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -1351,6 +1351,7 @@ namespace Sentry.Protocol.Envelopes
 }
 namespace Sentry.Reflection
 {
+    [System.Obsolete("Should not be public. This method will be removed in version 4.")]
     public static class AssemblyExtensions
     {
         public static Sentry.SdkVersion GetNameAndVersion(this System.Reflection.Assembly asm) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -1351,6 +1351,7 @@ namespace Sentry.Protocol.Envelopes
 }
 namespace Sentry.Reflection
 {
+    [System.Obsolete("Should not be public. This method will be removed in version 4.")]
     public static class AssemblyExtensions
     {
         public static Sentry.SdkVersion GetNameAndVersion(this System.Reflection.Assembly asm) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1352,6 +1352,7 @@ namespace Sentry.Protocol.Envelopes
 }
 namespace Sentry.Reflection
 {
+    [System.Obsolete("Should not be public. This method will be removed in version 4.")]
     public static class AssemblyExtensions
     {
         public static Sentry.SdkVersion GetNameAndVersion(this System.Reflection.Assembly asm) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1352,6 +1352,7 @@ namespace Sentry.Protocol.Envelopes
 }
 namespace Sentry.Reflection
 {
+    [System.Obsolete("Should not be public. This method will be removed in version 4.")]
     public static class AssemblyExtensions
     {
         public static Sentry.SdkVersion GetNameAndVersion(this System.Reflection.Assembly asm) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1352,6 +1352,7 @@ namespace Sentry.Protocol.Envelopes
 }
 namespace Sentry.Reflection
 {
+    [System.Obsolete("Should not be public. This method will be removed in version 4.")]
     public static class AssemblyExtensions
     {
         public static Sentry.SdkVersion GetNameAndVersion(this System.Reflection.Assembly asm) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1352,6 +1352,7 @@ namespace Sentry.Protocol.Envelopes
 }
 namespace Sentry.Reflection
 {
+    [System.Obsolete("Should not be public. This method will be removed in version 4.")]
     public static class AssemblyExtensions
     {
         public static Sentry.SdkVersion GetNameAndVersion(this System.Reflection.Assembly asm) { }

--- a/test/Sentry.Tests/Internals/ReleaseLocatorTests.cs
+++ b/test/Sentry.Tests/Internals/ReleaseLocatorTests.cs
@@ -10,7 +10,7 @@ public class ReleaseLocatorTests
     {
         const string expectedVersion = "the version";
         EnvironmentVariableGuard.WithVariable(
-            Sentry.Internal.Constants.ReleaseEnvironmentVariable,
+            Internal.Constants.ReleaseEnvironmentVariable,
             expectedVersion,
             () =>
             {
@@ -19,7 +19,7 @@ public class ReleaseLocatorTests
     }
 
 #if NET461
-        [SkippableFact]
+    [SkippableFact]
 #else
     [Fact]
 #endif
@@ -27,11 +27,11 @@ public class ReleaseLocatorTests
     {
         var ass = Assembly.GetEntryAssembly();
 #if NET461
-            Skip.If(ass == null, "GetEntryAssembly can return null on net461. eg on Mono or in certain test runners.");
+        Skip.If(ass == null, "GetEntryAssembly can return null on net461. eg on Mono or in certain test runners.");
 #endif
 
         EnvironmentVariableGuard.WithVariable(
-            Sentry.Internal.Constants.ReleaseEnvironmentVariable,
+            Internal.Constants.ReleaseEnvironmentVariable,
             null,
             () =>
             {

--- a/test/Sentry.Tests/Protocol/SdkVersionTests.cs
+++ b/test/Sentry.Tests/Protocol/SdkVersionTests.cs
@@ -1,10 +1,16 @@
 using System.Text.RegularExpressions;
-using Sentry.Tests.Helpers;
-
-namespace Sentry.Tests.Protocol;
 
 public class SdkVersionTests
 {
+    [Fact]
+    public void InstanceIsCorrect()
+    {
+        var instance = SdkVersion.Instance;
+        Assert.Equal("sentry.dotnet", instance.Name);
+        Assert.NotNull(instance.Version);
+        Assert.NotEmpty(instance.Version);
+    }
+
     [Fact]
     public void AddPackage_DoesNotExcludeCurrentOne()
     {


### PR DESCRIPTION
fixes #1219

`Sentry.Reflection.AssemblyExtensions` is also obsoleted. 