### PR TITLE
Fix test failures in Visual Studio

### DIFF
--- a/test/xunit.runner.json
+++ b/test/xunit.runner.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "appDomain": "denied",
 
   "// TODO:": "Re-enable parallelization (disabled due to test flakiness)",
   "parallelizeAssembly": false,

--- a/test/xunit.runner.json
+++ b/test/xunit.runner.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "shadowCopy": false,
 
   "// TODO:": "Re-enable parallelization (disabled due to test flakiness)",
   "parallelizeAssembly": false,


### PR DESCRIPTION
Fixes #1783 

- VS runner needs to use app domains on net framework for many of our tests
- Enabling app domains turns on shadow copy by default, which breaks our tests that use SQLite (see [dotnet/efcore#19396](https://github.com/dotnet/efcore/issues/19396)).  Turning off shadow copy fixes that.

Both settings are only applicable to net framework and have no apparent impact on other targets.
Reference: https://xunit.net/docs/configuration-files

#skip-changelog