### PR TITLE
Improve serialization perf and fix memory leak in SentryEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - Improve timestamp precision of transactions and spans ([#1680](https://github.com/getsentry/sentry-dotnet/pull/1680))
 - Flatten AggregateException ([#1672](https://github.com/getsentry/sentry-dotnet/pull/1672))
-  - NOTE: This can affect grouping. You can keep the original behavior by setting the option `KeepAggregateException` to `true`.  
+  - NOTE: This can affect grouping. You can keep the original behavior by setting the option `KeepAggregateException` to `true`.
+- Improve serialization perf and fix memory leak in `SentryEvent` ([#1693](https://github.com/getsentry/sentry-dotnet/pull/1693))
 
 ### Features
 

--- a/src/Sentry/Envelopes/Envelope.cs
+++ b/src/Sentry/Envelopes/Envelope.cs
@@ -232,7 +232,7 @@ namespace Sentry.Protocol.Envelopes
             }
 
             return
-                Json.Parse(buffer.ToArray()).GetDictionaryOrNull()
+                Json.Parse(buffer.ToArray(), JsonExtensions.GetDictionaryOrNull)
                 ?? throw new InvalidOperationException("Envelope header is malformed.");
         }
 

--- a/src/Sentry/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Envelopes/EnvelopeItem.cs
@@ -317,7 +317,7 @@ namespace Sentry.Protocol.Envelopes
             }
 
             return
-                Json.Parse(buffer.ToArray()).GetDictionaryOrNull()
+                Json.Parse(buffer.ToArray(), JsonExtensions.GetDictionaryOrNull)
                 ?? throw new InvalidOperationException("Envelope item header is malformed.");
         }
 
@@ -339,9 +339,9 @@ namespace Sentry.Protocol.Envelopes
             {
                 var bufferLength = (int)(payloadLength ?? stream.Length);
                 var buffer = await stream.ReadByteChunkAsync(bufferLength, cancellationToken).ConfigureAwait(false);
-                var json = Json.Parse(buffer);
+                var sentryEvent = Json.Parse(buffer, SentryEvent.FromJson);
 
-                return new JsonSerializable(SentryEvent.FromJson(json));
+                return new JsonSerializable(sentryEvent);
             }
 
             // User report
@@ -349,9 +349,9 @@ namespace Sentry.Protocol.Envelopes
             {
                 var bufferLength = (int)(payloadLength ?? stream.Length);
                 var buffer = await stream.ReadByteChunkAsync(bufferLength, cancellationToken).ConfigureAwait(false);
-                var json = Json.Parse(buffer);
+                var userFeedback = Json.Parse(buffer, UserFeedback.FromJson);
 
-                return new JsonSerializable(UserFeedback.FromJson(json));
+                return new JsonSerializable(userFeedback);
             }
 
             // Transaction
@@ -359,9 +359,9 @@ namespace Sentry.Protocol.Envelopes
             {
                 var bufferLength = (int)(payloadLength ?? stream.Length);
                 var buffer = await stream.ReadByteChunkAsync(bufferLength, cancellationToken).ConfigureAwait(false);
-                var json = Json.Parse(buffer);
+                var transaction = Json.Parse(buffer, Transaction.FromJson);
 
-                return new JsonSerializable(Transaction.FromJson(json));
+                return new JsonSerializable(transaction);
             }
 
             // Session
@@ -369,9 +369,9 @@ namespace Sentry.Protocol.Envelopes
             {
                 var bufferLength = (int)(payloadLength ?? stream.Length);
                 var buffer = await stream.ReadByteChunkAsync(bufferLength, cancellationToken).ConfigureAwait(false);
-                var json = Json.Parse(buffer);
+                var sessionUpdate = Json.Parse(buffer, SessionUpdate.FromJson);
 
-                return new JsonSerializable(SessionUpdate.FromJson(json));
+                return new JsonSerializable(sessionUpdate);
             }
 
             // Client Report
@@ -379,9 +379,9 @@ namespace Sentry.Protocol.Envelopes
             {
                 var bufferLength = (int)(payloadLength ?? stream.Length);
                 var buffer = await stream.ReadByteChunkAsync(bufferLength, cancellationToken).ConfigureAwait(false);
-                var json = Json.Parse(buffer);
+                var clientReport = Json.Parse(buffer, ClientReport.FromJson);
 
-                return new JsonSerializable(ClientReport.FromJson(json));
+                return new JsonSerializable(clientReport);
             }
 
             // Arbitrary payload

--- a/src/Sentry/GlobalSessionManager.cs
+++ b/src/Sentry/GlobalSessionManager.cs
@@ -41,7 +41,7 @@ namespace Sentry
             _options = options;
             _clock = clock ?? SystemClock.Clock;
             _persistedSessionProvider = persistedSessionProvider
-                                        ?? (filePath => PersistedSessionUpdate.FromJson(Json.Load(filePath)));
+                                        ?? (filePath => Json.Load(filePath, PersistedSessionUpdate.FromJson));
 
             // TODO: session file should really be process-isolated, but we
             // don't have a proper mechanism for that right now.

--- a/src/Sentry/Internal/Json.cs
+++ b/src/Sentry/Internal/Json.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Text.Json;
 
@@ -5,23 +6,23 @@ namespace Sentry.Internal
 {
     internal static class Json
     {
-        public static JsonElement Parse(byte[] json)
+        public static T Parse<T>(byte[] json, Func<JsonElement, T> factory)
         {
             using var jsonDocument = JsonDocument.Parse(json);
-            return jsonDocument.RootElement.Clone();
+            return factory.Invoke(jsonDocument.RootElement);
         }
 
-        public static JsonElement Parse(string json)
+        public static T Parse<T>(string json, Func<JsonElement, T> factory)
         {
             using var jsonDocument = JsonDocument.Parse(json);
-            return jsonDocument.RootElement.Clone();
+            return factory.Invoke(jsonDocument.RootElement);
         }
 
-        public static JsonElement Load(string filePath)
+        public static T Load<T>(string filePath, Func<JsonElement, T> factory)
         {
             using var file = File.OpenRead(filePath);
             using var jsonDocument = JsonDocument.Parse(file);
-            return jsonDocument.RootElement.Clone();
+            return factory.Invoke(jsonDocument.RootElement);
         }
     }
 }

--- a/src/Sentry/SentryEvent.cs
+++ b/src/Sentry/SentryEvent.cs
@@ -273,8 +273,8 @@ namespace Sentry
             var logger = json.GetPropertyOrNull("logger")?.GetString();
             var serverName = json.GetPropertyOrNull("server_name")?.GetString();
             var release = json.GetPropertyOrNull("release")?.GetString();
-            var exceptionValues = json.GetPropertyOrNull("exception")?.GetPropertyOrNull("values")?.EnumerateArray().Select(SentryException.FromJson).Pipe(v => new SentryValues<SentryException>(v));
-            var threadValues = json.GetPropertyOrNull("threads")?.GetPropertyOrNull("values")?.EnumerateArray().Select(SentryThread.FromJson).Pipe(v => new SentryValues<SentryThread>(v));
+            var exceptionValues = json.GetPropertyOrNull("exception")?.GetPropertyOrNull("values")?.EnumerateArray().Select(SentryException.FromJson).ToList().Pipe(v => new SentryValues<SentryException>(v));
+            var threadValues = json.GetPropertyOrNull("threads")?.GetPropertyOrNull("values")?.EnumerateArray().Select(SentryThread.FromJson).ToList().Pipe(v => new SentryValues<SentryThread>(v));
             var level = json.GetPropertyOrNull("level")?.GetString()?.ParseEnum<SentryLevel>();
             var transaction = json.GetPropertyOrNull("transaction")?.GetString();
             var request = json.GetPropertyOrNull("request")?.Pipe(Request.FromJson);

--- a/test/Sentry.Tests/Protocol/BreadcrumbTests.cs
+++ b/test/Sentry.Tests/Protocol/BreadcrumbTests.cs
@@ -8,7 +8,7 @@ public class BreadcrumbTests : ImmutableTests<Breadcrumb>
         var sut = new Breadcrumb("test", "unit");
 
         var actualJson = sut.ToJsonString();
-        var actual = Breadcrumb.FromJson(Json.Parse(actualJson));
+        var actual = Json.Parse(actualJson, Breadcrumb.FromJson);
 
         Assert.NotEqual(default, actual.Timestamp);
     }

--- a/test/Sentry.Tests/Protocol/Context/AppTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/AppTests.cs
@@ -18,7 +18,7 @@ public class AppTests
 
         var actualString = sut.ToJsonString();
 
-        var actual = App.FromJson(Json.Parse(actualString));
+        var actual = Json.Parse(actualString, App.FromJson);
         actual.Should().BeEquivalentTo(sut);
     }
 

