### PR TITLE
Recommend using x64 SDKs on Rider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ The M1 ("Apple silicon") is an Arm64 processor. While .NET 6 runs natively on th
     chmod +x ./dotnet-install.sh
     sudo ./dotnet-install.sh --version 2.1.818 --arch x64 --install-dir /usr/local/share/dotnet/x64
      ```
-- If using JetBrains Rider, use it to launch `Sentry.sln` (or one of the `slnf` files).  Then go to `Preferences` -> `Build, Execution, Deployment` -> `Toolset and Build`, and set the following, which will tell JetBrains to use the x64 versions of the SDKs.  (This is *required* to run unit tests or debug using .NET 5.0 and earlier .NET Core SDKs.)
+- If using JetBrains Rider, use it to launch `Sentry.sln` (or one of the `slnf` files).  Then go to `Preferences` -> `Build, Execution, Deployment` -> `Toolset and Build`, and set the following, which will tell Rider to use the x64 versions of the SDKs.  (This is *required* to run unit tests or debug using .NET 5.0 and earlier .NET Core SDKs.)
   - .NET Core CLI executable path: `/usr/local/share/dotnet/x64/dotnet`
   - Use MSBuild version: `17.0 - /usr/local/share/dotnet/x64/sdk/6.0.201/MSBuild.dll` (or higher version)
   - Click the arrow next to the "Save" button and choose `Solution "Sentry" personal"` to save these settings locally for yourself only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,10 @@ The M1 ("Apple silicon") is an Arm64 processor. While .NET 6 runs natively on th
     chmod +x ./dotnet-install.sh
     sudo ./dotnet-install.sh --version 2.1.818 --arch x64 --install-dir /usr/local/share/dotnet/x64
      ```
-- If using JetBrains Rider, launch it, go to `Preferences` -> `Build, Execution, Deployment` -> `Toolset and Build`, and set the following:
-  - .NET Core CLI executable path: `/usr/local/share/dotnet/dotnet` (*not* x64)
-  - Use MSBuild version: `17.0 - /usr/local/share/dotnet/sdk/6.0.201/MSBuild.dll` (or higher version)
+- If using JetBrains Rider, use it to launch `Sentry.sln` (or one of the `slnf` files).  Then go to `Preferences` -> `Build, Execution, Deployment` -> `Toolset and Build`, and set the following, which will tell JetBrains to use the x64 versions of the SDKs.  (This is *required* to run unit tests or debug using .NET 5.0 and earlier .NET Core SDKs.)
+  - .NET Core CLI executable path: `/usr/local/share/dotnet/x64/dotnet`
+  - Use MSBuild version: `17.0 - /usr/local/share/dotnet/x64/sdk/6.0.201/MSBuild.dll` (or higher version)
+  - Click the arrow next to the "Save" button and choose `Solution "Sentry" personal"` to save these settings locally for yourself only.
 
 Note that if you have accidentally corrupted your .NET installation by trying to install the .NET Core 2.1 SDK to the default location, you can wipe clean with the following, then start over:
 


### PR DESCRIPTION
Updated the contributing doc to recommend M1 devs use the x64 dotnet/msbuild toolchain from Rider.  This lets you test/debug in Rider under all targets.

See https://youtrack.jetbrains.com/issue/RIDER-75864#focus=Comments-27-5954593.0-0

#skip-changelog