### PR TITLE
nit: standardize on backslashes in build paths

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Version>3.19.0</Version>
     <LangVersion>10</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory).assets/Sentry.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory).assets\Sentry.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <Features>strict</Features>

--- a/before.Sentry.sln.targets
+++ b/before.Sentry.sln.targets
@@ -1,7 +1,7 @@
 <Project InitialTargets="RestoreSubmodule">
   <!-- If Ben.Demystifer is not found, restore git submodules -->
   <Target Name="RestoreSubmodule"
-    Condition="!Exists('modules/Ben.Demystifier/Ben.Demystifier.sln')">
+    Condition="!Exists('modules\Ben.Demystifier\Ben.Demystifier.sln')">
     <Message Importance="High" Text="Ben.Demystifer not found. Restoring git submodules." />
     <Exec Command="git submodule update --init --recursive" />
   </Target>

--- a/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
+++ b/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <Using Include="Android.App.Activity" Alias="Activity" />
-    <TransformFile Include="Kotlin/Metadata.xml" />
-    <AndroidLibrary Include="Kotlin/buggy.jar" />
+    <TransformFile Include="Kotlin\Metadata.xml" />
+    <AndroidLibrary Include="Kotlin\buggy.jar" />
   </ItemGroup>
 </Project>

--- a/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
+++ b/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>
- 
+
 </Project>

--- a/samples/Sentry.Samples.Console.Customized/Sentry.Samples.Console.Customized.csproj
+++ b/samples/Sentry.Samples.Console.Customized/Sentry.Samples.Console.Customized.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />

--- a/samples/Sentry.Samples.EntityFramework/Sentry.Samples.EntityFramework.csproj
+++ b/samples/Sentry.Samples.EntityFramework/Sentry.Samples.EntityFramework.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Effort.EF6" Version="2.2.13" />
-    <ProjectReference Include="../../src/Sentry.EntityFramework/Sentry.EntityFramework.csproj" />
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.EntityFramework\Sentry.EntityFramework.csproj" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.GenericHost/Sentry.Samples.GenericHost.csproj
+++ b/samples/Sentry.Samples.GenericHost/Sentry.Samples.GenericHost.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry.Extensions.Logging/Sentry.Extensions.Logging.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />

--- a/samples/Sentry.Samples.Google.Cloud.Functions/Sentry.Samples.Google.Cloud.Functions.csproj
+++ b/samples/Sentry.Samples.Google.Cloud.Functions/Sentry.Samples.Google.Cloud.Functions.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <!-- Must add the dependency directly here for AutoGenerateEntryPoint to work -->
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0" />
-    <ProjectReference Include="../../src/Sentry.Google.Cloud.Functions/Sentry.Google.Cloud.Functions.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.Google.Cloud.Functions\Sentry.Google.Cloud.Functions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.Log4Net/Sentry.Samples.Log4Net.csproj
+++ b/samples/Sentry.Samples.Log4Net/Sentry.Samples.Log4Net.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry.Log4Net/Sentry.Log4Net.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.Log4Net\Sentry.Log4Net.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.ME.Logging/Sentry.Samples.ME.Logging.csproj
+++ b/samples/Sentry.Samples.ME.Logging/Sentry.Samples.ME.Logging.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry.Extensions.Logging/Sentry.Extensions.Logging.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.Serilog/Sentry.Samples.Serilog.csproj
+++ b/samples/Sentry.Samples.Serilog/Sentry.Samples.Serilog.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry.Serilog/Sentry.Serilog.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.Serilog\Sentry.Serilog.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -45,7 +45,7 @@
 
   <PropertyGroup>
     <!-- Used by SIL.ReleaseTasks below -->
-    <ChangelogFile>$(MSBuildThisFileDirectory)../CHANGELOG.md</ChangelogFile>
+    <ChangelogFile>$(MSBuildThisFileDirectory)..\CHANGELOG.md</ChangelogFile>
     <AppendToReleaseNotesProperty>
       <![CDATA[-->
       See full changelog at https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md]]>
