### PR TITLE
Update nullable library to version 1.3.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="UnoptimizedAssemblyDetector" Version="0.1.1" PrivateAssets="All" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.1.1" PrivateAssets="All" />
-    <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="All" />
+    <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Addresses build issues with .NET SDK 6.0.300.  See https://github.com/manuelroemer/Nullable/issues/24

#skip-changelog

