### PR TITLE
Add workaround for apphost signing issue on M1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ The M1 ("Apple silicon") is an Arm64 processor. While .NET 6 runs natively on th
 - If using JetBrains Rider, use it to launch `Sentry.sln` (or one of the `slnf` files).  Then go to `Preferences` -> `Build, Execution, Deployment` -> `Toolset and Build`, and set the following, which will tell Rider to use the x64 versions of the SDKs.  (This is *required* to run unit tests or debug using .NET 5.0 and earlier .NET Core SDKs.)
   - .NET Core CLI executable path: `/usr/local/share/dotnet/x64/dotnet`
   - Use MSBuild version: `17.0 - /usr/local/share/dotnet/x64/sdk/6.0.201/MSBuild.dll` (or higher version)
+  - Under `MSBuild global properties` add a new item with name `_EnableMacOSCodeSign` and value `false`.  (See [dotnet/sdk#2201](https://github.com/dotnet/sdk/issues/22201#issuecomment-1089129133))
   - Click the arrow next to the "Save" button and choose `Solution "Sentry" personal"` to save these settings locally for yourself only.
 
 Note that if you have accidentally corrupted your .NET installation by trying to install the .NET Core 2.1 SDK to the default location, you can wipe clean with the following, then start over:


### PR DESCRIPTION
I started getting build errors on some projects after applying the latest macOS 12.3.1 update:

```
Microsoft.NET.Sdk.targets(550, 5): [NETSDK1177] Failed to sign apphost with error code 0: 
/Users/matt/Code/getsentry/sentry-dotnet/benchmarks/Sentry.Benchmarks/obj/Debug/net6.0/apphost: is already signed
```

Applying the workaround I suggested in https://github.com/dotnet/sdk/issues/22201#issuecomment-1089129133 resolves the issue.  Added a note about it to our contributing docs for now.  If it doesn't get resolved in .NET, we can consider disabling code signing in the csproj instead.

#skip-changelog