### PR TITLE
remove server_os in favor of only client_os

### DIFF
--- a/src/Sentry.AspNet/Internal/SystemWebRequestEventProcessor.cs
+++ b/src/Sentry.AspNet/Internal/SystemWebRequestEventProcessor.cs
@@ -100,11 +100,6 @@ internal class SystemWebRequestEventProcessor : ISentryEventProcessor
             @event.Contexts["server-runtime"] = runtime;
         }
 
-        if (@event.Contexts.TryRemove(Protocol.OperatingSystem.Type, out var os))
-        {
-            @event.Contexts["server-os"] = os;
-        }
-
         var body = PayloadExtractor.ExtractPayload(new SystemWebHttpRequest(context.Request));
         if (body != null)
         {

--- a/src/Sentry.AspNetCore/AspNetCoreEventProcessor.cs
+++ b/src/Sentry.AspNetCore/AspNetCoreEventProcessor.cs
@@ -15,19 +15,11 @@ internal class AspNetCoreEventProcessor : ISentryEventProcessor
             @event.Contexts["server-runtime"] = runtime;
         }
 
-        if (@event.Contexts.TryRemove(OperatingSystem.Type, out var os))
-        {
-            @event.Contexts["server-os"] = os;
-        }
-
         // Not PII as this is running on a server
-        if (@event.ServerName == null)
-        {
-            // ServerName from the environment machine name is set by the Sentry base package.
-            // That is guarded by the SendDefaultPii since the SDK can be used in desktop apps.
-            // For ASP.NET Core apps, we always set the machine name if not explicitly set by the user.
-            @event.ServerName = Environment.MachineName;
-        }
+        // ServerName from the environment machine name is set by the Sentry base package.
+        // That is guarded by the SendDefaultPii since the SDK can be used in desktop apps.
+        // For ASP.NET Core apps, we always set the machine name if not explicitly set by the user.
+        @event.ServerName ??= Environment.MachineName;
 
         return @event;
     }

--- a/src/Sentry/Protocol/OperatingSystem.cs
+++ b/src/Sentry/Protocol/OperatingSystem.cs
@@ -18,7 +18,7 @@ namespace Sentry.Protocol
         /// <summary>
         /// Tells Sentry which type of context this is.
         /// </summary>
-        public const string Type = "os";
+        public const string Type = "client-os";
 
         /// <summary>
         /// The name of the operating system.

--- a/test/Sentry.AspNetCore.Tests/AspNetCoreEventProcessorTests.cs
+++ b/test/Sentry.AspNetCore.Tests/AspNetCoreEventProcessorTests.cs
@@ -40,7 +40,7 @@ public class AspNetCoreEventProcessorTests
 
         _ = _sut.Process(target);
 