--- a/test/Sentry.Tests/Protocol/Context/BrowserTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/BrowserTests.cs
@@ -14,7 +14,7 @@ public class BrowserTests
 
         var actualString = sut.ToJsonString();
 
-        var actual = Browser.FromJson(Json.Parse(actualString));
+        var actual = Json.Parse(actualString, Browser.FromJson);
         actual.Should().BeEquivalentTo(sut);
     }
 

--- a/test/Sentry.Tests/Protocol/Context/ContextsTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/ContextsTests.cs
@@ -10,7 +10,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString();
 
-        var actual = Contexts.FromJson(Json.Parse(actualString));
+        var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("{}", actualString);
@@ -28,7 +28,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString();
 
-        var actual = Contexts.FromJson(Json.Parse(actualString));
+        var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("{\"server\":{\"type\":\"os\",\"name\":\"Linux\"}}", actualString);
@@ -47,7 +47,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString();
 
-        var actual = Contexts.FromJson(Json.Parse(actualString));
+        var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("{\"device\":{\"type\":\"device\",\"arch\":\"x86\"}}", actualString);
@@ -66,7 +66,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString();
 
-        var actual = Contexts.FromJson(Json.Parse(actualString));
+        var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("{\"app\":{\"type\":\"app\",\"app_name\":\"My.App\"}}", actualString);
@@ -85,7 +85,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString();
 
