### PR TITLE
Filter Android exception issues

### DIFF
--- a/src/Sentry/Android/SentrySdk.cs
+++ b/src/Sentry/Android/SentrySdk.cs
@@ -40,6 +40,10 @@ namespace Sentry
                 {
                     o.Dsn = options.Dsn;
                     //TODO: we'll need to pass other stuff here from SentryOptions to SentryAndroidOptions
+
+                    // Don't capture managed exceptions in the native SDK, since we already capture them in the managed SDK
+                    o.AddIgnoredExceptionForType(Class.ForName("android.runtime.JavaProxyThrowable"));
+
                 }));
 
             options.CrashedLastRun = () => Sentry.Java.Sentry.IsCrashedLastRun()?.BooleanValue() is true;

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -668,6 +668,7 @@ namespace Sentry
                     "IdentityModel",
                     "SqlitePclRaw",
                     "Xamarin",
+                    "Android.", // Ex: Android.Runtime.JNINativeWrapper...
                     "Google.",
                     "MongoDB.",
                     "Remotion.Linq",


### PR DESCRIPTION
When using the Android target, an unhandled exception in managed code will be sent to Sentry twice, once as the managed exception that was thrown, and again wrapped by `JavaProxyThrowable`.  The original exception is captured by the Sentry .NET SDK, and the `JavaProxyThrowable` exception is passed through the bundled Android SDK and captured there.

<img width="652" alt="image" src="https://user-images.githubusercontent.com/1396388/171960127-23692fbe-b378-4f5d-8efc-8ef12a1e59bb.png">


We don't need the noise, so filter out `android.runtime.JavaProxyThrowable` on the Android SDK.

Additionally, on the managed side we see some noise in the stack traces, such as `IOnClickListenerInvoker` and `JNINativeWrapper` seen here:

<img width="642" alt="image" src="https://user-images.githubusercontent.com/1396388/171960210-69f81690-7d25-464b-8b74-c62ff11fdc52.png">


Adding `"Android."` to the default exclude list will clean those up.

#skip-changelog