### PR TITLE
Fix docfx build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: nikeee/docfx-action@v1
+      - uses: nikeee/docfx-action@v1.0.0
         name: Build Documentation
         with:
           args: docs/docfx.json

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: nikeee/docfx-action@v1.0.0
+      - uses: nikeee/docfx-action@c2413c359a30494b894e30db268c5504478ff50a
         name: Build Documentation
         with:
           args: docs/docfx.json


### PR DESCRIPTION
In #1609 I accidentally broke the apidocs action, because `nikeee/docfx-action` is only tagged with `v1.0.0`.  Most other actions are dual tagged where the `v1` tag would point at the same place, but that action isn't tagged well.

It's also a bit stale internally with regard to the docfx version, so we might want to consider something else later.

For now, just putting it back.

#skip-changelog