### PR TITLE
remove code coverage exclude from build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -4,7 +4,6 @@ $testLogger = if ($env:GITHUB_ACTIONS -eq "true") {"GitHubActions;report-warning
 
 dotnet test SentryNoSamples.slnf -c Release -l $testLogger `
     /p:CopyLocalLockFileAssemblies=true `
-    /p:Exclude='"""[Sentry.Protocol.Test*]*,[xunit.*]*,[System.*]*,[Microsoft.*]*,[Sentry.Test*]*\"""'
 if ($LASTEXITCODE -ne 0) { exit 1 }
 
 dotnet pack SentryNoSamples.slnf -c Release /p:ContinuousIntegrationBuild=true

--- a/build.ps1
+++ b/build.ps1
@@ -3,7 +3,7 @@ $ErrorActionPreference = "Stop"
 $testLogger = if ($env:GITHUB_ACTIONS -eq "true") {"GitHubActions;report-warnings=false"} else {"console"}
 
 dotnet test SentryNoSamples.slnf -c Release -l $testLogger `
-    /p:CopyLocalLockFileAssemblies=true `
+    /p:CopyLocalLockFileAssemblies=true
 if ($LASTEXITCODE -ne 0) { exit 1 }
 
 dotnet pack SentryNoSamples.slnf -c Release /p:ContinuousIntegrationBuild=true

--- a/build.sh
+++ b/build.sh
@@ -10,5 +10,4 @@ fi
 
 dotnet test SentryNoSamples.slnf -c Release -l $testLogger \
     /p:CopyLocalLockFileAssemblies=true \
-    /p:Exclude=\"[Sentry.Protocol.Test*]*,[xunit.*]*,[System.*]*,[Microsoft.*]*,[Sentry.Test*]*\" \
     /p:UseSourceLink=true


### PR DESCRIPTION
#skip-changelog

reverts this https://github.com/getsentry/sentry-dotnet/pull/1522 since we dont have code coverage atm