### PR TITLE
Fix CS0122 on NotNullWhenAttribute

### DIFF
--- a/src/Sentry/Internal/StackFrameData.cs
+++ b/src/Sentry/Internal/StackFrameData.cs
@@ -42,7 +42,13 @@ namespace Sentry.Internal
         public StackFrameData Relocate(string typeName, string methodName)
             => new(Line, typeName, methodName, Offset, IsILOffset, MethodIndex, Mvid, Aotid);
 
-        public static bool TryParse(string line, [NotNullWhen(true)] out StackFrameData? stackFrame)
+        public static bool TryParse(
+            string line,
+#if NET461 || NETSTANDARD2_0
+            out StackFrameData? stackFrame)
+#else
+            [NotNullWhen(true)] out StackFrameData? stackFrame)
+#endif
         {
             stackFrame = default;
 
@@ -86,8 +92,13 @@ namespace Sentry.Internal
 
         private static bool ExtractSignatures(
             string str,
+#if NET461 || NETSTANDARD2_0
+            out string? typeFullName,
+            out string? methodSignature)
+#else
             [NotNullWhen(true)] out string? typeFullName,
             [NotNullWhen(true)] out string? methodSignature)
+#endif
         {
             typeFullName = null;
             methodSignature = null;


### PR DESCRIPTION
After updating to the latest .NET 6.0.300 SDK, I started getting these errors when doing a full (`--no-incremental`) build:

```
matt@Matts-MacBook-Pro sentry-dotnet % dotnet build --no-incremental src/Sentry/Sentry.csproj
Microsoft (R) Build Engine version 17.2.0+41abc5629 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
/Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/Internal/StackFrameData.cs(45,51): error CS0122: 'NotNullWhenAttribute' is inaccessible due to its protection level [/Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/Sentry.csproj]
/Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/Internal/StackFrameData.cs(89,14): error CS0122: 'NotNullWhenAttribute' is inaccessible due to its protection level [/Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/Sentry.csproj]
/Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/Internal/StackFrameData.cs(90,14): error CS0122: 'NotNullWhenAttribute' is inaccessible due to its protection level [/Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/Sentry.csproj]
/Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/Internal/StackFrameData.cs(45,51): error CS0122: 'NotNullWhenAttribute' is inaccessible due to its protection level [/Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/Sentry.csproj]
/Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/Internal/StackFrameData.cs(89,14): error CS0122: 'NotNullWhenAttribute' is inaccessible due to its protection level [/Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/Sentry.csproj]
/Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/Internal/StackFrameData.cs(90,14): error CS0122: 'NotNullWhenAttribute' is inaccessible due to its protection level [/Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/Sentry.csproj]
  Sentry -> /Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/bin/Debug/net5.0/Sentry.dll
  Sentry -> /Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/bin/Debug/netcoreapp3.0/Sentry.dll
  Sentry -> /Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/bin/Debug/net6.0/Sentry.dll
  Sentry -> /Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/bin/Debug/netstandard2.1/Sentry.dll
  Sentry -> /Users/matt/Code/getsentry/sentry-dotnet/src/Sentry/bin/Debug/net6.0-android/Sentry.dll

Build FAILED.
```

We are using the package "[Nullable](https://github.com/manuelroemer/Nullable)" to polyfill the missing `[NotNullWhen]` attribute on net461 and netstandard2.0, but it doesn't seem to be working at the moment.

We can just `#if` our way around this for now.

#skip-changelog