### PR TITLE
Add OS information from MAUI device data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   - MAUI events become extra context in Sentry events ([#1706](https://github.com/getsentry/sentry-dotnet/pull/1706))
   - Add options for PII breadcrumbs from MAUI events ([#1709](https://github.com/getsentry/sentry-dotnet/pull/1709))
   - Add device information to the event context ([#1713](https://github.com/getsentry/sentry-dotnet/pull/1713))
+  - Add platform OS information to the event context ([#1717](https://github.com/getsentry/sentry-dotnet/pull/1717))
 - Added a new `net6.0-android` target for the `Sentry` core library, which bundles the [Sentry Android SDK](https://docs.sentry.io/platforms/android/):
   - Initial .NET 6 Android support ([#1288](https://github.com/getsentry/sentry-dotnet/pull/1288))
   - Update Android Support ([#1669](https://github.com/getsentry/sentry-dotnet/pull/1669))

--- a/src/Sentry.Maui/Internal/MauiOsData.cs
+++ b/src/Sentry.Maui/Internal/MauiOsData.cs
@@ -1,0 +1,34 @@
+using Sentry.Extensibility;
+using OperatingSystem = Sentry.Protocol.OperatingSystem;
+
+namespace Sentry.Maui.Internal;
+
+internal static class MauiOsData
+{
+    public static void ApplyMauiOsData(this OperatingSystem os, IDiagnosticLogger? logger)
+    {
+        try
+        {
+            // https://docs.microsoft.com/dotnet/maui/platform-integration/device/information
+            var deviceInfo = DeviceInfo.Current;
+            if (deviceInfo.Platform == DevicePlatform.Unknown)
+            {
+                // return early so we don't get NotImplementedExceptions (i.e., in unit tests, etc.)
+                return;
+            }
+
+            os.Name ??= deviceInfo.Platform.ToString();
+            os.Version ??= deviceInfo.VersionString;
+
+            // TODO: fill in these
+            // os.Build ??= ?
+            // os.KernelVersion ??= ?
+            // os.Rooted ??= ?
+        }
+        catch (Exception ex)
+        {
+            // Log, but swallow the exception so we can continue sending events
+            logger?.LogError("Error getting MAUI device information.", ex);
+        }
+    }
+}

--- a/src/Sentry.Maui/Internal/MauiOsData.cs
+++ b/src/Sentry.Maui/Internal/MauiOsData.cs
@@ -28,7 +28,7 @@ internal static class MauiOsData
         catch (Exception ex)
         {
             // Log, but swallow the exception so we can continue sending events
-            logger?.LogError("Error getting MAUI device information.", ex);
+            logger?.LogError("Error getting MAUI OS information.", ex);
         }
     }
 }

--- a/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
@@ -16,6 +16,7 @@ internal class SentryMauiEventProcessor : ISentryEventProcessor
         @event.Sdk.Name = Constants.SdkName;
         @event.Sdk.Version = Constants.SdkVersion;
         @event.Contexts.Device.ApplyMauiDeviceData(_options.DiagnosticLogger);
+        @event.Contexts.OperatingSystem.ApplyMauiOsData(_options.DiagnosticLogger);
 
         return @event;
     }


### PR DESCRIPTION
Similar to #1716, this sets OS context info for all MAUI platforms.  For example on iOS:

<img width="849" alt="image" src="https://user-images.githubusercontent.com/1396388/173888203-b4ce7799-5cd6-436c-845f-e6232193481f.png">

<img width="873" alt="image" src="https://user-images.githubusercontent.com/1396388/173888252-e10f0488-261f-488a-8462-db784a4dce39.png">
