### PR TITLE
Re-enable dependency caching on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
             dotnet-version: 2.1.818
 
         - name: Dependency Caching
-          if: "!startsWith(matrix.os, 'windows')" # See https://github.com/getsentry/sentry-dotnet/issues/1647
           uses: actions/cache@v3
           with:
             path: ~/.nuget/packages


### PR DESCRIPTION
Even though dependency cache restore is slow on Windows, it's still apparently much slower to not use it.

This one took 19m for the build stage (which includes restore with no cache).
https://github.com/getsentry/sentry-dotnet/runs/6396147653?check_suite_focus=true

Let's turn it back on.   Reverts getsentry/sentry-dotnet#1648

#skip-changelog