### PR TITLE
feat: Capture Debug Images and StackFrame fields for Portable PDB symbolication

### DIFF
--- a/src/Sentry/DebugImage.cs
+++ b/src/Sentry/DebugImage.cs
@@ -33,6 +33,11 @@ public sealed class DebugImage : IJsonSerializable
     public string? DebugId { get; set; }
 
     /// <summary>
+    /// Checksum of the companion debug file.
+    /// </summary>
+    public string? DebugChecksum { get; set; }
+
+    /// <summary>
     /// Path and name of the debug companion file.
     /// </summary>
     public string? DebugFile { get; set; }
@@ -57,6 +62,7 @@ public sealed class DebugImage : IJsonSerializable
         writer.WriteStringIfNotWhiteSpace("image_addr", ImageAddress);
         writer.WriteNumberIfNotNull("image_size", ImageSize);
         writer.WriteStringIfNotWhiteSpace("debug_id", DebugId);
+        writer.WriteStringIfNotWhiteSpace("debug_checksum", DebugChecksum);
         writer.WriteStringIfNotWhiteSpace("debug_file", DebugFile);
         writer.WriteStringIfNotWhiteSpace("code_id", CodeId);
         writer.WriteStringIfNotWhiteSpace("code_file", CodeFile);
@@ -73,6 +79,7 @@ public sealed class DebugImage : IJsonSerializable
         var imageAddress = json.GetPropertyOrNull("image_addr")?.GetString();
         var imageSize = json.GetPropertyOrNull("image_size")?.GetInt64();
         var debugId = json.GetPropertyOrNull("debug_id")?.GetString();
+        var debugChecksum = json.GetPropertyOrNull("debug_checksum")?.GetString();
         var debugFile = json.GetPropertyOrNull("debug_file")?.GetString();
         var codeId = json.GetPropertyOrNull("code_id")?.GetString();
         var codeFile = json.GetPropertyOrNull("code_file")?.GetString();
@@ -83,6 +90,7 @@ public sealed class DebugImage : IJsonSerializable
             ImageAddress = imageAddress,
             ImageSize = imageSize,
             DebugId = debugId,
+            DebugChecksum = debugChecksum,
             DebugFile = debugFile,
             CodeId = codeId,
             CodeFile = codeFile,

--- a/src/Sentry/Extensibility/ISentryStackTraceFactory.cs
+++ b/src/Sentry/Extensibility/ISentryStackTraceFactory.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Sentry.Extensibility;
 
 /// <summary>
@@ -11,4 +13,10 @@ public interface ISentryStackTraceFactory
     /// <param name="exception">The exception to create the stacktrace from.</param>
     /// <returns>A Sentry stack trace.</returns>
     SentryStackTrace? Create(Exception? exception = null);
+
+    /// <summary>
+    /// Returns a list of <see cref="DebugImage" />s referenced from the previously processed <see cref="Exception" />s.
+    /// </summary>
+    /// <returns>A list of referenced debug images.</returns>
+    List<DebugImage>? DebugImages() { return null; }
 }

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -27,6 +27,7 @@ internal class MainExceptionProcessor : ISentryEventExceptionProcessor
         MoveExceptionExtrasToEvent(sentryEvent, sentryExceptions);
 
         sentryEvent.SentryExceptions = sentryExceptions;
+        sentryEvent.DebugImages = SentryStackTraceFactoryAccessor().DebugImages();
     }
 
     // SentryException.Extra is not supported by Sentry yet.

--- a/src/Sentry/SentryStackFrame.cs
+++ b/src/Sentry/SentryStackFrame.cs
@@ -139,6 +139,14 @@ public sealed class SentryStackFrame : IJsonSerializable
     /// </summary>
     public string? AddressMode { get; set; }
 
+    /// <summary>
+    /// The optional Function Id.<br/>
+    /// This is derived from the `MetadataToken`, and should be the record id
+    /// of a `MethodDef`.<br/>
+    /// This should be a string with a hexadecimal number that includes a <b>0x</b> prefix.<br/>
+    /// </summary>
+    public string? FunctionId { get; set; }
+
     /// <inheritdoc />
     public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? logger)
     {
@@ -163,6 +171,7 @@ public sealed class SentryStackFrame : IJsonSerializable
         writer.WriteStringIfNotWhiteSpace("instruction_addr", InstructionAddress);
         writer.WriteNumberIfNotNull("instruction_offset", InstructionOffset);
         writer.WriteStringIfNotWhiteSpace("addr_mode", AddressMode);
+        writer.WriteStringIfNotWhiteSpace("function_id", FunctionId);
 
         writer.WriteEndObject();
     }
@@ -214,6 +223,7 @@ public sealed class SentryStackFrame : IJsonSerializable
         var instructionAddress = json.GetPropertyOrNull("instruction_addr")?.GetString();
         var instructionOffset = json.GetPropertyOrNull("instruction_offset")?.GetInt64();
         var addressMode = json.GetPropertyOrNull("addr_mode")?.GetString();
+        var functionId = json.GetPropertyOrNull("function_id")?.GetString();
 
         return new SentryStackFrame
         {
@@ -236,6 +246,7 @@ public sealed class SentryStackFrame : IJsonSerializable
             InstructionAddress = instructionAddress,
             InstructionOffset = instructionOffset,
             AddressMode = addressMode,
+            FunctionId = functionId,
         };
     }
 }


### PR DESCRIPTION
This adds the new event properties defined in [RFC 0013](https://github.com/getsentry/rfcs/pull/13), namely InstructionAddress / FunctionId + Relative Indexing, and a list of `pe_dotnet` DebugImages.

The new information allows symbolicating .NET stack traces on symbolicator, using uploaded Portable PDB debug files.

Example events that were captured with this PR and symbolicated serverside:
- https://sentry.io/organizations/sentry-sdks/issues/3323330137/events/07c45ddfa9bd4ebbbcf0b56b2a7d0b4c/?project=5428537
- https://sentry.io/organizations/sentry-sdks/issues/2442781715/events/a4f4c59a7d1a4b06bd98c0d1dcfa7e8c/?project=5428537

The second event might be an example where it could be possible to load debug symbols from the Microsoft Symbol Server which is not possible yet, but we might add this later.

---

I open this PR with the hope of either delegating it to the .NET team, or at the very least get some dedicated mentoring to finish it up.
The problem I see right now are:
- The PR depends on default interface methods which I believe we can’t use because of backwards compatibility?
- The way that stack frame factories and event / exception processors are implemented means that we currently have no way to process frames while at the same time have "atomic" access to the list of debug images. The relative indexing that we need depends on having full control over the index of the referenced debug images in the DebugImages list. Currently the different factories and processors can change that list as they please, which makes it quite fragile.