### PR TITLE
Fix options internal reference to transport

### DIFF
--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -38,6 +38,9 @@ namespace Sentry.Internal.Http
         private readonly CancellationTokenSource _workerCts = new();
         private Task _worker = null!;
 
+        // Inner transport exposed internally primarily for testing
+        internal ITransport InnerTransport => _innerTransport;
+
         public static CachingTransport Create(ITransport innerTransport, SentryOptions options)
         {
             var transport = new CachingTransport(innerTransport, options);

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -47,7 +47,10 @@ namespace Sentry
         /// </summary>
         public bool EnableScopeSync { get; set; }
 
-        // Override for tests
+        /// <summary>
+        /// This holds a reference to the current transport, when one is active.
+        /// If set manually (for tests), it will be used instead of the default transport.
+        /// </summary>
         internal ITransport? Transport { get; set; }
 
         internal ISentryStackTraceFactory? SentryStackTraceFactory { get; set; }

--- a/test/Sentry.Tests/SentryOptionsTests.cs
+++ b/test/Sentry.Tests/SentryOptionsTests.cs
@@ -23,6 +23,13 @@ public class SentryOptionsTests
         Assert.Equal(CompressionLevel.Optimal, sut.RequestBodyCompressionLevel);
     }
 
+    [Fact]
+    public void Transport_ByDefault_IsNull()
+    {
+        var sut = new SentryOptions();
+        Assert.Null(sut.Transport);
+    }
+
 #if NET461
     [SkippableFact(typeof(IsTypeException))]
     public void StackTraceFactory_RunningOnMono_HasMonoStackTraceFactory()


### PR DESCRIPTION
While working on #1556, I found out that while the internal property `SentryOptions.Transport` is available, it is null unless manually set by a unit test.  For client reports to work, I'll need it to be populated with the current transport so I can access the transport from `SentryClient`.

I also found that if a transport is set on the options, and a cache path is also set, caching doesn't work because it was just using the provided transport as-is without wrapping it in a `CachingTransport`.

This PR fixes both, and adds tests.  There should be no externally noticeable behavior changed, so #skip-changelog