### PR TITLE
expose IsSystemModuleName as a public static function.

### DIFF
--- a/src/Sentry/Exceptions/SentryStackFrame.cs
+++ b/src/Sentry/Exceptions/SentryStackFrame.cs
@@ -170,16 +170,18 @@ namespace Sentry
         {
             var parameterName = Module ?? Function;
             if (InApp != null)
-            { }
-            else if (string.IsNullOrEmpty(parameterName))
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(parameterName))
             {
                 InApp = true;
+                return;
             }
-            else
-            {
-                InApp = options.InAppInclude?.Any(include => parameterName.StartsWith(include, StringComparison.Ordinal)) == true ||
-                        options.InAppExclude?.Any(exclude => parameterName.StartsWith(exclude, StringComparison.Ordinal)) != true;
-            }
+
+            InApp = options.InAppInclude?.Any(include => parameterName.StartsWith(include, StringComparison.Ordinal)) == true ||
+                    options.InAppExclude?.Any(exclude => parameterName.StartsWith(exclude, StringComparison.Ordinal)) != true;
         }
 
         /// <summary>

--- a/src/Sentry/Exceptions/SentryStackFrame.cs
+++ b/src/Sentry/Exceptions/SentryStackFrame.cs
@@ -162,7 +162,7 @@ namespace Sentry
         }
 
         /// <summary>
-        /// Configures <see cref="InApp"/> based on the InApp defined on SentryOptions.
+        /// Configures <see cref="InApp"/> based on the <see cref="SentryOptions.InAppInclude"/> and <see cref="SentryOptions.InAppExclude"/> or <paramref name="options"/>.
         /// </summary>
         /// <param name="options">The Sentry options.</param>
         /// <remarks><see cref="InApp"/> will remain with the same value if previously set.</remarks>

--- a/src/Sentry/Exceptions/SentryStackFrame.cs
+++ b/src/Sentry/Exceptions/SentryStackFrame.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -158,6 +159,27 @@ namespace Sentry
             writer.WriteNumberIfNotNull("instruction_offset", InstructionOffset);
 
             writer.WriteEndObject();
+        }
+
+        /// <summary>
+        /// Configures <see cref="InApp"/> based on the InApp defined on SentryOptions.
+        /// </summary>
+        /// <param name="options">The Sentry options.</param>
+        /// <remarks><see cref="InApp"/> will remain with the same value if previously set.</remarks>
+        public void ConfigureAppFrame(SentryOptions options)
+        {
+            var parameterName = Module ?? Function;
+            if (InApp != null)
+            { }
+            else if (string.IsNullOrEmpty(parameterName))
+            {
+                InApp = true;
+            }
+            else
+            {
+                InApp = options.InAppInclude?.Any(include => parameterName.StartsWith(include, StringComparison.Ordinal)) == true ||
+                        options.InAppExclude?.Any(exclude => parameterName.StartsWith(exclude, StringComparison.Ordinal)) != true;
+            }
         }
 
         /// <summary>

--- a/src/Sentry/Extensibility/SentryStackTraceFactory.cs
+++ b/src/Sentry/Extensibility/SentryStackTraceFactory.cs
@@ -164,7 +164,7 @@ namespace Sentry.Extensibility
                 }
             }
 
-            frame.InApp ??= !IsSystemModuleName(frame.Module);
+            frame.InApp ??= !IsSystemModuleName(frame.Module, _options);
 
             frame.FileName = stackFrame.GetFileName();
 
@@ -211,15 +211,21 @@ namespace Sentry.Extensibility
         protected virtual MethodBase? GetMethod(StackFrame stackFrame)
             => stackFrame.GetMethod();
 
-        private bool IsSystemModuleName(string? moduleName)
+        /// <summary>
+        /// Inform if the given module name belongs to the System or not.
+        /// </summary>
+        /// <param name="moduleName">The module name to be checked.</param>
+        /// <param name="options">The Sentry options.</param>
+        /// <returns>True if the module belongs to the System, false otherwise.</returns>
+        public static bool IsSystemModuleName(string? moduleName, SentryOptions options)
         {
             if (string.IsNullOrEmpty(moduleName))
             {
                 return false;
             }
 
-            return _options.InAppInclude?.Any(include => moduleName.StartsWith(include, StringComparison.Ordinal)) != true &&
-                   _options.InAppExclude?.Any(exclude => moduleName.StartsWith(exclude, StringComparison.Ordinal)) == true;
+            return options.InAppInclude?.Any(include => moduleName.StartsWith(include, StringComparison.Ordinal)) != true &&
+                   options.InAppExclude?.Any(exclude => moduleName.StartsWith(exclude, StringComparison.Ordinal)) == true;
         }
 
         /// <summary>

