### PR TITLE
Hide public extension method classes from Intellisense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Hide public extension method container classes from Intellisense. ([#1654](https://github.com/getsentry/sentry-dotnet/pull/1654))
+
 ## 3.17.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Fixes
-
-- Hide public extension method container classes from Intellisense. ([#1654](https://github.com/getsentry/sentry-dotnet/pull/1654))
-
 ## 3.17.1
 
 ### Fixes

--- a/src/Sentry.AspNet/HttpContextExtensions.cs
+++ b/src/Sentry.AspNet/HttpContextExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Web;
 
 namespace Sentry.AspNet;
@@ -6,6 +7,7 @@ namespace Sentry.AspNet;
 /// <summary>
 /// Sentry extensions for <see cref="HttpContext"/>.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class HttpContextExtensions
 {
     private const string HttpContextTransactionItemName = "__SentryTransaction";

--- a/src/Sentry.AspNet/SentryAspNetOptionsExtensions.cs
+++ b/src/Sentry.AspNet/SentryAspNetOptionsExtensions.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Web;
 using Sentry.AspNet.Internal;
 using Sentry.Extensibility;
@@ -8,6 +9,7 @@ namespace Sentry.AspNet;
 /// <summary>
 /// SentryOptions extensions.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class SentryAspNetOptionsExtensions
 {
     /// <summary>

--- a/src/Sentry.AspNet/SentryHttpServerUtilityExtensions.cs
+++ b/src/Sentry.AspNet/SentryHttpServerUtilityExtensions.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Web;
 using Sentry.Extensibility;
 using Sentry.Protocol;
@@ -7,6 +8,7 @@ namespace Sentry.AspNet;
 /// <summary>
 /// HttpServerUtility extensions.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class SentryHttpServerUtilityExtensions
 {
     /// <summary>

--- a/src/Sentry.AspNetCore.Grpc/SentryBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore.Grpc/SentryBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Microsoft.Extensions.DependencyInjection;
 using Sentry.Extensibility;
 using Sentry.Reflection;
@@ -7,6 +8,7 @@ namespace Sentry.AspNetCore.Grpc;
 /// <summary>
 /// Extension methods for <see cref="ISentryBuilder"/>
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class SentryBuilderExtensions
 {
     /// <summary>

--- a/src/Sentry.AspNetCore/SamplingExtensions.cs
+++ b/src/Sentry.AspNetCore/SamplingExtensions.cs
@@ -1,8 +1,11 @@
+using System.ComponentModel;
+
 namespace Sentry.AspNetCore;
 
 /// <summary>
 /// Methods to extract ASP.NET Core specific data from <see cref="TransactionSamplingContext"/>.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class SamplingExtensions
 {
     internal const string KeyForHttpMethod = "__HttpMethod";

--- a/src/Sentry.AspNetCore/SentryBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/SentryBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Sentry.AspNetCore;
@@ -5,6 +6,7 @@ namespace Sentry.AspNetCore;
 /// <summary>
 /// Extension methods for <see cref="ISentryBuilder"/>
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class SentryBuilderExtensions
 {
     /// <summary>

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Runtime.ExceptionServices;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
@@ -198,6 +199,7 @@ namespace Microsoft.AspNetCore.Builder
     /// <summary>
     /// Extensions for enabling <see cref="SentryTracingMiddleware"/>.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class SentryTracingMiddlewareExtensions
     {
         /// <summary>

--- a/src/Sentry.DiagnosticSource/SentryOptionsDiagnosticExtensions.cs
+++ b/src/Sentry.DiagnosticSource/SentryOptionsDiagnosticExtensions.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Linq;
 using Sentry.Internals.DiagnosticSource;
 
@@ -6,6 +7,7 @@ namespace Sentry
     /// <summary>
     /// The additional Sentry Options extensions from Sentry Diagnostic Listener.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class SentryOptionsDiagnosticExtensions
     {
         /// <summary>

--- a/src/Sentry.NLog/ConfigurationExtensions.cs
+++ b/src/Sentry.NLog/ConfigurationExtensions.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using NLog.Config;
 using NLog.Layouts;
 using NLog.Targets;
@@ -9,6 +10,7 @@ namespace NLog;
 /// <summary>
 /// NLog configuration extensions.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class ConfigurationExtensions
 {
     // Internal for testability

--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.IO.Compression;
 using System.Net;
 using Sentry;
@@ -12,6 +13,7 @@ namespace Serilog;
 /// <summary>
 /// Sentry Serilog Sink extensions.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class SentrySinkExtensions
 {
     /// <summary>

--- a/src/Sentry.Tunnel/SentryTunnelingApplicationBuilderExtensions.cs
+++ b/src/Sentry.Tunnel/SentryTunnelingApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -6,6 +7,7 @@ namespace Sentry.Tunnel;
 /// <summary>
 /// Extension methods to add Sentry ingestion tunnel.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class SentryTunnelingApplicationBuilderExtensions
 {
     /// <summary>

--- a/src/Sentry/Extensibility/DiagnosticLoggerExtensions.cs
+++ b/src/Sentry/Extensibility/DiagnosticLoggerExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace Sentry.Extensibility
 {
@@ -8,6 +9,7 @@ namespace Sentry.Extensibility
     /// <remarks>
     /// Calls to this class verify the level before calling the overload with object params.
     /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class DiagnosticLoggerExtensions
     {
         /// <summary>

--- a/src/Sentry/IEventLike.cs
+++ b/src/Sentry/IEventLike.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace Sentry
@@ -88,6 +89,7 @@ namespace Sentry
     /// <summary>
     /// Extensions for <see cref="IEventLike"/>.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class EventLikeExtensions
     {
         /// <summary>

--- a/src/Sentry/IHasBreadcrumbs.cs
+++ b/src/Sentry/IHasBreadcrumbs.cs
@@ -24,6 +24,7 @@ namespace Sentry
     /// <summary>
     /// Extensions for <see cref="IHasBreadcrumbs"/>.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class HasBreadcrumbsExtensions
     {
 #if !NET461

--- a/src/Sentry/IHasExtra.cs
+++ b/src/Sentry/IHasExtra.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Sentry
 {
@@ -21,6 +22,7 @@ namespace Sentry
     /// <summary>
     /// Extensions for <see cref="IHasExtra"/>.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class HasExtraExtensions
     {
         /// <summary>

--- a/src/Sentry/IHasTags.cs
+++ b/src/Sentry/IHasTags.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Sentry
 {
@@ -26,6 +27,7 @@ namespace Sentry
     /// <summary>
     /// Extensions for <see cref="IHasTags"/>.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class HasTagsExtensions
     {
         /// <summary>

--- a/src/Sentry/ISpan.cs
+++ b/src/Sentry/ISpan.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace Sentry
 {
@@ -54,6 +55,7 @@ namespace Sentry
     /// <summary>
     /// Extensions for <see cref="ISpan"/>.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class SpanExtensions
     {
         /// <summary>

--- a/src/Sentry/SentryExceptionExtensions.cs
+++ b/src/Sentry/SentryExceptionExtensions.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Sentry.Internal;
 
 /// <summary>
 /// Extends Exception with formatted data that can be used by Sentry SDK.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class SentryExceptionExtensions
 {
     /// <summary>


### PR DESCRIPTION
We were using `[EditorBrowsable(EditorBrowsableState.Never)]` in a few places, but not consistently. This PR is adding where it was missing.

This attribute makes it so that the *class name* containing the extension method does not appear in Intellisense in an IDE.  We should use it on any public class designed purely to contain extension methods.

#skip-changelog