### PR TITLE
chore: wrap GetFromRuntimeInformation() in try-catch

### DIFF
--- a/src/Sentry/PlatformAbstractions/RuntimeInfo.cs
+++ b/src/Sentry/PlatformAbstractions/RuntimeInfo.cs
@@ -102,20 +102,22 @@ namespace Sentry.PlatformAbstractions
 
         internal static Runtime? GetFromRuntimeInformation()
         {
+            string frameworkDescription;
             try
             {
                 // Preferred API: netstandard2.0
                 // https://github.com/dotnet/corefx/blob/master/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
                 // https://github.com/mono/mono/blob/90b49aa3aebb594e0409341f9dca63b74f9df52e/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs
                 // e.g: .NET Framework 4.7.2633.0, .NET Native, WebAssembly
-                var frameworkDescription = RuntimeInformation.FrameworkDescription;
-
-                return Parse(frameworkDescription);
+                // Note: this throws on some Unity IL2CPP versions
+                frameworkDescription = RuntimeInformation.FrameworkDescription;
             }
             catch
             {
                 return null;
             }
+
+            return Parse(frameworkDescription);
         }
 
         internal static Runtime? GetFromMonoRuntime()

--- a/src/Sentry/PlatformAbstractions/RuntimeInfo.cs
+++ b/src/Sentry/PlatformAbstractions/RuntimeInfo.cs
@@ -102,13 +102,20 @@ namespace Sentry.PlatformAbstractions
 
         internal static Runtime? GetFromRuntimeInformation()
         {
-            // Preferred API: netstandard2.0
-            // https://github.com/dotnet/corefx/blob/master/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
-            // https://github.com/mono/mono/blob/90b49aa3aebb594e0409341f9dca63b74f9df52e/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs
-            // e.g: .NET Framework 4.7.2633.0, .NET Native, WebAssembly
-            var frameworkDescription = RuntimeInformation.FrameworkDescription;
+            try
+            {
+                // Preferred API: netstandard2.0
+                // https://github.com/dotnet/corefx/blob/master/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
+                // https://github.com/mono/mono/blob/90b49aa3aebb594e0409341f9dca63b74f9df52e/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs
+                // e.g: .NET Framework 4.7.2633.0, .NET Native, WebAssembly
+                var frameworkDescription = RuntimeInformation.FrameworkDescription;
 
-            return Parse(frameworkDescription);
+                return Parse(frameworkDescription);
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         internal static Runtime? GetFromMonoRuntime()


### PR DESCRIPTION
This is a workaround for Unity 2020+ issue - throws on accessing `RuntimeInformation.FrameworkDescription` - [reported to Unity](https://fogbugz.unity3d.com/default.asp?1413035_ensfb816j2jfmq03)

#skip-changelog

