### PR TITLE
Fix collection modified exception in InMemoryDiagnosticLogger

### DIFF
--- a/test/Sentry.Testing/InMemoryDiagnosticLogger.cs
+++ b/test/Sentry.Testing/InMemoryDiagnosticLogger.cs
@@ -1,14 +1,16 @@
+using System.Collections.Concurrent;
+
 namespace Sentry.Testing;
 
 public class InMemoryDiagnosticLogger : IDiagnosticLogger
 {
-    public List<Entry> Entries { get; } = new();
+    public ConcurrentQueue<Entry> Entries { get; } = new();
 
     public bool IsEnabled(SentryLevel level) => true;
 
     public void Log(SentryLevel logLevel, string message, Exception exception = null, params object[] args)
     {
-        Entries.Add(new Entry(logLevel, message, exception, args));
+        Entries.Enqueue(new Entry(logLevel, message, exception, args));
     }
 
     public record Entry(


### PR DESCRIPTION
Got one of these intermittently while testing locally:

```
Test run for /Users/matt/Code/getsentry/sentry-dotnet/test/Sentry.Tests/bin/Debug/net5.0/Sentry.Tests.dll (.NETCoreApp,Version=v5.0)
Microsoft (R) Test Execution Command Line Tool Version 17.2.0 (arm64)
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
[xUnit.net 00:00:24.63]     Sentry.Tests.SentrySdkTests.CaptureEvent_WithConfiguredScopeNull_LogsError [FAIL]
  Failed Sentry.Tests.SentrySdkTests.CaptureEvent_WithConfiguredScopeNull_LogsError [8 ms]
  Error Message:
   System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
  Stack Trace:
     at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Sentry.Tests.SentrySdkTests.CaptureEvent_WithConfiguredScopeNull_LogsError() in /Users/matt/Code/getsentry/sentry-dotnet/test/Sentry.Tests/SentrySdkTests.cs:line 514

Failed!  - Failed:     1, Passed:  1113, Skipped:     0, Total:  1114, Duration: 29 s - /Users/matt/Code/getsentry/sentry-dotnet/test/Sentry.Tests/bin/Debug/net5.0/Sentry.Tests.dll (net5.0)
```

Fix attached.

#skip-changelog