### PR TITLE
Use async/await wherever possible in tests

### DIFF
--- a/test/Sentry.AspNetCore.Tests/IntegrationMockedBackgroundWorker.cs
+++ b/test/Sentry.AspNetCore.Tests/IntegrationMockedBackgroundWorker.cs
@@ -291,16 +291,16 @@ public class IntegrationMockedBackgroundWorker : SentrySdkTestFixture
     }
 
     [Fact]
-    public void Environment_NotOnOptions_ValueFromEnvVar()
+    public async Task Environment_NotOnOptions_ValueFromEnvVar()
     {
         const string expected = "environment";
 
-        EnvironmentVariableGuard.WithVariable("ASPNETCORE_ENVIRONMENT",
+        await EnvironmentVariableGuard.WithVariableAsync("ASPNETCORE_ENVIRONMENT",
             expected,
-            () =>
+            async () =>
             {
                 Build();
-                _ = HttpClient.GetAsync("/throw").GetAwaiter().GetResult();
+                _ = await HttpClient.GetAsync("/throw");
 
                 _ = Worker.Received(1).EnqueueEnvelope(Arg.Is<Envelope>(e =>
                     e.Items
@@ -315,19 +315,19 @@ public class IntegrationMockedBackgroundWorker : SentrySdkTestFixture
     }
 
     [Fact]
-    public void Environment_BothOnOptionsAndEnvVar_ValueFromOption()
+    public async Task Environment_BothOnOptionsAndEnvVar_ValueFromOption()
     {
         const string expected = "environment";
         const string other = "other";
 
         Configure = o => o.Environment = expected;
 
-        EnvironmentVariableGuard.WithVariable("ASPNETCORE_ENVIRONMENT",
+        await EnvironmentVariableGuard.WithVariableAsync("ASPNETCORE_ENVIRONMENT",
             other,
-            () =>
+            async () =>
             {
                 Build();
-                _ = HttpClient.GetAsync("/throw").GetAwaiter().GetResult();
+                _ = await HttpClient.GetAsync("/throw");
 
                 _ = Worker.Received(1).EnqueueEnvelope(Arg.Is<Envelope>(e =>
                     e.Items

--- a/test/Sentry.Google.Cloud.Functions.Tests/IntegrationTests.cs
+++ b/test/Sentry.Google.Cloud.Functions.Tests/IntegrationTests.cs
@@ -23,9 +23,10 @@ public class IntegrationTests
         var evt = new ManualResetEventSlim();
 
         var requests = new List<string>();
-        void Verify(HttpRequestMessage message)
+        async Task VerifyAsync(HttpRequestMessage message)
         {
-            requests.Add(message.Content.ReadAsStringAsync().Result);
+            var content = await message.Content.ReadAsStringAsync();
+            requests.Add(content);
             evt.Set();
         }
 
@@ -37,7 +38,7 @@ public class IntegrationTests
                     {
                         // So we can assert on the payload without the need to Gzip decompress
                         o.RequestBodyCompressionLevel = CompressionLevel.NoCompression;
-                        o.CreateHttpClientHandler = () => new CallbackHttpClientHandler(Verify);
+                        o.CreateHttpClientHandler = () => new CallbackHttpClientHandler(VerifyAsync);
                     });
                     services.AddFunctionTarget<FailingFunction>();
                 })

--- a/test/Sentry.Testing/CallbackHttpClientHandler.cs
+++ b/test/Sentry.Testing/CallbackHttpClientHandler.cs
@@ -5,13 +5,13 @@ namespace Sentry.Testing;
 
 public class CallbackHttpClientHandler : HttpClientHandler
 {
-    private readonly Action<HttpRequestMessage> _messageCallback;
+    private readonly Func<HttpRequestMessage, Task> _asyncMessageCallback;
 
-    public CallbackHttpClientHandler(Action<HttpRequestMessage> messageCallback) => _messageCallback = messageCallback;
+    public CallbackHttpClientHandler(Func<HttpRequestMessage, Task> asyncMessageCallback) => _asyncMessageCallback = asyncMessageCallback;
 
-    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        _messageCallback(request);
-        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        await _asyncMessageCallback(request);
+        return new HttpResponseMessage(HttpStatusCode.OK);
     }
 }

--- a/test/Sentry.Testing/EnvironmentVariableGuard.cs
+++ b/test/Sentry.Testing/EnvironmentVariableGuard.cs
@@ -3,21 +3,35 @@ namespace Sentry.Testing;
 public static class EnvironmentVariableGuard
 {
     // To allow different xunit collections use of this
-    private static readonly object Lock = new();
+    private static readonly SemaphoreSlim Lock = new(1, 1);
 
     public static void WithVariable(string key, string value, Action action)
     {
-        lock (Lock)
+        Lock.Wait();
+        Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
+        try
         {
-            Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
-            try
-            {
-                action();
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable(key, null, EnvironmentVariableTarget.Process);
-            }
+            action();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(key, null, EnvironmentVariableTarget.Process);
+            Lock.Release();
+        }
+    }
+
+    public static async Task WithVariableAsync(string key, string value, Func<Task> asyncAction)
+    {
+        await Lock.WaitAsync();
+        Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
+        try
+        {
+            await asyncAction();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(key, null, EnvironmentVariableTarget.Process);
+            Lock.Release();
         }
     }
 }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -311,9 +311,9 @@ public class HubTests
         var expectedMessage = Guid.NewGuid().ToString();
 
         var requests = new List<string>();
-        void Verify(HttpRequestMessage message)
+        async Task VerifyAsync(HttpRequestMessage message)
         {
-            var payload = message.Content.ReadAsStringAsync().Result;
+            var payload = await message.Content.ReadAsStringAsync();
             requests.Add(payload);
             if (payload.Contains(expectedMessage))
             {
@@ -332,7 +332,7 @@ public class HubTests
             Dsn = DsnSamples.ValidDsnWithSecret,
             CacheDirectoryPath = cachePath, // To go through a round trip serialization of cached envelope
             RequestBodyCompressionLevel = CompressionLevel.NoCompression, //  So we don't need to deal with gzip'ed payload
-            CreateHttpClientHandler = () => new CallbackHttpClientHandler(Verify),
+            CreateHttpClientHandler = () => new CallbackHttpClientHandler(VerifyAsync),
             AutoSessionTracking = false, // Not to send some session envelope
             Debug = true,
             DiagnosticLevel = expectedLevel,

--- a/test/Sentry.Tests/Internals/BackgroundWorkerTests.cs
+++ b/test/Sentry.Tests/Internals/BackgroundWorkerTests.cs
@@ -84,19 +84,22 @@ public class BackgroundWorkerTests
     }
 
     [Fact]
-    public void Dispose_SwallowsException()
+    public async Task Dispose_SwallowsException()
     {
         _fixture.CancellationTokenSource.Dispose();
         var sut = _fixture.GetSut();
 
-        _ = Assert.Throws<AggregateException>(() => sut.WorkerTask.Wait(TimeSpan.FromSeconds(3)));
+        // We expect an exception here, because we disposed the cancellation token source
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => sut.WorkerTask);
+
+        // No exception should be thrown here
         sut.Dispose();
 
         Assert.Equal(TaskStatus.Faulted, sut.WorkerTask.Status);
     }
 
     [Fact]
-    public void Dispose_EventQueuedZeroShutdownTimeout_CantEmptyQueueBeforeShutdown()
+    public async Task Dispose_EventQueuedZeroShutdownTimeout_CantEmptyQueueBeforeShutdown()
     {
         _fixture.SentryOptions.ShutdownTimeout = default; // Don't wait
 
@@ -118,7 +121,10 @@ public class BackgroundWorkerTests
 
         _ = sut.EnqueueEnvelope(envelope);
 
-        Assert.True(sut.WorkerTask.Wait(TimeSpan.FromSeconds(5)));
+        // Wait 5 seconds for task to finish
+        await Task.WhenAny(sut.WorkerTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        Assert.Equal(TaskStatus.RanToCompletion, sut.WorkerTask.Status);
 
         // First event was sent, second hit transport with a cancelled token.
         // Third never taken from the queue
@@ -165,7 +171,7 @@ public class BackgroundWorkerTests
     }
 
     [Fact]
-    public void Create_CancelledTaskAndNoShutdownTimeout_ConsumesNoEvents()
+    public async Task Create_CancelledTaskAndNoShutdownTimeout_ConsumesNoEvents()
     {
         // Arrange
         _fixture.SentryOptions.ShutdownTimeout = default;
@@ -174,8 +180,8 @@ public class BackgroundWorkerTests
         // Act
         using var sut = _fixture.GetSut();
 
-        // Make sure task has finished
-        Assert.True(sut.WorkerTask.Wait(TimeSpan.FromSeconds(3)));
+        // Wait 3 seconds for task to finish
+        await Task.WhenAny(sut.WorkerTask, Task.Delay(TimeSpan.FromSeconds(3)));
 
         // Assert
         Assert.Equal(TaskStatus.RanToCompletion, sut.WorkerTask.Status);

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -29,11 +29,11 @@ public class CachingTransportTests
         };
 
         Exception exception = null;
-        var innerTransport = new HttpTransport(options, new HttpClient(new CallbackHttpClientHandler(message =>
+        var innerTransport = new HttpTransport(options, new HttpClient(new CallbackHttpClientHandler(async message =>
          {
              try
              {
-                 message.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                 await message.Content!.ReadAsStringAsync();
              }
              catch (Exception readStreamException)
              {


### PR DESCRIPTION
This is an attempt to resolve some flaky tests such as #1516, on the wild guess that blocking waits might be part of the reason they fail sometimes.  I updated a few others as well.

#skip-changelog