### PR TITLE
Don't allow newlines in diagnostic logger messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Enable logging in MAUI ([#1738](https://github.com/getsentry/sentry-dotnet/pull/1738))
 - Catch permission exceptions on Android ([#1750](https://github.com/getsentry/sentry-dotnet/pull/1750))
 
+### Fixes
+
+- Don't allow newlines in diagnostic logger messages ([#1756](https://github.com/getsentry/sentry-dotnet/pull/1756))
+
 ## Sentry.Maui 3.18.0-preview.1
 
 ### Features

--- a/src/Sentry/Infrastructure/ConsoleDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/ConsoleDiagnosticLogger.cs
@@ -1,5 +1,4 @@
 using System;
-using Sentry.Extensibility;
 
 namespace Sentry.Infrastructure
 {
@@ -9,25 +8,16 @@ namespace Sentry.Infrastructure
     /// <remarks>
     /// The default logger, usually replaced by a higher level logging adapter like Microsoft.Extensions.Logging.
     /// </remarks>
-    public class ConsoleDiagnosticLogger : IDiagnosticLogger
+    public class ConsoleDiagnosticLogger : DiagnosticLogger
     {
-        private readonly SentryLevel _minimalLevel;
-
         /// <summary>
         /// Creates a new instance of <see cref="ConsoleDiagnosticLogger"/>.
         /// </summary>
-        public ConsoleDiagnosticLogger(SentryLevel minimalLevel) => _minimalLevel = minimalLevel;
+        public ConsoleDiagnosticLogger(SentryLevel minimalLevel) : base(minimalLevel)
+        {
+        }
 
-        /// <summary>
-        /// Whether the logger is enabled to the defined level.
-        /// </summary>
-        public bool IsEnabled(SentryLevel level) => level >= _minimalLevel;
-
-        /// <summary>
-        /// Log message with level, exception and parameters.
-        /// </summary>
-        public void Log(SentryLevel logLevel, string message, Exception? exception = null, params object?[] args)
-            => Console.Write($@"{logLevel,7}: {string.Format(message, args)}
-{exception}");
+        /// <inheritdoc />
+        protected override void LogMessage(string message) => Console.WriteLine(message);
     }
 }

--- a/src/Sentry/Infrastructure/DebugDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/DebugDiagnosticLogger.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using Sentry.Extensibility;
 
 namespace Sentry.Infrastructure
 {
@@ -11,25 +10,16 @@ namespace Sentry.Infrastructure
     /// Logger available when compiled in Debug mode. It's useful when debugging apps running under IIS which have no output to Console logger.
     /// </remarks>
     [Obsolete("Logger doesn't work outside of Sentry SDK. Please use TraceDiagnosticLogger instead")]
-    public class DebugDiagnosticLogger : IDiagnosticLogger
+    public class DebugDiagnosticLogger : DiagnosticLogger
     {
-        private readonly SentryLevel _minimalLevel;
-
         /// <summary>
         /// Creates a new instance of <see cref="DebugDiagnosticLogger"/>.
         /// </summary>
-        public DebugDiagnosticLogger(SentryLevel minimalLevel) => _minimalLevel = minimalLevel;
+        public DebugDiagnosticLogger(SentryLevel minimalLevel) : base(minimalLevel)
+        {
+        }
 
-        /// <summary>
-        /// Whether the logger is enabled to the defined level.
-        /// </summary>
-        public bool IsEnabled(SentryLevel level) => level >= _minimalLevel;
-
-        /// <summary>
-        /// Log message with level, exception and parameters.
-        /// </summary>
-        public void Log(SentryLevel logLevel, string message, Exception? exception = null, params object?[] args)
-            => Debug.Write($@"{logLevel,7}: {string.Format(message, args)}
-{exception}");
+        /// <inheritdoc />
+        protected override void LogMessage(string message) => Debug.WriteLine(message);
     }
 }

--- a/src/Sentry/Infrastructure/DiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/DiagnosticLogger.cs
@@ -3,6 +3,9 @@ using Sentry.Extensibility;
 
 namespace Sentry.Infrastructure
 {
+    /// <summary>
+    /// Base class for diagnostic loggers.
+    /// </summary>
     public abstract class DiagnosticLogger : IDiagnosticLogger
     {
         private readonly SentryLevel _minimalLevel;

--- a/src/Sentry/Infrastructure/DiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/DiagnosticLogger.cs
@@ -38,6 +38,10 @@ namespace Sentry.Infrastructure
             LogMessage(completeMessage);
         }
 
+        /// <summary>
+        /// Writes a formatted message to the log.
+        /// </summary>
+        /// <param name="message">The complete message, ready to be logged.</param>
         protected abstract void LogMessage(string message);
     }
 }

--- a/src/Sentry/Infrastructure/DiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/DiagnosticLogger.cs
@@ -1,0 +1,40 @@
+using System;
+using Sentry.Extensibility;
+
+namespace Sentry.Infrastructure
+{
+    public abstract class DiagnosticLogger : IDiagnosticLogger
+    {
+        private readonly SentryLevel _minimalLevel;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="DiagnosticLogger"/>.
+        /// </summary>
+        protected DiagnosticLogger(SentryLevel minimalLevel) => _minimalLevel = minimalLevel;
+
+        /// <summary>
+        /// Whether the logger is enabled to the defined level.
+        /// </summary>
+        public bool IsEnabled(SentryLevel level) => level >= _minimalLevel;
+
+        /// <summary>
+        /// Log message with level, exception and parameters.
+        /// </summary>
+        public void Log(SentryLevel logLevel, string message, Exception? exception = null, params object?[] args)
+        {
+            // Note, newlines are removed to guard against log injection attacks.
+            // See https://github.com/getsentry/sentry-dotnet/security/code-scanning/5
+
+            var formattedMessage = string.Format(message, args)
+                .Replace(Environment.NewLine, "");
+
+            var completeMessage = exception == null
+                ? $"{logLevel,7}: {formattedMessage}"
+                : $"{logLevel,7}: {formattedMessage}\n{exception}";
+
+            LogMessage(completeMessage);
+        }
+
+        protected abstract void LogMessage(string message);
+    }
+}

--- a/src/Sentry/Infrastructure/DiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/DiagnosticLogger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Sentry.Extensibility;
 
 namespace Sentry.Infrastructure
@@ -25,15 +26,15 @@ namespace Sentry.Infrastructure
         /// </summary>
         public void Log(SentryLevel logLevel, string message, Exception? exception = null, params object?[] args)
         {
-            // Note, newlines are removed to guard against log injection attacks.
+            // Note, linefeed and newline chars are removed to guard against log injection attacks.
             // See https://github.com/getsentry/sentry-dotnet/security/code-scanning/5
 
-            var formattedMessage = string.Format(message, args)
-                .Replace(Environment.NewLine, "");
+            var formattedMessage = new string(string.Format(message, args)
+                .Where(c => c != '\r' && c != '\n').ToArray());
 
             var completeMessage = exception == null
                 ? $"{logLevel,7}: {formattedMessage}"
-                : $"{logLevel,7}: {formattedMessage}\n{exception}";
+                : $"{logLevel,7}: {formattedMessage}{Environment.NewLine}{exception}";
 
             LogMessage(completeMessage);
         }

--- a/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/TraceDiagnosticLogger.cs
@@ -1,7 +1,5 @@
 #define TRACE
-using System;
 using System.Diagnostics;
-using Sentry.Extensibility;
 
 namespace Sentry.Infrastructure
 {
@@ -11,35 +9,16 @@ namespace Sentry.Infrastructure
     /// <remarks>
     /// Logger available when hooked to an IDE. It's useful when debugging apps running under IIS which have no output to Console logger.
     /// </remarks>
-    public class TraceDiagnosticLogger : IDiagnosticLogger
+    public class TraceDiagnosticLogger : DiagnosticLogger
     {
-        private readonly SentryLevel _minimalLevel;
-
         /// <summary>
         /// Creates a new instance of <see cref="TraceDiagnosticLogger"/>.
         /// </summary>
-        public TraceDiagnosticLogger(SentryLevel minimalLevel) => _minimalLevel = minimalLevel;
-
-        /// <summary>
-        /// Whether the logger is enabled to the defined level.
-        /// </summary>
-        public bool IsEnabled(SentryLevel level) => level >= _minimalLevel;
-
-        /// <summary>
-        /// Log message with level, exception and parameters.
-        /// </summary>
-        public void Log(SentryLevel logLevel, string message, Exception? exception = null, params object?[] args)
+        public TraceDiagnosticLogger(SentryLevel minimalLevel) : base(minimalLevel)
         {
-            var formattedMessage = string.Format(message, args);
-            if (exception == null)
-            {
-                Trace.WriteLine($"{logLevel,7}: {formattedMessage}");
-            }
-            else
-            {
-                Trace.WriteLine($@"{logLevel,7}: {formattedMessage}
-{exception}");
-            }
         }
+
+        /// <inheritdoc />
+        protected override void LogMessage(string message) => Trace.WriteLine(message);
     }
 }

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1094,19 +1094,24 @@ namespace Sentry.Http
 }
 namespace Sentry.Infrastructure
 {
-    public class ConsoleDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class ConsoleDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public ConsoleDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
     [System.Obsolete("Logger doesn\'t work outside of Sentry SDK. Please use TraceDiagnosticLogger inste" +
         "ad")]
-    public class DebugDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class DebugDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public DebugDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
+        protected override void LogMessage(string message) { }
+    }
+    public abstract class DiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    {
+        protected DiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
         public bool IsEnabled(Sentry.SentryLevel level) { }
         public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected abstract void LogMessage(string message);
     }
     public interface ISystemClock
     {
@@ -1118,11 +1123,10 @@ namespace Sentry.Infrastructure
         public SystemClock() { }
         public System.DateTimeOffset GetUtcNow() { }
     }
-    public class TraceDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class TraceDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public TraceDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
 }
 namespace Sentry.Integrations

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1094,19 +1094,24 @@ namespace Sentry.Http
 }
 namespace Sentry.Infrastructure
 {
-    public class ConsoleDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class ConsoleDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public ConsoleDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
     [System.Obsolete("Logger doesn\'t work outside of Sentry SDK. Please use TraceDiagnosticLogger inste" +
         "ad")]
-    public class DebugDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class DebugDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public DebugDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
+        protected override void LogMessage(string message) { }
+    }
+    public abstract class DiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    {
+        protected DiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
         public bool IsEnabled(Sentry.SentryLevel level) { }
         public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected abstract void LogMessage(string message);
     }
     public interface ISystemClock
     {
@@ -1118,11 +1123,10 @@ namespace Sentry.Infrastructure
         public SystemClock() { }
         public System.DateTimeOffset GetUtcNow() { }
     }
-    public class TraceDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class TraceDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public TraceDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
 }
 namespace Sentry.Integrations

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1094,19 +1094,24 @@ namespace Sentry.Http
 }
 namespace Sentry.Infrastructure
 {
-    public class ConsoleDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class ConsoleDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public ConsoleDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
     [System.Obsolete("Logger doesn\'t work outside of Sentry SDK. Please use TraceDiagnosticLogger inste" +
         "ad")]
-    public class DebugDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class DebugDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public DebugDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
+        protected override void LogMessage(string message) { }
+    }
+    public abstract class DiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    {
+        protected DiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
         public bool IsEnabled(Sentry.SentryLevel level) { }
         public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected abstract void LogMessage(string message);
     }
     public interface ISystemClock
     {
@@ -1118,11 +1123,10 @@ namespace Sentry.Infrastructure
         public SystemClock() { }
         public System.DateTimeOffset GetUtcNow() { }
     }
