### PR TITLE
ci checkout restore depth 1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
           uses: actions/checkout@v3
           with:
             submodules: recursive
-            fetch-depth: 2 # default is 1 and codecov needs > 1
 
         - name: Setup .NET SDK (Windows)
           if: startsWith(matrix.os, 'windows')


### PR DESCRIPTION
Not needed unless we tackle #726

#skip-changelog