### PR TITLE
make verify recognize 4x

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -41,7 +41,7 @@
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="Verify.Xunit" Version="17.2.0" />
+    <PackageReference Include="Verify.Xunit" Version="17.2.1" />
     <PackageReference Include="Verify.DiffPlex" Version="1.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.Net4_6.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.Net4_6.verified.txt
@@ -1,0 +1,63 @@
+[
+  {
+    Source: {
+      Exception: {
+        $type: Exception,
+        Type: Exception,
+        Message: my exception
+      },
+      Platform: csharp,
+      SentryExceptions: [
+        {
+          Type: System.Exception,
+          Value: my exception,
+          Mechanism: {}
+        }
+      ],
+      SentryThreads: [],
+      Level: error,
+      TransactionName: my transaction,
+      Request: {},
+      User: {},
+      Environment: production
+    }
+  },
+  {
+    Source: {
+      Name: my transaction,
+      Platform: csharp,
+      Operation: my operation,
+      Description: ,
+      Status: UnknownError,
+      IsSampled: true,
+      Request: {},
+      User: {},
+      Environment: production,
+      Spans: [
+        {
+          IsFinished: true,
+          Operation: db.query,
+          Description:
+SET NOCOUNT ON;
+INSERT INTO [TestEntities] ([Property])
+VALUES (@p0);
+SELECT [Id]
+FROM [TestEntities]
+WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();,
+          Status: Ok,
+          IsSampled: true
+        },
+        {
+          IsFinished: true,
+          Operation: db.query,
+          Description:
+SELECT [t].[Id], [t].[Property]
+FROM [TestEntities] AS [t],
+          Status: Ok,
+          IsSampled: true
+        }
+      ],
+      IsFinished: true
+    }
+  }
+]

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.Net4_7.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.Net4_7.verified.txt
@@ -1,0 +1,63 @@
+[
+  {
+    Source: {
+      Exception: {
+        $type: Exception,
+        Type: Exception,
+        Message: my exception
+      },
+      Platform: csharp,
+      SentryExceptions: [
+        {
+          Type: System.Exception,
+          Value: my exception,
+          Mechanism: {}
+        }
+      ],
+      SentryThreads: [],
+      Level: error,
+      TransactionName: my transaction,
+      Request: {},
+      User: {},
+      Environment: production
+    }
+  },
+  {
+    Source: {
+      Name: my transaction,
+      Platform: csharp,
+      Operation: my operation,
+      Description: ,
+      Status: UnknownError,
+      IsSampled: true,
+      Request: {},
+      User: {},
+      Environment: production,
+      Spans: [
+        {
+          IsFinished: true,
+          Operation: db.query,
+          Description:
+SET NOCOUNT ON;
+INSERT INTO [TestEntities] ([Property])
+VALUES (@p0);
+SELECT [Id]
+FROM [TestEntities]
+WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();,
+          Status: Ok,
+          IsSampled: true
+        },
+        {
+          IsFinished: true,
+          Operation: db.query,
+          Description:
+SELECT [t].[Id], [t].[Property]
+FROM [TestEntities] AS [t],
+          Status: Ok,
+          IsSampled: true
+        }
+      ],
+      IsFinished: true
+    }
+  }
+]


### PR DESCRIPTION
net461 and net472 were not being correctly determined. Was causing flaky tests on windows and missing verified files for the sql tests

#skip-changelog