### PR TITLE
remove confusing message Successfully sent cached envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Ignore zero properties for MemoryInfo ([#1531](https://github.com/getsentry/sentry-dotnet/pull/1531))
 - Cleanup diagnostic source ([#1529](https://github.com/getsentry/sentry-dotnet/pull/1529))
+- Remove confusing message Successfully sent cached envelope ([#1542](https://github.com/getsentry/sentry-dotnet/pull/1542))
 
 ## 3.15.0
 

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -176,8 +176,6 @@ namespace Sentry.Internal.Http
                     _options.LogDebug("Sending cached envelope: {0}", envelope.TryGetEventId());
 
                     await _innerTransport.SendEnvelopeAsync(envelope, cancellation).ConfigureAwait(false);
-
-                    _options.LogDebug("Successfully sent cached envelope: {0}", envelope.TryGetEventId());
                 }
                 // OperationCancel should not log an error
                 catch (OperationCanceledException ex)


### PR DESCRIPTION
In the CachingTransport we have:

```
_options.LogDebug("Sending cached envelope: {0}", envelope.TryGetEventId());

await _innerTransport.SendEnvelopeAsync(envelope, cancellation).ConfigureAwait(false);

_options.LogDebug("Successfully sent cached envelope: {0}", envelope.TryGetEventId());
```

But inside the HttpTransport we have:

```
if (response.StatusCode != HttpStatusCode.OK)
{
    await HandleFailureAsync(response, processedEnvelope, cancellationToken).ConfigureAwait(false);
    return;
}
```

So for error response codes (eg bad payloads like #1523 ) it is swallowed.

so the diagnostic log says

```
Sending cached envelope: ...
Sentry rejected the envelope...
Successfully sent cached envelope...
```

IMO since HttpTransport  does a `Envelope '{0}' sent successfully` on success. the CachingTransport  `Successfully sent` is redundant on success, and misleading on failure.