### PR TITLE
Catch Android/MAUI permission exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Expose EnumerateChainedExceptions ([#1733](https://github.com/getsentry/sentry-dotnet/pull/1733))
 - Android Scope Sync ([#1737](https://github.com/getsentry/sentry-dotnet/pull/1737))
 - Enable logging in MAUI ([#1738](https://github.com/getsentry/sentry-dotnet/pull/1738))
+- Catch permission exceptions on Android ([#1750](https://github.com/getsentry/sentry-dotnet/pull/1750))
 
 ## Sentry.Maui 3.18.0-preview.1
 

--- a/src/Sentry/Android/SentrySdk.cs
+++ b/src/Sentry/Android/SentrySdk.cs
@@ -162,6 +162,10 @@ public static partial class SentrySdk
         options.CrashedLastRun = () => Java.Sentry.IsCrashedLastRun()?.BooleanValue() is true;
         options.EnableScopeSync = true;
         options.ScopeObserver = new AndroidScopeObserver(options);
+
+        // "Best" mode throws permission exception on Android
+        options.DetectStartupTime = StartupTimeDetectionMode.Fast;
+
         // TODO: Pause/Resume
 
         // Init the managed SDK

--- a/src/Sentry/Internal/ProcessInfo.cs
+++ b/src/Sentry/Internal/ProcessInfo.cs
@@ -19,8 +19,6 @@ namespace Sentry.Internal
         /// </summary>
         internal DateTimeOffset? BootTime { get; }
 
-        private readonly SentryOptions _options;
-        private readonly Func<DateTimeOffset> _findPreciseStartupTime;
         private volatile Task _preciseAppStartupTask = Task.CompletedTask;
 
         // For testability
@@ -34,12 +32,9 @@ namespace Sentry.Internal
             SentryOptions options,
             Func<DateTimeOffset>? findPreciseStartupTime = null)
         {
-            _options = options;
-            _findPreciseStartupTime = findPreciseStartupTime ?? GetStartupTime;
             if (options.DetectStartupTime == StartupTimeDetectionMode.None)
             {
-                _options.LogDebug("Not detecting startup time due to option: {0}",
-                    _options.DetectStartupTime);
+                options.LogDebug("Not detecting startup time due to option: {0}", options.DetectStartupTime);
                 return;
             }
 
@@ -64,7 +59,7 @@ namespace Sentry.Internal
                 // ArgumentOutOfRangeException: The added or subtracted value results in an un-representable DateTime.
                 // https://github.com/getsentry/sentry-unity/issues/233
 
-                _options.LogError(
+                options.LogError(
                     "Failed to find BootTime: Now {0}, GetTimestamp {1}, Frequency {2}, TicksPerSecond: {3}",
                     e,
                     now,
@@ -75,33 +70,41 @@ namespace Sentry.Internal
 
             // An opt-out to the more precise approach (mainly due to IL2CPP):
             // https://issuetracker.unity3d.com/issues/il2cpp-player-crashes-when-calling-process-dot-getcurrentprocess-dot-starttime
-            if (_options.DetectStartupTime == StartupTimeDetectionMode.Best)
+            if (options.DetectStartupTime == StartupTimeDetectionMode.Best)
             {
+#if ANDROID
+                options.LogWarning("StartupTimeDetectionMode.Best is not available on android.  Using 'Fast' mode.");
+                return;
+#else
                 // StartupTime is set to UtcNow in this constructor.
                 // That's computationally cheap but not very precise.
                 // This method will give a better precision to the StartupTime at a cost
                 // of calling Process.GetCurrentProcess, on a thread pool thread.
+                var preciseStartupTimeFunc = findPreciseStartupTime ??  GetStartupTime;
                 PreciseAppStartupTask = Task.Run(() =>
                 {
                     try
                     {
-                        StartupTime = _findPreciseStartupTime();
+                        StartupTime = preciseStartupTimeFunc();
                     }
                     catch (Exception e)
                     {
-                        _options.LogError("Failure getting precise App startup time.", e);
+                        options.LogError("Failure getting precise App startup time.", e);
                         //Ignore any exception and stay with the less-precise DateTime.UtcNow value.
                     }
                 }).ContinueWith(_ =>
                     // Let the actual task get collected
                     PreciseAppStartupTask = Task.CompletedTask);
+#endif
             }
         }
 
+#if !ANDROID
         private static DateTimeOffset GetStartupTime()
         {
             using var proc = Process.GetCurrentProcess();
             return proc.StartTime.ToUniversalTime();
         }
+#endif
     }
 }


### PR DESCRIPTION
Battery and Network device info is not available unless the application has specific permissions.  Swallow those permission errors.

Neither is reading the process start time.  We may be able to find a better way to collect this later, but for now just use "Fast" mode instead of "Best".