### PR TITLE
Skip failing test on M1

### DIFF
--- a/test/Sentry.Tests/Internals/ProcessInfoTests.cs
+++ b/test/Sentry.Tests/Internals/ProcessInfoTests.cs
@@ -1,10 +1,23 @@
+using System.Runtime.InteropServices;
+
 namespace Sentry.Tests.Internals;
 
 public class ProcessInfoTests
 {
-    [Fact]
+    [SkippableFact]
     public async Task Ctor_StartupTimeSimilarToUtcNow()
     {
+
+#if NETCOREAPP
+        // Skip this test when running on macOS with Apple Silicon (M1) hardware due to a bug in .NET with Process.StartTime.
+        // See https://github.com/getsentry/sentry-dotnet/issues/1508
+        // and https://github.com/dotnet/runtime/issues/66170
+        // TODO: When .NET resolves the issue, change the version number below to reflect the fixed version of 3.1.xxx
+        Skip.If(RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+                RuntimeInformation.OSDescription.Contains("ARM64") &&
+                Environment.Version < Version.Parse("5.0.0"));
+#endif
+
         //Arrange
         var options = new SentryOptions();
 


### PR DESCRIPTION
Resolves #1508 by skipping the failing test on M1 hardware for affected .NET runtime versions.

#skip-changelog