### PR TITLE
Fix blocking wait in caching transport test

### DIFF
--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -119,11 +119,11 @@ public class CachingTransportTests
 
         innerTransport
             .SendEnvelopeAsync(Arg.Any<Envelope>(), Arg.Any<CancellationToken>())
-            .ThrowsForAnyArgs(_ =>
+            .ReturnsForAnyArgs(async _ =>
             {
                 capturingCompletionSource.SetResult(null);
-                cancelingCompletionSource.Task.Wait(TimeSpan.FromSeconds(4));
-                return new OperationCanceledException();
+                await Task.WhenAny(cancelingCompletionSource.Task, Task.Delay(TimeSpan.FromSeconds(4)));
+                throw new OperationCanceledException();
             });
 
         await using var transport = CachingTransport.Create(innerTransport, options);


### PR DESCRIPTION
Attempt to fix `CachingTransportTests.ShouldNotLogOperationCanceledExceptionWhenIsCancellationRequested` failure:

https://github.com/getsentry/sentry-dotnet/runs/6274787708?check_suite_focus=true#step:8:420


#skip-changelog