### PR TITLE
changelog note on grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Fixes
 
-- Flatten AggregateException ([#1672](https://github.com/getsentry/sentry-dotnet/pull/1672))
 - Improve timestamp precision of transactions and spans ([#1680](https://github.com/getsentry/sentry-dotnet/pull/1680))
+- Flatten AggregateException ([#1672](https://github.com/getsentry/sentry-dotnet/pull/1672))
+  - NOTE: This can affect grouping. You can keep the original behavior by setting the option `KeepAggregateException` to `true`.  
 
 ### Features
 


### PR DESCRIPTION
I believe dropping the top level exception done in https://github.com/getsentry/sentry-dotnet/pull/1672/files will affect grouping.
Best to add a note on the changelog.

#skip-changelog