### PR TITLE
Send client report when flushing queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Enable logging in MAUI ([#1738](https://github.com/getsentry/sentry-dotnet/pull/1738))
 - Support IntPtr and UIntPtr serialization ([#1746](https://github.com/getsentry/sentry-dotnet/pull/1746))
 - Catch permission exceptions on Android ([#1750](https://github.com/getsentry/sentry-dotnet/pull/1750))
+- Send client report when flushing queue ([#1757](https://github.com/getsentry/sentry-dotnet/pull/1757))
 
 ### Fixes
 

--- a/src/Sentry/Envelopes/Envelope.cs
+++ b/src/Sentry/Envelopes/Envelope.cs
@@ -212,6 +212,21 @@ namespace Sentry.Protocol.Envelopes
             return new Envelope(header, items);
         }
 
+        /// <summary>
+        /// Creates an envelope that contains a client report.
+        /// </summary>
+        internal static Envelope FromClientReport(ClientReport clientReport)
+        {
+            var header = CreateHeader();
+
+            var items = new[]
+            {
+                EnvelopeItem.FromClientReport(clientReport)
+            };
+
+            return new Envelope(header, items);
+        }
+
         private static async Task<IReadOnlyDictionary<string, object?>> DeserializeHeaderAsync(
             Stream stream,
             CancellationToken cancellationToken = default)

--- a/src/Sentry/Internal/BackgroundWorker.cs
+++ b/src/Sentry/Internal/BackgroundWorker.cs
@@ -175,9 +175,35 @@ namespace Sentry.Internal
 
         public async Task FlushAsync(TimeSpan timeout)
         {
+            // Start timer from here.
+            using var timeoutSource = new CancellationTokenSource(timeout.AdjustForMaxTimeout());
+            using var timeoutWithShutdown = CancellationTokenSource.CreateLinkedTokenSource(
+                timeoutSource.Token, _shutdownSource.Token);
+
+            try
+            {
+                await DoFlushAsync(timeoutWithShutdown.Token).ConfigureAwait(false);
+            }
+            finally
+            {
+                // Send a final client report, if there is one.  We do this after flushing the queue, because sending
+                // the queued envelopes might encounter situations such as rate limiting, and we want to report those.
+                // (Client reports themselves are never rate limited.)
+                await SendFinalClientReportAsync(timeoutWithShutdown.Token).ConfigureAwait(false);
+            }
+        }
+
+        private async Task DoFlushAsync(CancellationToken cancellationToken)
+        {
             if (_disposed)
             {
                 _options.LogDebug("Worker disposed. Nothing to flush.");
+                return;
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _options.LogDebug("Timeout or shutdown already requested. Exiting.");
                 return;
             }
 
@@ -187,15 +213,8 @@ namespace Sentry.Internal
                 return;
             }
 
-            // Start timer from here.
-            var timeoutSource = new CancellationTokenSource();
-            timeoutSource.CancelAfter(timeout);
-            var flushSuccessSource = new CancellationTokenSource();
-
-            var timeoutWithShutdown = CancellationTokenSource.CreateLinkedTokenSource(
-                timeoutSource.Token,
-                _shutdownSource.Token,
-                flushSuccessSource.Token);
+            var completionSource = new TaskCompletionSource<bool>();
+            cancellationToken.Register(() => completionSource.SetCanceled());
 
             var counter = 0;
             var depth = int.MaxValue;
@@ -205,50 +224,67 @@ namespace Sentry.Internal
                 // ReSharper disable once AccessToModifiedClosure
                 if (Interlocked.Increment(ref counter) >= depth)
                 {
-                    try
-                    {
-                        _options.LogDebug("Signaling flush completed.");
-                        // ReSharper disable once AccessToDisposedClosure
-                        flushSuccessSource.Cancel();
-                    }
-                    catch // Timeout or Shutdown might have been called so this token was disposed.
-                    {
-                        // Flush will release when timeout is hit.
-                    }
+                    _options.LogDebug("Signaling flush completed.");
+                    completionSource.TrySetResult(true);
                 }
             }
 
             OnFlushObjectReceived += EventFlushedCallback; // Started counting events
+
+            var trackedDepth = _queue.Count;
+            if (trackedDepth == 0) // now we're subscribed and counting, make sure it's not already empty.
+            {
+                return;
+            }
+
+            _ = Interlocked.Exchange(ref depth, trackedDepth);
+            _options.LogDebug("Tracking depth: {0}.", trackedDepth);
+
+            if (counter >= depth) // When the worker finished flushing before we set the depth
+            {
+                return;
+            }
+
             try
             {
-                var trackedDepth = _queue.Count;
-                if (trackedDepth == 0) // now we're subscribed and counting, make sure it's not already empty.
-                {
-                    return;
-                }
-
-                _ = Interlocked.Exchange(ref depth, trackedDepth);
-                _options.LogDebug("Tracking depth: {0}.", trackedDepth);
-
-                if (counter >= depth) // When the worker finished flushing before we set the depth
-                {
-                    return;
-                }
-
-                // Await until event is flushed or one of the tokens triggers
-                await Task.Delay(timeout, timeoutWithShutdown.Token).ConfigureAwait(false);
-                _options.LogDebug("Timeout when trying to flush queue.");
+                // Await until event is flushed (or we have cancelled)
+                await completionSource.Task.ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
-                _options.LogDebug(flushSuccessSource.IsCancellationRequested
-                    ? "Successfully flushed all events up to call to FlushAsync."
-                    : "Timeout when trying to flush queue.");
+                // timeout occured. We'll log it below.
             }
             finally
             {
+                _options.LogDebug(completionSource.Task.Status == TaskStatus.RanToCompletion
+                    ? "Successfully flushed all events up to call to FlushAsync."
+                    : "Timeout when trying to flush queue.");
+
                 OnFlushObjectReceived -= EventFlushedCallback;
-                timeoutWithShutdown.Dispose();
+            }
+        }
+
+        private async Task SendFinalClientReportAsync(CancellationToken cancellationToken)
+        {
+            var clientReport = _options.ClientReportRecorder.GenerateClientReport();
+            if (clientReport != null)
+            {
+                _options.LogDebug("Sending client report after flushing queue.");
+                using var envelope = Envelope.FromClientReport(clientReport);
+
+                try
+                {
+                    await _transport.SendEnvelopeAsync(envelope, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    _options.LogInfo("Timeout or shutdown while trying to send final client report. Exiting.");
+                }
+                catch (Exception exception)
+                {
+                    _options.LogError("Error while sending final client report (event ID: '{0}').",
+                        exception, envelope.TryGetEventId());
+                }
             }
         }
 

--- a/src/Sentry/Internal/Extensions/MiscExtensions.cs
+++ b/src/Sentry/Internal/Extensions/MiscExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading;
 
 namespace Sentry.Internal.Extensions
 {
@@ -15,5 +16,8 @@ namespace Sentry.Internal.Extensions
 
         public static string ToHexString(this long l) =>
             "0x" + l.ToString("x", CultureInfo.InvariantCulture);
+
+        public static TimeSpan AdjustForMaxTimeout(this TimeSpan timeout) =>
+            timeout.TotalMilliseconds > int.MaxValue ? Timeout.InfiniteTimeSpan : timeout;
     }
 }

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -280,7 +280,7 @@ namespace Sentry
         /// Disposes this client
         /// </summary>
         /// <inheritdoc />
-        [Obsolete("Sentry client should no be explicitly disposed of. This method will be removed in version 4.")]
+        [Obsolete("Sentry client should not be explicitly disposed of. This method will be removed in version 4.")]
         public void Dispose()
         {
             _options.LogDebug("Flushing SentryClient.");

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -358,8 +358,8 @@ namespace Sentry
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.Transaction transaction) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
-        [System.Obsolete("Sentry client should no be explicitly disposed of. This method will be removed in" +
-            " version 4.")]
+        [System.Obsolete("Sentry client should not be explicitly disposed of. This method will be removed i" +
+            "n version 4.")]
         public void Dispose() { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
     }

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -358,8 +358,8 @@ namespace Sentry
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.Transaction transaction) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
-        [System.Obsolete("Sentry client should no be explicitly disposed of. This method will be removed in" +
-            " version 4.")]
+        [System.Obsolete("Sentry client should not be explicitly disposed of. This method will be removed i" +
+            "n version 4.")]
         public void Dispose() { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
     }

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -358,8 +358,8 @@ namespace Sentry
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.Transaction transaction) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
-        [System.Obsolete("Sentry client should no be explicitly disposed of. This method will be removed in" +
-            " version 4.")]
+        [System.Obsolete("Sentry client should not be explicitly disposed of. This method will be removed i" +
+            "n version 4.")]
         public void Dispose() { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -358,8 +358,8 @@ namespace Sentry
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.Transaction transaction) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
-        [System.Obsolete("Sentry client should no be explicitly disposed of. This method will be removed in" +
-            " version 4.")]
+        [System.Obsolete("Sentry client should not be explicitly disposed of. This method will be removed i" +
+            "n version 4.")]
         public void Dispose() { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -358,8 +358,8 @@ namespace Sentry
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.Transaction transaction) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
-        [System.Obsolete("Sentry client should no be explicitly disposed of. This method will be removed in" +
-            " version 4.")]
+        [System.Obsolete("Sentry client should not be explicitly disposed of. This method will be removed i" +
+            "n version 4.")]
         public void Dispose() { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -358,8 +358,8 @@ namespace Sentry
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.Transaction transaction) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
-        [System.Obsolete("Sentry client should no be explicitly disposed of. This method will be removed in" +
-            " version 4.")]
+        [System.Obsolete("Sentry client should not be explicitly disposed of. This method will be removed i" +
+            "n version 4.")]
         public void Dispose() { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -357,8 +357,8 @@ namespace Sentry
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.Transaction transaction) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
-        [System.Obsolete("Sentry client should no be explicitly disposed of. This method will be removed in" +
-            " version 4.")]
+        [System.Obsolete("Sentry client should not be explicitly disposed of. This method will be removed i" +
+            "n version 4.")]
         public void Dispose() { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -358,8 +358,8 @@ namespace Sentry
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.Transaction transaction) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
-        [System.Obsolete("Sentry client should no be explicitly disposed of. This method will be removed in" +
-            " version 4.")]
+        [System.Obsolete("Sentry client should not be explicitly disposed of. This method will be removed i" +
+            "n version 4.")]
         public void Dispose() { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -358,8 +358,8 @@ namespace Sentry
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.Transaction transaction) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
-        [System.Obsolete("Sentry client should no be explicitly disposed of. This method will be removed in" +
-            " version 4.")]
+        [System.Obsolete("Sentry client should not be explicitly disposed of. This method will be removed i" +
+            "n version 4.")]
         public void Dispose() { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
     }


### PR DESCRIPTION
During shutdown (and when manually requested), we flush the worker queue of all events.  However, if there are no events to send, we'll potentially lose accumulated client report information.

This updates the `BackgroundWorker.FlushAsync` method to send a final client report after flushing, if there is one to send.  That also ensures that if events are rate-limited as they are flushed, that the count of discarded events from rate limiting will be sent.

Note that we still respect the shutdown timeout, so if the queue is very backed up there's a chance the client report *won't* get sent.  If instead we wanted to ensure that it *always* get sent, then we would need to be ok with going past the timeout period.

Additionally, this PR includes some general implementation improvements with `FlushAsync`, and an unrelated typo fixed.