### PR TITLE
Handle BadHttpRequestException from Kestrel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Remove IInternalSdkIntegration ([#1656](https://github.com/getsentry/sentry-dotnet/pull/1656))
 - On async Main, dont unregister unhandled exception before capturing crash  ([#321](https://github.com/getsentry/sentry-dotnet/issues/321))
+- Handle BadHttpRequestException from Kestrel inside SentryTunnelMiddleware ([#1673](https://github.com/getsentry/sentry-dotnet/pull/1673))
 
 ## 3.17.1
 

--- a/src/Sentry.AspNetCore/SentryTunnelMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTunnelMiddleware.cs
@@ -50,7 +50,7 @@ public class SentryTunnelMiddleware : IMiddleware
         catch(BadHttpRequestException)
         {
             // See https://github.com/dotnet/aspnetcore/issues/23949
-            // This is an exception thrown by Kestrel if the client breaks off the request while trying to read the input stram
+            // This is an exception thrown by Kestrel if the client breaks off the request while trying to read the input stream
             // We can't forward this to Sentry so we just return a 400
             response.StatusCode = StatusCodes.Status400BadRequest;
             return;


### PR DESCRIPTION
Sentry Tunnel should gracefully handle if a client breaks off a request stream by catching the exception and returning a 400 to the client.