### PR TITLE
Fix test failing on Windows

### DIFF
--- a/src/Sentry/AttributeReader.cs
+++ b/src/Sentry/AttributeReader.cs
@@ -1,5 +1,7 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace Sentry
 {
@@ -10,6 +12,22 @@ namespace Sentry
             projectDirectory = assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
                 .FirstOrDefault(x => x.Key == "Sentry.ProjectDirectory")
                 ?.Value;
+
+            // On Windows, ensure that we have "C:\" rather than "c:\" so that later when we replace
+            // we don't have to worry about case sensitivity.
+            if (projectDirectory != null && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var root = Path.GetPathRoot(projectDirectory);
+                if (root?.Contains(Path.VolumeSeparatorChar) is true)
+                {
+#if NETCOREAPP3_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    projectDirectory = root.ToUpperInvariant() + projectDirectory[root.Length..];
+#else
+                    projectDirectory = root.ToUpperInvariant() + projectDirectory.Substring(root.Length);
+#endif
+                }
+            }
+
             return projectDirectory != null;
         }
     }


### PR DESCRIPTION
For some unknown reason, my local Windows machine was giving project paths with `c:\` instead of `C:\`, which was causing `FileNameShouldBeRelative` to fail.  I'm still hunting down why, but this will prevent it.


Related to #1739 

#skip-changelog