### PR TITLE
Disable dependency caching on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
             dotnet-version: 2.1.818
 
         - name: Dependency Caching
+          if: "!startsWith(matrix.os, 'windows')" # See https://github.com/getsentry/sentry-dotnet/issues/1647
           uses: actions/cache@v3
           with:
             path: ~/.nuget/packages


### PR DESCRIPTION
Dependency caching is slowing us down on Windows builds, not speeding us up.  See #1647.

Disabling it on Windows for now.  When GitHub fixes the underlying issue, we can turn it back on.

#skip-changelog