### PR TITLE
remove System.Runtime.Versioning.TargetFramework  from api snapshot

### DIFF
--- a/test/Sentry.AspNet.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.AspNet.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1,4 +1,3 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
 namespace Sentry.AspNet
 {
     public static class HttpContextExtensions

--- a/test/Sentry.AspNetCore.Grpc.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.AspNetCore.Grpc.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1,4 +1,3 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v3.0", FrameworkDisplayName="")]
 namespace Sentry.AspNetCore.Grpc
 {
     public class DefaultProtobufRequestPayloadExtractor : Sentry.AspNetCore.Grpc.IProtobufRequestPayloadExtractor

--- a/test/Sentry.AspNetCore.Grpc.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.AspNetCore.Grpc.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1,5 +1,4 @@
-﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName="")]
-namespace Sentry.AspNetCore.Grpc
+﻿namespace Sentry.AspNetCore.Grpc
 {
     public class DefaultProtobufRequestPayloadExtractor : Sentry.AspNetCore.Grpc.IProtobufRequestPayloadExtractor
     {

--- a/test/Sentry.AspNetCore.Grpc.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.AspNetCore.Grpc.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,5 +1,4 @@
-﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName="")]
-namespace Sentry.AspNetCore.Grpc
+﻿namespace Sentry.AspNetCore.Grpc
 {
     public class DefaultProtobufRequestPayloadExtractor : Sentry.AspNetCore.Grpc.IProtobufRequestPayloadExtractor
     {

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -1,4 +1,3 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace Microsoft.AspNetCore.Builder
 {
     public static class SentryTracingMiddlewareExtensions { }

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1,4 +1,3 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v3.0", FrameworkDisplayName="")]
 namespace Microsoft.AspNetCore.Builder
 {
     public static class SentryTracingMiddlewareExtensions { }

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1,4 +1,3 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace Microsoft.AspNetCore.Builder
 {
     public static class SentryTracingMiddlewareExtensions { }

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1,5 +1,4 @@
-﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName="")]
-namespace Microsoft.AspNetCore.Builder
+﻿namespace Microsoft.AspNetCore.Builder
 {
     public static class SentryTracingMiddlewareExtensions { }
 }

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,5 +1,4 @@
-﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName="")]
-namespace Microsoft.AspNetCore.Builder
+﻿namespace Microsoft.AspNetCore.Builder
 {
     public static class SentryTracingMiddlewareExtensions { }
 }

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -1,4 +1,3 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace Sentry
 {
     public static class SentryOptionsDiagnosticExtensions

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -1,4 +1,3 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
 namespace Sentry
 {
     public static class SentryOptionsDiagnosticExtensions

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1,5 +1,4 @@
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v3.0", FrameworkDisplayName="")]
 namespace Sentry
 {
     [System.Diagnostics.DebuggerDisplay("{FileName}")]

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1,4 +1,3 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
 namespace Sentry
 {
     public static class SentryOptionsDiagnosticExtensions

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1,5 +1,4 @@
 ﻿[assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName="")]
 namespace Sentry
 {
     [System.Diagnostics.DebuggerDisplay("{FileName}")]

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,5 +1,4 @@
 ﻿[assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName="")]
 namespace Sentry
 {
     [System.Diagnostics.DebuggerDisplay("{FileName}")]

--- a/test/Sentry.EntityFramework.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.EntityFramework.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1,4 +1,3 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
 namespace Sentry.EntityFramework.ErrorProcessors
 {
     public class DbConcurrencyExceptionProcessor : Sentry.Extensibility.SentryEventExceptionProcessor<System.Data.DBConcurrencyException>

--- a/test/Sentry.EntityFramework.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.EntityFramework.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1,4 +1,3 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
 namespace Sentry.EntityFramework.ErrorProcessors
 {
     public class DbConcurrencyExceptionProcessor : Sentry.Extensibility.SentryEventExceptionProcessor<System.Data.DBConcurrencyException>

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -1,4 +1,3 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace Microsoft.Extensions.Logging
 {
     public static class LoggingBuilderExtensions { }

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1,4 +1,3 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v3.0", FrameworkDisplayName="")]
 namespace Microsoft.Extensions.Logging
 {
     public static class LoggingBuilderExtensions { }

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1,4 +1,3 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace Microsoft.Extensions.Logging
 {
     public static class LoggingBuilderExtensions { }

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1,5 +1,4 @@
-﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName="")]
-namespace Microsoft.Extensions.Logging
+﻿namespace Microsoft.Extensions.Logging
 {
     public static class LoggingBuilderExtensions { }
     public static class SentryLoggerFactoryExtensions { }

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,5 +1,4 @@
-﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName="")]
-namespace Microsoft.Extensions.Logging
+﻿namespace Microsoft.Extensions.Logging
 {
     public static class LoggingBuilderExtensions { }
     public static class SentryLoggerFactoryExtensions { }

--- a/test/Sentry.Google.Cloud.Functions.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Google.Cloud.Functions.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1,4 +1,3 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v3.1", FrameworkDisplayName="")]
 namespace Google.Cloud.Functions.Framework
 {
     public class SentryStartup : Google.Cloud.Functions.Hosting.FunctionsStartup

--- a/test/Sentry.Google.Cloud.Functions.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Google.Cloud.Functions.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1,5 +1,4 @@
-﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName="")]
-namespace Google.Cloud.Functions.Framework
+﻿namespace Google.Cloud.Functions.Framework
 {
     public class SentryStartup : Google.Cloud.Functions.Hosting.FunctionsStartup
     {

--- a/test/Sentry.Google.Cloud.Functions.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Google.Cloud.Functions.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,5 +1,4 @@
-﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName="")]
-namespace Google.Cloud.Functions.Framework
+﻿namespace Google.Cloud.Functions.Framework
 {
     public class SentryStartup : Google.Cloud.Functions.Hosting.FunctionsStartup
     {

--- a/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -1,5 +1,4 @@
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace Sentry.Log4Net
 {
     public class SentryAppender : log4net.Appender.AppenderSkeleton

--- a/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1,5 +1,4 @@
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
 namespace Sentry.Log4Net
 {
     public class SentryAppender : log4net.Appender.AppenderSkeleton

--- a/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1,5 +1,4 @@
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
 namespace Sentry.Log4Net
 {
     public class SentryAppender : log4net.Appender.AppenderSkeleton

--- a/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1,5 +1,4 @@
 ﻿[assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
 namespace Sentry.Log4Net
 {
     public class SentryAppender : log4net.Appender.AppenderSkeleton

--- a/test/Sentry.Maui.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Maui.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,5 +1,4 @@
-﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName="")]
-namespace Microsoft.Maui.Hosting
+﻿namespace Microsoft.Maui.Hosting
 {
     public static class SentryMauiAppBuilderExtensions { }
 }

--- a/test/Sentry.NLog.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.NLog.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -1,5 +1,4 @@
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace NLog
 {
     public static class ConfigurationExtensions

--- a/test/Sentry.NLog.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.NLog.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1,5 +1,4 @@
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
 namespace NLog
 {
     public static class ConfigurationExtensions

--- a/test/Sentry.NLog.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.NLog.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1,5 +1,4 @@
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
 namespace NLog
 {
     public static class ConfigurationExtensions

--- a/test/Sentry.NLog.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.NLog.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1,5 +1,4 @@
 ﻿[assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName="")]
 namespace NLog
 {
     public static class ConfigurationExtensions

--- a/test/Sentry.NLog.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.NLog.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,5 +1,4 @@
 ﻿[assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName="")]
 namespace NLog
 {
     public static class ConfigurationExtensions

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -1,5 +1,4 @@
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace Sentry.Serilog
 {
     public class SentrySerilogOptions : Sentry.SentryOptions

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1,5 +1,4 @@
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
 namespace Sentry.Serilog
 {
     public class SentrySerilogOptions : Sentry.SentryOptions

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1,5 +1,4 @@
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
 namespace Sentry.Serilog
 {
     public class SentrySerilogOptions : Sentry.SentryOptions

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1,5 +1,4 @@
 ﻿[assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName="")]
 namespace Sentry.Serilog
 {
     public class SentrySerilogOptions : Sentry.SentryOptions

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,5 +1,4 @@
 ﻿[assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName="")]
 namespace Sentry.Serilog
 {
     public class SentrySerilogOptions : Sentry.SentryOptions

--- a/test/Sentry.Testing/ApiExtensions.cs
+++ b/test/Sentry.Testing/ApiExtensions.cs
@@ -17,6 +17,7 @@ public static class ApiExtensions
             .ScrubLines(l =>
                 l.StartsWith("[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(") ||
                 l.StartsWith("[assembly: AssemblyVersion(") ||
+                l.StartsWith("[assembly: System.Runtime.Versioning.TargetFramework(") ||
                 l.StartsWith("[assembly: AssemblyFileVersion(") ||
                 l.StartsWith("[assembly: AssemblyInformationalVersion(") ||
                 l.StartsWith("[assembly: System.Reflection.AssemblyMetadata("));

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -1,5 +1,4 @@
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace Sentry
 {
     [System.Diagnostics.DebuggerDisplay("{FileName}")]

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -1,5 +1,4 @@
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
 namespace Sentry
 {
     [System.Diagnostics.DebuggerDisplay("{FileName}")]

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1,5 +1,4 @@
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v3.0", FrameworkDisplayName="")]
 namespace Sentry
 {
     [System.Diagnostics.DebuggerDisplay("{FileName}")]

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1,5 +1,4 @@
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
 namespace Sentry
 {
     [System.Diagnostics.DebuggerDisplay("{FileName}")]

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1,5 +1,4 @@
 ﻿[assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName="")]
 namespace Sentry
 {
     [System.Diagnostics.DebuggerDisplay("{FileName}")]

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,5 +1,4 @@
 ﻿[assembly: System.CLSCompliant(true)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName="")]
 namespace Sentry
 {
     [System.Diagnostics.DebuggerDisplay("{FileName}")]


### PR DESCRIPTION
After an update to some runtime, i noticed the value for `System.Runtime.Versioning.TargetFramework` had a bug fix that added the framework name to the attribute. but given we dont care about that attribute for API purposes, i removed it

#skip-changelog