-    public class TraceDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class TraceDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public TraceDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
 }
 namespace Sentry.Integrations

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -1093,19 +1093,24 @@ namespace Sentry.Http
 }
 namespace Sentry.Infrastructure
 {
-    public class ConsoleDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class ConsoleDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public ConsoleDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
     [System.Obsolete("Logger doesn\'t work outside of Sentry SDK. Please use TraceDiagnosticLogger inste" +
         "ad")]
-    public class DebugDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class DebugDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public DebugDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
+        protected override void LogMessage(string message) { }
+    }
+    public abstract class DiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    {
+        protected DiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
         public bool IsEnabled(Sentry.SentryLevel level) { }
         public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected abstract void LogMessage(string message);
     }
     public interface ISystemClock
     {
@@ -1117,11 +1122,10 @@ namespace Sentry.Infrastructure
         public SystemClock() { }
         public System.DateTimeOffset GetUtcNow() { }
     }
-    public class TraceDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class TraceDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public TraceDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
 }
 namespace Sentry.Integrations

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -1093,19 +1093,24 @@ namespace Sentry.Http
 }
 namespace Sentry.Infrastructure
 {
-    public class ConsoleDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class ConsoleDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public ConsoleDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
     [System.Obsolete("Logger doesn\'t work outside of Sentry SDK. Please use TraceDiagnosticLogger inste" +
         "ad")]
-    public class DebugDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class DebugDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public DebugDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
+        protected override void LogMessage(string message) { }
+    }
+    public abstract class DiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    {
+        protected DiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
         public bool IsEnabled(Sentry.SentryLevel level) { }
         public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected abstract void LogMessage(string message);
     }
     public interface ISystemClock
     {
@@ -1117,11 +1122,10 @@ namespace Sentry.Infrastructure
         public SystemClock() { }
         public System.DateTimeOffset GetUtcNow() { }
     }
