### PR TITLE
Fix vulnerabilities workflow

### DIFF
--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -1,21 +1,77 @@
 name: List vulnerable packages
 
 on:
+  workflow_dispatch:
   schedule:
     # once a day
     - cron:  '0 0 * * *'
+
 jobs:
   List-vulnerable-packages:
-    runs-on: windows-latest
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_NOLOGO: 1
+      # Prevent setup-dotnet action from stepping on pre-installed dotnet SDKs on Ubuntu and Windows (doesn't happen on macOS)
+      DOTNET_INSTALL_DIR: ${{ startsWith(matrix.os, 'ubuntu') && '/usr/share/dotnet' || startsWith(matrix.os, 'windows') && 'C:\Program Files\dotnet' || '' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Using macos-12 because we need Xcode 13.3 or later to build Sentry.Samples.Maui. (macos-latest currently points at macos-11 which uses Xcode 13.2)
+        os: [ubuntu-latest, windows-latest, macos-12]
+
     steps:
         - name: Checkout
           uses: actions/checkout@v3
           with:
             submodules: recursive
-            fetch-depth: 2
 
-        - name: Build
-          run: dotnet build
+        - name: Setup .NET SDK (Windows)
+          if: startsWith(matrix.os, 'windows')
+          uses: actions/setup-dotnet@v2
+          with:
+            dotnet-version: 2.1.818
+        - name: Setup .NET SDK (macOS)
+          if: startsWith(matrix.os, 'macos')
+          uses: actions/setup-dotnet@v2
+          with:
+            dotnet-version: |
+              2.1.818
+              6.0.x
+        - name: Setup .NET SDK (Ubuntu)
+          if: startsWith(matrix.os, 'ubuntu')
+          uses: actions/setup-dotnet@v2
+          with:
+            dotnet-version: 2.1.818
+
+        - name: Dependency Caching
+          uses: actions/cache@v3
+          with:
+            path: ~/.nuget/packages
+            # We don't use a lockfile, so hash all files where we might be keeping <PackageReference> tags
+            # Workloads also get installed in the nuget packages cache, so if you modify workloads below, increment the number in the cache keys
+            key: ${{ runner.os }}-nuget+workloads3-${{ hashFiles('**/*.*proj', '**/*.props') }}
+            restore-keys: ${{ runner.os }}-nuget+workloads3
+
+        - name: Install .NET Workloads (Ubuntu)
+          if: startsWith(matrix.os, 'ubuntu')
+          run: 'dotnet workload install maui-android --temp-dir "${{ runner.temp }}"'
+        - name: Install .NET Workloads (Windows)
+          if: startsWith(matrix.os, 'windows')
+          run: 'dotnet workload install maui-android maui-windows --temp-dir "${{ runner.temp }}"'
+        - name: Install .NET Workloads (macOS)
+          if: startsWith(matrix.os, 'macos')
+          run: 'dotnet workload install maui-android maui-ios maui-maccatalyst --temp-dir "${{ runner.temp }}"'
+
+
+# Everything above here is the same as the main build.
+# We only need to restore to check for vulnerable packages
+
+        - name: Restore dependencies
+          run: dotnet restore
 
         - name: List vulnerable packages
           run: dotnet list package --vulnerable --include-transitive


### PR DESCRIPTION
I noticed that [this workflow has been failing](https://github.com/getsentry/sentry-dotnet/actions/workflows/vulnerabilities.yml).

I copied over the pre-build steps from the main build workflow.  We don't actually need to build though, just fully restore.

We should do this on all platforms, because they may restore different things.

Not sure what we do with the output from this, if anything?

#skip-changelog