### PR TITLE
Always use .NET 6 SDK, non-prerelease

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "6.0.300",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}

--- a/samples/Sentry.Samples.Maui/global.json
+++ b/samples/Sentry.Samples.Maui/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "6.0.300",
-    "rollForward": "latestMinor"
-  }
-}

--- a/src/Sentry.Maui/global.json
+++ b/src/Sentry.Maui/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "6.0.300",
-    "rollForward": "latestMinor"
-  }
-}

--- a/test/Sentry.Maui.Tests/global.json
+++ b/test/Sentry.Maui.Tests/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "6.0.300",
-    "rollForward": "latestMinor"
-  }
-}


### PR DESCRIPTION
This ensures we won't try to use a pre-release of a .NET SDK installed locally, or .NET 7 (yet).

#skip-changelog