### PR TITLE
try verbosity quiet

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -3,6 +3,7 @@ $ErrorActionPreference = "Stop"
 $testLogger = if ($env:GITHUB_ACTIONS -eq "true") {"GitHubActions;report-warnings=false"} else {"console"}
 
 dotnet test SentryNoSamples.slnf -c Release -l $testLogger `
+    --verbosity quiet `
     /p:CollectCoverage=true `
     /p:CoverletOutputFormat=opencover `
     /p:CopyLocalLockFileAssemblies=true `

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ if [ "$GITHUB_ACTIONS" == "true" ]
 fi
 
 dotnet test SentryNoSamples.slnf -c Release -l $testLogger \
+    --verbosity quiet \
     /p:CollectCoverage=true \
     /p:CoverletOutputFormat=opencover \
     /p:CopyLocalLockFileAssemblies=true \


### PR DESCRIPTION
#skip-changelog

to minimise the ~2000 lines in our build output