@@ -54,8 +54,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)../.assets/sentry-nuget.png" Pack="true" PackagePath=""/>
-    <None Include="$(MSBuildThisFileDirectory)../README.md" Pack="true" PackagePath=""/>
+    <None Include="$(MSBuildThisFileDirectory)..\.assets\sentry-nuget.png" Pack="true" PackagePath=""/>
+    <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath=""/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sentry.DiagnosticSource/Sentry.DiagnosticSource.csproj
+++ b/src/Sentry.DiagnosticSource/Sentry.DiagnosticSource.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Sentry.Extensions.Logging/Sentry.Extensions.Logging.csproj
+++ b/src/Sentry.Extensions.Logging/Sentry.Extensions.Logging.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Sentry.Google.Cloud.Functions/Sentry.Google.Cloud.Functions.csproj
+++ b/src/Sentry.Google.Cloud.Functions/Sentry.Google.Cloud.Functions.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Sentry.AspNetCore/Sentry.AspNetCore.csproj" />
+    <ProjectReference Include="..\Sentry.AspNetCore\Sentry.AspNetCore.csproj" />
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0" />
   </ItemGroup>
 

--- a/src/Sentry.Log4Net/Sentry.Log4Net.csproj
+++ b/src/Sentry.Log4Net/Sentry.Log4Net.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sentry.NLog/Sentry.NLog.csproj
+++ b/src/Sentry.NLog/Sentry.NLog.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="NLog" Version="4.5.11" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Sentry.Serilog/Sentry.Serilog.csproj
+++ b/src/Sentry.Serilog/Sentry.Serilog.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net461' or $(TargetFramework) == 'netstandard2.0'">

--- a/src/Sentry/Android/Sentry.Android.props
+++ b/src/Sentry/Android/Sentry.Android.props
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Android/Transforms/*.xml" />
-    <TransformFile Include="Android/Transforms/*.xml" />
+    <None Remove="Android\Transforms\*.xml" />
+    <TransformFile Include="Android\Transforms\*.xml" />
     <!-- TODO: How to add JavaDocPaths for each package? -->
     <AndroidLibrary Include="$(AndroidLibsDirectory)sentry-$(SentryAndroidSdkVersion).jar" />
     <AndroidLibrary Include="$(AndroidLibsDirectory)sentry-android-core-$(SentryAndroidSdkVersion).aar" />
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="Android/**/*.cs" />
+    <Compile Include="Android\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -9,18 +9,18 @@
     <NoWarn Condition="$(TargetFramework) == 'netstandard2.0'">$(NoWarn);RS0017</NoWarn>
     <DefineConstants>$(AdditionalConstants)</DefineConstants>
     <!-- Files under Android are included below when TFM ends with android -->
-    <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)/Android/**</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\Android\**</DefaultItemExcludes>
   </PropertyGroup>
 
-  <Import Condition="$(TargetFramework.EndsWith('android'))" Project="Android/Sentry.Android.props" />
+  <Import Condition="$(TargetFramework.EndsWith('android'))" Project="Android\Sentry.Android.props" />
 
   <!-- Ben.Demystifier -->
   <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.0' and !$(TargetFramework.StartsWith('net4'))">
     <DefineConstants>$(DefineConstants);HAS_ASYNC_ENUMERATOR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="../../modules/Ben.Demystifier/src/**/*.cs">
-      <Link>%(RecursiveDir)/%(Filename)%(Extension)</Link>
+    <Compile Include="..\..\modules\Ben.Demystifier\src\**\*.cs">
+      <Link>%(RecursiveDir)\%(Filename)%(Extension)</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) or $(TargetFramework.StartsWith('netcoreapp')) or '$(TargetFramework)' == 'net461'">
@@ -33,8 +33,8 @@
     <DefineConstants>$(DefineConstants);HAS_DIAGNOSTIC_INTEGRATION</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition="!$(TargetFramework.StartsWith('netstandard')) and '$(TargetFramework)' != 'net461'">
