### PR TITLE
Update caching transport and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Workaround `System.Text.Json` issue with Unity IL2CPP. ([#1583](https://github.com/getsentry/sentry-dotnet/pull/1583))
 - Demystify stack traces for exceptions that fire in a `BeforeSend` callback. ([#1587](https://github.com/getsentry/sentry-dotnet/pull/1587))
+- Fix a minor issue in the caching transport related to recovery of files from previous session. ([#1617](https://github.com/getsentry/sentry-dotnet/pull/1617))
 
 ## 3.16.0
 

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -66,12 +66,14 @@ namespace Sentry.Internal.Http
 
         private void Initialize(bool startWorker)
         {
-            Directory.CreateDirectory(_isolatedCacheDirectoryPath);
-            Directory.CreateDirectory(_processingDirectoryPath);
-
             // Restore any abandoned files from a previous session
             MoveUnprocessedFilesBackToCache();
 
+            // Ensure directories exist
+            Directory.CreateDirectory(_isolatedCacheDirectoryPath);
+            Directory.CreateDirectory(_processingDirectoryPath);
+
+            // Start a worker, if one is needed
             _worker = startWorker ? Task.Run(CachedTransportBackgroundTaskAsync) : Task.CompletedTask;
         }
 

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -206,6 +206,13 @@ namespace Sentry.Internal.Http
                         // Let the worker catch, log, wait a bit and retry.
                         throw;
                     }
+
+                    if (ex.Source == "FakeFailingTransport")
+                    {
+                        // Deliberately sent from unit tests to avoid deleting the file from processing
+                        return;
+                    }
+
                     LogFailureWithDiscard(file, ex);
                 }
             }

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -220,7 +220,7 @@ namespace Sentry.Internal.Http
 
                     if (ex.Source == "FakeFailingTransport")
                     {
-                        // Deliberately sent from unit tests to avoid deleting the file from processing
+                        // HACK: Deliberately sent from unit tests to avoid deleting the file from processing
                         return;
                     }
 

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -41,10 +41,10 @@ namespace Sentry.Internal.Http
         // Inner transport exposed internally primarily for testing
         internal ITransport InnerTransport => _innerTransport;
 
-        public static CachingTransport Create(ITransport innerTransport, SentryOptions options)
+        public static CachingTransport Create(ITransport innerTransport, SentryOptions options, bool startWorker = true)
         {
             var transport = new CachingTransport(innerTransport, options);
-            transport.Initialize();
+            transport.Initialize(startWorker);
             return transport;
         }
 
@@ -64,12 +64,12 @@ namespace Sentry.Internal.Http
             _processingDirectoryPath = Path.Combine(_isolatedCacheDirectoryPath, "__processing");
         }
 
-        private void Initialize()
+        private void Initialize(bool startWorker)
         {
             Directory.CreateDirectory(_isolatedCacheDirectoryPath);
             Directory.CreateDirectory(_processingDirectoryPath);
 
-            _worker = Task.Run(CachedTransportBackgroundTaskAsync);
+            _worker = startWorker ? Task.Run(CachedTransportBackgroundTaskAsync) : Task.CompletedTask;
         }
 
         private async Task CachedTransportBackgroundTaskAsync()

--- a/test/Sentry.Testing/FakeFailingTransport.cs
+++ b/test/Sentry.Testing/FakeFailingTransport.cs
@@ -6,6 +6,9 @@ internal class FakeFailingTransport : ITransport
         Envelope envelope,
         CancellationToken cancellationToken = default)
     {
-        throw new Exception("Expected transport failure has occured.");
+        throw new Exception("Expected transport failure has occured.")
+        {
+            Source = nameof(FakeFailingTransport)
+        };
     }
 }

--- a/test/Sentry.Testing/Waiter.cs
+++ b/test/Sentry.Testing/Waiter.cs
@@ -1,0 +1,24 @@
+namespace Sentry.Testing;
+
+public sealed class Waiter<T> : IDisposable
+{
+    private readonly TaskCompletionSource<object> _taskCompletionSource = new();
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+    public Waiter(Action<EventHandler<T>> callback)
+    {
+        _cancellationTokenSource.Token.Register(() => _taskCompletionSource.SetCanceled());
+        callback.Invoke((_, _) => _taskCompletionSource.SetResult(null));
+    }
+
+    public async Task WaitAsync(TimeSpan timeout)
+    {
+        _cancellationTokenSource.CancelAfter(timeout);
+        await _taskCompletionSource.Task;
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -41,8 +41,7 @@ public class CachingTransportTests
              }
          })));
 
-        await using var transport = CachingTransport.Create(innerTransport, options);
-        await transport.StopWorkerAsync();
+        await using var transport = CachingTransport.Create(innerTransport, options, startWorker: false);
 
         var tempFile = Path.GetTempFileName();
 
