### PR TITLE
Improve Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
-      # Prevent setup-dotnet action from steping on pre-installed dotnet SDKs on Ubuntu
-      DOTNET_INSTALL_DIR: ${{ startsWith(matrix.os, 'ubuntu') && '/usr/share/dotnet' || '' }}
+      # Prevent setup-dotnet action from steping on pre-installed dotnet SDKs on Ubuntut and Windows (doesn't happen on macOS)
+      DOTNET_INSTALL_DIR: ${{ startsWith(matrix.os, 'ubuntu') && '/usr/share/dotnet' || startsWith(matrix.os, 'windows') && 'C:\Program Files\dotnet' || '' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,11 +56,8 @@ jobs:
             key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.*proj', '**/*.props') }}
             restore-keys: ${{ runner.os }}-nuget
 
-        - name: Restore Dependencies
-          run: dotnet restore SentryNoSamples.slnf
-
         - name: Build
-          run: dotnet build SentryNoSamples.slnf -c Release --no-restore /p:CopyLocalLockFileAssemblies=true
+          run: dotnet build SentryNoSamples.slnf -c Release /p:CopyLocalLockFileAssemblies=true
 
         - name: Test
           run: dotnet test SentryNoSamples.slnf -c Release --no-build -l "GitHubActions;report-warnings=false" -l "trx;LogFileName=${{ matrix.os }}-test-results.trx"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
             restore-keys: ${{ runner.os }}-nuget
 
         - name: Restore Dependencies
-          run: dotnet restore SentryNoSamples.slnf -c Release
+          run: dotnet restore SentryNoSamples.slnf
 
         - name: Build
           run: dotnet build SentryNoSamples.slnf -c Release --no-restore /p:CopyLocalLockFileAssemblies=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
-      # Prevent setup-dotnet action from steping on pre-installed dotnet SDKs
-      DOTNET_INSTALL_DIR: ${{ startsWith(matrix.os, 'ubuntu') && '/usr/share/dotnet' || startsWith(matrix.os, 'macos') && '/usr/local/share/dotnet' || startsWith(matrix.os, 'windows') && 'C:\Program Files\dotnet' || '' }}
+      # Prevent setup-dotnet action from steping on pre-installed dotnet SDKs on Ubuntu
+      DOTNET_INSTALL_DIR: ${{ startsWith(matrix.os, 'ubuntu') && '/usr/share/dotnet' || '' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           with:
             dotnet-version: 2.1.818
 
-        - name: Enable Dependency Caching
+        - name: Dependency Caching
           uses: actions/cache@v3
           with:
             path: ~/.nuget/packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,19 @@ jobs:
           with:
             dotnet-version: 2.1.818
 
+        - name: Enable Dependency Caching
+          uses: actions/cache@v3
+          with:
+            path: ~/.nuget/packages
+            ## we don't use a lockfile, so hash all files where we might be keeping <PackageReference> tags
+            key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.*proj', '**/*.props') }}
+            restore-keys: ${{ runner.os }}-nuget
+
+        - name: Restore Dependencies
+          run: dotnet restore SentryNoSamples.slnf -c Release
+
         - name: Build
-          run: dotnet build SentryNoSamples.slnf -c Release /p:CopyLocalLockFileAssemblies=true
+          run: dotnet build SentryNoSamples.slnf -c Release --no-restore /p:CopyLocalLockFileAssemblies=true
 
         - name: Test
           run: dotnet test SentryNoSamples.slnf -c Release --no-build -l "GitHubActions;report-warnings=false" -l "trx;LogFileName=${{ matrix.os }}-test-results.trx"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
-      # Prevent setup-dotnet action from steping on pre-installed dotnet SDKs on Ubuntut and Windows (doesn't happen on macOS)
+      # Prevent setup-dotnet action from stepping on pre-installed dotnet SDKs on Ubuntut and Windows (doesn't happen on macOS)
       DOTNET_INSTALL_DIR: ${{ startsWith(matrix.os, 'ubuntu') && '/usr/share/dotnet' || startsWith(matrix.os, 'windows') && 'C:\Program Files\dotnet' || '' }}
 
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,14 +6,18 @@ on:
       - main
       - release/*
   pull_request:
+
 jobs:
   build:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
-      DOTNET_MULTILEVEL_LOOKUP: 1
+      # Prevent setup-dotnet action from steping on pre-installed dotnet SDKs
+      DOTNET_INSTALL_DIR: ${{ startsWith(matrix.os, 'ubuntu') && '/usr/share/dotnet' || startsWith(matrix.os, 'macos') && '/usr/local/share/dotnet' || startsWith(matrix.os, 'windows') && 'C:\Program Files\dotnet' || '' }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -26,30 +30,23 @@ jobs:
             submodules: recursive
             fetch-depth: 2 # default is 1 and codecov needs > 1
 
-        - name: Setup .NET SDK
-          if: matrix.os == 'windows-latest'
+        - name: Setup .NET SDK (Windows)
+          if: startsWith(matrix.os, 'windows')
           uses: actions/setup-dotnet@v2
           with:
-            dotnet-version: |
-              2.1.818
-              3.1.x
-        - name: Setup .NET SDK
-          if: matrix.os == 'macos-latest'
+            dotnet-version: 2.1.818
+        - name: Setup .NET SDK (macOS)
+          if: startsWith(matrix.os, 'macos')
           uses: actions/setup-dotnet@v2
           with:
             dotnet-version: |
               2.1.818
               6.0.x
-        - name: Setup .NET SDK
-          if: matrix.os == 'ubuntu-latest'
+        - name: Setup .NET SDK (Ubuntu)
+          if: startsWith(matrix.os, 'ubuntu')
           uses: actions/setup-dotnet@v2
           with:
-          # Installing 2.1.818 on ubuntu has the side-effect of uninstalling the previous Frameworks.
-            dotnet-version: |
-              2.1.818
-              3.1.x
-              5.0.x
-              6.0.x
+            dotnet-version: 2.1.818
 
         - name: Build
           run: dotnet build SentryNoSamples.slnf -c Release /p:CopyLocalLockFileAssemblies=true
@@ -70,7 +67,7 @@ jobs:
 
         - name: Pack
           # only pack on windows since we need classic .net assemblies
-          if: matrix.os == 'windows-latest'
+          if: startsWith(matrix.os, 'windows')
           run: dotnet pack SentryNoSamples.slnf -c Release --no-build /p:ContinuousIntegrationBuild=true
 
         - name: Upload Verify Results
@@ -83,7 +80,7 @@ jobs:
 
         - name: Archive Artifacts
           # only archive on windows since we only pack on windows. See Pack step.
-          if: matrix.os == 'windows-latest'
+          if: startsWith(matrix.os, 'windows')
           uses: actions/upload-artifact@v3
           with:
             name: ${{ github.sha }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,10 +26,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - name: Setup .NET SDK (v2.1)
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '2.1.818'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -37,8 +33,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
 
-    - run: |
-       dotnet build -c release
+    - run: dotnet build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,13 +27,25 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Enable Dependency Caching
+      uses: actions/cache@v3
+      with:
+        path: ~/.nuget/packages
+        ## we don't use a lockfile, so hash all files where we might be keeping <PackageReference> tags
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.*proj', '**/*.props') }}
+        restore-keys: ${{ runner.os }}-nuget
+
+    - name: Restore Dependencies
+      run: dotnet restore
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
-    - run: dotnet build
+    - name: Build
+      run: dotnet build --no-restore
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Enable Dependency Caching
+    - name: Dependency Caching
       uses: actions/cache@v3
       with:
         path: ~/.nuget/packages

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,9 +35,6 @@ jobs:
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.*proj', '**/*.props') }}
         restore-keys: ${{ runner.os }}-nuget
 
-    - name: Restore Dependencies
-      run: dotnet restore
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
@@ -45,7 +42,7 @@ jobs:
         languages: ${{ matrix.language }}
 
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
-      DOTNET_MULTILEVEL_LOOKUP: 1
+      DOTNET_INSTALL_DIR: /usr/share/dotnet
     strategy:
       fail-fast: false
       matrix:
@@ -30,19 +30,6 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: '2.1.818'
-    - name: Setup .NET SDK (v3.1)
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '3.1.x'
-    - name: Setup .NET SDK (v5.0)
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '5.0.x'
-    - name: Setup .NET SDK (v6.0)
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '6.0.x'
-        include-prerelease: true
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
We can reduce the number of SDKs we need to install manually, which should improve end-to-end time to complete the build action.  This relies on setting `DOTNET_INSTALL_DIR` for the new SDKs to the same locations that the base images are already putting them.  See https://github.com/actions/setup-dotnet/issues/284

Also I removed `DOTNET_MULTILEVEL_LOOKUP: 1` just because it is already the default.  Some other misc cleanup here as well.

On the CodeQL build - we don't need any additional SDKs beyond what's on the base Ubuntu image, and we should probably analyze debug builds, not release builds.

I also added the dependency caching (see #1568) to this PR, which should help improve restore times significantly.

#skip-changelog