### PR TITLE
Make HttpContext available for sampling decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Features
 
 - Move tunnel functionality into Sentry.AspNetCore ([#1645](https://github.com/getsentry/sentry-dotnet/pull/1645))
+- Make `HttpContext` available for sampling decisions ([#1682](https://github.com/getsentry/sentry-dotnet/pull/1682))
 - Initial support for .NET MAUI ([#1663](https://github.com/getsentry/sentry-dotnet/pull/1663)) ([#1670](https://github.com/getsentry/sentry-dotnet/pull/1670))
 - Initial support for `net6.0-android` apps ([#1288](https://github.com/getsentry/sentry-dotnet/pull/1288)) ([#1669](https://github.com/getsentry/sentry-dotnet/pull/1669))
 

--- a/samples/Sentry.Samples.AspNetCore5.Mvc/Program.cs
+++ b/samples/Sentry.Samples.AspNetCore5.Mvc/Program.cs
@@ -20,6 +20,15 @@ public static class Program
                     o.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
                     o.TracesSampler = ctx =>
                     {
+                        // This is an example of using a custom HTTP request header to make the sampling decision
+                        var httpContext = ctx.TryGetHttpContext()!;
+                        var requestHeaders = httpContext.Request.Headers;
+                        if (requestHeaders.ContainsKey("X-Sentry-No-Tracing"))
+                        {
+                            return 0;
+                        }
+
+                        // This is an example of changing the sample rate for a specific HTTP route
                         if (string.Equals(ctx.TryGetHttpRoute(), "/Home/Privacy", StringComparison.Ordinal))
                         {
                             // Collect fewer traces for this page

--- a/src/Sentry.AspNetCore/SamplingExtensions.cs
+++ b/src/Sentry.AspNetCore/SamplingExtensions.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Microsoft.AspNetCore.Http;
 
 namespace Sentry.AspNetCore;
 
@@ -11,6 +12,7 @@ public static class SamplingExtensions
     internal const string KeyForHttpMethod = "__HttpMethod";
     internal const string KeyForHttpRoute = "__HttpRoute";
     internal const string KeyForHttpPath = "__HttpPath";
+    internal const string KeyForHttpContext = "__HttpContext";
 
     /// <summary>
     /// Gets the HTTP method associated with the transaction.
@@ -44,4 +46,15 @@ public static class SamplingExtensions
     /// </remarks>
     public static string? TryGetHttpPath(this TransactionSamplingContext samplingContext) =>
         samplingContext.CustomSamplingContext.GetValueOrDefault(KeyForHttpPath) as string;
+
+    /// <summary>
+    /// Gets the <see cref="HttpContext"/> associated with the transaction.
+    /// May return null if the value has not been set by the integration.
+    /// </summary>
+    /// <remarks>
+    /// This method extracts data from <see cref="TransactionSamplingContext.CustomSamplingContext"/>
+    /// which is populated by Sentry's ASP.NET Core integration.
+    /// </remarks>
+    public static HttpContext? TryGetHttpContext(this TransactionSamplingContext samplingContext) =>
+        samplingContext.CustomSamplingContext.GetValueOrDefault(KeyForHttpContext) as HttpContext;
 }

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -72,11 +72,12 @@ namespace Sentry.AspNetCore
                     ? new TransactionContext(transactionName ?? string.Empty, OperationName, traceHeader)
                     : new TransactionContext(transactionName ?? string.Empty, OperationName);
 
-                var customSamplingContext = new Dictionary<string, object?>(3, StringComparer.Ordinal)
+                var customSamplingContext = new Dictionary<string, object?>(4, StringComparer.Ordinal)
                 {
                     [SamplingExtensions.KeyForHttpMethod] = context.Request.Method,
                     [SamplingExtensions.KeyForHttpRoute] = context.TryGetRouteTemplate(),
-                    [SamplingExtensions.KeyForHttpPath] = context.Request.Path.Value
+                    [SamplingExtensions.KeyForHttpPath] = context.Request.Path.Value,
+                    [SamplingExtensions.KeyForHttpContext] = context,
                 };
 
                 var transaction = hub.StartTransaction(transactionContext, customSamplingContext);

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -23,6 +23,7 @@ namespace Sentry.AspNetCore
     }
     public static class SamplingExtensions
     {
+        public static Microsoft.AspNetCore.Http.HttpContext? TryGetHttpContext(this Sentry.TransactionSamplingContext samplingContext) { }
         public static string? TryGetHttpMethod(this Sentry.TransactionSamplingContext samplingContext) { }
         public static string? TryGetHttpPath(this Sentry.TransactionSamplingContext samplingContext) { }
         public static string? TryGetHttpRoute(this Sentry.TransactionSamplingContext samplingContext) { }

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -23,6 +23,7 @@ namespace Sentry.AspNetCore
     }
     public static class SamplingExtensions
     {
+        public static Microsoft.AspNetCore.Http.HttpContext? TryGetHttpContext(this Sentry.TransactionSamplingContext samplingContext) { }
         public static string? TryGetHttpMethod(this Sentry.TransactionSamplingContext samplingContext) { }
         public static string? TryGetHttpPath(this Sentry.TransactionSamplingContext samplingContext) { }
         public static string? TryGetHttpRoute(this Sentry.TransactionSamplingContext samplingContext) { }

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -23,6 +23,7 @@ namespace Sentry.AspNetCore
     }
     public static class SamplingExtensions
     {
+        public static Microsoft.AspNetCore.Http.HttpContext? TryGetHttpContext(this Sentry.TransactionSamplingContext samplingContext) { }
         public static string? TryGetHttpMethod(this Sentry.TransactionSamplingContext samplingContext) { }
         public static string? TryGetHttpPath(this Sentry.TransactionSamplingContext samplingContext) { }
         public static string? TryGetHttpRoute(this Sentry.TransactionSamplingContext samplingContext) { }

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -23,6 +23,7 @@ namespace Sentry.AspNetCore
     }
     public static class SamplingExtensions
     {
+        public static Microsoft.AspNetCore.Http.HttpContext? TryGetHttpContext(this Sentry.TransactionSamplingContext samplingContext) { }
         public static string? TryGetHttpMethod(this Sentry.TransactionSamplingContext samplingContext) { }
         public static string? TryGetHttpPath(this Sentry.TransactionSamplingContext samplingContext) { }
         public static string? TryGetHttpRoute(this Sentry.TransactionSamplingContext samplingContext) { }

--- a/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
@@ -198,6 +198,7 @@ public class SentryTracingMiddlewareTests
     {
         // Arrange
         TransactionSamplingContext samplingContext = null;
+        HttpContext httpContext = null;
 
         var sentryClient = Substitute.For<ISentryClient>();
 
@@ -226,7 +227,11 @@ public class SentryTracingMiddlewareTests
                 app.UseRouting();
                 app.UseSentryTracing();
 
-                app.UseEndpoints(routes => routes.Map("/person/{id}", _ => Task.CompletedTask));
+                app.UseEndpoints(routes => routes.Map("/person/{id}", context =>
+                {
+                    httpContext = context;
+                    return Task.CompletedTask;
+                }));
             }));
 
         var client = server.CreateClient();
@@ -239,6 +244,7 @@ public class SentryTracingMiddlewareTests
         samplingContext.TryGetHttpMethod().Should().Be("GET");
         samplingContext.TryGetHttpRoute().Should().Be("/person/{id}");
         samplingContext.TryGetHttpPath().Should().Be("/person/13");
+        samplingContext.TryGetHttpContext().Should().BeSameAs(httpContext);
     }
 
     [Fact]


### PR DESCRIPTION
Resolves #1533 by making the `HttpContext` available.

See included sample for example usage.