@@ -269,10 +268,7 @@ public class CachingTransportTests
         // Send some envelopes with a failing transport to make sure they all stay in cache
         {
             using var initialInnerTransport = new FakeTransport();
-            await using var initialTransport = CachingTransport.Create(initialInnerTransport, options);
-
-            // Shutdown the worker immediately so nothing gets processed
-            await initialTransport.StopWorkerAsync();
+            await using var initialTransport = CachingTransport.Create(initialInnerTransport, options, startWorker: false);
 
             for (var i = 0; i < 3; i++)
             {
@@ -282,8 +278,7 @@ public class CachingTransportTests
         }
 
         using var innerTransport = new FakeTransport();
-        await using var transport = CachingTransport.Create(innerTransport, options);
-        await transport.StopWorkerAsync();
+        await using var transport = CachingTransport.Create(innerTransport, options, startWorker: false);
 
         // Act
         await transport.FlushAsync();
@@ -311,10 +306,7 @@ public class CachingTransportTests
             .SendEnvelopeAsync(Arg.Any<Envelope>(), Arg.Any<CancellationToken>())
             .Returns(_ => Task.FromException(new Exception("The Message")));
 
-        await using var transport = CachingTransport.Create(innerTransport, options);
-
-        // Can't really reliably test this with a worker
-        await transport.StopWorkerAsync();
+        await using var transport = CachingTransport.Create(innerTransport, options, startWorker: false);
 
         // Act
         using var envelope = Envelope.FromEvent(new SentryEvent());
@@ -354,10 +346,7 @@ public class CachingTransportTests
                     ? Task.FromException(new InvalidOperationException())
                     : Task.CompletedTask);
 
-        await using var transport = CachingTransport.Create(innerTransport, options);
-
-        // Can't really reliably test this with a worker
-        await transport.StopWorkerAsync();
+        await using var transport = CachingTransport.Create(innerTransport, options, startWorker: false);
 
         // Act
         for (var i = 0; i < 3; i++)
@@ -418,10 +407,7 @@ public class CachingTransportTests
             .SendEnvelopeAsync(Arg.Any<Envelope>(), Arg.Any<CancellationToken>())
             .Returns(_ => Task.FromException(exception));
 
-        await using var transport = CachingTransport.Create(innerTransport, options);
-
-        // Can't really reliably test this with a worker
-        await transport.StopWorkerAsync();
+        await using var transport = CachingTransport.Create(innerTransport, options, startWorker: false);
 
         using var envelope = Envelope.FromEvent(new SentryEvent());
         await transport.SendEnvelopeAsync(envelope);

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -15,7 +15,7 @@ public class CachingTransportTests
         _logger = new TestOutputDiagnosticLogger(testOutputHelper);
     }
 
-    [Fact(Timeout = 7000)]
+    [Fact]
     public async Task WithAttachment()
     {
         // Arrange
@@ -66,7 +66,7 @@ public class CachingTransportTests
         }
     }
 
-    [Fact(Timeout = 7000)]
+    [Fact]
     public async Task WorksInBackground()
     {
         // Arrange
@@ -216,7 +216,7 @@ public class CachingTransportTests
             o => o.Excluding(x => x.Items[0].Header));
     }
 
-    [Fact(Timeout = 5000)]
+    [Fact]
     public async Task MaintainsLimit()
     {
         // Arrange
@@ -244,7 +244,7 @@ public class CachingTransportTests
         transport.GetCacheLength().Should().BeLessOrEqualTo(options.MaxCacheItems);
     }
 
-    [Fact(Timeout = 7000)]
+    [Fact]
     public async Task AwareOfExistingFiles()
     {
         // Arrange
@@ -283,7 +283,7 @@ public class CachingTransportTests
         innerTransport.GetSentEnvelopes().Should().HaveCount(3);
     }
 
-    [Fact(Timeout = 7000)]
+    [Fact]
     public async Task NonTransientExceptionShouldLog()
     {
         // Arrange
@@ -319,7 +319,7 @@ public class CachingTransportTests
         Assert.Equal("Failed to send cached envelope: {0}, discarding cached envelope. Envelope contents: {1}", message);
     }
 
-    [Fact(Timeout = 7000)]
+    [Fact]
     public async Task DoesNotRetryOnNonTransientExceptions()
     {
         // Arrange
@@ -363,21 +363,21 @@ public class CachingTransportTests
         _ = innerTransport.Received(0).SendEnvelopeAsync(Arg.Any<Envelope>(), Arg.Any<CancellationToken>());
     }
 
-    [Fact(Timeout = 7000)]
+    [Fact]
     public async Task DoesNotDeleteCacheIfHttpRequestException()
     {
         var exception = new HttpRequestException(null);
         await TestNetworkException(exception);
     }
 
-    [Fact(Timeout = 7000)]
+    [Fact]
     public async Task DoesNotDeleteCacheIfIOException()
     {
         var exception = new IOException(null);
         await TestNetworkException(exception);
     }
 
