### PR TITLE
Demystify beforesend stacktraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Workaround `System.Text.Json` issue with Unity IL2CPP. ([#1583](https://github.com/getsentry/sentry-dotnet/pull/1583))
+- Demystify stack traces for exceptions that fire in a `BeforeSend` callback. ([#1587](https://github.com/getsentry/sentry-dotnet/pull/1587))
 
 ## 3.16.0
 

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -255,6 +255,9 @@ namespace Sentry
             }
             catch (Exception e)
             {
+                // Attempt to demystify exceptions before adding them as breadcrumbs.
+                e.Demystify();
+
                 _options.LogError("The BeforeSend callback threw an exception. It will be added as breadcrumb and continue.", e);
                 var data = new Dictionary<string, string>
                 {

--- a/test/Sentry.Tests/SentryClientTests.CaptureEvent_BeforeEventThrows_ErrorToEventBreadcrumb.verified.txt
+++ b/test/Sentry.Tests/SentryClientTests.CaptureEvent_BeforeEventThrows_ErrorToEventBreadcrumb.verified.txt
@@ -5,8 +5,8 @@
     Data: {
       message: Exception message!,
       stackTrace:
-at Sentry.Tests.SentryClientTests.<>c__DisplayClass21_0.<CaptureEvent_BeforeEventThrows_ErrorToEventBreadcrumb>b__0(...)
-at Sentry.SentryClient.BeforeSend(...)
+at Task Sentry.Tests.SentryClientTests.CaptureEvent_BeforeEventThrows_ErrorToEventBreadcrumb()
+at SentryEvent Sentry.SentryClient.BeforeSend(...)
     },
     Category: SentryClient,
     Level: error


### PR DESCRIPTION
When an exception is thrown in a `BeforeSend` callback, we add it as a breadcrumb, including a stack trace.  This PR makes sure that stack trace is demystified.

I found this because the test for it broke when adding a different test to the same test class.  The test serializes the exception, including the stack trace, and verifies the exception matched the previous serialized version.  I see in the git history that this has happened a few times before.  This PR will also make the test less fragile.