### PR TITLE
Resolve System.Text.Json compatibility warning

### DIFF
--- a/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
+++ b/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
@@ -28,6 +28,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.20" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.20" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="3.1.20" />
+    <!-- NET Core 3.0's built-in STJ is lower version which causes conflicts, so we have to explicitly reference it -->
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <ProjectReference Include="../../src/Sentry.DiagnosticSource/Sentry.DiagnosticSource.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />

--- a/test/Sentry.Tests/Sentry.Tests.csproj
+++ b/test/Sentry.Tests/Sentry.Tests.csproj
@@ -17,7 +17,7 @@
   <!-- Run netcoreapp3.0 against netstandard2.1 target of Sentry -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <ProjectReference Update="../../src/Sentry/Sentry.csproj" SetTargetFramework="TargetFramework=netstandard2.1" />
-    <!-- NET Core's built-in STJ is lower version which causes conflicts, so we have to explicitly reference it -->
+    <!-- NET Core 3.0's built-in STJ is lower version which causes conflicts, so we have to explicitly reference it -->
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
     <!-- Ben.Demystifier uses S.R.M v5 and also requires it via package reference when on nca3.x -->
     <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />


### PR DESCRIPTION
I'm get the following warning building the solution.

```
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277: Found conflicts between different versions of "System.Text.Json" that could not be resolved. [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277: There was a conflict between "System.Text.Json, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" and "System.Text.Json, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51". [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277:     "System.Text.Json, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" was chosen because it was primary and "System.Text.Json, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" was not. [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277:     References which depend on "System.Text.Json, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" [/Users/matt/.nuget/packages/system.text.json/4.7.2/lib/netcoreapp3.0/System.Text.Json.dll]. [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277:         /Users/matt/.nuget/packages/system.text.json/4.7.2/lib/netcoreapp3.0/System.Text.Json.dll [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277:           Project file item includes which caused reference "/Users/matt/.nuget/packages/system.text.json/4.7.2/lib/netcoreapp3.0/System.Text.Json.dll". [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277:             /Users/matt/.nuget/packages/system.text.json/4.7.2/lib/netcoreapp3.0/System.Text.Json.dll [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277:     References which depend on "System.Text.Json, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" []. [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277:         /Users/matt/Code/sentry-dotnet/src/Sentry/bin/Debug/netstandard2.1/Sentry.dll [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277:           Project file item includes which caused reference "/Users/matt/Code/sentry-dotnet/src/Sentry/bin/Debug/netstandard2.1/Sentry.dll". [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277:             /Users/matt/Code/sentry-dotnet/src/Sentry/bin/Debug/netstandard2.1/Sentry.dll [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277:             /Users/matt/Code/sentry-dotnet/src/Sentry.DiagnosticSource/bin/Debug/netstandard2.1/Sentry.DiagnosticSource.dll [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277:             /Users/matt/Code/sentry-dotnet/test/Sentry.Testing/bin/Debug/netcoreapp2.1/Sentry.Testing.dll [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277:         /Users/matt/Code/sentry-dotnet/test/Sentry.Testing/bin/Debug/netcoreapp2.1/Sentry.Testing.dll [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277:           Project file item includes which caused reference "/Users/matt/Code/sentry-dotnet/test/Sentry.Testing/bin/Debug/netcoreapp2.1/Sentry.Testing.dll". [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.200/Microsoft.Common.CurrentVersion.targets(2301,5): warning MSB3277:             /Users/matt/Code/sentry-dotnet/test/Sentry.Testing/bin/Debug/netcoreapp2.1/Sentry.Testing.dll [/Users/matt/Code/sentry-dotnet/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj]
```

Adding an explicit reference to `System.Text.Json` 5.0.2 for the netcoreapp3.0 target in Sentry.Diagnosticsource.Tests.csproj resolves the warning.  This is the same approach already done in Sentry.Tests.csproj.  (Also updated the comment in both places.)

#skip-changelog
