### PR TITLE
Add UseAsyncFileIO option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Use a default value of 60 seconds if a `Retry-After` header is not present. ([#1537](https://github.com/getsentry/sentry-dotnet/pull/1537))
 - Add new Protocol definitions for DebugImages and AddressMode ([#1513](https://github.com/getsentry/sentry-dotnet/pull/1513))
 - Add `HttpTransport` extensibility and synchronous serialization support ([#1560](https://github.com/getsentry/sentry-dotnet/pull/1560))
+- Add `UseAsyncFileIO` to Sentry options (enabled by default) ([#1564](https://github.com/getsentry/sentry-dotnet/pull/1564))
 
 ### Fixes
 

--- a/src/Sentry/FileAttachmentContent.cs
+++ b/src/Sentry/FileAttachmentContent.cs
@@ -14,8 +14,16 @@ namespace Sentry
         /// Creates a new instance of <see cref="FileAttachmentContent"/>.
         /// </summary>
         /// <param name="filePath">The path to the file to attach.</param>
+        public FileAttachmentContent(string filePath) : this(filePath, true)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="FileAttachmentContent"/>.
+        /// </summary>
+        /// <param name="filePath">The path to the file to attach.</param>
         /// <param name="readFileAsynchronously">Whether to use async file I/O to read the file.</param>
-        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true)
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously)
         {
             _filePath = filePath;
             _readFileAsynchronously = readFileAsynchronously;

--- a/src/Sentry/FileAttachmentContent.cs
+++ b/src/Sentry/FileAttachmentContent.cs
@@ -8,11 +8,18 @@ namespace Sentry
     public class FileAttachmentContent : IAttachmentContent
     {
         private readonly string _filePath;
+        private readonly bool _readFileAsynchronously;
 
         /// <summary>
         /// Creates a new instance of <see cref="FileAttachmentContent"/>.
         /// </summary>
-        public FileAttachmentContent(string filePath) => _filePath = filePath;
+        /// <param name="filePath">The path to the file to attach.</param>
+        /// <param name="readFileAsynchronously">Whether to use async file I/O to read the file.</param>
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true)
+        {
+            _filePath = filePath;
+            _readFileAsynchronously = readFileAsynchronously;
+        }
 
         /// <inheritdoc />
         public Stream GetStream() => new FileStream(
@@ -21,6 +28,6 @@ namespace Sentry
             FileAccess.Read,
             FileShare.ReadWrite,
             bufferSize: 4096,
-            useAsync: true);
+            useAsync: _readFileAsynchronously);
     }
 }

--- a/src/Sentry/ScopeExtensions.cs
+++ b/src/Sentry/ScopeExtensions.cs
@@ -159,7 +159,7 @@ namespace Sentry
             scope.AddAttachment(
                 new Attachment(
                     type,
-                    new FileAttachmentContent(filePath),
+                    new FileAttachmentContent(filePath, scope.Options.UseAsyncFileIO),
                     Path.GetFileName(filePath),
                     contentType));
 

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -565,6 +565,15 @@ namespace Sentry
         public bool AutoSessionTracking { get; set; } = false;
 
         /// <summary>
+        /// Whether the SDK should attempt to use asynchronous file I/O.
+        /// For example, when reading a file to use as an attachment.
+        /// </summary>
+        /// <remarks>
+        /// This option should rarely be disabled, but is necessary in some environments such as Unity WebGL.
+        /// </remarks>
+        public bool UseAsyncFileIO { get; set; } = true;
+
+        /// <summary>
         /// Delegate which is used to check whether the application crashed during last run.
         /// </summary>
         public Func<bool>? CrashedLastRun { get; set; }

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -111,7 +111,7 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions
@@ -497,6 +497,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
     {

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -111,7 +111,8 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
+        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -111,7 +111,7 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions
@@ -497,6 +497,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
     {

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -111,7 +111,8 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
+        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -111,7 +111,7 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions
@@ -497,6 +497,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
     {

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -111,7 +111,8 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
+        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -111,7 +111,7 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions
@@ -497,6 +497,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -111,7 +111,8 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
+        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -111,7 +111,7 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions
@@ -497,6 +497,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -111,7 +111,8 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
+        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -111,7 +111,7 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions
@@ -497,6 +497,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -111,7 +111,8 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
+        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -111,7 +111,7 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions
@@ -496,6 +496,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -111,7 +111,8 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
+        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -111,7 +111,7 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions
@@ -497,6 +497,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -111,7 +111,8 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
+        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -111,7 +111,7 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions
@@ -497,6 +497,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -111,7 +111,8 @@ namespace Sentry
     }
     public class FileAttachmentContent : Sentry.IAttachmentContent
     {
-        public FileAttachmentContent(string filePath, bool readFileAsynchronously = true) { }
+        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasBreadcrumbsExtensions


### PR DESCRIPTION
Adds an option to control whether async file i/o is used when reading attachments from disk.

This was hard-coded previously, but created a problem for when adding support for Unity WebGL.

@vaind - I think this should unblock you?