### PR TITLE
use Trace.WriteLine for TraceDiagnosticLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Reduced the logger noise from EF when not using Performance Monitoring ([#1441](https://github.com/getsentry/sentry-dotnet/pull/1441))
 - Create CachingTransport directories in constructor to avoid DirectoryNotFoundException ([#1432](https://github.com/getsentry/sentry-dotnet/pull/1432))
 - UnobservedTaskException is now considered as Unhandled ([#1447](https://github.com/getsentry/sentry-dotnet/pull/1447))
+- Use Trace.WriteLine for TraceDiagnosticLogger ([#1475](https://github.com/getsentry/sentry-dotnet/pull/1475))
 
 ## 3.13.0
 

--- a/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
@@ -1,6 +1,8 @@
+#define TRACE
 using System;
 using System.Diagnostics;
 using Sentry.Extensibility;
+
 namespace Sentry.Infrastructure
 {
     /// <summary>
@@ -28,22 +30,15 @@ namespace Sentry.Infrastructure
         /// </summary>
         public void Log(SentryLevel logLevel, string message, Exception? exception = null, params object?[] args)
         {
-            try
+            var formattedMessage = string.Format(message, args);
+            if (exception == null)
             {
-                for (var i = 0; i < Trace.Listeners.Count; i++)
-                {
-                    var listener = Trace.Listeners[i];
-                    listener.WriteLine($"{logLevel,7}: {string.Format(message, args)}");
-                    if (exception != null)
-                    {
-                        listener.WriteLine(exception);
-                    }
-                }
+                Trace.WriteLine($"{logLevel,7}: {formattedMessage}");
             }
-            catch (ArgumentOutOfRangeException)
+            else
             {
-                // Trace.Listeners is a public mutable static property and listeners can be removed
-                // from anywhere at anytime.
+                Trace.WriteLine($@"{logLevel,7}: {formattedMessage}
+{exception}");
             }
         }
     }

--- a/test/Sentry.Tests/Infrastructure/TraceDiagnosticLoggerTests.cs
+++ b/test/Sentry.Tests/Infrastructure/TraceDiagnosticLoggerTests.cs
@@ -1,5 +1,5 @@
 using System.Diagnostics;
-using Trace=System.Diagnostics.Trace;
+using Trace = System.Diagnostics.Trace;
 
 [UsesVerify]
 public class TraceDiagnosticLoggerTests
@@ -15,7 +15,7 @@ public class TraceDiagnosticLoggerTests
             logger.Log(SentryLevel.Debug, "the message {0}", new Exception("the exception"), "arg1");
             Trace.Flush();
             Assert.Equal(@"  Debug: the message arg1
-System.Exception: the exception",listener.Messages.Single());
+System.Exception: the exception", listener.Messages.Single());
         }
         finally
         {
@@ -23,7 +23,7 @@ System.Exception: the exception",listener.Messages.Single());
         }
     }
 
-    class Listener : TraceListener
+    private class Listener : TraceListener
     {
         public List<string> Messages = new();
 

--- a/test/Sentry.Tests/Infrastructure/TraceDiagnosticLoggerTests.cs
+++ b/test/Sentry.Tests/Infrastructure/TraceDiagnosticLoggerTests.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics;
+using Trace=System.Diagnostics.Trace;
+
+[UsesVerify]
+public class TraceDiagnosticLoggerTests
+{
+    [Fact]
+    public void CanTrace()
+    {
+        var listener = new Listener();
+        Trace.Listeners.Add(listener);
+        try
+        {
+            var logger = new TraceDiagnosticLogger(SentryLevel.Debug);
+            logger.Log(SentryLevel.Debug, "the message {0}", new Exception("the exception"), "arg1");
+            Trace.Flush();
+            Assert.Equal(@"  Debug: the message arg1
+System.Exception: the exception",listener.Messages.Single());
+        }
+        finally
+        {
+            Trace.Listeners.Remove(listener);
+        }
+    }
+
+    class Listener : TraceListener
+    {
+        public List<string> Messages = new();
+
+        public override void Write(string message)
+        {
+            Messages.Add(message);
+        }
+
+        public override void WriteLine(string message)
+        {
+            Messages.Add(message);
+        }
+    }
+}


### PR DESCRIPTION
 * force Trace in `TraceDiagnosticLogger` using `#define TRACE`
 * this unlocks using `Trace.WriteLine` instead of iterating Listeners
 * No longer need `catch (ArgumentOutOfRangeException)`
 * Fixes race condition where the `listener.WriteLine($"{logLevel,7}: {string.Format(message, args)}");` and `listener.WriteLine(exception);` can interleave with another `Trace.WriteLine` causing a confusing sequence of log lines.
 * Add a test for TraceDiagnosticLogger