### PR TITLE
Add device information for MAUI and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - Continue with adding MAUI support ([#1670](https://github.com/getsentry/sentry-dotnet/pull/1670))
   - MAUI events become extra context in Sentry events ([#1706](https://github.com/getsentry/sentry-dotnet/pull/1706))
   - Add options for PII breadcrumbs from MAUI events ([#1709](https://github.com/getsentry/sentry-dotnet/pull/1709))
+  - Add device information to the event context ([#1713](https://github.com/getsentry/sentry-dotnet/pull/1713))
 - Added a new `net6.0-android` target for the `Sentry` core library, which bundles the [Sentry Android SDK](https://docs.sentry.io/platforms/android/):
   - Initial .NET 6 Android support ([#1288](https://github.com/getsentry/sentry-dotnet/pull/1288))
   - Update Android Support ([#1669](https://github.com/getsentry/sentry-dotnet/pull/1669))

--- a/samples/Sentry.Samples.Maui/MauiProgram.cs
+++ b/samples/Sentry.Samples.Maui/MauiProgram.cs
@@ -9,7 +9,7 @@ public static class MauiProgram
             {
                 options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
                 options.Debug = true;
-                options.MaxBreadcrumbs = int.MaxValue; // TODO: reduce breadcrumbs, remove this
+                options.MaxBreadcrumbs = 1000; // TODO: reduce breadcrumbs, remove this
             })
             .ConfigureFonts(fonts =>
             {

--- a/src/Sentry.Maui/Internal/MauiDeviceData.cs
+++ b/src/Sentry.Maui/Internal/MauiDeviceData.cs
@@ -1,0 +1,90 @@
+using Sentry.Protocol;
+using Device = Sentry.Protocol.Device;
+
+namespace Sentry.Maui.Internal;
+
+internal static class MauiDeviceData
+{
+    public static void ApplyMauiDeviceData(this Device device)
+    {
+        // TODO: Add more device data where indicated
+
+        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/information
+        var deviceInfo = DeviceInfo.Current;
+        device.Name ??= deviceInfo.Name;
+        device.Manufacturer ??= deviceInfo.Manufacturer;
+        device.Model ??= deviceInfo.Model;
+        device.DeviceType ??= deviceInfo.Idiom.ToString();
+        device.Simulator ??= deviceInfo.DeviceType switch
+        {
+            DeviceType.Virtual => true,
+            DeviceType.Physical => false,
+            _ => null
+        };
+        // device.Brand ??= ?
+        // device.Family ??= ?
+        // device.ModelId ??= ?
+        // device.Architecture ??= ?
+        // ? = deviceInfo.Platform;
+        // ? = deviceInfo.VersionString;
+
+        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/battery
+        var battery = Battery.Default;
+        device.BatteryLevel ??= battery.ChargeLevel < 0 ? null : (short)battery.ChargeLevel;
+        device.BatteryStatus ??= battery.State.ToString();
+        device.IsCharging ??= battery.State switch
+        {
+            BatteryState.Unknown => null,
+            BatteryState.Charging => true,
+            _ => false
+        };
+
+        // https://docs.microsoft.com/dotnet/maui/platform-integration/communication/networking#using-connectivity
+        var connectivity = Connectivity.Current;
+        device.IsOnline ??= connectivity.NetworkAccess == NetworkAccess.Internet;
+
+        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/display
+        var display = DeviceDisplay.Current.MainDisplayInfo;
+        device.ScreenResolution ??= $"{(int)display.Width}x{(int)display.Height}";
+        device.ScreenDensity ??= (float)display.Density;
+        device.Orientation ??= display.Orientation switch
+        {
+            DisplayOrientation.Portrait => DeviceOrientation.Portrait,
+            DisplayOrientation.Landscape => DeviceOrientation.Landscape,
+            _ => null
+        };
+        // device.ScreenDpi ??= ?
+        // ? = display.RefreshRate;
+        // ? = display.Rotation;
+
+        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/vibrate
+        device.SupportsVibration ??= Vibration.Default.IsSupported;
+
+        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/sensors
+        device.SupportsAccelerometer ??= Accelerometer.IsSupported;
+        device.SupportsGyroscope ??= Gyroscope.IsSupported;
+
+        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/geolocation
+        // TODO: How to get without actually trying to make a location request?
+        // device.SupportsLocationService ??= Geolocation.Default.???
+
+        // device.SupportsAudio ??= ?
+
+        // device.MemorySize ??=
+        // device.FreeMemory ??=
+        // device.UsableMemory ??=
+        // device.LowMemory ??=
+
+        // device.StorageSize ??=
+        // device.FreeStorage ??=
+        // device.ExternalStorageSize ??=
+        // device.ExternalFreeStorage ??=
+
+        // device.BootTime ??=
+        // device.DeviceUniqueIdentifier ??=
+
+        //device.CpuDescription ??= ?
+        //device.ProcessorCount ??= ?
+        //device.ProcessorFrequency ??= ?
+    }
+}

--- a/src/Sentry.Maui/Internal/MauiDeviceData.cs
+++ b/src/Sentry.Maui/Internal/MauiDeviceData.cs
@@ -1,3 +1,4 @@
+using Sentry.Extensibility;
 using Sentry.Protocol;
 using Device = Sentry.Protocol.Device;
 
@@ -5,86 +6,100 @@ namespace Sentry.Maui.Internal;
 
 internal static class MauiDeviceData
 {
-    public static void ApplyMauiDeviceData(this Device device)
+    public static void ApplyMauiDeviceData(this Device device, IDiagnosticLogger? logger)
     {
-        // TODO: Add more device data where indicated
-
-        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/information
-        var deviceInfo = DeviceInfo.Current;
-        device.Name ??= deviceInfo.Name;
-        device.Manufacturer ??= deviceInfo.Manufacturer;
-        device.Model ??= deviceInfo.Model;
-        device.DeviceType ??= deviceInfo.Idiom.ToString();
-        device.Simulator ??= deviceInfo.DeviceType switch
+        try
         {
-            DeviceType.Virtual => true,
-            DeviceType.Physical => false,
-            _ => null
-        };
-        // device.Brand ??= ?
-        // device.Family ??= ?
-        // device.ModelId ??= ?
-        // device.Architecture ??= ?
-        // ? = deviceInfo.Platform;
-        // ? = deviceInfo.VersionString;
+            // TODO: Add more device data where indicated
 
-        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/battery
-        var battery = Battery.Default;
-        device.BatteryLevel ??= battery.ChargeLevel < 0 ? null : (short)battery.ChargeLevel;
-        device.BatteryStatus ??= battery.State.ToString();
-        device.IsCharging ??= battery.State switch
+            // https://docs.microsoft.com/dotnet/maui/platform-integration/device/information
+            var deviceInfo = DeviceInfo.Current;
+            if (deviceInfo.Platform == DevicePlatform.Unknown)
+            {
+                // return early so we don't get NotImplementedExceptions (i.e., in unit tests, etc.)
+                return;
+            }
+            device.Name ??= deviceInfo.Name;
+            device.Manufacturer ??= deviceInfo.Manufacturer;
+            device.Model ??= deviceInfo.Model;
+            device.DeviceType ??= deviceInfo.Idiom.ToString();
+            device.Simulator ??= deviceInfo.DeviceType switch
+            {
+                DeviceType.Virtual => true,
+                DeviceType.Physical => false,
+                _ => null
+            };
+            // device.Brand ??= ?
+            // device.Family ??= ?
+            // device.ModelId ??= ?
+            // device.Architecture ??= ?
+            // ? = deviceInfo.Platform;
+            // ? = deviceInfo.VersionString;
+
+            // https://docs.microsoft.com/dotnet/maui/platform-integration/device/battery
+            var battery = Battery.Default;
+            device.BatteryLevel ??= battery.ChargeLevel < 0 ? null : (short)battery.ChargeLevel;
+            device.BatteryStatus ??= battery.State.ToString();
+            device.IsCharging ??= battery.State switch
+            {
+                BatteryState.Unknown => null,
+                BatteryState.Charging => true,
+                _ => false
+            };
+
+            // https://docs.microsoft.com/dotnet/maui/platform-integration/communication/networking#using-connectivity
+            var connectivity = Connectivity.Current;
+            device.IsOnline ??= connectivity.NetworkAccess == NetworkAccess.Internet;
+
+            // https://docs.microsoft.com/dotnet/maui/platform-integration/device/display
+            var display = DeviceDisplay.Current.MainDisplayInfo;
+            device.ScreenResolution ??= $"{(int)display.Width}x{(int)display.Height}";
+            device.ScreenDensity ??= (float)display.Density;
+            device.Orientation ??= display.Orientation switch
+            {
+                DisplayOrientation.Portrait => DeviceOrientation.Portrait,
+                DisplayOrientation.Landscape => DeviceOrientation.Landscape,
+                _ => null
+            };
+            // device.ScreenDpi ??= ?
+            // ? = display.RefreshRate;
+            // ? = display.Rotation;
+
+            // https://docs.microsoft.com/dotnet/maui/platform-integration/device/vibrate
+            device.SupportsVibration ??= Vibration.Default.IsSupported;
+
+            // https://docs.microsoft.com/dotnet/maui/platform-integration/device/sensors
+            device.SupportsAccelerometer ??= Accelerometer.IsSupported;
+            device.SupportsGyroscope ??= Gyroscope.IsSupported;
+
+            // https://docs.microsoft.com/dotnet/maui/platform-integration/device/geolocation
+            // TODO: How to get without actually trying to make a location request?
+            // device.SupportsLocationService ??= Geolocation.Default.???
+
+            // device.SupportsAudio ??= ?
+
+            // device.MemorySize ??=
+            // device.FreeMemory ??=
+            // device.UsableMemory ??=
+            // device.LowMemory ??=
+
+            // device.StorageSize ??=
+            // device.FreeStorage ??=
+            // device.ExternalStorageSize ??=
+            // device.ExternalFreeStorage ??=
+
+            // device.BootTime ??=
+            // device.DeviceUniqueIdentifier ??=
+
+            //device.CpuDescription ??= ?
+            //device.ProcessorCount ??= ?
+            //device.ProcessorFrequency ??= ?
+
+        }
+        catch (Exception ex)
         {
-            BatteryState.Unknown => null,
-            BatteryState.Charging => true,
-            _ => false
-        };
-
-        // https://docs.microsoft.com/dotnet/maui/platform-integration/communication/networking#using-connectivity
-        var connectivity = Connectivity.Current;
-        device.IsOnline ??= connectivity.NetworkAccess == NetworkAccess.Internet;
-
-        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/display
-        var display = DeviceDisplay.Current.MainDisplayInfo;
-        device.ScreenResolution ??= $"{(int)display.Width}x{(int)display.Height}";
-        device.ScreenDensity ??= (float)display.Density;
-        device.Orientation ??= display.Orientation switch
-        {
-            DisplayOrientation.Portrait => DeviceOrientation.Portrait,
-            DisplayOrientation.Landscape => DeviceOrientation.Landscape,
-            _ => null
-        };
-        // device.ScreenDpi ??= ?
-        // ? = display.RefreshRate;
-        // ? = display.Rotation;
-
-        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/vibrate
-        device.SupportsVibration ??= Vibration.Default.IsSupported;
-
-        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/sensors
-        device.SupportsAccelerometer ??= Accelerometer.IsSupported;
-        device.SupportsGyroscope ??= Gyroscope.IsSupported;
-
-        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/geolocation
-        // TODO: How to get without actually trying to make a location request?
-        // device.SupportsLocationService ??= Geolocation.Default.???
-
-        // device.SupportsAudio ??= ?
-
-        // device.MemorySize ??=
-        // device.FreeMemory ??=
-        // device.UsableMemory ??=
-        // device.LowMemory ??=
-
-        // device.StorageSize ??=
-        // device.FreeStorage ??=
-        // device.ExternalStorageSize ??=
-        // device.ExternalFreeStorage ??=
-
-        // device.BootTime ??=
-        // device.DeviceUniqueIdentifier ??=
-
-        //device.CpuDescription ??= ?
-        //device.ProcessorCount ??= ?
-        //device.ProcessorFrequency ??= ?
+            // Log, but swallow the exception so we can continue sending events
+            logger?.LogError("Error getting MAUI device information.", ex);
+        }
     }
 }

--- a/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
@@ -4,11 +4,18 @@ namespace Sentry.Maui.Internal;
 
 internal class SentryMauiEventProcessor : ISentryEventProcessor
 {
+    private readonly SentryMauiOptions _options;
+
+    public SentryMauiEventProcessor(SentryMauiOptions options)
+    {
+        _options = options;
+    }
+
     public SentryEvent Process(SentryEvent @event)
     {
         @event.Sdk.Name = Constants.SdkName;
         @event.Sdk.Version = Constants.SdkVersion;
-        @event.Contexts.Device.ApplyMauiDeviceData();
+        @event.Contexts.Device.ApplyMauiDeviceData(_options.DiagnosticLogger);
 
         return @event;
     }

--- a/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
@@ -6,9 +6,9 @@ internal class SentryMauiEventProcessor : ISentryEventProcessor
 {
     public SentryEvent Process(SentryEvent @event)
     {
-        // Set SDK name and version for MAUI
         @event.Sdk.Name = Constants.SdkName;
         @event.Sdk.Version = Constants.SdkVersion;
+        @event.Contexts.Device.ApplyMauiDeviceData();
 
         return @event;
     }

--- a/src/Sentry.Maui/Internal/SentryMauiOptionsSetup.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiOptionsSetup.cs
@@ -20,6 +20,6 @@ internal class SentryMauiOptionsSetup : ConfigureFromConfigurationOptions<Sentry
         options.IsGlobalModeEnabled = true;
 
         // We'll use an event processor to set things like SDK name
-        options.AddEventProcessor(new SentryMauiEventProcessor());
+        options.AddEventProcessor(new SentryMauiEventProcessor(options));
     }
 }

--- a/src/Sentry/Android/AndroidEventProcessor.cs
+++ b/src/Sentry/Android/AndroidEventProcessor.cs
@@ -6,7 +6,7 @@ namespace Sentry.Android;
 
 internal class AndroidEventProcessor : ISentryEventProcessor, IDisposable
 {
-    private readonly Java.IEventProcessor _androidProcessor;
+    private readonly Java.IEventProcessor? _androidProcessor;
     private readonly Java.Hint _hint = new();
 
     public AndroidEventProcessor(SentryAndroidOptions androidOptions)
@@ -14,25 +14,37 @@ internal class AndroidEventProcessor : ISentryEventProcessor, IDisposable
         _androidProcessor = androidOptions.EventProcessors.OfType<JavaObject>()
             .Where(x => x.Class.Name == "io.sentry.android.core.DefaultAndroidEventProcessor")
             .Cast<Java.IEventProcessor>()
-            .First();
+            .FirstOrDefault();
     }
 
     public SentryEvent Process(SentryEvent @event)
     {
-        // Run a fake event through the Android processor, so we can get context info from the Android SDK.
-        // We'll want to do this every time, so that all information is current. (ex: device orientation)
-        using var e = new Java.SentryEvent();
-        _androidProcessor.Process(e, _hint);
+        // Get what information we can ourselves first
+        @event.Contexts.Device.ApplyFromAndroidRuntime();
 
-        // Copy what we need to the managed event
-        e.Contexts.Device?.ApplyTo(@event.Contexts.Device);
+        // Copy more information from the Android SDK
+        if (_androidProcessor is { } androidProcessor)
+        {
+            // TODO: Can we gather more device data directly and remove this?
+
+            // Run a fake event through the Android processor, so we can get context info from the Android SDK.
+            // We'll want to do this every time, so that all information is current. (ex: device orientation)
+            using var e = new Java.SentryEvent();
+            androidProcessor.Process(e, _hint);
+
+            // Copy what we need to the managed event
+            if (e.Contexts.Device is { } device)
+            {
+                @event.Contexts.Device.ApplyFromSentryAndroidSdk(device);
+            }
+        }
 
         return @event;
     }
 
     public void Dispose()
     {
-        _androidProcessor.Dispose();
+        _androidProcessor?.Dispose();
         _hint.Dispose();
     }
 }

--- a/src/Sentry/Android/AndroidEventProcessor.cs
+++ b/src/Sentry/Android/AndroidEventProcessor.cs
@@ -1,0 +1,38 @@
+using Sentry.Android.Extensions;
+using Sentry.Extensibility;
+using Sentry.Protocol;
+
+namespace Sentry.Android;
+
+internal class AndroidEventProcessor : ISentryEventProcessor, IDisposable
+{
+    private readonly Java.IEventProcessor _androidProcessor;
+    private readonly Java.Hint _hint = new();
+
+    public AndroidEventProcessor(SentryAndroidOptions androidOptions)
+    {
+        _androidProcessor = androidOptions.EventProcessors.OfType<JavaObject>()
+            .Where(x => x.Class.Name == "io.sentry.android.core.DefaultAndroidEventProcessor")
+            .Cast<Java.IEventProcessor>()
+            .First();
+    }
+
+    public SentryEvent Process(SentryEvent @event)
+    {
+        // Run a fake event through the Android processor, so we can get context info from the Android SDK.
+        // We'll want to do this every time, so that all information is current. (ex: device orientation)
+        using var e = new Java.SentryEvent();
+        _androidProcessor.Process(e, _hint);
+
+        // Copy what we need to the managed event
+        e.Contexts.Device?.ApplyTo(@event.Contexts.Device);
+
+        return @event;
+    }
+
+    public void Dispose()
+    {
+        _androidProcessor.Dispose();
+        _hint.Dispose();
+    }
+}

--- a/src/Sentry/Android/AndroidEventProcessor.cs
+++ b/src/Sentry/Android/AndroidEventProcessor.cs
@@ -1,6 +1,5 @@
 using Sentry.Android.Extensions;
 using Sentry.Extensibility;
-using Sentry.Protocol;
 
 namespace Sentry.Android;
 
@@ -11,10 +10,17 @@ internal class AndroidEventProcessor : ISentryEventProcessor, IDisposable
 
     public AndroidEventProcessor(SentryAndroidOptions androidOptions)
     {
+        // Locate the Android SDK's default event processor by its class
+        // NOTE: This approach avoids hardcoding the class name (which could be obfuscated by proguard)
         _androidProcessor = androidOptions.EventProcessors.OfType<JavaObject>()
-            .Where(x => x.Class.Name == "io.sentry.android.core.DefaultAndroidEventProcessor")
+            .Where(o => o.Class == JavaClass.FromType(typeof(DefaultAndroidEventProcessor)))
             .Cast<Java.IEventProcessor>()
             .FirstOrDefault();
+
+        // TODO: This would be cleaner, but doesn't compile. Figure out why.
+        // _androidProcessor = androidOptions.EventProcessors
+        //     .OfType<DefaultAndroidEventProcessor>()
+        //     .FirstOrDefault();
     }
 
     public SentryEvent Process(SentryEvent @event)

--- a/src/Sentry/Android/Extensions/DeviceExtensions.cs
+++ b/src/Sentry/Android/Extensions/DeviceExtensions.cs
@@ -6,43 +6,43 @@ internal static class DeviceExtensions
 {
     public static void ApplyTo(this Java.Protocol.Device d, Device device)
     {
-        device.Name = d.Name;
-        device.Manufacturer = d.Manufacturer;
-        device.Brand = d.Brand;
-        device.Family = d.Family;
-        device.Model = d.Model;
-        device.ModelId = d.ModelId;
-        device.Architecture = d.GetArchs()?.FirstOrDefault();
-        device.BatteryLevel = d.BatteryLevel?.ShortValue();
-        device.IsCharging = d.IsCharging()?.BooleanValue();
-        device.IsOnline = d.IsOnline()?.BooleanValue();
-        device.Orientation = d.Orientation?.ToDeviceOrientation();
-        device.Simulator = d.IsSimulator()?.BooleanValue();
-        device.MemorySize = d.MemorySize?.LongValue();
-        device.FreeMemory = d.FreeMemory?.LongValue();
-        device.UsableMemory = d.UsableMemory?.LongValue();
-        device.LowMemory = d.IsLowMemory()?.BooleanValue();
-        device.StorageSize = d.StorageSize?.LongValue();
-        device.FreeStorage = d.FreeStorage?.LongValue();
-        device.ExternalStorageSize = d.ExternalStorageSize?.LongValue();
-        device.ExternalFreeStorage = d.ExternalFreeStorage?.LongValue();
-        device.ScreenResolution = $"{d.ScreenWidthPixels}x{d.ScreenHeightPixels}";
-        device.ScreenDensity = d.ScreenDensity?.FloatValue();
-        device.ScreenDpi = d.ScreenDpi?.IntValue();
-        device.BootTime = d.BootTime?.ToDateTimeOffset();
-        device.DeviceUniqueIdentifier = d.Id;
+        device.Name ??= d.Name;
+        device.Manufacturer ??= d.Manufacturer;
+        device.Brand ??= d.Brand;
+        device.Family ??= d.Family;
+        device.Model ??= d.Model;
+        device.ModelId ??= d.ModelId;
+        device.Architecture ??= d.GetArchs()?.FirstOrDefault();
+        device.BatteryLevel ??= d.BatteryLevel?.ShortValue();
+        device.IsCharging ??= d.IsCharging()?.BooleanValue();
+        device.IsOnline ??= d.IsOnline()?.BooleanValue();
+        device.Orientation ??= d.Orientation?.ToDeviceOrientation();
+        device.Simulator ??= d.IsSimulator()?.BooleanValue();
+        device.MemorySize ??= d.MemorySize?.LongValue();
+        device.FreeMemory ??= d.FreeMemory?.LongValue();
+        device.UsableMemory ??= d.UsableMemory?.LongValue();
+        device.LowMemory ??= d.IsLowMemory()?.BooleanValue();
+        device.StorageSize ??= d.StorageSize?.LongValue();
+        device.FreeStorage ??= d.FreeStorage?.LongValue();
+        device.ExternalStorageSize ??= d.ExternalStorageSize?.LongValue();
+        device.ExternalFreeStorage ??= d.ExternalFreeStorage?.LongValue();
+        device.ScreenResolution ??= $"{d.ScreenWidthPixels}x{d.ScreenHeightPixels}";
+        device.ScreenDensity ??= d.ScreenDensity?.FloatValue();
+        device.ScreenDpi ??= d.ScreenDpi?.IntValue();
+        device.BootTime ??= d.BootTime?.ToDateTimeOffset();
+        device.DeviceUniqueIdentifier ??= d.Id;
 
         // TODO: Can we get these from somewhere?
-        //device.ProcessorCount = ?
-        //device.CpuDescription = ?
-        //device.ProcessorFrequency = ?
-        //device.DeviceType = ?
-        //device.BatteryStatus = ?
-        //device.SupportsVibration = ?
-        //device.SupportsAccelerometer = ?
-        //device.SupportsGyroscope = ?
-        //device.SupportsAudio = ?
-        //device.SupportsLocationService = ?
+        //device.ProcessorCount ??= ?
+        //device.CpuDescription ??= ?
+        //device.ProcessorFrequency ??= ?
+        //device.DeviceType ??= ?
+        //device.BatteryStatus ??= ?
+        //device.SupportsVibration ??= ?
+        //device.SupportsAccelerometer ??= ?
+        //device.SupportsGyroscope ??= ?
+        //device.SupportsAudio ??= ?
+        //device.SupportsLocationService ??= ?
 
     }
 

--- a/src/Sentry/Android/Extensions/DeviceExtensions.cs
+++ b/src/Sentry/Android/Extensions/DeviceExtensions.cs
@@ -1,0 +1,56 @@
+using Sentry.Protocol;
+
+namespace Sentry.Android.Extensions;
+
+internal static class DeviceExtensions
+{
+    public static void ApplyTo(this Java.Protocol.Device d, Device device)
+    {
+        device.Name = d.Name;
+        device.Manufacturer = d.Manufacturer;
+        device.Brand = d.Brand;
+        device.Family = d.Family;
+        device.Model = d.Model;
+        device.ModelId = d.ModelId;
+        device.Architecture = d.GetArchs()?.FirstOrDefault();
+        device.BatteryLevel = d.BatteryLevel?.ShortValue();
+        device.IsCharging = d.IsCharging()?.BooleanValue();
+        device.IsOnline = d.IsOnline()?.BooleanValue();
+        device.Orientation = d.Orientation?.ToDeviceOrientation();
+        device.Simulator = d.IsSimulator()?.BooleanValue();
+        device.MemorySize = d.MemorySize?.LongValue();
+        device.FreeMemory = d.FreeMemory?.LongValue();
+        device.UsableMemory = d.UsableMemory?.LongValue();
+        device.LowMemory = d.IsLowMemory()?.BooleanValue();
+        device.StorageSize = d.StorageSize?.LongValue();
+        device.FreeStorage = d.FreeStorage?.LongValue();
+        device.ExternalStorageSize = d.ExternalStorageSize?.LongValue();
+        device.ExternalFreeStorage = d.ExternalFreeStorage?.LongValue();
+        device.ScreenResolution = $"{d.ScreenWidthPixels}x{d.ScreenHeightPixels}";
+        device.ScreenDensity = d.ScreenDensity?.FloatValue();
+        device.ScreenDpi = d.ScreenDpi?.IntValue();
+        device.BootTime = d.BootTime?.ToDateTimeOffset();
+        device.DeviceUniqueIdentifier = d.Id;
+
+        // TODO: Can we get these from somewhere?
+        //device.ProcessorCount = ?
+        //device.CpuDescription = ?
+        //device.ProcessorFrequency = ?
+        //device.DeviceType = ?
+        //device.BatteryStatus = ?
+        //device.SupportsVibration = ?
+        //device.SupportsAccelerometer = ?
+        //device.SupportsGyroscope = ?
+        //device.SupportsAudio = ?
+        //device.SupportsLocationService = ?
+
+    }
+
+    public static DeviceOrientation ToDeviceOrientation(this Java.Protocol.Device.DeviceOrientation orientation) =>
+        orientation.Name() switch
+        {
+            "PORTRAIT" => DeviceOrientation.Portrait,
+            "LANDSCAPE" => DeviceOrientation.Landscape,
+            _ => throw new ArgumentOutOfRangeException(nameof(orientation), orientation.Name(), message: default)
+        };
+}

--- a/src/Sentry/Android/Extensions/DeviceExtensions.cs
+++ b/src/Sentry/Android/Extensions/DeviceExtensions.cs
@@ -4,15 +4,35 @@ namespace Sentry.Android.Extensions;
 
 internal static class DeviceExtensions
 {
-    public static void ApplyTo(this Java.Protocol.Device d, Device device)
+    public static void ApplyFromAndroidRuntime(this Device device)
     {
+        device.Manufacturer ??= AndroidBuild.Manufacturer;
+        device.Brand ??= AndroidBuild.Brand;
+        device.Model ??= AndroidBuild.Model;
+
+        if (AndroidBuild.SupportedAbis is { } abis)
+        {
+            device.Architecture ??= abis[0];
+        }
+        else
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            device.Architecture ??= AndroidBuild.CpuAbi;
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+    }
+
+    public static void ApplyFromSentryAndroidSdk(this Device device, Java.Protocol.Device d)
+    {
+        // We already have these above
+        // device.Manufacturer ??= d.Manufacturer;
+        // device.Brand ??= d.Brand;
+        // device.Model ??= d.Model;
+        // device.Architecture ??= d.GetArchs()?.FirstOrDefault();
+
         device.Name ??= d.Name;
-        device.Manufacturer ??= d.Manufacturer;
-        device.Brand ??= d.Brand;
         device.Family ??= d.Family;
-        device.Model ??= d.Model;
         device.ModelId ??= d.ModelId;
-        device.Architecture ??= d.GetArchs()?.FirstOrDefault();
         device.BatteryLevel ??= d.BatteryLevel?.ShortValue();
         device.IsCharging ??= d.IsCharging()?.BooleanValue();
         device.IsOnline ??= d.IsOnline()?.BooleanValue();

--- a/src/Sentry/Android/Transforms/Metadata.xml
+++ b/src/Sentry/Android/Transforms/Metadata.xml
@@ -46,6 +46,9 @@
   <attr path="/api/package[@name='io.sentry']/class[@name='SentryTraceHeader']/field[@name='SENTRY_TRACE_HEADER']" name="managedName">SentryTraceHeaderName</attr>
   <attr path="/api/package[@name='io.sentry']/class[@name='TraceStateHeader']/field[@name='TRACE_STATE_HEADER']" name="managedName">TraceStateHeaderName</attr>
 
+  <!-- Fix visibility of this type, for use in AndroidEventProcessor.cs -->
+  <attr path="/api/package[@name='io.sentry.android.core']/class[@name='DefaultAndroidEventProcessor']" name="visibility">internal</attr>
+
   <!--
     The remaining APIS are removed to prevent various errors/warnings.
     TODO: Find other workarounds for each one, rather than removing the APIs.

--- a/src/Sentry/Protocol/Device.cs
+++ b/src/Sentry/Protocol/Device.cs
@@ -209,10 +209,12 @@ namespace Sentry.Protocol
         /// </summary>
         /// <example>
         /// iOS: UIDevice.identifierForVendor (UUID)
-        /// Android: md5 of ANDROID_ID
+        /// Android: The generated Installation ID
         /// Windows Store Apps: AdvertisingManager::AdvertisingId (possible fallback to HardwareIdentification::GetPackageSpecificToken().Id)
         /// Windows Standalone: hash from the concatenation of strings taken from Computer System Hardware Classes
         /// </example>
+        /// TODO: Investigate - Do ALL platforms now return a generated installation ID?
+        ///       See https://github.com/getsentry/sentry-java/pull/1455
         public string? DeviceUniqueIdentifier { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Continuing #1651

- For all MAUI platforms, add device information to the event context as given by MAUI
- For Android (with or without MAUI), augment with information gathered by the Sentry Android SDK

There are some gaps identified with `TODO` markers, but we can fill them in later.  I think this is good enough for now.