### PR TITLE
Improve LocalDB tests

### DIFF
--- a/test/Sentry.DiagnosticSource.IntegrationTests/LocalDbFixture.cs
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/LocalDbFixture.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using LocalDb;
 
 public sealed class LocalDbFixture : IDisposable
@@ -6,6 +7,11 @@ public sealed class LocalDbFixture : IDisposable
 
     public LocalDbFixture()
     {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
         SqlInstance = new SqlInstance(
             name: "SqlListenerTests" + Namer.RuntimeAndVersion,
             buildTemplate: TestDbBuilder.CreateTable);
@@ -13,6 +19,6 @@ public sealed class LocalDbFixture : IDisposable
 
     public void Dispose()
     {
-        SqlInstance.Cleanup();
+        SqlInstance?.Cleanup();
     }
 }

--- a/test/Sentry.DiagnosticSource.IntegrationTests/LocalDbFixture.cs
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/LocalDbFixture.cs
@@ -1,0 +1,18 @@
+using LocalDb;
+
+public sealed class LocalDbFixture : IDisposable
+{
+    public SqlInstance SqlInstance { get; }
+
+    public LocalDbFixture()
+    {
+        SqlInstance = new SqlInstance(
+            name: "SqlListenerTests" + Namer.RuntimeAndVersion,
+            buildTemplate: TestDbBuilder.CreateTable);
+    }
+
+    public void Dispose()
+    {
+        SqlInstance.Cleanup();
+    }
+}

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.cs
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.cs
@@ -27,7 +27,12 @@ public class SqlListenerTests : IClassFixture<LocalDbFixture>
 
         options.AddIntegration(new SentryDiagnosticListenerIntegration());
 
-        using var database = await _fixture.SqlInstance.Build();
+        var database = await _fixture.SqlInstance.Build();
+#if NET5_0 //TODO: Change to NET5_0_OR_GREATER after updating for https://github.com/SimonCropp/LocalDb/pull/422
+        await using (database)
+#else
+        using (database)
+#endif
         using (var hub = new Hub(options))
         {
             var transaction = hub.StartTransaction("my transaction", "my operation");
@@ -63,7 +68,12 @@ public class SqlListenerTests : IClassFixture<LocalDbFixture>
 
         options.AddIntegration(new SentryDiagnosticListenerIntegration());
 
-        using var database = await _fixture.SqlInstance.Build();
+        var database = await _fixture.SqlInstance.Build();
+#if NET5_0 //TODO: Change to NET5_0_OR_GREATER after updating for https://github.com/SimonCropp/LocalDb/pull/422
+        await using (database)
+#else
+        using (database)
+#endif
         using (var hub = new Hub(options))
         {
             var transaction = hub.StartTransaction("my transaction", "my operation");

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.cs
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.cs
@@ -1,17 +1,14 @@
 using System.Runtime.InteropServices;
-using LocalDb;
 using Sentry.Internals.DiagnosticSource;
 
 [UsesVerify]
-public class SqlListenerTests
+public class SqlListenerTests : IClassFixture<LocalDbFixture>
 {
-    private static SqlInstance sqlInstance;
+    private readonly LocalDbFixture _fixture;
 
-    static SqlListenerTests()
+    public SqlListenerTests(LocalDbFixture fixture)
     {
-        sqlInstance = new SqlInstance(
-            name: "SqlListenerTests" + Namer.RuntimeAndVersion,
-            buildTemplate: TestDbBuilder.CreateTable);
+        _fixture = fixture;
     }
 
 #if !NETFRAMEWORK
@@ -30,7 +27,7 @@ public class SqlListenerTests
 
         options.AddIntegration(new SentryDiagnosticListenerIntegration());
 
-        using var database = await sqlInstance.Build();
+        using var database = await _fixture.SqlInstance.Build();
         using (var hub = new Hub(options))
         {
             var transaction = hub.StartTransaction("my transaction", "my operation");
@@ -66,7 +63,7 @@ public class SqlListenerTests
 
         options.AddIntegration(new SentryDiagnosticListenerIntegration());
 
-        using var database = await sqlInstance.Build();
+        using var database = await _fixture.SqlInstance.Build();
         using (var hub = new Hub(options))
         {
             var transaction = hub.StartTransaction("my transaction", "my operation");


### PR DESCRIPTION
Clean up the local DB instances when we're done with them, rather than leaving them running.  This should hopefully improve test times on Windows builds in CI.

#skip-changelog