### PR TITLE
Do not re throw on a failed Attachment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- Fix event dropped by bad attachment when no logger is set.
+- Fix event dropped by bad attachment when no logger is set.  ([#1557](https://github.com/getsentry/sentry-dotnet/pull/1557))
 - Ignore zero properties for MemoryInfo ([#1531](https://github.com/getsentry/sentry-dotnet/pull/1531))
 - Cleanup diagnostic source ([#1529](https://github.com/getsentry/sentry-dotnet/pull/1529))
 - Remove confusing message Successfully sent cached envelope ([#1542](https://github.com/getsentry/sentry-dotnet/pull/1542))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- Fix event dropped by bad attachment when no logger is set.  ([#1557](https://github.com/getsentry/sentry-dotnet/pull/1557))
+- Fix event dropped by bad attachment when no logger is set. ([#1557](https://github.com/getsentry/sentry-dotnet/pull/1557))
 - Ignore zero properties for MemoryInfo ([#1531](https://github.com/getsentry/sentry-dotnet/pull/1531))
 - Cleanup diagnostic source ([#1529](https://github.com/getsentry/sentry-dotnet/pull/1529))
 - Remove confusing message Successfully sent cached envelope ([#1542](https://github.com/getsentry/sentry-dotnet/pull/1542))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Fix event dropped by bad attachment when no logger is set.
 - Ignore zero properties for MemoryInfo ([#1531](https://github.com/getsentry/sentry-dotnet/pull/1531))
 - Cleanup diagnostic source ([#1529](https://github.com/getsentry/sentry-dotnet/pull/1529))
 - Remove confusing message Successfully sent cached envelope ([#1542](https://github.com/getsentry/sentry-dotnet/pull/1542))

--- a/src/Sentry/Envelopes/Envelope.cs
+++ b/src/Sentry/Envelopes/Envelope.cs
@@ -132,12 +132,7 @@ namespace Sentry.Protocol.Envelopes
                     }
                     catch (Exception exception)
                     {
-                        if (logger is null)
-                        {
-                            throw;
-                        }
-
-                        logger.LogError("Failed to add attachment: {0}.", exception, attachment.FileName);
+                        logger?.LogError("Failed to add attachment: {0}.", exception, attachment.FileName);
                     }
                 }
             }


### PR DESCRIPTION
The code behavior from CaptureEnvelope when capturing an event diverges when an attachment fails to get the stream content.
- With the logger set, the event is sent without the failed attachment and logs a warning about the failed attachment.
- Without the logger set (Debug = false), the events gets dropped by the failed attachment.

This PR fixes the behavior when debug is set to false by only dropping the failed attachment and not the event.