### PR TITLE
Not to be merged Exp/stack trace rewrite

### DIFF
--- a/src/Sentry/Exceptions/ExceptionProcessor.cs
+++ b/src/Sentry/Exceptions/ExceptionProcessor.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using Sentry.Extensibility;
+using Sentry.Protocol;
+
+namespace Sentry.Exceptions
+{
+    public abstract class ExceptionProcessor : ISentryEventExceptionProcessor
+    {
+        private readonly SentryOptions _options;
+
+        internal static readonly string ExceptionDataTagKey = "sentry:tag:";
+        internal static readonly string ExceptionDataContextKey = "sentry:context:";
+
+        protected ExceptionProcessor(SentryOptions options) => _options = options;
+
+        public void Process(Exception exception, SentryEvent sentryEvent)
+        {
+            _options.LogDebug("Running processor {0} on exception: {1}", GetType(), exception.Message);
+
+            var sentryExceptionList = new List<SentryException>();
+
+            foreach (var flattenedEx in Flatten(exception))
+            {
+                var sentryException = CreateSentryException(flattenedEx);
+
+                sentryExceptionList.Add(sentryException);
+
+                Process(flattenedEx, sentryException, sentryEvent);
+                ProcessExceptionData(flattenedEx, sentryException, sentryEvent);
+            }
+
+            sentryEvent.SentryExceptions = sentryExceptionList;
+        }
+
+        protected abstract void Process(Exception exception, SentryException sentryException, SentryEvent sentryEvent);
+        protected abstract SentryStackTrace CreateStackTrace(Exception exception);
+
+        private void ProcessExceptionData(Exception exception, SentryException sentryException, SentryEvent sentryEvent)
+        {
+            int i = 0;
+            foreach (var key in exception.Data.Keys)
+            {
+                if (key is not string keyString)
+                {
+                    continue;
+                }
+
+                var value = exception.Data[key];
+                sentryException.Data[keyString] = value;
+
+                // Support for Tag and Extra via Exception.Data:
+                if (keyString.StartsWith("sentry:", StringComparison.OrdinalIgnoreCase) &&
+                    value != null)
+                {
+                    if (keyString.StartsWith(ExceptionDataTagKey, StringComparison.OrdinalIgnoreCase) &&
+                        value is string tagValue &&
+                        ExceptionDataTagKey.Length < keyString.Length)
+                    {
+                        // Set the key after the ExceptionDataTagKey string.
+                        sentryEvent.SetTag(keyString.Substring(ExceptionDataTagKey.Length), tagValue);
+                    }
+                    else if (keyString.StartsWith(ExceptionDataContextKey, StringComparison.OrdinalIgnoreCase) &&
+                             ExceptionDataContextKey.Length < keyString.Length)
+                    {
+                        // Set the key after the ExceptionDataTagKey string.
+                        _ = sentryEvent.Contexts[keyString.Substring(ExceptionDataContextKey.Length)] = value;
+                    }
+                    else
+                    {
+                        sentryEvent.SetExtra($"Exception[{i++}][{keyString}]", sentryException.Data[keyString]);
+                    }
+                }
+                else
+                {
+                    sentryEvent.SetExtra($"Exception[{i++}][{keyString}]", sentryException.Data[keyString]);
+                }
+            }
+        }
+
+        private SentryException CreateSentryException(Exception exception)
+            => new()
+            {
+                Type = exception.GetType()?.FullName,
+                Module = exception.GetType()?.Assembly?.FullName,
+                Value = exception.Message,
+                ThreadId = Environment.CurrentManagedThreadId,
+                Mechanism = GetMechanism(exception),
+                Stacktrace = CreateStackTrace(exception)
+            };
+
+        private IEnumerable<Exception> Flatten(Exception exception)
+        {
+            while (true)
+            {
+                if (exception is AggregateException ae)
+                {
+                    foreach (var inner in ae.InnerExceptions)
+                    {
+                        yield return inner;
+                    }
+
+                    if (_options.KeepAggregateException)
+                    {
+                        yield return ae;
+                    }
+                }
+                else if (exception.InnerException != null)
+                {
+                    exception = exception.InnerException;
+                    continue;
+                }
+                else
+                {
+                    yield return exception;
+                }
+
+                break;
+            }
+        }
+
+        internal static Mechanism GetMechanism(Exception exception)
+        {
+            var mechanism = new Mechanism();
+
+            if (exception.HelpLink != null)
+            {
+                mechanism.HelpLink = exception.HelpLink;
+            }
+
+            if (exception.Data[Mechanism.HandledKey] is bool handled)
+            {
+                mechanism.Handled = handled;
+                exception.Data.Remove(Mechanism.HandledKey);
+            }
+
+            if (exception.Data[Mechanism.MechanismKey] is string mechanismName)
+            {
+                mechanism.Type = mechanismName;
+                exception.Data.Remove(Mechanism.MechanismKey);
+            }
+
+            return mechanism;
+        }
+    }
+}

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -1,149 +1,30 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Sentry.Exceptions;
 using Sentry.Extensibility;
 using Sentry.Protocol;
 
 namespace Sentry.Internal
 {
-    internal class MainExceptionProcessor : ISentryEventExceptionProcessor
+    internal class MainExceptionProcessor : ExceptionProcessor
     {
-        internal static readonly string ExceptionDataTagKey = "sentry:tag:";
-        internal static readonly string ExceptionDataContextKey = "sentry:context:";
-
         private readonly SentryOptions _options;
         internal Func<ISentryStackTraceFactory> SentryStackTraceFactoryAccessor { get; }
 
         public MainExceptionProcessor(SentryOptions options, Func<ISentryStackTraceFactory> sentryStackTraceFactoryAccessor)
+            : base(options)
         {
             _options = options;
             SentryStackTraceFactoryAccessor = sentryStackTraceFactoryAccessor;
         }
 
-        public void Process(Exception exception, SentryEvent sentryEvent)
+        protected override void Process(Exception exception, SentryException sentryException, SentryEvent sentryEvent)
         {
-            _options.LogDebug("Running processor on exception: {0}", exception.Message);
-
-            var sentryExceptions = CreateSentryException(exception)
-                // Otherwise realization happens on the worker thread before sending event.
-                .ToList();
-
-            MoveExceptionExtrasToEvent(sentryEvent, sentryExceptions);
-
-            sentryEvent.SentryExceptions = sentryExceptions;
+            throw new NotImplementedException();
         }
 
-        // SentryException.Extra is not supported by Sentry yet.
-        // Move the extras to the Event Extra while marking
-        // by index the Exception which owns it.
-        private static void MoveExceptionExtrasToEvent(
-            SentryEvent sentryEvent,
-            IReadOnlyList<SentryException> sentryExceptions)
-        {
-            for (var i = 0; i < sentryExceptions.Count; i++)
-            {
-                var sentryException = sentryExceptions[i];
-
-                if (sentryException.Data.Count <= 0)
-                {
-                    continue;
-                }
-
-                foreach (var keyValue in sentryException.Data)
-                {
-                    if (keyValue.Key.StartsWith("sentry:", StringComparison.OrdinalIgnoreCase) &&
-                        keyValue.Value != null)
-                    {
-                        if (keyValue.Key.StartsWith(ExceptionDataTagKey, StringComparison.OrdinalIgnoreCase) &&
-                            keyValue.Value is string tagValue &&
-                            ExceptionDataTagKey.Length < keyValue.Key.Length)
-                        {
-                            // Set the key after the ExceptionDataTagKey string.
-                            sentryEvent.SetTag(keyValue.Key.Substring(ExceptionDataTagKey.Length), tagValue);
-                        }
-                        else if (keyValue.Key.StartsWith(ExceptionDataContextKey, StringComparison.OrdinalIgnoreCase) &&
-                            ExceptionDataContextKey.Length < keyValue.Key.Length)
-                        {
-                            // Set the key after the ExceptionDataTagKey string.
-                            _ = sentryEvent.Contexts[keyValue.Key.Substring(ExceptionDataContextKey.Length)] = keyValue.Value;
-                        }
-                        else
-                        {
-                            sentryEvent.SetExtra($"Exception[{i}][{keyValue.Key}]", sentryException.Data[keyValue.Key]);
-                        }
-                    }
-                    else
-                    {
-                        sentryEvent.SetExtra($"Exception[{i}][{keyValue.Key}]", sentryException.Data[keyValue.Key]);
-                    }
-                }
-            }
-        }
-
-        internal IEnumerable<SentryException> CreateSentryException(Exception exception)
-        {
-            if (exception is AggregateException ae)
-            {
-                foreach (var inner in ae.InnerExceptions.SelectMany(CreateSentryException))
-                {
-                    yield return inner;
-                }
-            }
-            else if (exception.InnerException != null)
-            {
-                foreach (var inner in CreateSentryException(exception.InnerException))
-                {
-                    yield return inner;
-                }
-            }
-
-            var sentryEx = new SentryException
-            {
-                Type = exception.GetType()?.FullName,
-                Module = exception.GetType()?.Assembly?.FullName,
-                Value = exception.Message,
-                ThreadId = Environment.CurrentManagedThreadId,
-                Mechanism = GetMechanism(exception)
-            };
-
-            if (exception.Data.Count != 0)
-            {
-                foreach (var key in exception.Data.Keys)
-                {
-                    if (key is string keyString)
-                    {
-                        sentryEx.Data[keyString] = exception.Data[key];
-                    }
-                }
-            }
-
-            sentryEx.Stacktrace = SentryStackTraceFactoryAccessor().Create(exception);
-
-            yield return sentryEx;
-        }
-
-        internal static Mechanism GetMechanism(Exception exception)
-        {
-            var mechanism = new Mechanism();
-
-            if (exception.HelpLink != null)
-            {
-                mechanism.HelpLink = exception.HelpLink;
-            }
-
-            if (exception.Data[Mechanism.HandledKey] is bool handled)
-            {
-                mechanism.Handled = handled;
-                exception.Data.Remove(Mechanism.HandledKey);
-            }
-
-            if (exception.Data[Mechanism.MechanismKey] is string mechanismName)
-            {
-                mechanism.Type = mechanismName;
-                exception.Data.Remove(Mechanism.MechanismKey);
-            }
-
-            return mechanism;
-        }
+        protected override SentryStackTrace CreateStackTrace(Exception exception)
+            => SentryStackTraceFactoryAccessor().Create(exception);
     }
 }

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -592,6 +592,13 @@ namespace Sentry
         public Func<bool>? CrashedLastRun { get; set; }
 
         /// <summary>
+        /// Keep <see cref="AggregateException"/> in sentry logging.
+        /// The default behaviour is to only log <see cref="AggregateException.InnerExceptions"/> and not include the root <see cref="AggregateException"/>.
+        /// Set KeepAggregateException to true to include the root <see cref="AggregateException"/>.
+        /// </summary>
+        public bool KeepAggregateException { get; set; }
+
+        /// <summary>
         /// Creates a new instance of <see cref="SentryOptions"/>
         /// </summary>
         public SentryOptions()


### PR DESCRIPTION
The goal was to avoid iterating over things multiple times, and give the native integration a simpler hook:

https://github.com/getsentry/sentry-unity/pull/827/files#diff-d7c6f55c576cbd905ba5affcc1c578fd120655cdfcdc520994c837efeeebccc2R26