-        Assert.Same(expected, target.Contexts["server-os"]);
+        Assert.Same(expected, target.Contexts["client-os"]);
     }
 
     [Fact]

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1309,7 +1309,7 @@ namespace Sentry.Protocol
     }
     public sealed class OperatingSystem : Sentry.IJsonSerializable
     {
-        public const string Type = "os";
+        public const string Type = "client-os";
         public OperatingSystem() { }
         public string? Build { get; set; }
         public string? KernelVersion { get; set; }

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1309,7 +1309,7 @@ namespace Sentry.Protocol
     }
     public sealed class OperatingSystem : Sentry.IJsonSerializable
     {
-        public const string Type = "os";
+        public const string Type = "client-os";
         public OperatingSystem() { }
         public string? Build { get; set; }
         public string? KernelVersion { get; set; }

--- a/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1309,7 +1309,7 @@ namespace Sentry.Protocol
     }
     public sealed class OperatingSystem : Sentry.IJsonSerializable
     {
-        public const string Type = "os";
+        public const string Type = "client-os";
         public OperatingSystem() { }
         public string? Build { get; set; }
         public string? KernelVersion { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -1308,7 +1308,7 @@ namespace Sentry.Protocol
     }
     public sealed class OperatingSystem : Sentry.IJsonSerializable
     {
-        public const string Type = "os";
+        public const string Type = "client-os";
         public OperatingSystem() { }
         public string? Build { get; set; }
         public string? KernelVersion { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -1308,7 +1308,7 @@ namespace Sentry.Protocol
     }
     public sealed class OperatingSystem : Sentry.IJsonSerializable
     {
-        public const string Type = "os";
+        public const string Type = "client-os";
         public OperatingSystem() { }
         public string? Build { get; set; }
         public string? KernelVersion { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1309,7 +1309,7 @@ namespace Sentry.Protocol
     }
     public sealed class OperatingSystem : Sentry.IJsonSerializable
     {
-        public const string Type = "os";
+        public const string Type = "client-os";
         public OperatingSystem() { }
         public string? Build { get; set; }
         public string? KernelVersion { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1309,7 +1309,7 @@ namespace Sentry.Protocol
     }
     public sealed class OperatingSystem : Sentry.IJsonSerializable
     {
-        public const string Type = "os";
+        public const string Type = "client-os";
         public OperatingSystem() { }
         public string? Build { get; set; }
         public string? KernelVersion { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1309,7 +1309,7 @@ namespace Sentry.Protocol
     }
     public sealed class OperatingSystem : Sentry.IJsonSerializable
     {
-        public const string Type = "os";
+        public const string Type = "client-os";
         public OperatingSystem() { }
         public string? Build { get; set; }
         public string? KernelVersion { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1309,7 +1309,7 @@ namespace Sentry.Protocol
     }
     public sealed class OperatingSystem : Sentry.IJsonSerializable
     {
-        public const string Type = "os";
+        public const string Type = "client-os";
         public OperatingSystem() { }
         public string? Build { get; set; }
         public string? KernelVersion { get; set; }

--- a/test/Sentry.Tests/Protocol/Context/ContextsTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/ContextsTests.cs
@@ -41,7 +41,7 @@ public class ContextsTests
         var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
-        Assert.Equal("{\"server\":{\"type\":\"os\",\"name\":\"Linux\"}}", actualString);
+        Assert.Equal("{\"server\":{\"type\":\"client-os\",\"name\":\"Linux\"}}", actualString);
     }
 
     [Fact]
@@ -178,7 +178,7 @@ public class ContextsTests
         var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
-        Assert.Equal("{\"os\":{\"type\":\"os\",\"name\":\"BeOS 1\"}}", actualString);
+        Assert.Equal("{\"client-os\":{\"type\":\"client-os\",\"name\":\"BeOS 1\"}}", actualString);
     }
 
     [Fact]

--- a/test/Sentry.Tests/Protocol/Context/OperatingSystemTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/OperatingSystemTests.cs
@@ -29,7 +29,7 @@ public class OperatingSystemTests
         var actual = sut.ToJsonString(_testOutputLogger);
 
         Assert.Equal(
-            "{\"type\":\"os\"," +
+            "{\"type\":\"client-os\"," +
             "\"name\":\"Windows\"," +
             "\"version\":\"2016\"," +
             "\"raw_description\":\"Windows 2016\"," +
@@ -73,11 +73,11 @@ public class OperatingSystemTests
 
     public static IEnumerable<object[]> TestCases()
     {
-        yield return new object[] { (new OperatingSystem(), "{\"type\":\"os\"}") };
-        yield return new object[] { (new OperatingSystem { Name = "some name" }, "{\"type\":\"os\",\"name\":\"some name\"}") };
-        yield return new object[] { (new OperatingSystem { RawDescription = "some Name, some version" }, "{\"type\":\"os\",\"raw_description\":\"some Name, some version\"}") };
-        yield return new object[] { (new OperatingSystem { Build = "some build" }, "{\"type\":\"os\",\"build\":\"some build\"}") };
-        yield return new object[] { (new OperatingSystem { KernelVersion = "some kernel version" }, "{\"type\":\"os\",\"kernel_version\":\"some kernel version\"}") };
-        yield return new object[] { (new OperatingSystem { Rooted = false }, "{\"type\":\"os\",\"rooted\":false}") };
+        yield return new object[] { (new OperatingSystem(), "{\"type\":\"client-os\"}") };
+        yield return new object[] { (new OperatingSystem { Name = "some name" }, "{\"type\":\"client-os\",\"name\":\"some name\"}") };
+        yield return new object[] { (new OperatingSystem { RawDescription = "some Name, some version" }, "{\"type\":\"client-os\",\"raw_description\":\"some Name, some version\"}") };
+        yield return new object[] { (new OperatingSystem { Build = "some build" }, "{\"type\":\"client-os\",\"build\":\"some build\"}") };
+        yield return new object[] { (new OperatingSystem { KernelVersion = "some kernel version" }, "{\"type\":\"client-os\",\"kernel_version\":\"some kernel version\"}") };
+        yield return new object[] { (new OperatingSystem { Rooted = false }, "{\"type\":\"client-os\",\"rooted\":false}") };
     }
 }


### PR DESCRIPTION
@mattjohnsonpint  I am not sure i properly understand this one. so i took a shot at it 

fixes #1575

side note: does the generated android code need to change?
```
	// Metadata.xml XPath class reference: path="/api/package[@name='io.sentry.protocol']/class[@name='OperatingSystem']"
	[global::Android.Runtime.Register ("io/sentry/protocol/OperatingSystem", DoNotGenerateAcw=true)]
	internal sealed partial class OperatingSystem : global::Java.Lang.Object {
		// Metadata.xml XPath field reference: path="/api/package[@name='io.sentry.protocol']/class[@name='OperatingSystem']/field[@name='TYPE']"
		[Register ("TYPE")]
		public const string Type = (string) "os";
```