### PR TITLE
chore: Added documentation to InApp options extension methods

### DIFF
--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -139,7 +139,7 @@ namespace Sentry
         /// Whether to report the <see cref="System.Environment.UserName"/> as the User affected in the event.
         /// </summary>
         /// <remarks>
-        /// This configuration is only relevant is <see cref="SendDefaultPii"/> is set to true.
+        /// This configuration is only relevant if <see cref="SendDefaultPii"/> is set to true.
         /// In environments like server applications this is set to false in order to not report server account names as user names.
         /// </remarks>
         public bool IsEnvironmentUser { get; set; } = true;

--- a/src/Sentry/SentryOptionsExtensions.cs
+++ b/src/Sentry/SentryOptionsExtensions.cs
@@ -117,16 +117,36 @@ namespace Sentry
             => options.AddExceptionFilter(new ExceptionTypeFilter<TException>());
 
         /// <summary>
-        /// Add prefix to exclude from 'InApp' stack trace list.
+        /// Add prefix to exclude from 'InApp' stacktrace list.
         /// </summary>
+        /// <param name="options">The SentryOptions which holds the stacktrace list.</param>
+        /// <param name="prefix">The string used to filter the stacktrace to be excluded from InApp.</param>
+        /// <remarks>
+        /// Sentry by default filters the stacktrace to display only application code.
+        /// A user can optionally click to see all which will include framework and libraries.
+        /// A <see cref="string.StartsWith(string)"/> is executed
+        /// </remarks>
+        /// <example>
+        /// 'System.', 'Microsoft.'
+        /// </example>
         public static void AddInAppExclude(this SentryOptions options, string prefix)
             => options.InAppExclude = options.InAppExclude != null
                 ? options.InAppExclude.Concat(new[] { prefix }).ToArray()
                 : new[] { prefix };
 
         /// <summary>
-        /// Add prefix to include as in 'InApp' stack trace.
+        /// Add prefix to include as in 'InApp' stacktrace.
         /// </summary>
+        /// <param name="options">The SentryOptions which holds the stacktrace list.</param>
+        /// <param name="prefix">The string used to filter the stacktrace to be included in InApp.</param>
+        /// <remarks>
+        /// Sentry by default filters the stacktrace to display only application code.
+        /// A user can optionally click to see all which will include framework and libraries.
+        /// A <see cref="string.StartsWith(string)"/> is executed
+        /// </remarks>
+        /// <example>
+        /// 'System.CustomNamespace', 'Microsoft.Azure.App'
+        /// </example>
         public static void AddInAppInclude(this SentryOptions options, string prefix)
             => options.InAppInclude = options.InAppInclude != null
                 ? options.InAppInclude.Concat(new[] { prefix }).ToArray()


### PR DESCRIPTION
The options properties for InAppInclude/Exclude are internal but made accessible via the OptionsExtension. Unfortunately, this means the XML documentation gets lost on its way to the user.

#skip-changelog