### PR TITLE
Fix bug report GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,6 +52,7 @@ body:
   - type: dropdown
     id: os
     attributes:
+      label: OS
       description: Operating System
       options:
         - Windows


### PR DESCRIPTION
Creating a new issue is only showing the feature request template.  The bug report template isn't available.

![image](https://user-images.githubusercontent.com/1396388/161601312-fee2a77b-2955-48d7-9cd4-cc2e7884dda8.png)

Editing the bug report template on GitHub shows the problem

![image](https://user-images.githubusercontent.com/1396388/161601345-d8acff3f-69c7-45f3-859a-308509820827.png)

Adding the missing label should help.

#skip-changelog