### PR TITLE
Add tolerance to timeout check

### DIFF
--- a/test/Sentry.Tests/Internals/BackgroundWorkerTests.cs
+++ b/test/Sentry.Tests/Internals/BackgroundWorkerTests.cs
@@ -384,7 +384,9 @@ public class BackgroundWorkerTests
 
         _fixture.Logger.Received(1).Log(SentryLevel.Debug, "Timeout when trying to flush queue.");
         Assert.Single(_fixture.Queue); // Only the item being processed at the blocked callback
-        sw.Elapsed.Should().BeGreaterThanOrEqualTo(flushTimeout);
+
+        // Test the timeout, with a bit of tolerance on the lower bound
+        sw.Elapsed.Should().BeGreaterThan(flushTimeout - TimeSpan.FromMilliseconds(10));
     }
 
     [Fact]


### PR DESCRIPTION
Got a few of these:

```
[xUnit.net 00:00:06.85]     Sentry.Tests.Internals.BackgroundWorkerTests.FlushAsync_FullQueue_RespectsTimeout [FAIL]
Error: Expected sw.Elapsed to be greater than or equal to 500ms, but found 499ms and 98.0µs.
  Failed Sentry.Tests.Internals.BackgroundWorkerTests.FlushAsync_FullQueue_RespectsTimeout [585 ms]
```

https://github.com/getsentry/sentry-dotnet/runs/7329426667?check_suite_focus=true#step:11:46

Adjusting the lower bound to add some tolerance.

#skip-changelog