-    public class TraceDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class TraceDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public TraceDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
 }
 namespace Sentry.Integrations

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1094,19 +1094,24 @@ namespace Sentry.Http
 }
 namespace Sentry.Infrastructure
 {
-    public class ConsoleDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class ConsoleDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public ConsoleDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
     [System.Obsolete("Logger doesn\'t work outside of Sentry SDK. Please use TraceDiagnosticLogger inste" +
         "ad")]
-    public class DebugDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class DebugDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public DebugDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
+        protected override void LogMessage(string message) { }
+    }
+    public abstract class DiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    {
+        protected DiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
         public bool IsEnabled(Sentry.SentryLevel level) { }
         public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected abstract void LogMessage(string message);
     }
     public interface ISystemClock
     {
@@ -1118,11 +1123,10 @@ namespace Sentry.Infrastructure
         public SystemClock() { }
         public System.DateTimeOffset GetUtcNow() { }
     }
-    public class TraceDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class TraceDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public TraceDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
 }
 namespace Sentry.Integrations

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1093,19 +1093,24 @@ namespace Sentry.Http
 }
 namespace Sentry.Infrastructure
 {
-    public class ConsoleDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class ConsoleDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public ConsoleDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
     [System.Obsolete("Logger doesn\'t work outside of Sentry SDK. Please use TraceDiagnosticLogger inste" +
         "ad")]
-    public class DebugDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class DebugDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public DebugDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
+        protected override void LogMessage(string message) { }
+    }
+    public abstract class DiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    {
+        protected DiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
         public bool IsEnabled(Sentry.SentryLevel level) { }
         public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected abstract void LogMessage(string message);
     }
     public interface ISystemClock
     {
@@ -1117,11 +1122,10 @@ namespace Sentry.Infrastructure
         public SystemClock() { }
         public System.DateTimeOffset GetUtcNow() { }
     }
