### PR TITLE
chore: unity stack trace fix

### DIFF
--- a/src/Sentry/Extensibility/SentryStackTraceFactory.cs
+++ b/src/Sentry/Extensibility/SentryStackTraceFactory.cs
@@ -15,7 +15,7 @@ namespace Sentry.Extensibility
     {
         private readonly SentryOptions _options;
 
-        private static readonly Regex RegexAsyncFunctionName = new(@"^(.*)\+(?:<\w*>c__.*\+)?<(\w*|<\w*>b__\d*)>d(?:__\d*)?$",
+        private static readonly Regex RegexAsyncFunctionName = new(@"^(.*)\+<(\w*|<\w*>b__\d*)>d(?:__\d*)?$",
             RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         private static readonly Regex RegexAnonymousFunction = new(@"^<(\w*)>b__\w+$",

--- a/src/Sentry/Extensibility/SentryStackTraceFactory.cs
+++ b/src/Sentry/Extensibility/SentryStackTraceFactory.cs
@@ -15,7 +15,13 @@ namespace Sentry.Extensibility
     {
         private readonly SentryOptions _options;
 
-        private static readonly Regex RegexAsyncFunctionName = new(@"^(.*)\+<(\w*|<\w*>b__\d*)>d(?:__\d*)?$",
+        /*
+         *  NOTE: While we could improve these regexes, doing so might break exception grouping on the backend.
+         *        Specifically, RegexAsyncFunctionName would be better as:  @"^(.*)\+<(\w*|<\w*>b__\d*)>d(?:__\d*)?$"
+         *        But we cannot make this change without consequences of ignored events coming back to life in Sentry.
+         */
+
+        private static readonly Regex RegexAsyncFunctionName = new(@"^(.*)\+<(\w*)>d__\d*$",
             RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         private static readonly Regex RegexAnonymousFunction = new(@"^<(\w*)>b__\w+$",
@@ -239,18 +245,12 @@ namespace Sentry.Extensibility
                 return;
             }
 
-            //  Search for the function name in angle brackets in either of the following forms
+            //  Search for the function name in angle brackets followed by d__<digits>.
             //
             // Change:
             //   RemotePrinterService+<UpdateNotification>d__24 in MoveNext at line 457:13
             // to:
             //   RemotePrinterService in UpdateNotification at line 457:13
-            //
-            // Also will change:
-            //   RemotePrinterService+<>c__DisplayClass5_0+<<UpdateNotificationAsync>b__0>d in MoveNext at line 457:13
-            // to:
-            //   RemotePrinterService in <UpdateNotificationAsync>b__0 at line 457:13
-            //  (The second part will be demangled later by DemangleAnonymousFunction)
 
             var match = RegexAsyncFunctionName.Match(frame.Module);
             if (match.Success && match.Groups.Count == 3)

--- a/src/Sentry/Extensibility/SentryStackTraceFactory.cs
+++ b/src/Sentry/Extensibility/SentryStackTraceFactory.cs
@@ -15,6 +15,12 @@ namespace Sentry.Extensibility
     {
         private readonly SentryOptions _options;
 
+        private static readonly Regex RegexAsyncFunctionName = new(@"^(.*)\+<(\w*)>d__\d*$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly Regex RegexAnonymousFunction = new(@"^<(\w*)>b__\w+$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
         private static readonly Regex RegexAsyncReturn = new(@"^(System.Threading.Tasks.Task`[0-9]+)\[\[",
             RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
@@ -240,7 +246,7 @@ namespace Sentry.Extensibility
             // to:
             //   RemotePrinterService in UpdateNotification at line 457:13
 
-            var match = Regex.Match(frame.Module, @"^(.*)\+<(\w*)>d__\d*$");
+            var match = RegexAsyncFunctionName.Match(frame.Module);
             if (match.Success && match.Groups.Count == 3)
             {
                 frame.Module = match.Groups[1].Value;
@@ -265,7 +271,7 @@ namespace Sentry.Extensibility
             // to:
             //   BeginInvokeAsynchronousActionMethod { <lambda> }
 
-            var match = Regex.Match(frame.Function, @"^<(\w*)>b__\w+$");
+            var match = RegexAnonymousFunction.Match(frame.Function);
             if (match.Success && match.Groups.Count == 2)
             {
                 frame.Function = match.Groups[1].Value + " { <lambda> }";

--- a/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
+++ b/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
@@ -46,9 +46,9 @@ public class SentryStackTraceFactoryTests
     }
 
     [Theory]
-    [InlineData(StackTraceMode.Original, "Create_Async_CurrentStackTrace { <lambda> }")]
-    [InlineData(StackTraceMode.Enhanced, "void SentryStackTraceFactoryTests.Create_Async_CurrentStackTrace(StackTraceMode mode, string method)+() => { }")]
-    public void Create_Async_CurrentStackTrace(StackTraceMode mode, string method)
+    [InlineData(StackTraceMode.Original, "AsyncWithWait_StackTrace { <lambda> }")]
+    [InlineData(StackTraceMode.Enhanced, "void SentryStackTraceFactoryTests.AsyncWithWait_StackTrace(StackTraceMode mode, string method)+() => { }")]
+    public void AsyncWithWait_StackTrace(StackTraceMode mode, string method)
     {
         _fixture.SentryOptions.AttachStacktrace = true;
         _fixture.SentryOptions.StackTraceMode = mode;
@@ -65,6 +65,26 @@ public class SentryStackTraceFactoryTests
         {
             Assert.Equal("System.Threading.Tasks.Task`1", stackTrace.Frames[stackTrace.Frames.Count - 2].Module);
         }
+    }
+
+    [Theory]
+    [InlineData(StackTraceMode.Original, "MoveNext")] // TODO fixme: "AsyncWithAwait_StackTrace { <lambda> }"
+    [InlineData(StackTraceMode.Enhanced, "async Task SentryStackTraceFactoryTests.AsyncWithAwait_StackTrace(StackTraceMode mode, string method)+(?) => { }")]
+    public async Task AsyncWithAwait_StackTrace(StackTraceMode mode, string method)
+    {
+        _fixture.SentryOptions.AttachStacktrace = true;
+        _fixture.SentryOptions.StackTraceMode = mode;
+        var sut = _fixture.GetSut();
+
+        var stackTrace = await Task.Run(async () =>
+        {
+            await Task.Yield();
+            return sut.Create();
+        });
+
+        Assert.NotNull(stackTrace);
+
+        Assert.Equal(method, stackTrace.Frames.Last().Function);
     }
 
     [Fact]

--- a/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
+++ b/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
@@ -68,7 +68,7 @@ public class SentryStackTraceFactoryTests
     }
 
     [Theory]
-    [InlineData(StackTraceMode.Original, "MoveNext")] // TODO fixme: "AsyncWithAwait_StackTrace { <lambda> }"
+    [InlineData(StackTraceMode.Original, "AsyncWithAwait_StackTrace { <lambda> }")]
     [InlineData(StackTraceMode.Enhanced, "async Task SentryStackTraceFactoryTests.AsyncWithAwait_StackTrace(StackTraceMode mode, string method)+(?) => { }")]
     public async Task AsyncWithAwait_StackTrace(StackTraceMode mode, string method)
     {

--- a/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
+++ b/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
@@ -60,6 +60,11 @@ public class SentryStackTraceFactoryTests
         Assert.NotNull(stackTrace);
 
         Assert.Equal(method, stackTrace.Frames.Last().Function);
+
+        if (_fixture.SentryOptions.StackTraceMode == StackTraceMode.Original)
+        {
+            Assert.Equal("System.Threading.Tasks.Task`1", stackTrace.Frames[stackTrace.Frames.Count - 2].Module);
+        }
     }
 
     [Fact]

--- a/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
+++ b/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
@@ -68,7 +68,7 @@ public class SentryStackTraceFactoryTests
     }
 
     [Theory]
-    [InlineData(StackTraceMode.Original, "AsyncWithAwait_StackTrace { <lambda> }")]
+    [InlineData(StackTraceMode.Original, "MoveNext")] // Should be "AsyncWithAwait_StackTrace { <lambda> }", but see note in SentryStackTraceFactory
     [InlineData(StackTraceMode.Enhanced, "async Task SentryStackTraceFactoryTests.AsyncWithAwait_StackTrace(StackTraceMode mode, string method)+(?) => { }")]
     public async Task AsyncWithAwait_StackTrace(StackTraceMode mode, string method)
     {

--- a/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
+++ b/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
@@ -45,6 +45,23 @@ public class SentryStackTraceFactoryTests
             ) == true);
     }
 
+    [Theory]
+    [InlineData(StackTraceMode.Original, "Create_Async_CurrentStackTrace { <lambda> }")]
+    [InlineData(StackTraceMode.Enhanced, "void SentryStackTraceFactoryTests.Create_Async_CurrentStackTrace(StackTraceMode mode, string method)+() => { }")]
+    public void Create_Async_CurrentStackTrace(StackTraceMode mode, string method)
+    {
+        _fixture.SentryOptions.AttachStacktrace = true;
+        _fixture.SentryOptions.StackTraceMode = mode;
+        var sut = _fixture.GetSut();
+
+        SentryStackTrace stackTrace = null!;
+        Task.Run(() => stackTrace = sut.Create()).Wait();
+
+        Assert.NotNull(stackTrace);
+
+        Assert.Equal(method, stackTrace.Frames.Last().Function);
+    }
+
     [Fact]
     public void Create_NoExceptionAndAttachStackTraceOptionOnWithEnhancedMode_CurrentStackTrace()
     {


### PR DESCRIPTION
See https://github.com/getsentry/sentry-unity/issues/845 - we're implementing a workaround to demangle the stack trace.

Additionally, I've changed existing code to use pre-compiled regex too.

The added test doesn't actually test the new code, it's just something I've added while trying to reproduce it. In the end, I couldn't make a reproduction in the sentry-dotnet repo which led me to believe the issue is Unity specific.

#skip-changelog