### PR TITLE
make SentryDiagnosticSubscriber._disposableListeners threadsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Features
 
 - Expose ConfigureAppFrame as a public static function. ([#1493](https://github.com/getsentry/sentry-dotnet/pull/1493))
+
+### Fixes
+
+- Make `SentryDiagnosticSubscriber._disposableListeners` thread safe ([#1506](https://github.com/getsentry/sentry-dotnet/pull/1506))
  
 ## 3.14.1
 

--- a/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentryDiagnosticSubscriber.cs
+++ b/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentryDiagnosticSubscriber.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Sentry.Extensibility;
 
@@ -12,7 +12,7 @@ namespace Sentry.Internals.DiagnosticSource
     {
         private SentryEFCoreListener? _efInterceptor { get; set; }
         private SentrySqlListener? _sqlListener { get; set; }
-        private List<IDisposable> _disposableListeners = new();
+        private ConcurrentBag<IDisposable> _disposableListeners = new();
         private IHub _hub { get; }
         private SentryOptions _options { get; }
 


### PR DESCRIPTION
`IObserver.OnNext` can be called from multiple thread. so `SentryDiagnosticSubscriber._disposableListeners ` needs to be thread safe