-    <Compile Include="../Sentry.DiagnosticSource/Internals/**/*.cs">
-      <Link>Internal/%(RecursiveDir)%(Filename)%(Extension)</Link>
+    <Compile Include="..\Sentry.DiagnosticSource\Internals\**\*.cs">
+      <Link>Internal\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
   </ItemGroup>
   <!-- DiagnosticSource -->

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -13,7 +13,7 @@
   <ItemGroup>
     <!-- An attempt to use run netfx tests with Mono and .NET Core CLI https://github.com/xunit/xunit/issues/1357 -->
     <!-- After strong name signing assemblies, only net462 target stopped working. Again xunit -noshadow seems to solve it: https://github.com/Microsoft/vstest/issues/1684 -->
-    <Content Include="../xunit.runner.json">
+    <Content Include="..\xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/test/Sentry.AspNetCore.Tests/Sentry.AspNetCore.Tests.csproj
+++ b/test/Sentry.AspNetCore.Tests/Sentry.AspNetCore.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry.AspNetCore/Sentry.AspNetCore.csproj" />
-    <ProjectReference Include="../Sentry.Testing/Sentry.Testing.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.AspNetCore\Sentry.AspNetCore.csproj" />
+    <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'net461'">

--- a/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
@@ -17,14 +17,14 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net461' ">
-    <ProjectReference Include="../../src/Sentry.DiagnosticSource/Sentry.DiagnosticSource.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.DiagnosticSource\Sentry.DiagnosticSource.csproj" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.26" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../Sentry.Testing/Sentry.Testing.csproj" />
+    <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
     <PackageReference Include="LocalDb" Version="13.8.0" />
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
+++ b/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
@@ -14,26 +14,26 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="6.0.6" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.17" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.17" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="5.0.17" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="3.1.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-    <ProjectReference Include="../../src/Sentry.DiagnosticSource/Sentry.DiagnosticSource.csproj" SetTargetFramework="TargetFramework=netstandard2.1" />
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" SetTargetFramework="TargetFramework=netstandard2.1" />
+    <ProjectReference Include="..\..\src\Sentry.DiagnosticSource\Sentry.DiagnosticSource.csproj" SetTargetFramework="TargetFramework=netstandard2.1" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" SetTargetFramework="TargetFramework=netstandard2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="3.1.26" />
@@ -41,22 +41,22 @@
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <ProjectReference Include="../../src/Sentry.DiagnosticSource/Sentry.DiagnosticSource.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
+    <ProjectReference Include="..\..\src\Sentry.DiagnosticSource\Sentry.DiagnosticSource.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="3.1.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <ProjectReference Include="../../src/Sentry.DiagnosticSource/Sentry.DiagnosticSource.csproj" SetTargetFramework="TargetFramework=net461" />
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" SetTargetFramework="TargetFramework=net461" />
+    <ProjectReference Include="..\..\src\Sentry.DiagnosticSource\Sentry.DiagnosticSource.csproj" SetTargetFramework="TargetFramework=net461" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" SetTargetFramework="TargetFramework=net461" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="3.1.26" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Sentry.Testing/Sentry.Testing.csproj" />
+    <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Sentry.EntityFramework.Tests/Sentry.EntityFramework.Tests.csproj
+++ b/test/Sentry.EntityFramework.Tests/Sentry.EntityFramework.Tests.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry.EntityFramework/Sentry.EntityFramework.csproj" />
-    <ProjectReference Include="../Sentry.Testing/Sentry.Testing.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.EntityFramework\Sentry.EntityFramework.csproj" />
+    <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Sentry.Extensions.Logging.EfCore.Tests/Sentry.Extensions.Logging.EfCore.Tests.csproj
+++ b/test/Sentry.Extensions.Logging.EfCore.Tests/Sentry.Extensions.Logging.EfCore.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.17" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.17" />
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry.Extensions.Logging/Sentry.Extensions.Logging.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
   </ItemGroup>
 
 

--- a/test/Sentry.Extensions.Logging.Tests/Sentry.Extensions.Logging.Tests.csproj
+++ b/test/Sentry.Extensions.Logging.Tests/Sentry.Extensions.Logging.Tests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry.Extensions.Logging/Sentry.Extensions.Logging.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
   </ItemGroup>
 

