### PR TITLE
Enable logging in MAUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Android Scope Sync ([#1737](https://github.com/getsentry/sentry-dotnet/pull/1737))
+- Enable logging in MAUI ([#1738](https://github.com/getsentry/sentry-dotnet/pull/1738))
 
 ## Sentry.Maui 3.18.0-preview.1
 

--- a/samples/Sentry.Samples.Maui/MainPage.xaml.cs
+++ b/samples/Sentry.Samples.Maui/MainPage.xaml.cs
@@ -1,11 +1,17 @@
+using Microsoft.Extensions.Logging;
+
 namespace Sentry.Samples.Maui;
 
 public partial class MainPage : ContentPage
 {
+    private readonly ILogger<MainPage> _logger;
+
     int count = 0;
 
-    public MainPage()
+    // NOTE: You can only inject an ILogger<T>, not a plain ILogger
+    public MainPage(ILogger<MainPage> logger)
     {
+        _logger = logger;
         InitializeComponent();
     }
 
@@ -19,6 +25,8 @@ public partial class MainPage : ContentPage
             CounterBtn.Text = $"Clicked {count} times";
 
         SemanticScreenReader.Announce(CounterBtn.Text);
+
+        _logger.LogInformation("The button has been clicked {ClickCount} times", count);
     }
 
     private void OnUnhandledExceptionClicked(object sender, EventArgs e)

--- a/samples/Sentry.Samples.Maui/MauiProgram.cs
+++ b/samples/Sentry.Samples.Maui/MauiProgram.cs
@@ -2,19 +2,31 @@ namespace Sentry.Samples.Maui;
 
 public static class MauiProgram
 {
-    public static MauiApp CreateMauiApp() =>
-        MauiApp.CreateBuilder()
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder()
             .UseMauiApp<App>()
+
+            // This adds Sentry to your Maui application
             .UseSentry(options =>
             {
+                // The DSN is the only required option.
                 options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
-                options.Debug = true;
-                options.MaxBreadcrumbs = 1000; // TODO: reduce breadcrumbs, remove this
+
+                // By default, we will send the last 100 breadcrumbs with each event.
+                // If you want to see everything we can capture from MAUI, you may wish to use a larger value.
+                options.MaxBreadcrumbs = 1000;
             })
+
             .ConfigureFonts(fonts =>
             {
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                 fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
-            })
-            .Build();
+            });
+
+        // For this sample, we'll also register the main page for DI so we can inject a logger there.
+        builder.Services.AddTransient<MainPage>();
+
+        return builder.Build();
+    }
 }

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System.ComponentModel;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Sentry.Extensions.Logging;
 using Sentry.Extensions.Logging.Extensions.DependencyInjection;
 using Sentry.Maui;
 using Sentry.Maui.Internal;
@@ -40,10 +42,6 @@ public static class SentryMauiAppBuilderExtensions
     public static MauiAppBuilder UseSentry(this MauiAppBuilder builder,
         Action<SentryMauiOptions>? configureOptions)
     {
-        // TODO: Verify that each of these dependencies is needed.
-
-        // builder.Logging.AddConfiguration();
-
         var services = builder.Services;
         services.Configure<SentryMauiOptions>(options =>
             builder.Configuration.GetSection("Sentry").Bind(options));
@@ -53,6 +51,8 @@ public static class SentryMauiAppBuilderExtensions
             services.Configure(configureOptions);
         }
 
+        services.AddLogging();
+        services.AddSingleton<ILoggerProvider, SentryLoggerProvider>();
         services.AddSingleton<IMauiInitializeService, SentryMauiInitializer>();
         services.AddSingleton<IConfigureOptions<SentryMauiOptions>, SentryMauiOptionsSetup>();
         services.AddSingleton<Disposer>();


### PR DESCRIPTION
- Enables logging features from Sentry.Extensions.Logging
- Fixes an issue where logging was being filtered from the Sentry sample apps (Debug configuration only)
- Update the sample app to demonstrate logging adding breadcrumbs

<img width="724" alt="image" src="https://user-images.githubusercontent.com/1396388/174921066-7d9d8985-3ca1-48ef-99fa-a1029e4f5dc1.png">
