### PR TITLE
Serialize addresses as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improve timestamp precision of transactions and spans ([#1680](https://github.com/getsentry/sentry-dotnet/pull/1680))
 - Flatten AggregateException ([#1672](https://github.com/getsentry/sentry-dotnet/pull/1672))
   - NOTE: This can affect grouping. You can keep the original behavior by setting the option `KeepAggregateException` to `true`.  
+- Serialize stack frame addresses as strings. ([#1692](https://github.com/getsentry/sentry-dotnet/pull/1692))
 
 ### Features
 

--- a/src/Sentry/Exceptions/SentryStackFrame.cs
+++ b/src/Sentry/Exceptions/SentryStackFrame.cs
@@ -161,8 +161,8 @@ namespace Sentry
             writer.WriteBooleanIfNotNull("in_app", InApp);
             writer.WriteStringIfNotWhiteSpace("package", Package);
             writer.WriteStringIfNotWhiteSpace("platform", Platform);
-            writer.WriteNumberIfNotNull("image_addr", ImageAddress.NullIfDefault());
-            writer.WriteNumberIfNotNull("symbol_addr", SymbolAddress);
+            writer.WriteStringIfNotWhiteSpace("image_addr", ImageAddress.NullIfDefault()?.ToHexString());
+            writer.WriteStringIfNotWhiteSpace("symbol_addr", SymbolAddress?.ToHexString());
             writer.WriteStringIfNotWhiteSpace("instruction_addr", InstructionAddress);
             writer.WriteNumberIfNotNull("instruction_offset", InstructionOffset);
             writer.WriteStringIfNotWhiteSpace("addr_mode", AddressMode);
@@ -212,8 +212,8 @@ namespace Sentry
             var inApp = json.GetPropertyOrNull("in_app")?.GetBoolean();
             var package = json.GetPropertyOrNull("package")?.GetString();
             var platform = json.GetPropertyOrNull("platform")?.GetString();
-            var imageAddress = json.GetPropertyOrNull("image_addr")?.GetInt64() ?? 0;
-            var symbolAddress = json.GetPropertyOrNull("symbol_addr")?.GetInt64();
+            var imageAddress = json.GetPropertyOrNull("image_addr")?.GetAddressAsLong() ?? 0;
+            var symbolAddress = json.GetPropertyOrNull("symbol_addr")?.GetAddressAsLong();
             var instructionAddress = json.GetPropertyOrNull("instruction_addr")?.GetString();
             var instructionOffset = json.GetPropertyOrNull("instruction_offset")?.GetInt64();
             var addressMode = json.GetPropertyOrNull("addr_mode")?.GetString();

--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -104,6 +104,36 @@ namespace Sentry.Internal.Extensions
             return double.Parse(json.ToString()!);
         }
 
+        public static long? GetAddressAsLong(this JsonElement json)
+        {
+            // If the address is in json as a number, we can just use it.
+            if (json.ValueKind == JsonValueKind.Number)
+            {
+                return json.GetInt64();
+            }
+
+            // Otherwise it will be a string, but we need to convert it to a number.
+            var s = json.GetString();
+            if (s == null)
+            {
+                return null;
+            }
+
+            // It should be in hex format, such as "0x7fff5bf346c0"
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+            var substring = s[2..];
+#else
+            var substring = s.Substring(2);
+#endif
+            if (s.StartsWith("0x") &&
+                long.TryParse(substring, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result))
+            {
+                return result;
+            }
+
+            throw new FormatException();
+        }
+
         public static string GetStringOrThrow(this JsonElement json) =>
             json.GetString() ?? throw new InvalidOperationException("JSON string is null.");
 

--- a/src/Sentry/Internal/Extensions/MiscExtensions.cs
+++ b/src/Sentry/Internal/Extensions/MiscExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Sentry.Internal.Extensions
 {
@@ -11,5 +12,8 @@ namespace Sentry.Internal.Extensions
             !EqualityComparer<T>.Default.Equals(value, default)
                 ? value
                 : null;
+
+        public static string ToHexString(this long l) =>
+            "0x" + l.ToString("x", CultureInfo.InvariantCulture);
     }
 }

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
@@ -46,8 +46,8 @@ public class SentryStackFrameTests
             "\"in_app\":true," +
             "\"package\":\"Package\"," +
             "\"platform\":\"Platform\"," +
-            "\"image_addr\":3," +
-            "\"symbol_addr\":4," +
+            "\"image_addr\":\"0x3\"," +
+            "\"symbol_addr\":\"0x4\"," +
             "\"instruction_addr\":\"0xffffffff\"," +
             "\"instruction_offset\":5," +
             "\"addr_mode\":\"rel:0\"" +


### PR DESCRIPTION
Address properties on stack traces were previously being serialized to JSON as long integers, rather than in hex string format.  For example, `"image_addr": 140734736058048` instead of `"image_addr": "0x7fff5bf346c0"`.

While either format is allowed by the back end (handled in [this function](https://github.com/getsentry/symbolic/blob/b736c22b7b2c12e07a7584a3d8a2cfc6c6b056e6/py/symbolic/common.py#L47-L57)), most of the other Sentry SDKs are using the string format.

Specifically, `image_addr` and `symbol_addr` are represented as strings in the Java SDK.  Passing events via serialization/deserialization between the two SDKs will fail unless they are strings here.  (I'll be doing that in a future PR soon, when sending data between the managed and Android-native SDKs.)

I've left the actual properties alone, as they are public and we don't need a breaking change.