### PR TITLE
Always include stack frames from samples in DEBUG configuration

### DIFF
--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -680,10 +680,15 @@ namespace Sentry
                     "ServiceStack"
             };
 
+#if DEBUG
             InAppInclude = new[]
             {
                 "Sentry.Samples."
             };
+#else
+            InAppInclude = Array.Empty<string>();
+#endif
+
         }
     }
 }

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -680,7 +680,10 @@ namespace Sentry
                     "ServiceStack"
             };
 
-            InAppInclude = Array.Empty<string>();
+            InAppInclude = new[]
+            {
+                "Sentry.Samples."
+            };
         }
     }
 }


### PR DESCRIPTION
In some cases, an exception will be shown in sentry as "Crashed in non-app", as in the first line of this one:

<img width="650" alt="image" src="https://user-images.githubusercontent.com/1396388/171963376-11dd0891-22ba-4f32-b19f-986b9bcee6c8.png">

In this case, it's because `"Sentry."` is in the `InAppExclude` list, and we're coming from code in `Sentry.Samples.`

Samples should be treated the same as a real application, so add them to the `InAppInclude` list.

#skip-changelog