--- a/src/Sentry/Extensibility/SentryStackTraceFactory.cs
+++ b/src/Sentry/Extensibility/SentryStackTraceFactory.cs
@@ -164,7 +164,7 @@ namespace Sentry.Extensibility
                 }
             }
 
-            frame.InApp ??= !IsSystemModuleName(frame.Module, _options);
+            frame.ConfigureAppFrame(_options);
 
             frame.FileName = stackFrame.GetFileName();
 
@@ -210,23 +210,6 @@ namespace Sentry.Extensibility
         /// <param name="stackFrame">The <see cref="StackFrame"/></param>.
         protected virtual MethodBase? GetMethod(StackFrame stackFrame)
             => stackFrame.GetMethod();
-
-        /// <summary>
-        /// Inform if the given module name belongs to the System or not.
-        /// </summary>
-        /// <param name="moduleName">The module name to be checked.</param>
-        /// <param name="options">The Sentry options.</param>
-        /// <returns>True if the module belongs to the System, false otherwise.</returns>
-        public static bool IsSystemModuleName(string? moduleName, SentryOptions options)
-        {
-            if (string.IsNullOrEmpty(moduleName))
-            {
-                return false;
-            }
-
-            return options.InAppInclude?.Any(include => moduleName.StartsWith(include, StringComparison.Ordinal)) != true &&
-                   options.InAppExclude?.Any(exclude => moduleName.StartsWith(exclude, StringComparison.Ordinal)) == true;
-        }
 
         /// <summary>
         /// Clean up function and module names produced from `async` state machine calls.

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1047,6 +1047,7 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
+        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -573,6 +573,7 @@ namespace Sentry
         public System.Collections.Generic.IList<string> PreContext { get; }
         public long? SymbolAddress { get; set; }
         public System.Collections.Generic.IDictionary<string, string> Vars { get; }
+        public void ConfigureAppFrame(Sentry.SentryOptions options) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackFrame FromJson(System.Text.Json.JsonElement json) { }
     }
@@ -1047,7 +1048,6 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
-        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1047,6 +1047,7 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
+        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -573,6 +573,7 @@ namespace Sentry
         public System.Collections.Generic.IList<string> PreContext { get; }
         public long? SymbolAddress { get; set; }
         public System.Collections.Generic.IDictionary<string, string> Vars { get; }
+        public void ConfigureAppFrame(Sentry.SentryOptions options) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackFrame FromJson(System.Text.Json.JsonElement json) { }
     }
@@ -1047,7 +1048,6 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
-        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1047,6 +1047,7 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
+        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -573,6 +573,7 @@ namespace Sentry
         public System.Collections.Generic.IList<string> PreContext { get; }
         public long? SymbolAddress { get; set; }
         public System.Collections.Generic.IDictionary<string, string> Vars { get; }
+        public void ConfigureAppFrame(Sentry.SentryOptions options) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackFrame FromJson(System.Text.Json.JsonElement json) { }
     }
@@ -1047,7 +1048,6 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
-        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -572,6 +572,7 @@ namespace Sentry
         public System.Collections.Generic.IList<string> PreContext { get; }
         public long? SymbolAddress { get; set; }
         public System.Collections.Generic.IDictionary<string, string> Vars { get; }
+        public void ConfigureAppFrame(Sentry.SentryOptions options) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackFrame FromJson(System.Text.Json.JsonElement json) { }
     }
@@ -1046,7 +1047,6 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
-        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -1046,6 +1046,7 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
+        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -572,6 +572,7 @@ namespace Sentry
         public System.Collections.Generic.IList<string> PreContext { get; }
         public long? SymbolAddress { get; set; }
         public System.Collections.Generic.IDictionary<string, string> Vars { get; }
+        public void ConfigureAppFrame(Sentry.SentryOptions options) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackFrame FromJson(System.Text.Json.JsonElement json) { }
     }
@@ -1046,7 +1047,6 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
-        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -1046,6 +1046,7 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
+        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1047,6 +1047,7 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
+        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -573,6 +573,7 @@ namespace Sentry
         public System.Collections.Generic.IList<string> PreContext { get; }
         public long? SymbolAddress { get; set; }
         public System.Collections.Generic.IDictionary<string, string> Vars { get; }
