### PR TITLE
Continue with adding MAUI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Initial support for .NET MAUI ([#1663](https://github.com/getsentry/sentry-dotnet/pull/1663))
+- Initial support for .NET MAUI ([#1663](https://github.com/getsentry/sentry-dotnet/pull/1663)) ([#1670](https://github.com/getsentry/sentry-dotnet/pull/1670))
 - Initial support for `net6.0-android` apps ([#1288](https://github.com/getsentry/sentry-dotnet/pull/1288)) ([#1669](https://github.com/getsentry/sentry-dotnet/pull/1669))
 
 ### Fixes

--- a/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
+++ b/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
@@ -60,4 +60,11 @@
     <ProjectReference Include="..\..\src\Sentry.Maui\Sentry.Maui.csproj" />
   </ItemGroup>
 
+  <!-- Workaround for https://github.com/dotnet/maui/issues/7272 -->
+  <Target Name="_SetPublishFolderTypeNoneOnDocFileItems" BeforeTargets="_ComputePublishLocation">
+    <ItemGroup>
+      <ResolvedFileToPublish Update="@(DocFileItem)" PublishFolderType="None" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
+++ b/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
@@ -29,6 +29,13 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+
+    <!--
+      This avoids attaching a debugger when we crash the app when targeting Windows while running in Visual Studio.
+      It is not strictly necessary, but makes the demo sligtly cleaner.
+    -->
+    <DefineConstants>DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sentry.Maui/Constants.cs
+++ b/src/Sentry.Maui/Constants.cs
@@ -1,0 +1,12 @@
+using System.Reflection;
+
+namespace Sentry.Maui;
+
+internal static class Constants
+{
+    // See: https://github.com/getsentry/sentry-release-registry
+    public const string SdkName = "sentry.dotnet.maui";
+
+    public static string SdkVersion = typeof(SentryMauiOptions).Assembly
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
+}

--- a/src/Sentry.Maui/MauiEventProcessor.cs
+++ b/src/Sentry.Maui/MauiEventProcessor.cs
@@ -1,0 +1,15 @@
+using Sentry.Extensibility;
+
+namespace Sentry.Maui;
+
+internal class MauiEventProcessor : ISentryEventProcessor
+{
+    public SentryEvent Process(SentryEvent @event)
+    {
+        // Set SDK name and version for MAUI
+        @event.Sdk.Name = Constants.SdkName;
+        @event.Sdk.Version = Constants.SdkVersion;
+
+        return @event;
+    }
+}

--- a/src/Sentry.Maui/SentryMauiInitializer.cs
+++ b/src/Sentry.Maui/SentryMauiInitializer.cs
@@ -9,6 +9,12 @@ internal class SentryMauiInitializer : IMauiInitializeService
     public void Initialize(IServiceProvider services)
     {
         var options = services.GetRequiredService<IOptions<SentryMauiOptions>>().Value;
+
+#if ANDROID
+        var context = global::Android.App.Application.Context;
+        SentrySdk.Init(context, options);
+#else
         SentrySdk.Init(options);
+#endif
     }
 }

--- a/src/Sentry.Maui/SentryMauiOptionsSetup.cs
+++ b/src/Sentry.Maui/SentryMauiOptionsSetup.cs
@@ -18,5 +18,8 @@ internal class SentryMauiOptionsSetup : ConfigureFromConfigurationOptions<Sentry
 
         // Global Mode makes sense for client apps
         options.IsGlobalModeEnabled = true;
+
+        // We'll use an event processor to set things like SDK name
+        options.AddEventProcessor(new MauiEventProcessor());
     }
 }

--- a/src/Sentry.Maui/SentryMauiOptionsSetup.cs
+++ b/src/Sentry.Maui/SentryMauiOptionsSetup.cs
@@ -16,6 +16,7 @@ internal class SentryMauiOptionsSetup : ConfigureFromConfigurationOptions<Sentry
         // We'll initialize the SDK in SentryMauiInitializer
         options.InitializeSdk = false;
 
-        // TODO: Anything MAUI specific for setting up the options. (Can inject dependencies.)
+        // Global Mode makes sense for client apps
+        options.IsGlobalModeEnabled = true;
     }
 }

--- a/src/Sentry/Android/SentrySdk.cs
+++ b/src/Sentry/Android/SentrySdk.cs
@@ -15,6 +15,14 @@ namespace Sentry
             Action<SentryOptions>? configureOptions)
         {
             var options = new SentryOptions();
+            configureOptions?.Invoke(options);
+            return Init(context, options);
+        }
+
+        public static IDisposable Init(
+            global::Android.Content.Context context,
+            SentryOptions options)
+        {
             // TODO: Pause/Resume
             options.AutoSessionTracking = true;
             options.IsGlobalModeEnabled = true;
@@ -26,8 +34,6 @@ namespace Sentry
                 evt.Contexts.Device.Manufacturer = Build.Manufacturer;
                 return evt;
             }));
