### PR TITLE
shorten variable names

### DIFF
--- a/src/Sentry/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Envelopes/EnvelopeItem.cs
@@ -285,16 +285,16 @@ namespace Sentry.Protocol.Envelopes
         }
 
         /// <summary>
-        /// Creates an envelope item from <paramref name="clientReport"/>.
+        /// Creates an <see cref="EnvelopeItem"/> from <paramref name="report"/>.
         /// </summary>
-        internal static EnvelopeItem FromClientReport(ClientReport clientReport)
+        internal static EnvelopeItem FromClientReport(ClientReport report)
         {
             var header = new Dictionary<string, object?>(1, StringComparer.Ordinal)
             {
                 [TypeKey] = TypeValueClientReport
             };
 
-            return new EnvelopeItem(header, new JsonSerializable(clientReport));
+            return new EnvelopeItem(header, new JsonSerializable(report));
         }
 
         private static async Task<IReadOnlyDictionary<string, object?>> DeserializeHeaderAsync(

--- a/src/Sentry/Internal/ClientReportRecorder.cs
+++ b/src/Sentry/Internal/ClientReportRecorder.cs
@@ -6,7 +6,7 @@ namespace Sentry.Internal
 {
     internal class ClientReportRecorder : IClientReportRecorder
     {
-        private readonly SentryOptions _sentryOptions;
+        private readonly SentryOptions _options;
         private readonly ISystemClock _clock;
 
         private readonly ThreadsafeCounterDictionary<DiscardReasonWithCategory> _discardedEvents = new();
@@ -14,16 +14,16 @@ namespace Sentry.Internal
         // discarded events are exposed internally for testing
         internal IReadOnlyDictionary<DiscardReasonWithCategory, int> DiscardedEvents => _discardedEvents;
 
-        public ClientReportRecorder(SentryOptions sentryOptions, ISystemClock? clock = default)
+        public ClientReportRecorder(SentryOptions options, ISystemClock? clock = default)
         {
-            _sentryOptions = sentryOptions;
+            _options = options;
             _clock = clock ?? new SystemClock();
         }
 
         public void RecordDiscardedEvent(DiscardReason reason, DataCategory category)
         {
             // Don't count discarded events if we're not going to be sending them.
-            if (!_sentryOptions.SendClientReports)
+            if (!_options.SendClientReports)
             {
                 return;
             }
@@ -35,7 +35,7 @@ namespace Sentry.Internal
         public ClientReport? GenerateClientReport()
         {
             // Don't attach a client report if we've turned them off.
-            if (!_sentryOptions.SendClientReports)
+            if (!_options.SendClientReports)
             {
                 return null;
             }

--- a/src/Sentry/Internal/IClientReportRecorder.cs
+++ b/src/Sentry/Internal/IClientReportRecorder.cs
@@ -25,7 +25,7 @@ namespace Sentry.Internal
         /// <remarks>
         /// Useful when recovering from failures while sending client reports.
         /// </remarks>
-        /// <param name="clientReport">The client report to load into the recorder.</param>
-        void Load(ClientReport clientReport);
+        /// <param name="report">The client report to load into the recorder.</param>
+        void Load(ClientReport report);
     }
 }

--- a/test/Sentry.Testing/FakeTransportWithRecorder.cs
+++ b/test/Sentry.Testing/FakeTransportWithRecorder.cs
@@ -2,20 +2,20 @@ namespace Sentry.Testing;
 
 internal class FakeTransportWithRecorder : FakeTransport
 {
-    private readonly IClientReportRecorder _clientReportRecorder;
+    private readonly IClientReportRecorder _recorder;
 
-    public FakeTransportWithRecorder(IClientReportRecorder clientReportRecorder)
+    public FakeTransportWithRecorder(IClientReportRecorder recorder)
     {
-        _clientReportRecorder = clientReportRecorder;
+        _recorder = recorder;
     }
 
     public override async Task SendEnvelopeAsync(Envelope envelope, CancellationToken cancellationToken = default)
     {
         // Attach a client report in the same way that the HttpTransportBase class does.
-        var clientReport = _clientReportRecorder.GenerateClientReport();
-        if (clientReport != null)
+        var report = _recorder.GenerateClientReport();
+        if (report != null)
         {
-            envelope = envelope.WithItem(EnvelopeItem.FromClientReport(clientReport));
+            envelope = envelope.WithItem(EnvelopeItem.FromClientReport(report));
         }
 
         try
@@ -25,9 +25,9 @@ internal class FakeTransportWithRecorder : FakeTransport
         catch
         {
             // Restore client reports on any failure
-            if (clientReport != null)
+            if (report != null)
             {
-                _clientReportRecorder.Load(clientReport);
+                _recorder.Load(report);
             }
 
             throw;


### PR DESCRIPTION
my pref: variables and fields should be as short as possible given the current context.
we seem to use this approach in other places. eg `options` instead of `sentryOptions` [here](https://github.com/getsentry/sentry-dotnet/blob/main/src/Sentry/Extensibility/RequestBodyExtractionDispatcher.cs#L11) 

#skip-changelog