+        public void ConfigureAppFrame(Sentry.SentryOptions options) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackFrame FromJson(System.Text.Json.JsonElement json) { }
     }
@@ -1047,7 +1048,6 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
-        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -572,6 +572,7 @@ namespace Sentry
         public System.Collections.Generic.IList<string> PreContext { get; }
         public long? SymbolAddress { get; set; }
         public System.Collections.Generic.IDictionary<string, string> Vars { get; }
+        public void ConfigureAppFrame(Sentry.SentryOptions options) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackFrame FromJson(System.Text.Json.JsonElement json) { }
     }
@@ -1046,7 +1047,6 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
-        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1046,6 +1046,7 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
+        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1047,6 +1047,7 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
+        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -573,6 +573,7 @@ namespace Sentry
         public System.Collections.Generic.IList<string> PreContext { get; }
         public long? SymbolAddress { get; set; }
         public System.Collections.Generic.IDictionary<string, string> Vars { get; }
+        public void ConfigureAppFrame(Sentry.SentryOptions options) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackFrame FromJson(System.Text.Json.JsonElement json) { }
     }
@@ -1047,7 +1048,6 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
-        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1047,6 +1047,7 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
+        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -573,6 +573,7 @@ namespace Sentry
         public System.Collections.Generic.IList<string> PreContext { get; }
         public long? SymbolAddress { get; set; }
         public System.Collections.Generic.IDictionary<string, string> Vars { get; }
+        public void ConfigureAppFrame(Sentry.SentryOptions options) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackFrame FromJson(System.Text.Json.JsonElement json) { }
     }
@@ -1047,7 +1048,6 @@ namespace Sentry.Extensibility
         protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
         protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
         protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
-        public static bool IsSystemModuleName(string? moduleName, Sentry.SentryOptions options) { }
     }
 }
 namespace Sentry.Http

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
@@ -83,4 +83,72 @@ public class SentryStackFrameTests
         var sut = new SentryStackFrame();
         Assert.NotNull(sut.FramesOmitted);
     }
+
+    [Fact]
+    public void ConfigureAppFrame_InAppIncludeMatches_TrueSet()
+    {
+        // Arrange
+        var module = "IncludedModule";
+        var sut = new SentryStackFrame();
+        sut.Module = module;
+        var options = new SentryOptions();
+        options.AddInAppInclude(module);
+
+        // Act
+        sut.ConfigureAppFrame(options);
+
+        // Assert
+        Assert.True(sut.InApp);
+    }
+
+    [Fact]
+    public void ConfigureAppFrame_InAppExcludeMatches_TrueSet()
+    {
+        // Arrange
+        var module = "ExcludedModule";
+        var sut = new SentryStackFrame();
+        sut.Module = module;
+        var options = new SentryOptions();
+        options.AddInAppExclude(module);
+
+        // Act
+        sut.ConfigureAppFrame(options);
+
+        // Assert
+        Assert.False(sut.InApp);
+    }
+
+    [Fact]
+    public void ConfigureAppFrame_InAppRuleDoesntMatch_TrueSet()
+    {
+        // Arrange
+        var module = "AppModule";
+        var sut = new SentryStackFrame();
+        sut.Module = module;
+        var options = new SentryOptions();
+
+        // Act
+        sut.ConfigureAppFrame(options);
+
+        // Assert
+        Assert.True(sut.InApp);
+    }
+
+    [Fact]
+    public void ConfigureAppFrame_InAppAlreadySet_InAppIgnored()
+    {
+        // Arrange
+        var module = "ExcludedModule";
+        var sut = new SentryStackFrame();
+        sut.Module = module;
+        var options = new SentryOptions();
+        options.AddInAppExclude(module);
+        sut.InApp = true;
+
+        // Act
+        sut.ConfigureAppFrame(options);
+
+        // Assert
+        Assert.True(sut.InApp, "InApp started as true but ConfigureAppFrame changed it to false.");
+    }
 }


### PR DESCRIPTION
#skip-changelog.

I don' believe this function belongs to SentryOptionsExtensions since it's not exactly an extension to SentryOptions so leaving it on SentryStackTraceFactory may be thet best place from what I say.

The goal of this PR is to expose IsSystemModuleName so a proper fix can be implemented for https://github.com/getsentry/sentry-unity/issues/575