### PR TITLE
Make ITransport and SentryOptions.Transport public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Expose `ITransport` and `SentryOptions.Transport` public, to support using custom transports ([#1602](https://github.com/getsentry/sentry-dotnet/pull/1602)
+- Expose `ITransport` and `SentryOptions.Transport` public, to support using custom transports ([#1602](https://github.com/getsentry/sentry-dotnet/pull/1602))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Expose `ITransport` and `SentryOptions.Transport` public, to support using custom transports ([#1602](https://github.com/getsentry/sentry-dotnet/pull/1602)
+
 ### Fixes
 
 - Workaround `System.Text.Json` issue with Unity IL2CPP. ([#1583](https://github.com/getsentry/sentry-dotnet/pull/1583))

--- a/src/Sentry/Extensibility/ITransport.cs
+++ b/src/Sentry/Extensibility/ITransport.cs
@@ -16,9 +16,4 @@ namespace Sentry.Extensibility
         /// <param name="cancellationToken">The cancellation token.</param>
         Task SendEnvelopeAsync(Envelope envelope, CancellationToken cancellationToken = default);
     }
-
-    internal interface IFlushableTransport : ITransport
-    {
-        Task FlushAsync(CancellationToken cancellationToken = default);
-    }
 }

--- a/src/Sentry/Extensibility/ITransport.cs
+++ b/src/Sentry/Extensibility/ITransport.cs
@@ -7,7 +7,7 @@ namespace Sentry.Extensibility
     /// <summary>
     /// An abstraction to the transport of the event.
     /// </summary>
-    internal interface ITransport
+    public interface ITransport
     {
         /// <summary>
         /// Sends the <see cref="Envelope" /> to Sentry asynchronously.

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -11,7 +11,7 @@ using Sentry.Protocol.Envelopes;
 
 namespace Sentry.Internal.Http
 {
-    internal class CachingTransport : IFlushableTransport, IAsyncDisposable, IDisposable
+    internal class CachingTransport : ITransport, IAsyncDisposable, IDisposable
     {
         private const string EnvelopeFileExt = "envelope";
 

--- a/src/Sentry/Internal/SdkComposer.cs
+++ b/src/Sentry/Internal/SdkComposer.cs
@@ -52,7 +52,7 @@ namespace Sentry.Internal
             return new HttpTransport(_options, httpClient);
         }
 
-        internal void BlockCacheFlush(IFlushableTransport transport)
+        internal void BlockCacheFlush(CachingTransport transport)
         {
             // If configured, flush existing cache
             if (_options.InitCacheFlushTimeout > TimeSpan.Zero)

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -8,6 +8,7 @@ using Sentry.Extensibility;
 using Sentry.Http;
 using Sentry.Integrations;
 using Sentry.Internal;
+using Sentry.Internal.Http;
 using Sentry.Internal.ScopeStack;
 using static Sentry.Constants;
 using static Sentry.Internal.Constants;
@@ -49,9 +50,13 @@ namespace Sentry
 
         /// <summary>
         /// This holds a reference to the current transport, when one is active.
-        /// If set manually (for tests), it will be used instead of the default transport.
+        /// If set manually before initialization, the provided transport will be used instead of the default transport.
         /// </summary>
-        internal ITransport? Transport { get; set; }
+        /// <remarks>
+        /// If <seealso cref="CacheDirectoryPath"/> is set, any transport set here will be wrapped in a
+        /// <seealso cref="CachingTransport"/> and used as its inner transport.
+        /// </remarks>
+        public ITransport? Transport { get; set; }
 
         internal ISentryStackTraceFactory? SentryStackTraceFactory { get; set; }
 

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -498,6 +498,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public Sentry.Extensibility.ITransport? Transport { get; set; }
         public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
@@ -1037,6 +1038,10 @@ namespace Sentry.Extensibility
     public interface ISentryStackTraceFactory
     {
         Sentry.SentryStackTrace? Create(System.Exception? exception = null);
+    }
+    public interface ITransport
+    {
+        System.Threading.Tasks.Task SendEnvelopeAsync(Sentry.Protocol.Envelopes.Envelope envelope, System.Threading.CancellationToken cancellationToken = default);
     }
     public class RequestBodyExtractionDispatcher : Sentry.Extensibility.IRequestPayloadExtractor
     {

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -498,6 +498,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public Sentry.Extensibility.ITransport? Transport { get; set; }
         public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
@@ -1037,6 +1038,10 @@ namespace Sentry.Extensibility
     public interface ISentryStackTraceFactory
     {
         Sentry.SentryStackTrace? Create(System.Exception? exception = null);
+    }
+    public interface ITransport
+    {
+        System.Threading.Tasks.Task SendEnvelopeAsync(Sentry.Protocol.Envelopes.Envelope envelope, System.Threading.CancellationToken cancellationToken = default);
     }
     public class RequestBodyExtractionDispatcher : Sentry.Extensibility.IRequestPayloadExtractor
     {

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -498,6 +498,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public Sentry.Extensibility.ITransport? Transport { get; set; }
         public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
@@ -1037,6 +1038,10 @@ namespace Sentry.Extensibility
     public interface ISentryStackTraceFactory
     {
         Sentry.SentryStackTrace? Create(System.Exception? exception = null);
+    }
+    public interface ITransport
+    {
+        System.Threading.Tasks.Task SendEnvelopeAsync(Sentry.Protocol.Envelopes.Envelope envelope, System.Threading.CancellationToken cancellationToken = default);
     }
     public class RequestBodyExtractionDispatcher : Sentry.Extensibility.IRequestPayloadExtractor
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -498,6 +498,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public Sentry.Extensibility.ITransport? Transport { get; set; }
         public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
@@ -1036,6 +1037,10 @@ namespace Sentry.Extensibility
     public interface ISentryStackTraceFactory
     {
         Sentry.SentryStackTrace? Create(System.Exception? exception = null);
+    }
+    public interface ITransport
+    {
+        System.Threading.Tasks.Task SendEnvelopeAsync(Sentry.Protocol.Envelopes.Envelope envelope, System.Threading.CancellationToken cancellationToken = default);
     }
     public class RequestBodyExtractionDispatcher : Sentry.Extensibility.IRequestPayloadExtractor
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -498,6 +498,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public Sentry.Extensibility.ITransport? Transport { get; set; }
         public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
@@ -1036,6 +1037,10 @@ namespace Sentry.Extensibility
     public interface ISentryStackTraceFactory
     {
         Sentry.SentryStackTrace? Create(System.Exception? exception = null);
+    }
+    public interface ITransport
+    {
+        System.Threading.Tasks.Task SendEnvelopeAsync(Sentry.Protocol.Envelopes.Envelope envelope, System.Threading.CancellationToken cancellationToken = default);
     }
     public class RequestBodyExtractionDispatcher : Sentry.Extensibility.IRequestPayloadExtractor
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -498,6 +498,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public Sentry.Extensibility.ITransport? Transport { get; set; }
         public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
@@ -1037,6 +1038,10 @@ namespace Sentry.Extensibility
     public interface ISentryStackTraceFactory
     {
         Sentry.SentryStackTrace? Create(System.Exception? exception = null);
+    }
+    public interface ITransport
+    {
+        System.Threading.Tasks.Task SendEnvelopeAsync(Sentry.Protocol.Envelopes.Envelope envelope, System.Threading.CancellationToken cancellationToken = default);
     }
     public class RequestBodyExtractionDispatcher : Sentry.Extensibility.IRequestPayloadExtractor
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -497,6 +497,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public Sentry.Extensibility.ITransport? Transport { get; set; }
         public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
@@ -1036,6 +1037,10 @@ namespace Sentry.Extensibility
     public interface ISentryStackTraceFactory
     {
         Sentry.SentryStackTrace? Create(System.Exception? exception = null);
+    }
+    public interface ITransport
+    {
+        System.Threading.Tasks.Task SendEnvelopeAsync(Sentry.Protocol.Envelopes.Envelope envelope, System.Threading.CancellationToken cancellationToken = default);
     }
     public class RequestBodyExtractionDispatcher : Sentry.Extensibility.IRequestPayloadExtractor
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -498,6 +498,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public Sentry.Extensibility.ITransport? Transport { get; set; }
         public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
@@ -1037,6 +1038,10 @@ namespace Sentry.Extensibility
     public interface ISentryStackTraceFactory
     {
         Sentry.SentryStackTrace? Create(System.Exception? exception = null);
+    }
+    public interface ITransport
+    {
+        System.Threading.Tasks.Task SendEnvelopeAsync(Sentry.Protocol.Envelopes.Envelope envelope, System.Threading.CancellationToken cancellationToken = default);
     }
     public class RequestBodyExtractionDispatcher : Sentry.Extensibility.IRequestPayloadExtractor
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -498,6 +498,7 @@ namespace Sentry
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public Sentry.Extensibility.ITransport? Transport { get; set; }
         public bool UseAsyncFileIO { get; set; }
     }
     public static class SentryOptionsExtensions
@@ -1037,6 +1038,10 @@ namespace Sentry.Extensibility
     public interface ISentryStackTraceFactory
     {
         Sentry.SentryStackTrace? Create(System.Exception? exception = null);
+    }
+    public interface ITransport
+    {
+        System.Threading.Tasks.Task SendEnvelopeAsync(Sentry.Protocol.Envelopes.Envelope envelope, System.Threading.CancellationToken cancellationToken = default);
     }
     public class RequestBodyExtractionDispatcher : Sentry.Extensibility.IRequestPayloadExtractor
     {


### PR DESCRIPTION
In #1560, we created the `HttpTransportBase` class, containing the "guts" of the `HttpTransport` assembled such that others could extend it to create their own transports without loss of features that are wired at the transport.  However, we didn't create an easy way to actually attach a custom transport at that time, because we were primarily focused on getsentry/sentry-unity#657, which was already building it's own implementation of `IBackgroundWorker` where it could connect its own custom transport.

For others, the ideal place to attach a custom transport is on `SentryOptions.Transport`, as we do in unit tests.  This PR makes that property, and the corresponding `ITransport` type public so that can happen.   (It also removes `IFlushableTransport` just for cleanup.  It wasn't adding anything.)

After this is released, the recommendation for custom transports is to implement similarly to the built-in [`HttpTransport`](https://github.com/getsentry/sentry-dotnet/blob/main/src/Sentry/Internal/Http/HttpTransport.cs).

```csharp
public class SomeCustomTransport : HttpTransportBase, ITransport
```

One *could* also just implement `ITransport` without implementing `HttpTransportBase`, but then they would be missing out on any functionality wired up in the transport such as processing event handlers, client reports, etc.