### PR TITLE
fix: Unity targetframeworks

### DIFF
--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SolutionName)' == 'Sentry.Unity'">
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Condition="$(TargetFramework.EndsWith('android'))" Project="Android\Sentry.Android.props" />


### PR DESCRIPTION
Followup of: https://github.com/getsentry/sentry-dotnet/pull/1780

Builds from within Unity failed with: `Possible null reference assignment.`
Turns out the `s` in TargetFrameworks is actually important.

#skip-changelog