### PR TITLE
Fix null ref in aspnet TryGetTraceHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix null ref in aspnet TryGetTraceHeader ([#1807](https://github.com/getsentry/sentry-dotnet/pull/1807))
+
+
 ## 3.20.0
 
 ### Features

--- a/src/Sentry.AspNet/HttpContextExtensions.cs
+++ b/src/Sentry.AspNet/HttpContextExtensions.cs
@@ -14,9 +14,14 @@ public static class HttpContextExtensions
 
     private static SentryTraceHeader? TryGetTraceHeader(NameValueCollection headers)
     {
+        var traceHeader = headers.Get(SentryTraceHeader.HttpHeaderName);
+        if (traceHeader == null)
+        {
+            return null;
+        }
+
         try
         {
-            var traceHeader = headers.Get(SentryTraceHeader.HttpHeaderName);
             return SentryTraceHeader.Parse(traceHeader);
         }
         catch


### PR DESCRIPTION
was making it a pain to debug things when i was looking into the client os change

instead of null ref ex in PolyfillExtensions, we can early return

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at PolyfillExtensions.Split(String str, Char c, StringSplitOptions options) in D:\Code\sentry-dotnet\src\Sentry\Internal\Polyfills.cs:line 23
   at Sentry.SentryTraceHeader.Parse(String value) in D:\Code\sentry-dotnet\src\Sentry\SentryTraceHeader.cs:line 47
   at Sentry.AspNet.HttpContextExtensions.TryGetTraceHeader(NameValueCollection headers) in D:\Code\sentry-dotnet\src\Sentry.AspNet\HttpContextExtensions.cs:line 20
```
