### PR TITLE
Send the .NET Runtime Identifier to Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Move tunnel functionality into Sentry.AspNetCore ([#1645](https://github.com/getsentry/sentry-dotnet/pull/1645))
 - Make `HttpContext` available for sampling decisions ([#1682](https://github.com/getsentry/sentry-dotnet/pull/1682))
+- Send the .NET Runtime Identifier to Sentry ([#1708](https://github.com/getsentry/sentry-dotnet/pull/1708)) 
 - Added a new `Sentry.Maui` integration library for the [.NET MAUI](https://dotnet.microsoft.com/apps/maui) platform:
   - Initial MAUI support ([#1663](https://github.com/getsentry/sentry-dotnet/pull/1663))
   - Continue with adding MAUI support ([#1670](https://github.com/getsentry/sentry-dotnet/pull/1670))

--- a/src/Sentry/Internal/Enricher.cs
+++ b/src/Sentry/Internal/Enricher.cs
@@ -17,6 +17,7 @@ namespace Sentry.Internal
             {
                 Name = current.Name,
                 Version = current.Version,
+                Identifier = current.Identifier,
                 RawDescription = current.Raw
             };
         });
@@ -82,6 +83,13 @@ namespace Sentry.Internal
 
             // Default tags
             _options.ApplyDefaultTags(eventLike);
+
+            // Pass the runtime identifier as a tag also
+            const string ridTag = "runtime.identifier";
+            if (_runtimeLazy.Value.Identifier is { } ridValue && !eventLike.Tags.ContainsKey(ridTag))
+            {
+                eventLike.SetTag(ridTag, ridValue);
+            }
         }
     }
 }

--- a/src/Sentry/Internal/Enricher.cs
+++ b/src/Sentry/Internal/Enricher.cs
@@ -83,13 +83,6 @@ namespace Sentry.Internal
 
             // Default tags
             _options.ApplyDefaultTags(eventLike);
-
-            // Pass the runtime identifier as a tag also
-            const string ridTag = "runtime.identifier";
-            if (_runtimeLazy.Value.Identifier is { } ridValue && !eventLike.Tags.ContainsKey(ridTag))
-            {
-                eventLike.SetTag(ridTag, ridValue);
-            }
         }
     }
 }

--- a/src/Sentry/PlatformAbstractions/Runtime.cs
+++ b/src/Sentry/PlatformAbstractions/Runtime.cs
@@ -57,6 +57,14 @@ namespace Sentry.PlatformAbstractions
         public string? Raw { get; }
 
         /// <summary>
+        /// The .NET Runtime Identifier of the runtime
+        /// </summary>
+        /// <remarks>
+        /// This property will be populated for .NET 5 and newer, or <c>null</c> otherwise.
+        /// </remarks>
+        public string? Identifier { get; set; }
+
+        /// <summary>
         /// Creates a new Runtime instance
         /// </summary>
         public Runtime(

--- a/src/Sentry/PlatformAbstractions/RuntimeInfo.cs
+++ b/src/Sentry/PlatformAbstractions/RuntimeInfo.cs
@@ -31,6 +31,9 @@ namespace Sentry.PlatformAbstractions
 #else
             SetNetCoreVersion(runtime);
 #endif
+#if NET5_0_OR_GREATER
+            SetRuntimeIdentifier(runtime);
+#endif
         }
 
         internal static Runtime? Parse(string rawRuntimeDescription, string? name = null)
@@ -96,6 +99,20 @@ namespace Sentry.PlatformAbstractions
                 {
                     runtime.Version = assemblyPath[netCoreAppIndex + 1];
                 }
+            }
+        }
+#endif
+
+#if NET5_0_OR_GREATER
+        internal static void SetRuntimeIdentifier(Runtime runtime)
+        {
+            try
+            {
+                runtime.Identifier = RuntimeInformation.RuntimeIdentifier;
+            }
+            catch
+            {
+                return;
             }
         }
 #endif

--- a/src/Sentry/Protocol/Runtime.cs
+++ b/src/Sentry/Protocol/Runtime.cs
@@ -40,6 +40,11 @@ namespace Sentry.Protocol
         public string? RawDescription { get; set; }
 
         /// <summary>
+        /// An optional .NET Runtime Identifier string.
+        /// </summary>
+        public string? Identifier { get; set; }
+
+        /// <summary>
         /// An optional build number.
         /// </summary>
         /// <see href="https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed"/>
@@ -53,6 +58,7 @@ namespace Sentry.Protocol
             {
                 Name = Name,
                 Version = Version,
+                Identifier = Identifier,
                 Build = Build,
                 RawDescription = RawDescription
             };
@@ -66,6 +72,7 @@ namespace Sentry.Protocol
             writer.WriteStringIfNotWhiteSpace("name", Name);
             writer.WriteStringIfNotWhiteSpace("version", Version);
             writer.WriteStringIfNotWhiteSpace("raw_description", RawDescription);
+            writer.WriteStringIfNotWhiteSpace("identifier", Identifier);
             writer.WriteStringIfNotWhiteSpace("build", Build);
 
             writer.WriteEndObject();
@@ -79,6 +86,7 @@ namespace Sentry.Protocol
             var name = json.GetPropertyOrNull("name")?.GetString();
             var version = json.GetPropertyOrNull("version")?.GetString();
             var rawDescription = json.GetPropertyOrNull("raw_description")?.GetString();
+            var identifier = json.GetPropertyOrNull("identifier")?.GetString();
             var build = json.GetPropertyOrNull("build")?.GetString();
 
             return new Runtime
@@ -86,6 +94,7 @@ namespace Sentry.Protocol
                 Name = name,
                 Version = version,
                 RawDescription = rawDescription,
+                Identifier = identifier,
                 Build = build
             };
         }

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1158,6 +1158,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime
     {
         public Runtime(string? name = null, string? version = null, string? raw = null) { }
+        public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
@@ -1313,6 +1314,7 @@ namespace Sentry.Protocol
         public const string Type = "runtime";
         public Runtime() { }
         public string? Build { get; set; }
+        public string? Identifier { get; set; }
         public string? Name { get; set; }
         public string? RawDescription { get; set; }
         public string? Version { get; set; }

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1158,6 +1158,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime
     {
         public Runtime(string? name = null, string? version = null, string? raw = null) { }
+        public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
@@ -1313,6 +1314,7 @@ namespace Sentry.Protocol
         public const string Type = "runtime";
         public Runtime() { }
         public string? Build { get; set; }
+        public string? Identifier { get; set; }
         public string? Name { get; set; }
         public string? RawDescription { get; set; }
         public string? Version { get; set; }

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1158,6 +1158,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime
     {
         public Runtime(string? name = null, string? version = null, string? raw = null) { }
+        public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
@@ -1313,6 +1314,7 @@ namespace Sentry.Protocol
         public const string Type = "runtime";
         public Runtime() { }
         public string? Build { get; set; }
+        public string? Identifier { get; set; }
         public string? Name { get; set; }
         public string? RawDescription { get; set; }
         public string? Version { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -1157,6 +1157,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime
     {
         public Runtime(string? name = null, string? version = null, string? raw = null) { }
+        public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
@@ -1312,6 +1313,7 @@ namespace Sentry.Protocol
         public const string Type = "runtime";
         public Runtime() { }
         public string? Build { get; set; }
+        public string? Identifier { get; set; }
         public string? Name { get; set; }
         public string? RawDescription { get; set; }
         public string? Version { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -1157,6 +1157,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime
     {
         public Runtime(string? name = null, string? version = null, string? raw = null) { }
+        public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
@@ -1312,6 +1313,7 @@ namespace Sentry.Protocol
         public const string Type = "runtime";
         public Runtime() { }
         public string? Build { get; set; }
+        public string? Identifier { get; set; }
         public string? Name { get; set; }
         public string? RawDescription { get; set; }
         public string? Version { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1158,6 +1158,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime
     {
         public Runtime(string? name = null, string? version = null, string? raw = null) { }
+        public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
@@ -1313,6 +1314,7 @@ namespace Sentry.Protocol
         public const string Type = "runtime";
         public Runtime() { }
         public string? Build { get; set; }
+        public string? Identifier { get; set; }
         public string? Name { get; set; }
         public string? RawDescription { get; set; }
         public string? Version { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1158,6 +1158,7 @@ namespace Sentry.PlatformAbstractions
     {
         public Runtime(string? name = null, string? version = null, Sentry.PlatformAbstractions.FrameworkInstallation? frameworkInstallation = null, string? raw = null) { }
         public Sentry.PlatformAbstractions.FrameworkInstallation FrameworkInstallation { get; }
+        public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
@@ -1313,6 +1314,7 @@ namespace Sentry.Protocol
         public const string Type = "runtime";
         public Runtime() { }
         public string? Build { get; set; }
+        public string? Identifier { get; set; }
         public string? Name { get; set; }
         public string? RawDescription { get; set; }
         public string? Version { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1158,6 +1158,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime
     {
         public Runtime(string? name = null, string? version = null, string? raw = null) { }
+        public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
@@ -1313,6 +1314,7 @@ namespace Sentry.Protocol
         public const string Type = "runtime";
         public Runtime() { }
         public string? Build { get; set; }
+        public string? Identifier { get; set; }
         public string? Name { get; set; }
         public string? RawDescription { get; set; }
         public string? Version { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1158,6 +1158,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime
     {
         public Runtime(string? name = null, string? version = null, string? raw = null) { }
+        public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
@@ -1313,6 +1314,7 @@ namespace Sentry.Protocol
         public const string Type = "runtime";
         public Runtime() { }
         public string? Build { get; set; }
+        public string? Identifier { get; set; }
         public string? Name { get; set; }
         public string? RawDescription { get; set; }
         public string? Version { get; set; }

--- a/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
@@ -83,18 +83,6 @@ public class MainSentryEventProcessorTests
         var runtime = evt.Contexts.Runtime;
         Assert.Equal(System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier, runtime.Identifier);
     }
-
-    [Fact]
-    public void EnsureRuntimeIdentifierTagExists()
-    {
-        var evt = new SentryEvent();
-        var sut = _fixture.GetSut();
-
-        _ = sut.Process(evt);
-
-        var runtimeIdentifier = evt.Tags["runtime.identifier"];
-        Assert.Equal(System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier, runtimeIdentifier);
-    }
 #endif
 
     [Fact]

--- a/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
@@ -71,6 +71,32 @@ public class MainSentryEventProcessorTests
     }
 #endif
 
+#if NET5_0_OR_GREATER
+    [Fact]
+    public void EnsureRuntimeIdentifierExists()
+    {
+        var evt = new SentryEvent();
+        var sut = _fixture.GetSut();
+
+        _ = sut.Process(evt);
+
+        var runtime = evt.Contexts.Runtime;
+        Assert.Equal(System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier, runtime.Identifier);
+    }
+
+    [Fact]
+    public void EnsureRuntimeIdentifierTagExists()
+    {
+        var evt = new SentryEvent();
+        var sut = _fixture.GetSut();
+
+        _ = sut.Process(evt);
+
+        var runtimeIdentifier = evt.Tags["runtime.identifier"];
+        Assert.Equal(System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier, runtimeIdentifier);
+    }
+#endif
+
     [Fact]
     public void Process_SendDefaultPiiTrueIdEnvironmentTrue_UserNameSet()
     {

--- a/test/Sentry.Tests/PlatformAbstractions/RuntimeInfoTests.cs
+++ b/test/Sentry.Tests/PlatformAbstractions/RuntimeInfoTests.cs
@@ -78,6 +78,16 @@ public class RuntimeInfoTests
         Assert.Equal(".NET", input.Name);
         Assert.Null(input.Version);
     }
+
+    [Fact]
+    public void SetRuntimeIdentifier()
+    {
+        var input = new Runtime(".NET");
+        RuntimeInfo.SetRuntimeIdentifier(input);
+
+        Assert.Equal(".NET", input.Name);
+        Assert.Equal(System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier, input.Identifier);
+    }
 #endif
 
     public static IEnumerable<object[]> ParseTestCases()

--- a/test/Sentry.Tests/Protocol/Context/RuntimeTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/RuntimeTests.cs
@@ -26,6 +26,7 @@ public class RuntimeTests
         {
             Name = "name",
             RawDescription = "RawDescription",
+            Identifier = "identifier",
             Build = "build",
             Version = "version"
         };
@@ -34,6 +35,7 @@ public class RuntimeTests
 
         Assert.Equal(sut.Name, clone.Name);
         Assert.Equal(sut.RawDescription, clone.RawDescription);
+        Assert.Equal(sut.Identifier, clone.Identifier);
         Assert.Equal(sut.Build, clone.Build);
         Assert.Equal(sut.Version, clone.Version);
     }
@@ -52,6 +54,7 @@ public class RuntimeTests
         yield return new object[] { (new Runtime(), "{\"type\":\"runtime\"}") };
         yield return new object[] { (new Runtime { Name = "some name" }, "{\"type\":\"runtime\",\"name\":\"some name\"}") };
         yield return new object[] { (new Runtime { Version = "some version" }, "{\"type\":\"runtime\",\"version\":\"some version\"}") };
+        yield return new object[] { (new Runtime { Identifier = "some identifier" }, "{\"type\":\"runtime\",\"identifier\":\"some identifier\"}") };
         yield return new object[] { (new Runtime { Build = "some build" }, "{\"type\":\"runtime\",\"build\":\"some build\"}") };
         yield return new object[] { (new Runtime { RawDescription = "some Name, some version" }, "{\"type\":\"runtime\",\"raw_description\":\"some Name, some version\"}") };
     }


### PR DESCRIPTION
This sends the value from `System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier` to Sentry with all events, on the runtime context info.  This is helpful (for example) when working with MAUI events.

It shows up in the Sentry issues page under the Runtime section further down the page.

<img width="337" alt="image" src="https://user-images.githubusercontent.com/1396388/173434773-fb18a20a-548a-4c2f-b35b-eaea5a969c13.png">

Note, that the `RuntimeIdentifier` property is only available on .NET 5 and greater, so it is not sent for other targets.