### PR TITLE
Improve caching transport tests

### DIFF
--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -454,7 +454,7 @@ public class CachingTransportTests
             return;
         }
 
-        var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(7));
+        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(7));
 
         using var watcher = new FileSystemWatcher(directoryPath);
         watcher.IncludeSubdirectories = true;

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -468,6 +468,14 @@ public class CachingTransportTests
             var tcs = new TaskCompletionSource<bool>();
             cts.Token.Register(() => tcs.TrySetCanceled());
             watcher.Deleted += (_, _) => tcs.SetResult(true);
+
+            // One final check before waiting
+            if (DirectoryIsEmpty())
+            {
+                return;
+            }
+
+            // Wait for a file to be deleted
             await tcs.Task;
         }
     }

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -79,6 +79,7 @@ public class CachingTransportTests
         {
             Dsn = DsnSamples.ValidDsnWithoutSecret,
             DiagnosticLogger = _logger,
+            Debug = true,
             CacheDirectoryPath = cacheDirectory.Path
         };
 
@@ -233,6 +234,7 @@ public class CachingTransportTests
         {
             Dsn = DsnSamples.ValidDsnWithoutSecret,
             DiagnosticLogger = _logger,
+            Debug = true,
             CacheDirectoryPath = cacheDirectory.Path,
             MaxCacheItems = 2
         };
@@ -268,6 +270,7 @@ public class CachingTransportTests
         {
             Dsn = DsnSamples.ValidDsnWithoutSecret,
             DiagnosticLogger = _logger,
+            Debug = true,
             CacheDirectoryPath = cacheDirectory.Path
         };
 
@@ -349,6 +352,7 @@ public class CachingTransportTests
         {
             Dsn = DsnSamples.ValidDsnWithoutSecret,
             DiagnosticLogger = _logger,
+            Debug = true,
             CacheDirectoryPath = cacheDirectory.Path
         };
 
@@ -415,6 +419,7 @@ public class CachingTransportTests
         {
             Dsn = DsnSamples.ValidDsnWithoutSecret,
             DiagnosticLogger = _logger,
+            Debug = true,
             CacheDirectoryPath = cacheDirectory.Path
         };
 


### PR DESCRIPTION
This PR improves caching transport tests, as follows:

- Adds `Debug = true` to options in all tests, so that future test failures will have more detail logged.
- Removes the delay loop in `EnvelopeReachesInnerTransport` by hooking the existing `FakeTransport.EnvelopeSent` event, which should resolve #1591 
- Removes the delay loops in three other tests where the test needed to wait for a directory to become empty.  Refactored and replaced with a `FileSystemWatcher` based implementation.

#skip-changelog