### PR TITLE
Fix AggregateExceptions in FlushTask async

### DIFF
--- a/src/Sentry/Internal/SdkComposer.cs
+++ b/src/Sentry/Internal/SdkComposer.cs
@@ -87,6 +87,14 @@ namespace Sentry.Internal
                             "Cache flushing is taking longer than the configured timeout of {0}. " +
                             "Continuing without waiting for the task to finish.",
                             _options.InitCacheFlushTimeout);
+                        flushTask.ContinueWith(task =>
+                        {
+                            var aggragateException = task.Exception.Flatten();
+                            foreach (var exception in aggragateException.InnerExceptions)
+                                _options.LogInfo(
+                                    "Cache flushing reported this exception after it timed out: {0}. ",
+                                    exception.ToString());
+                        }, TaskContinuationOptions.OnlyOnFaulted);
                     }
 #endif
                 }


### PR DESCRIPTION
If the FlushTask ran longer than the timeout, the task was abandoned and should it throw an exception, that exception would be brought up during garbage collection, showing up in Sentry.

This uses the ContinueWith method that deals with the exceptions, logging them and letting the task gracefully complete.

Resolves #1640

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
