### PR TITLE
Use the existing scope for EFCore

### DIFF
--- a/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentryEFCoreListener.cs
+++ b/src/Sentry.DiagnosticSource/Internals/DiagnosticSource/SentryEFCoreListener.cs
@@ -62,7 +62,7 @@ namespace Sentry.Internals.DiagnosticSource
                 return scope.GetSpan();
             }
 
-            return scope.Transaction;
+            return scope.Transaction?.GetLastActiveSpan() ?? scope.Transaction;
         }
 
         private void AddSpan(SentryEFSpanType type, string operation, string? description)


### PR DESCRIPTION
Instead of always tracing on the transaction, checking if there is a span already would be better to properly link the span to it.