### PR TITLE
Fix wrong assertion in unit test

### DIFF
--- a/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
@@ -371,7 +371,7 @@ public class HttpTransportTests
             e.Message == "Failed to add attachment: {0}." &&
             (string)e.Args[0] == "test1.txt");
 
-        actualEnvelopeSerialized.Should().NotContain("test2.txt");
+        actualEnvelopeSerialized.Should().NotContain("test1.txt");
     }
 
     [Fact]


### PR DESCRIPTION
Just noticed that `SendEnvelopeAsync_AttachmentFail_DropsItem` was checking for the wrong string.

#skip-changelog