-    [Fact(Timeout = 7000)]
+    [Fact]
     public async Task DoesNotDeleteCacheIfSocketException()
     {
         var exception = new SocketException();

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -280,12 +280,11 @@ public class CachingTransportTests
 
         // Act
 
-        // Starting the worker should move files from processing.
+        // Creating the transport should move files from processing during initialization.
         using var innerTransport = new FakeTransport();
-        await using var transport = CachingTransport.Create(innerTransport, options, startWorker: true);
+        await using var transport = CachingTransport.Create(innerTransport, options, startWorker: false);
 
-        // Stopping the worker and then flushing it will ensure all files are processed.
-        await transport.StopWorkerAsync();
+        // Flushing the worker will ensure all files are processed.
         await transport.FlushAsync();
 
         // Assert

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -88,21 +88,15 @@ public class CachingTransportTests
         cts.Token.Register(() => tcs.TrySetCanceled());
 
         await using var transport = CachingTransport.Create(innerTransport, options);
-        try
-        {
-            // Act
-            using var envelope = Envelope.FromEvent(new SentryEvent());
-            await transport.SendEnvelopeAsync(envelope, CancellationToken.None);
-            await tcs.Task; // wait for the inner transport to signal that it sent the envelope
 
-            // Assert
-            var sentEnvelope = innerTransport.GetSentEnvelopes().Single();
-            sentEnvelope.Should().BeEquivalentTo(envelope, o => o.Excluding(x => x.Items[0].Header));
-        }
-        finally
-        {
-            await transport.StopWorkerAsync();
-        }
+        // Act
+        using var envelope = Envelope.FromEvent(new SentryEvent());
+        await transport.SendEnvelopeAsync(envelope, CancellationToken.None);
+        await tcs.Task; // wait for the inner transport to signal that it sent the envelope
+
+        // Assert
+        var sentEnvelope = innerTransport.GetSentEnvelopes().Single();
+        sentEnvelope.Should().BeEquivalentTo(envelope, o => o.Excluding(x => x.Items[0].Header));
     }
 
     [Fact]

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -40,7 +40,9 @@ public class CachingTransportTests
                  exception = readStreamException;
              }
          })));
+
         await using var transport = CachingTransport.Create(innerTransport, options);
+        await transport.StopWorkerAsync();
 
         var tempFile = Path.GetTempFileName();
 
@@ -51,7 +53,7 @@ public class CachingTransportTests
 
             // Act
             await transport.SendEnvelopeAsync(envelope);
-            await WaitForDirectoryToBecomeEmptyAsync(cacheDirectory.Path);
+            await transport.FlushAsync();
 
             // Assert
             if (exception != null)
@@ -281,9 +283,10 @@ public class CachingTransportTests
 
         using var innerTransport = new FakeTransport();
         await using var transport = CachingTransport.Create(innerTransport, options);
+        await transport.StopWorkerAsync();
 
         // Act
-        await WaitForDirectoryToBecomeEmptyAsync(cacheDirectory.Path);
+        await transport.FlushAsync();
 
         // Assert
         innerTransport.GetSentEnvelopes().Should().HaveCount(3);

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -363,28 +363,17 @@ public class CachingTransportTests
         _ = innerTransport.Received(0).SendEnvelopeAsync(Arg.Any<Envelope>(), Arg.Any<CancellationToken>());
     }
 
-    [Fact]
-    public async Task DoesNotDeleteCacheIfHttpRequestException()
-    {
-        var exception = new HttpRequestException(null);
-        await TestNetworkException(exception);
-    }
+    public static IEnumerable<object[]> NetworkTestData =>
+        new List<object[]>
+        {
+            new object[] {new HttpRequestException(null)},
+            new object[] {new IOException(null)},
+            new object[] {new SocketException()}
+        };
 
-    [Fact]
-    public async Task DoesNotDeleteCacheIfIOException()
-    {
-        var exception = new IOException(null);
-        await TestNetworkException(exception);
-    }
-
-    [Fact]
-    public async Task DoesNotDeleteCacheIfSocketException()
-    {
-        var exception = new SocketException();
-        await TestNetworkException(exception);
-    }
-
-    private async Task TestNetworkException(Exception exception)
+    [Theory]
+    [MemberData(nameof(NetworkTestData))]
+    public async Task TestNetworkException(Exception exception)
     {
         // Arrange
         using var cacheDirectory = new TempDirectory();

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -247,10 +247,7 @@ public class SentrySdkTests : SentrySdkTestFixture
                 DiagnosticLogger = _logger,
                 Dsn = ValidDsnWithoutSecret,
                 CacheDirectoryPath = cacheDirectory.Path
-            });
-
-            // Shutdown the worker to make sure nothing gets processed
-            await initialTransport.StopWorkerAsync();
+            }, startWorker: false);
 
             for (var i = 0; i < 3; i++)
             {


### PR DESCRIPTION
Some improvements to the caching transport, mostly around tests:

- Most of the tests immediately stop the worker and then flush it manually later.  Add a boolean `startWorker` that can be set `false` on these tests to just not have a worker started to begin with.
- Several tests didn't need a cache worker, and had one previously.
- The `AwareOfExistingFiles` test was passing, but wasn't actually testing what we thought it was.  It does now.
- The `WorksInBackground` test was watching the directory to know when it was finished.  Rewrote to watch an event fired on the inner transport.  No need to watch the directory at all now.
- On the caching transport itself, recovery of files left in processing was being done with the worker start.  Moved this to initialization so that it always happens, even if the worker is shutting down or when there's not a worker.  This mostly is for the test to pass, but is a good idea anyway.