-
-            configureOptions?.Invoke(options);
 
             Sentry.Android.SentryAndroid.Init(context, new JavaLogger(options),
                 new ConfigureOption(o =>

--- a/test/Sentry.Maui.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Maui.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,0 +1,12 @@
+﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName="")]
+namespace Microsoft.Maui.Hosting
+{
+    public static class SentryMauiAppBuilderExtensions { }
+}
+namespace Sentry.Maui
+{
+    public class SentryMauiOptions : Sentry.Extensions.Logging.SentryLoggingOptions
+    {
+        public SentryMauiOptions() { }
+    }
+}

--- a/test/Sentry.Maui.Tests/ApiApprovalTests.cs
+++ b/test/Sentry.Maui.Tests/ApiApprovalTests.cs
@@ -1,0 +1,13 @@
+using Sentry.Tests;
+
+namespace Sentry.Maui.Tests;
+
+[UsesVerify]
+public class ApiApprovalTests
+{
+    [Fact]
+    public Task Run()
+    {
+        return typeof(SentryMauiOptions).Assembly.CheckApproval();
+    }
+}

--- a/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.cs
+++ b/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.cs
@@ -111,4 +111,34 @@ public class SentryMauiAppBuilderExtensionsTests
         // Assert
         Assert.True(options.IsGlobalModeEnabled);
     }
+
+    [Fact]
+    public void UseSentry_SetsMauiSdkNameAndVersion()
+    {
+        // Arrange
+        SentryEvent @event = null;
+        var builder = MauiApp.CreateBuilder()
+            .UseSentry(options =>
+            {
+                options.Dsn = DsnSamples.ValidDsnWithoutSecret;
+                options.BeforeSend = e =>
+                {
+                    // capture the event
+                    @event = e;
+
+                    // but don't actually send it
+                    return null;
+                };
+            });
+
+        // Act
+        using var app = builder.Build();
+        var client = app.Services.GetRequiredService<ISentryClient>();
+        client.CaptureMessage("test");
+
+        // Assert
+        Assert.NotNull(@event);
+        Assert.Equal(Constants.SdkName, @event.Sdk.Name);
+        Assert.Equal(Constants.SdkVersion, @event.Sdk.Version);
+    }
 }

--- a/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.cs
+++ b/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.cs
@@ -95,4 +95,20 @@ public class SentryMauiAppBuilderExtensionsTests
         Assert.Equal(DsnSamples.ValidDsnWithoutSecret, options.Dsn);
         Assert.True(options.Debug);
     }
+
+    [Fact]
+    public void UseSentry_EnablesGlobalMode()
+    {
+        // Arrange
+        var builder = MauiApp.CreateBuilder();
+
+        // Act
+        _ = builder.UseSentry(DsnSamples.ValidDsnWithoutSecret);
+
+        using var app = builder.Build();
+        var options = app.Services.GetRequiredService<IOptions<SentryMauiOptions>>().Value;
+
+        // Assert
+        Assert.True(options.IsGlobalModeEnabled);
+    }
 }


### PR DESCRIPTION
Continues #1651 

- Enable global mode
- Set the MAUI SDK name and version on the event
- Hook up the Android SDK

Also
- Resolves some noisy warnings
- Add the API Approval tests like our other projects
- Adds a constant to the sample to prevent VS from attaching a debugger on Windows apps 