### PR TITLE
why the fixture / sut pattern

### DIFF
--- a/test/Sentry.Testing/DsnSamples.cs
+++ b/test/Sentry.Testing/DsnSamples.cs
@@ -16,3 +16,20 @@ public static class DsnSamples
     /// </summary>
     public const string InvalidDsn = "https://d4d82fc1c2c4032a83f3a29aa3a3aff@fake-sentry.io:65535/";
 }
+
+public class ValidDsnNoSecretOptions : SentryOptions
+{
+    public ValidDsnNoSecretOptions()
+    {
+        Dsn = DsnSamples.ValidDsnWithoutSecret;
+    }
+}
+
+public class ValidDsnOptions : SentryOptions
+{
+    public static ValidDsnOptions Instance = new ValidDsnOptions();
+    public ValidDsnOptions()
+    {
+        Dsn = DsnSamples.ValidDsnWithSecret;
+    }
+}


### PR DESCRIPTION
so i dont like the fixture/sut pattern. when reading a test i need so continually scan back to the top of the page to see what the fixture is doing. and in many cases it is doing nothing useful, often only an empty new. Also they set a field that some test can than mutate. 

IMO it is better for each test to, in most cases, to own its own construction + setup. 