-        var actual = Contexts.FromJson(Json.Parse(actualString));
+        var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("{\"gpu\":{\"type\":\"gpu\",\"name\":\"My.Gpu\"}}", actualString);
@@ -104,7 +104,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString();
 
-        var actual = Contexts.FromJson(Json.Parse(actualString));
+        var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("{\"runtime\":{\"type\":\"runtime\",\"version\":\"2.1.1.100\"}}", actualString);
@@ -121,7 +121,7 @@ public class ContextsTests
 
         // Act
         var json = contexts.ToJsonString();
-        var roundtrip = Contexts.FromJson(Json.Parse(json));
+        var roundtrip = Json.Parse(json, Contexts.FromJson);
 
         // Assert
         json.Should().Be("{\"foo\":{\"Bar\":42,\"Baz\":\"kek\"}}");
@@ -146,7 +146,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString();
 
-        var actual = Contexts.FromJson(Json.Parse(actualString));
+        var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("{\"browser\":{\"type\":\"browser\",\"name\":\"Netscape 1\"}}", actualString);
@@ -165,7 +165,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString();
 
-        var actual = Contexts.FromJson(Json.Parse(actualString));
+        var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("{\"os\":{\"type\":\"os\",\"name\":\"BeOS 1\"}}", actualString);

--- a/test/Sentry.Tests/Protocol/Context/DeviceTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/DeviceTests.cs
@@ -203,7 +203,7 @@ public class DeviceTests
         const string json = "{\"type\":\"device\",\"timezone\":\"tz_id\",\"timezone_display_name\":\"tz_name\"}";
 
         // Act
-        var device = Device.FromJson(Json.Parse(json));
+        var device = Json.Parse(json, Device.FromJson);
 
         // Assert
         device.Timezone.Should().NotBeNull();

--- a/test/Sentry.Tests/Protocol/DebugImageTests.cs
+++ b/test/Sentry.Tests/Protocol/DebugImageTests.cs
@@ -30,7 +30,7 @@ public class DebugImageTests
             "}",
             actual);
 
-        var parsed = DebugImage.FromJson(Json.Parse(actual));
+        var parsed = Json.Parse(actual, DebugImage.FromJson);
 
         parsed.Should().BeEquivalentTo(sut);
     }

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
@@ -54,7 +54,7 @@ public class SentryStackFrameTests
             "}",
             actual);
 
-        var parsed = SentryStackFrame.FromJson(Json.Parse(actual));
+        var parsed = Json.Parse(actual, SentryStackFrame.FromJson);
 
         parsed.Should().BeEquivalentTo(sut);
     }

--- a/test/Sentry.Tests/Protocol/SentryEventTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryEventTests.cs
@@ -64,7 +64,7 @@ public class SentryEventTests
             "{\"type\":\"wasm\",\"debug_id\":\"900f7d1b868432939de4457478f34720\"}" +
             "]}");
 
-        var actual = SentryEvent.FromJson(Json.Parse(actualString));
+        var actual = Json.Parse(actualString, SentryEvent.FromJson);
 
         // Assert
         actual.Should().BeEquivalentTo(sut, o =>

--- a/test/Sentry.Tests/Protocol/TransactionTests.cs
+++ b/test/Sentry.Tests/Protocol/TransactionTests.cs
@@ -74,7 +74,7 @@ public class TransactionTests
         // Act
         var finalTransaction = new Transaction(transaction);
         var actualString = finalTransaction.ToJsonString();
-        var actual = Transaction.FromJson(Json.Parse(actualString));
+        var actual = Json.Parse(actualString, Transaction.FromJson);
 
         // Assert
         actual.Should().BeEquivalentTo(finalTransaction, o =>


### PR DESCRIPTION
I ran into an issue wherein the `SentryExceptions` and `SentryThreads` properties on `SentryEvent` can return open `JsonElement` objects instead of their actual properties.  If the `JsonDocument` holding those elements is not disposed, we get a memory leak.  But also, if the document *is* disposed, we can't deserialize the data without getting an `ObjectDisposedException`.  The root cause turned out to be an un-materialized `IEnumerable` on those properties coming from `SentryEvent.FromJson`.

The tests were hiding this, because we were using our `Json.Parse(string)` helper function, which was using `.Clone()`, so the elements wouldn't have been disposed with the document.  Since cloning is semi-costly, I revised the helper methods to avoid it, by passing in a factory method delegate instead and using it to return a concrete object instead of a `JsonElement`.

Only one test failed with the change to the JSON helpers, which was for the issue had already found on `SentryEvent`.  Adding `.ToList()` in the correct place made the test pass again.

So - part fix, part perf improvement.