### PR TITLE
fix: Use the OFFSET_UNKNOWN to check for valid ILOffset

### DIFF
--- a/src/Sentry/Extensibility/SentryStackTraceFactory.cs
+++ b/src/Sentry/Extensibility/SentryStackTraceFactory.cs
@@ -186,9 +186,9 @@ namespace Sentry.Extensibility
 
             // stackFrame.HasILOffset() throws NotImplemented on Mono 5.12
             var ilOffset = stackFrame.GetILOffset();
-            if (ilOffset != 0)
+            if (ilOffset != StackFrame.OFFSET_UNKNOWN)
             {
-                frame.InstructionOffset = stackFrame.GetILOffset();
+                frame.InstructionOffset = ilOffset;
             }
 
             var lineNo = stackFrame.GetFileLineNumber();


### PR DESCRIPTION
A value of 0 is perfectly valid as ILOffset, the sentinel value is OFFSET_UNKNOWN
which we now explicitly check for.

#skip-changelog I doubt this is worth a changelog entry :-D