### PR TITLE
Only build DiagnosticSource tests in Release mode for .NET Core 3.0

### DIFF
--- a/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
+++ b/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
@@ -1,7 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp3.0;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
+  </PropertyGroup>
+
+  <!--
+  Build these tests for .NET Core 3.0 only in Release configuration.
+  This avoids false-negatives with solution analysis.
+  See https://github.com/getsentry/sentry-dotnet/pull/1563
+  -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <TargetFrameworks>$(TargetFrameworks);netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">


### PR DESCRIPTION
In Rider (at least on my machine), I always get false-negatives from the solution analysis.  There are no issues at build time and all tests pass, but the IDE always shows there are problems anyway.  This is a bit of friction that I'd like to remove.

<img width="236" alt="Screen Shot 2022-04-01 at 2 00 01 PM" src="https://user-images.githubusercontent.com/1396388/161342248-85fa194b-0002-47a2-8f08-22538618c720.png">

<img width="925" alt="Screen Shot 2022-04-01 at 2 15 15 PM" src="https://user-images.githubusercontent.com/1396388/161342259-20dbd4cc-2cb9-4ec1-97d8-1c62b47924b2.png">

The problems go away if the test project doesn't target .NET Core 3.0.  Since solution analysis always runs in `Debug` configuration, the easiest fix I could think of was to only build the `netcoreapp3.0` target in `Release` configuration.  Our `build.sh` and `build.ps1` scripts run tests in `Release` configuration, and thus so does CI, so I don't think there's a lot of risk in this change.

After this change, it looks like this:

<img width="1049" alt="image" src="https://user-images.githubusercontent.com/1396388/161342930-b80e77f7-392f-4a7a-8247-5e78c988a75f.png">


#skip-changelog