-    public class TraceDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class TraceDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public TraceDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
 }
 namespace Sentry.Integrations

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1094,19 +1094,24 @@ namespace Sentry.Http
 }
 namespace Sentry.Infrastructure
 {
-    public class ConsoleDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class ConsoleDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public ConsoleDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
     [System.Obsolete("Logger doesn\'t work outside of Sentry SDK. Please use TraceDiagnosticLogger inste" +
         "ad")]
-    public class DebugDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class DebugDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public DebugDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
+        protected override void LogMessage(string message) { }
+    }
+    public abstract class DiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    {
+        protected DiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
         public bool IsEnabled(Sentry.SentryLevel level) { }
         public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected abstract void LogMessage(string message);
     }
     public interface ISystemClock
     {
@@ -1118,11 +1123,10 @@ namespace Sentry.Infrastructure
         public SystemClock() { }
         public System.DateTimeOffset GetUtcNow() { }
     }
-    public class TraceDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class TraceDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public TraceDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
 }
 namespace Sentry.Integrations

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1094,19 +1094,24 @@ namespace Sentry.Http
 }
 namespace Sentry.Infrastructure
 {
-    public class ConsoleDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class ConsoleDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public ConsoleDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
     [System.Obsolete("Logger doesn\'t work outside of Sentry SDK. Please use TraceDiagnosticLogger inste" +
         "ad")]
-    public class DebugDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class DebugDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public DebugDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
+        protected override void LogMessage(string message) { }
+    }
+    public abstract class DiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    {
+        protected DiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
         public bool IsEnabled(Sentry.SentryLevel level) { }
         public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected abstract void LogMessage(string message);
     }
     public interface ISystemClock
     {
@@ -1118,11 +1123,10 @@ namespace Sentry.Infrastructure
         public SystemClock() { }
         public System.DateTimeOffset GetUtcNow() { }
     }
