### PR TITLE
add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,115 @@
+name: 🐞 Bug Report
+description: Tell us about something that's not working the way we (probably) intend.
+labels: ["Platform: .NET", "bug"]
+body:
+  - type: dropdown
+    id: nuget
+    attributes:
+      description: NuGet Package
+      label: Package
+      options:
+        - Sentry
+        - Sentry.AspNetCore
+        - Sentry.AspNetCore.Grpc
+        - Sentry.AspNet
+        - Sentry.EntityFramework
+        - Sentry.Google.Cloud.Functions
+        - Sentry.DiagnosticSource
+        - Sentry.Serilog
+        - Sentry.Nlog
+        - Sentry.Log4net
+        - Sentry.Extensions.Logging
+        - Sentry.Tunnel
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: dotnet_flavor
+    attributes:
+      description: .NET Flavor
+      label: .NET Flavor
+      options:
+        - .NET
+        - .NET Core
+        - .NET Framework
+        - Mono
+        - Xamarin
+        - IL2CPP
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: dotnet_version
+    attributes:
+      label: .NET Version
+      description: .NET Version
+      placeholder: 6.0.0 ← should look like this
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      description: Operating System
+      options:
+        - Windows
+        - Linux
+        - macOS
+        - Android
+        - iOS
+        - Browser
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: sentry_sdk_version
+    attributes:
+      label: SDK Version
+      description: Sentry SDK Version
+      placeholder: 6.0.0 ← should look like this
+    validations:
+      required: true
+
+  - type: input
+    id: sentry_version
+    attributes:
+      label: Self-Hosted Sentry Version
+      description: Leave blank if using sentry.io
+    validations:
+      required: false
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to Reproduce
+      description: How can we see what you're seeing? Specific is terrific.
+      placeholder: |-
+        1. foo
+        2. bar
+        3. baz
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result
+      description: Logs? Screenshots?
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |-
+        ## Thanks 🙏
+        Check our [triage docs](https://open.sentry.io/triage/) for what to expect next.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,29 @@
+name: 💡 Feature Request
+description: Tell us about a problem our SDK could solve but doesn't.
+labels: ["Platform: .NET", "enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem could Sentry solve that it doesn't?
+      placeholder: |-
+        I want to make whirled peas, but Sentry doesn't blend.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Solution Brainstorm
+      description: We know you have bright ideas to share ... share away, friend.
+      placeholder: |-
+        Add a blender to Sentry.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |-
+        ## Thanks 🙏
+        Check our [triage docs](https://open.sentry.io/triage/) for what to expect next.


### PR DESCRIPTION
The [first issue templates were added to `.github`](https://github.com/getsentry/.github/commit/bccbe66933649d855511d883ed4a279ed0a29dff) so we could have some basic guide for people to fill out in all repos.

![image](https://user-images.githubusercontent.com/1633368/159123650-b4fc0528-f941-4f8a-a14a-a609b2500a9e.png)

Since then, GH introduced a template, which is helpful as users can select an item instead of having to edit the template, or read comment blocks. We've recently started adopting this in more SDKs, [e.g Java/Android](https://github.com/getsentry/sentry-java/issues/new/choose)


#skip-changelog