### PR TITLE
Commit shared vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 .vscode/*
 !.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
 .idea/
 .vs/
 *.userprefs
@@ -22,7 +19,4 @@ docs/_site/*
 docs/docfx/*
 docs/docfx.zip
 /samples/Sentry.Samples.Aws.Lambda.AspNetCoreServer/Properties/launchSettings.json
-
 *.received.*
-
-.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "omnisharp.useModernNet": true
+}


### PR DESCRIPTION
The `"omnisharp.useModernNet": true` setting is required for macOS on M1, and works great in other environments.  Checking it in here will save some pain for others.

#skip-changelog