-    public class TraceDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    public class TraceDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
     {
         public TraceDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
-        public bool IsEnabled(Sentry.SentryLevel level) { }
-        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected override void LogMessage(string message) { }
     }
 }
 namespace Sentry.Integrations

--- a/test/Sentry.Tests/Infrastructure/DiagnosticLoggerTests.cs
+++ b/test/Sentry.Tests/Infrastructure/DiagnosticLoggerTests.cs
@@ -1,0 +1,39 @@
+namespace Sentry.Tests.Infrastructure;
+
+public class DiagnosticLoggerTests
+{
+    [Fact]
+    public void StripsEnvironmentNewlineFromMessage()
+    {
+        var logger = new FakeLogger(SentryLevel.Debug);
+        logger.LogDebug("Foo" + Environment.NewLine + "Bar");
+        Assert.Equal("  Debug: FooBar", logger.LastMessageLogged);
+    }
+
+    [Fact]
+    public void StripsNewlineCharsFromMessage()
+    {
+        var logger = new FakeLogger(SentryLevel.Debug);
+        logger.LogDebug("Foo\nBar");
+        Assert.Equal("  Debug: FooBar", logger.LastMessageLogged);
+    }
+
+    [Fact]
+    public void StripsLinefeedCharsFromMessage()
+    {
+        var logger = new FakeLogger(SentryLevel.Debug);
+        logger.LogDebug("Foo\rBar");
+        Assert.Equal("  Debug: FooBar", logger.LastMessageLogged);
+    }
+
+    private class FakeLogger : DiagnosticLogger
+    {
+        public FakeLogger(SentryLevel minimalLevel) : base(minimalLevel)
+        {
+        }
+
+        public string LastMessageLogged { get; private set; }
+
+        protected override void LogMessage(string message) => LastMessageLogged = message;
+    }
+}

--- a/test/Sentry.Tests/Infrastructure/DiagnosticLoggerTests.cs
+++ b/test/Sentry.Tests/Infrastructure/DiagnosticLoggerTests.cs
@@ -6,24 +6,32 @@ public class DiagnosticLoggerTests
     public void StripsEnvironmentNewlineFromMessage()
     {
         var logger = new FakeLogger(SentryLevel.Debug);
-        logger.LogDebug("Foo" + Environment.NewLine + "Bar");
-        Assert.Equal("  Debug: FooBar", logger.LastMessageLogged);
+        logger.LogDebug("Foo" + Environment.NewLine + "Bar" + Environment.NewLine);
+        Assert.Equal("  Debug: Foo Bar", logger.LastMessageLogged);
     }
 
     [Fact]
     public void StripsNewlineCharsFromMessage()
     {
         var logger = new FakeLogger(SentryLevel.Debug);
-        logger.LogDebug("Foo\nBar");
-        Assert.Equal("  Debug: FooBar", logger.LastMessageLogged);
+        logger.LogDebug("Foo\nBar\n");
+        Assert.Equal("  Debug: Foo Bar", logger.LastMessageLogged);
     }
 
     [Fact]
     public void StripsLinefeedCharsFromMessage()
     {
         var logger = new FakeLogger(SentryLevel.Debug);
-        logger.LogDebug("Foo\rBar");
-        Assert.Equal("  Debug: FooBar", logger.LastMessageLogged);
+        logger.LogDebug("Foo\rBar\r");
+        Assert.Equal("  Debug: Foo Bar", logger.LastMessageLogged);
+    }
+
+    [Fact]
+    public void StripsComboCharsFromMessage()
+    {
+        var logger = new FakeLogger(SentryLevel.Debug);
+        logger.LogDebug("Foo\r\nBar\r\n");
+        Assert.Equal("  Debug: Foo Bar", logger.LastMessageLogged);
     }
 
     private class FakeLogger : DiagnosticLogger


### PR DESCRIPTION
Addresses CodeQL alert https://github.com/getsentry/sentry-dotnet/pull/1755/checks?check_run_id=7079180169

This appears to have been raised twice before:
- https://github.com/getsentry/sentry-dotnet/security/code-scanning/5
- https://github.com/getsentry/sentry-dotnet/security/code-scanning/6

Not sure why it was marked fixed and suddenly reappeared, but doesn't look like it was ever actually addressed.