--- a/test/Sentry.Google.Cloud.Functions.Tests/Sentry.Google.Cloud.Functions.Tests.csproj
+++ b/test/Sentry.Google.Cloud.Functions.Tests/Sentry.Google.Cloud.Functions.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry.Google.Cloud.Functions/Sentry.Google.Cloud.Functions.csproj" />
-    <ProjectReference Include="../Sentry.AspNetCore.Tests/Sentry.AspNetCore.Tests.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.Google.Cloud.Functions\Sentry.Google.Cloud.Functions.csproj" />
+    <ProjectReference Include="..\Sentry.AspNetCore.Tests\Sentry.AspNetCore.Tests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Sentry.Log4Net.Tests/Sentry.Log4Net.Tests.csproj
+++ b/test/Sentry.Log4Net.Tests/Sentry.Log4Net.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry.Log4Net/Sentry.Log4Net.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.Log4Net\Sentry.Log4Net.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
   </ItemGroup>
 

--- a/test/Sentry.Testing/Sentry.Testing.csproj
+++ b/test/Sentry.Testing/Sentry.Testing.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Sentry.Tests/Sentry.Tests.csproj
+++ b/test/Sentry.Tests/Sentry.Tests.csproj
@@ -5,18 +5,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Sentry/Sentry.csproj" />
-    <ProjectReference Include="../Sentry.Testing/Sentry.Testing.csproj" />
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
+    <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
   </ItemGroup>
 
   <!-- Run netcoreapp3.1 against netcoreapp3.0 target of Sentry -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <ProjectReference Update="../../src/Sentry/Sentry.csproj" SetTargetFramework="TargetFramework=netcoreapp3.0" />
+    <ProjectReference Update="..\..\src\Sentry\Sentry.csproj" SetTargetFramework="TargetFramework=netcoreapp3.0" />
   </ItemGroup>
 
   <!-- Run netcoreapp3.0 against netstandard2.1 target of Sentry -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-    <ProjectReference Update="../../src/Sentry/Sentry.csproj" SetTargetFramework="TargetFramework=netstandard2.1" />
+    <ProjectReference Update="..\..\src\Sentry\Sentry.csproj" SetTargetFramework="TargetFramework=netstandard2.1" />
     <!-- NET Core 3.0's built-in STJ is lower version which causes conflicts, so we have to explicitly reference it -->
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
     <!-- Ben.Demystifier uses S.R.M v5 and also requires it via package reference when on nca3.x -->
@@ -26,11 +26,11 @@
   <!-- DiagnosticSource Tests -->
   <!-- netcoreapp3.0 skipped since it'll target NET standard on Sentry. -->
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0' and '$(TargetFramework)' != 'netcoreapp2.1' and !$(TargetFramework.StartsWith('net4'))">
-    <Compile Include="../Sentry.DiagnosticSource.Tests/*.cs">
-      <Link>Internals/DiagnosticSource/%(Filename)%(Extension)</Link>
+    <Compile Include="..\Sentry.DiagnosticSource.Tests\*.cs">
+      <Link>Internals\DiagnosticSource\%(Filename)%(Extension)</Link>
     </Compile>
-    <Compile Include="../Sentry.Diagnostics.DiagnosticSource.Tests/Integration/**/*.cs">
-      <Link>Internals/DiagnosticSource/Integration/%(RecursiveDir)/%(Filename)%(Extension)</Link>
+    <Compile Include="..\Sentry.Diagnostics.DiagnosticSource.Tests\Integration\**\*.cs">
+      <Link>Internals\DiagnosticSource\Integration\%(RecursiveDir)\%(Filename)%(Extension)</Link>
     </Compile>
   </ItemGroup>
 


### PR DESCRIPTION
MSBuild supports both directions of slashes in paths, but really `\` is the normal case and `/` is tolerated.  We've got a mess of a mix of both. Let's just use `\` for consistency.

#skip-changelog