### PR TITLE
Abstract the filesystem for caching transport tests

### DIFF
--- a/src/Sentry/Internal/FileSystem.cs
+++ b/src/Sentry/Internal/FileSystem.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Sentry.Internal
+{
+    internal class FileSystem : IFileSystem
+    {
+        public IEnumerable<string> EnumerateFiles(string path) => Directory.EnumerateFiles(path);
+
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern) =>
+            Directory.EnumerateFiles(path, searchPattern);
+
+        public void CreateDirectory(string path) => Directory.CreateDirectory(path);
+
+        public void DeleteDirectory(string path, bool recursive = false) => Directory.Delete(path, recursive);
+
+        public bool DirectoryExists(string path) => Directory.Exists(path);
+
+        public bool FileExists(string path) => File.Exists(path);
+
+        public void MoveFile(string sourceFileName, string destFileName, bool overwrite = false)
+        {
+#if NETCOREAPP3_0_OR_GREATER
+            File.Move(sourceFileName, destFileName, overwrite);
+#else
+            if (overwrite)
+            {
+                File.Copy(sourceFileName, destFileName, overwrite: true);
+                File.Delete(sourceFileName);
+            }
+            else
+            {
+                File.Move(sourceFileName, destFileName);
+            }
+#endif
+        }
+
+        public void DeleteFile(string path) => File.Delete(path);
+
+        public DateTimeOffset GetFileCreationTime(string path) => new FileInfo(path).CreationTimeUtc;
+
+        public string ReadAllTextFromFile(string path) => File.ReadAllText(path);
+
+        public Stream OpenFileForReading(string path) => File.OpenRead(path);
+
+        public Stream CreateFileForWriting(string path) => File.Create(path);
+    }
+}

--- a/src/Sentry/Internal/FileSystem.cs
+++ b/src/Sentry/Internal/FileSystem.cs
@@ -6,6 +6,12 @@ namespace Sentry.Internal
 {
     internal class FileSystem : IFileSystem
     {
+        public static IFileSystem Instance { get; } = new FileSystem();
+
+        private FileSystem()
+        {
+        }
+
         public IEnumerable<string> EnumerateFiles(string path) => Directory.EnumerateFiles(path);
 
         public IEnumerable<string> EnumerateFiles(string path, string searchPattern) =>

--- a/src/Sentry/Internal/FileSystem.cs
+++ b/src/Sentry/Internal/FileSystem.cs
@@ -11,6 +11,9 @@ namespace Sentry.Internal
         public IEnumerable<string> EnumerateFiles(string path, string searchPattern) =>
             Directory.EnumerateFiles(path, searchPattern);
 
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption) =>
+            Directory.EnumerateFiles(path, searchPattern, searchOption);
+
         public void CreateDirectory(string path) => Directory.CreateDirectory(path);
 
         public void DeleteDirectory(string path, bool recursive = false) => Directory.Delete(path, recursive);

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -63,7 +63,7 @@ namespace Sentry.Internal.Http
             _innerTransport = innerTransport;
             _options = options;
             _failStorage = failStorage; // For testing
-            _fileSystem = options.FileSystem ?? FileSystem.Instance;
+            _fileSystem = options.FileSystem;
 
             _keepCount = _options.MaxCacheItems >= 1
                 ? _options.MaxCacheItems - 1

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -47,6 +47,8 @@ namespace Sentry.Internal.Http
         // Inner transport exposed internally primarily for testing
         internal ITransport InnerTransport => _innerTransport;
 
+        private readonly IFileSystem _fileSystem;
+
         public static CachingTransport Create(ITransport innerTransport, SentryOptions options,
             bool startWorker = true,
             bool failStorage = false)
@@ -61,6 +63,7 @@ namespace Sentry.Internal.Http
             _innerTransport = innerTransport;
             _options = options;
             _failStorage = failStorage; // For testing
+            _fileSystem = options.FileSystem ?? new FileSystem();
 
             _keepCount = _options.MaxCacheItems >= 1
                 ? _options.MaxCacheItems - 1
@@ -79,8 +82,8 @@ namespace Sentry.Internal.Http
             MoveUnprocessedFilesBackToCache();
 
             // Ensure directories exist
-            Directory.CreateDirectory(_isolatedCacheDirectoryPath);
-            Directory.CreateDirectory(_processingDirectoryPath);
+            _fileSystem.CreateDirectory(_isolatedCacheDirectoryPath);
+            _fileSystem.CreateDirectory(_processingDirectoryPath);
 
             // Start a worker, if one is needed
             if (startWorker)
@@ -172,13 +175,13 @@ namespace Sentry.Internal.Http
             // if the cache was working when the process terminated unexpectedly.
             // Move everything from that directory back to cache directory.
 
-            if (!Directory.Exists(_processingDirectoryPath))
+            if (!_fileSystem.DirectoryExists(_processingDirectoryPath))
             {
                 // nothing to do
                 return;
             }
 
-            foreach (var filePath in Directory.EnumerateFiles(_processingDirectoryPath))
+            foreach (var filePath in _fileSystem.EnumerateFiles(_processingDirectoryPath))
             {
                 var destinationPath = Path.Combine(_isolatedCacheDirectoryPath, Path.GetFileName(filePath));
                 _options.LogDebug("Moving unprocessed file back to cache: {0} to {1}.", filePath, destinationPath);
@@ -188,12 +191,12 @@ namespace Sentry.Internal.Http
                 {
                     try
                     {
-                        File.Move(filePath, destinationPath);
+                        _fileSystem.MoveFile(filePath, destinationPath);
                         break;
                     }
                     catch (Exception ex)
                     {
-                        if (!File.Exists(filePath))
+                        if (!_fileSystem.FileExists(filePath))
                         {
                             _options.LogDebug(
                                 "Failed to move unprocessed file back to cache (attempt {0}), " +
@@ -238,7 +241,7 @@ namespace Sentry.Internal.Http
             {
                 try
                 {
-                    File.Delete(filePath);
+                    _fileSystem.DeleteFile(filePath);
                     _options.LogDebug("Deleted cached file {0}.", filePath);
                 }
                 catch (FileNotFoundException)
@@ -252,9 +255,8 @@ namespace Sentry.Internal.Http
         }
 
         private IEnumerable<string> GetCacheFilePaths() =>
-            Directory
-                .EnumerateFiles(_isolatedCacheDirectoryPath, $"*.{EnvelopeFileExt}")
-                .OrderBy(f => new FileInfo(f).CreationTimeUtc);
+            _fileSystem.EnumerateFiles(_isolatedCacheDirectoryPath, $"*.{EnvelopeFileExt}")
+                .OrderBy(f => _fileSystem.GetFileCreationTime(f));
 
         private async Task ProcessCacheAsync(CancellationToken cancellation)
         {
@@ -282,7 +284,7 @@ namespace Sentry.Internal.Http
 
             _options.LogDebug("Reading cached envelope: {0}", file);
 
-            var stream = File.OpenRead(file);
+            var stream = _fileSystem.OpenFileForReading(file);
 #if NET461 || NETSTANDARD2_0
             using (stream)
 #else
@@ -327,7 +329,7 @@ namespace Sentry.Internal.Http
             // Envelope & file stream must be disposed prior to reaching this point
 
             // Delete the envelope file and move on to the next one
-            File.Delete(file);
+            _fileSystem.DeleteFile(file);
         }
 
         private void LogFailureWithDiscard(string file, Exception ex)
@@ -335,9 +337,9 @@ namespace Sentry.Internal.Http
             string? envelopeContents = null;
             try
             {
-                if (File.Exists(file))
+                if (_fileSystem.FileExists(file))
                 {
-                    envelopeContents = File.ReadAllText(file);
+                    envelopeContents = _fileSystem.ReadAllTextFromFile(file);
                 }
             }
             // ReSharper disable once EmptyGeneralCatchClause
@@ -370,16 +372,9 @@ namespace Sentry.Internal.Http
             var targetFilePath = Path.Combine(_processingDirectoryPath, Path.GetFileName(filePath));
 
             // Move the file to processing.
-            // We move with overwrite just in case a file with the same name
-            // already exists in the output directory.
-            // That should never happen under normal workflows because the filenames
-            // have high variance.
-#if NETCOREAPP3_0_OR_GREATER
-            File.Move(filePath, targetFilePath, true);
-#else
-            File.Copy(filePath, targetFilePath, true);
-            File.Delete(filePath);
-#endif
+            // We move with overwrite just in case a file with the same name already exists in the output directory.
+            // That should never happen under normal workflows because the filenames have high variance.
+            _fileSystem.MoveFile(filePath, targetFilePath, overwrite: true);
 
             return targetFilePath;
         }
@@ -411,7 +406,7 @@ namespace Sentry.Internal.Http
 
             EnsureFreeSpaceInCache();
 
-            var stream = File.Create(envelopeFilePath);
+            var stream = _fileSystem.CreateFileForWriting(envelopeFilePath);
 #if NET461 || NETSTANDARD2_0
             using(stream)
 #else

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -63,7 +63,7 @@ namespace Sentry.Internal.Http
             _innerTransport = innerTransport;
             _options = options;
             _failStorage = failStorage; // For testing
-            _fileSystem = options.FileSystem ?? new FileSystem();
+            _fileSystem = options.FileSystem ?? FileSystem.Instance;
 
             _keepCount = _options.MaxCacheItems >= 1
                 ? _options.MaxCacheItems - 1

--- a/src/Sentry/Internal/IFileSystem.cs
+++ b/src/Sentry/Internal/IFileSystem.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Sentry.Internal
+{
+    internal interface IFileSystem
+    {
+        IEnumerable<string> EnumerateFiles(string path);
+        IEnumerable<string> EnumerateFiles(string path, string searchPattern);
+        void CreateDirectory(string path);
+        void DeleteDirectory(string path, bool recursive = false);
+        bool DirectoryExists(string path);
+        bool FileExists(string path);
+        void MoveFile(string sourceFileName, string destFileName, bool overwrite = false);
+        void DeleteFile(string path);
+        DateTimeOffset GetFileCreationTime(string path);
+        string ReadAllTextFromFile(string file);
+        Stream OpenFileForReading(string path);
+        Stream CreateFileForWriting(string path);
+    }
+}

--- a/src/Sentry/Internal/IFileSystem.cs
+++ b/src/Sentry/Internal/IFileSystem.cs
@@ -6,8 +6,12 @@ namespace Sentry.Internal
 {
     internal interface IFileSystem
     {
+        // Note: This is not comprehensive.  If you need other filesystem methods, add to this interface,
+        // then implement in both Sentry.Internal.FileSystem and Sentry.Testing.FakeFileSystem.
+
         IEnumerable<string> EnumerateFiles(string path);
         IEnumerable<string> EnumerateFiles(string path, string searchPattern);
+        IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption);
         void CreateDirectory(string path);
         void DeleteDirectory(string path, bool recursive = false);
         bool DirectoryExists(string path);

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -446,7 +446,7 @@ namespace Sentry
         /// Sets the filesystem instance to use. Defaults to the actual <see cref="FileSystem"/>.
         /// Used for testing.
         /// </summary>
-        internal IFileSystem? FileSystem { get; set; }
+        internal IFileSystem FileSystem { get; set; } = Internal.FileSystem.Instance;
 
         /// <summary>
         /// If set to a positive value, Sentry will attempt to flush existing local event cache when initializing.

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -443,6 +443,12 @@ namespace Sentry
         public string? CacheDirectoryPath { get; set; }
 
         /// <summary>
+        /// Sets the filesystem instance to use. Defaults to the actual <see cref="FileSystem"/>.
+        /// Used for testing.
+        /// </summary>
+        internal IFileSystem? FileSystem { get; set; }
+
+        /// <summary>
         /// If set to a positive value, Sentry will attempt to flush existing local event cache when initializing.
         /// Set to <see cref="TimeSpan.Zero"/> to disable this feature.
         /// This option only works if <see cref="CacheDirectoryPath"/> is configured as well.

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -443,7 +443,7 @@ namespace Sentry
         public string? CacheDirectoryPath { get; set; }
 
         /// <summary>
-        /// Sets the filesystem instance to use. Defaults to the actual <see cref="FileSystem"/>.
+        /// Sets the filesystem instance to use. Defaults to the actual <see cref="Internal.FileSystem"/>.
         /// Used for testing.
         /// </summary>
         internal IFileSystem FileSystem { get; set; } = Internal.FileSystem.Instance;

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -45,6 +45,7 @@
     <PackageReference Include="Verify.DiffPlex" Version="1.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.0.24" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net461' And '$(TargetFramework)' != 'netcoreapp3.0' And '$(TargetFramework)' != 'netcoreapp2.1'">

--- a/test/Sentry.Testing/FakeFileSystem.cs
+++ b/test/Sentry.Testing/FakeFileSystem.cs
@@ -1,0 +1,50 @@
+using MockFileSystem = System.IO.Abstractions.TestingHelpers.MockFileSystem;
+
+namespace Sentry.Testing;
+
+public class FakeFileSystem : IFileSystem
+{
+    private readonly MockFileSystem _mockFileSystem = new();
+
+    public IEnumerable<string> EnumerateFiles(string path) => _mockFileSystem.Directory.EnumerateFiles(path);
+
+    public IEnumerable<string> EnumerateFiles(string path, string searchPattern) =>
+        _mockFileSystem.Directory.EnumerateFiles(path, searchPattern);
+
+    public void CreateDirectory(string path) => _mockFileSystem.Directory.CreateDirectory(path);
+
+    public void DeleteDirectory(string path, bool recursive = false) =>
+        _mockFileSystem.Directory.Delete(path, recursive);
+
+    public bool DirectoryExists(string path) => _mockFileSystem.Directory.Exists(path);
+
+    public bool FileExists(string path) => _mockFileSystem.File.Exists(path);
+
+    public void MoveFile(string sourceFileName, string destFileName, bool overwrite = false)
+    {
+#if NET5_0_OR_GREATER
+        _mockFileSystem.File.Move(sourceFileName, destFileName, overwrite);
+#else
+        if (overwrite)
+        {
+            _mockFileSystem.File.Copy(sourceFileName, destFileName, overwrite: true);
+            _mockFileSystem.File.Delete(sourceFileName);
+        }
+        else
+        {
+            _mockFileSystem.File.Move(sourceFileName, destFileName);
+        }
+#endif
+    }
+
+    public void DeleteFile(string path) => _mockFileSystem.File.Delete(path);
+
+    public DateTimeOffset GetFileCreationTime(string path) =>
+        _mockFileSystem.FileInfo.FromFileName(path).CreationTimeUtc;
+
+    public string ReadAllTextFromFile(string file) => _mockFileSystem.File.ReadAllText(file);
+
+    public Stream OpenFileForReading(string path) => _mockFileSystem.File.OpenRead(path);
+
+    public Stream CreateFileForWriting(string path) => _mockFileSystem.File.Create(path);
+}

--- a/test/Sentry.Testing/FakeFileSystem.cs
+++ b/test/Sentry.Testing/FakeFileSystem.cs
@@ -4,12 +4,16 @@ namespace Sentry.Testing;
 
 public class FakeFileSystem : IFileSystem
 {
+    // This is an in-memory implementation provided by https://github.com/TestableIO/System.IO.Abstractions
     private readonly MockFileSystem _mockFileSystem = new();
 
     public IEnumerable<string> EnumerateFiles(string path) => _mockFileSystem.Directory.EnumerateFiles(path);
 
     public IEnumerable<string> EnumerateFiles(string path, string searchPattern) =>
         _mockFileSystem.Directory.EnumerateFiles(path, searchPattern);
+
+    public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption) =>
+        _mockFileSystem.Directory.EnumerateFiles(path, searchPattern, searchOption);
 
     public void CreateDirectory(string path) => _mockFileSystem.Directory.CreateDirectory(path);
 

--- a/test/Sentry.Testing/TempDirectory.cs
+++ b/test/Sentry.Testing/TempDirectory.cs
@@ -11,7 +11,7 @@ public class TempDirectory : IDisposable
 
     internal TempDirectory(IFileSystem fileSystem, string path = default)
     {
-        _fileSystem = fileSystem ?? new FileSystem();
+        _fileSystem = fileSystem ?? FileSystem.Instance;
         Path = path ?? System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
         _fileSystem.CreateDirectory(Path);
     }

--- a/test/Sentry.Testing/TempDirectory.cs
+++ b/test/Sentry.Testing/TempDirectory.cs
@@ -2,23 +2,25 @@ namespace Sentry.Testing;
 
 public class TempDirectory : IDisposable
 {
+    private readonly IFileSystem _fileSystem;
     public string Path { get; }
 
-    public TempDirectory(string path)
+    public TempDirectory(string path = default) : this(default, path)
     {
-        Path = path;
-        Directory.CreateDirectory(path);
     }
 
-    public TempDirectory()
-        : this(System.IO.Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString()))
-    { }
+    internal TempDirectory(IFileSystem fileSystem, string path = default)
+    {
+        _fileSystem = fileSystem ?? new FileSystem();
+        Path = path ?? System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
+        _fileSystem.CreateDirectory(Path);
+    }
 
     public void Dispose()
     {
-        if (Directory.Exists(Path))
+        if (_fileSystem.DirectoryExists(Path))
         {
-            Directory.Delete(Path, true);
+            _fileSystem.DeleteDirectory(Path, true);
         }
     }
 }

--- a/test/Sentry.Tests/GlobalSessionManagerTests.cs
+++ b/test/Sentry.Tests/GlobalSessionManagerTests.cs
@@ -6,7 +6,7 @@ public class GlobalSessionManagerTests : IDisposable
 {
     private class Fixture : IDisposable
     {
-        private readonly TempDirectory _cacheDirectory = new();
+        private readonly TempDirectory _cacheDirectory;
 
         public InMemoryDiagnosticLogger Logger { get; }
 
@@ -19,13 +19,16 @@ public class GlobalSessionManagerTests : IDisposable
         public Fixture(Action<SentryOptions> configureOptions = null)
         {
             Clock.GetUtcNow().Returns(DateTimeOffset.Now);
-
             Logger = new InMemoryDiagnosticLogger();
+
+            var fileSystem = new FakeFileSystem();
+            _cacheDirectory = new TempDirectory(fileSystem);
 
             Options = new SentryOptions
             {
                 Dsn = ValidDsn,
                 CacheDirectoryPath = _cacheDirectory.Path,
+                FileSystem = fileSystem,
                 Release = "test",
                 Debug = true,
                 DiagnosticLogger = Logger

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -276,7 +276,8 @@ public class HubTests
             }
         }
 
-        using var tempDirectory = offlineCaching ? new TempDirectory() : null;
+        var fileSystem = new FakeFileSystem();
+        using var tempDirectory = offlineCaching ? new TempDirectory(fileSystem) : null;
 
         var logger = Substitute.For<IDiagnosticLogger>();
         logger.IsEnabled(SentryLevel.Error).Returns(true);
@@ -286,6 +287,7 @@ public class HubTests
             Dsn = ValidDsn,
             // To go through a round trip serialization of cached envelope
             CacheDirectoryPath = tempDirectory?.Path,
+            FileSystem = fileSystem,
             // So we don't need to deal with gzip'ed payload
             RequestBodyCompressionLevel = CompressionLevel.NoCompression,
             CreateHttpClientHandler = () => new CallbackHttpClientHandler(VerifyAsync),

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -10,6 +10,7 @@ namespace Sentry.Tests.Internals.Http;
 public class CachingTransportTests
 {
     private readonly TestOutputDiagnosticLogger _logger;
+    private readonly IFileSystem _fileSystem = new FakeFileSystem();
 
     public CachingTransportTests(ITestOutputHelper testOutputHelper)
     {
@@ -20,13 +21,14 @@ public class CachingTransportTests
     public async Task WithAttachment()
     {
         // Arrange
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             Debug = true,
-            CacheDirectoryPath = cacheDirectory.Path
+            CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem
         };
 
         Exception exception = null;
@@ -71,13 +73,14 @@ public class CachingTransportTests
     public async Task WorksInBackground()
     {
         // Arrange
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             Debug = true,
-            CacheDirectoryPath = cacheDirectory.Path
+            CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem
         };
 
         using var innerTransport = new FakeTransport();
@@ -103,13 +106,14 @@ public class CachingTransportTests
     public async Task ShouldNotLogOperationCanceledExceptionWhenIsCancellationRequested()
     {
         // Arrange
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
 
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem,
             Debug = true
         };
 
@@ -146,7 +150,7 @@ public class CachingTransportTests
     public async Task ShouldLogOperationCanceledExceptionWhenNotIsCancellationRequested()
     {
         // Arrange
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var loggerCompletionSource = new TaskCompletionSource<object>();
 
         _logger
@@ -162,6 +166,7 @@ public class CachingTransportTests
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem,
             Debug = true
         };
 
@@ -191,13 +196,14 @@ public class CachingTransportTests
     public async Task EnvelopeReachesInnerTransport()
     {
         // Arrange
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             Debug = true,
-            CacheDirectoryPath = cacheDirectory.Path
+            CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem
         };
 
         using var innerTransport = new FakeTransport();
@@ -217,13 +223,14 @@ public class CachingTransportTests
     public async Task MaintainsLimit()
     {
         // Arrange
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             Debug = true,
             CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem,
             MaxCacheItems = 2
         };
 
@@ -245,13 +252,14 @@ public class CachingTransportTests
     public async Task AwareOfExistingFiles()
     {
         // Arrange
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             Debug = true,
-            CacheDirectoryPath = cacheDirectory.Path
+            CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem
         };
 
         // Send some envelopes with a failing transport to make sure they all stay in cache
@@ -284,13 +292,14 @@ public class CachingTransportTests
     public async Task NonTransientExceptionShouldLog()
     {
         // Arrange
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             Debug = true,
-            CacheDirectoryPath = cacheDirectory.Path
+            CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem
         };
 
         var innerTransport = Substitute.For<ITransport>();
@@ -320,13 +329,14 @@ public class CachingTransportTests
     public async Task DoesNotRetryOnNonTransientExceptions()
     {
         // Arrange
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             Debug = true,
-            CacheDirectoryPath = cacheDirectory.Path
+            CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem
         };
 
         var innerTransport = Substitute.For<ITransport>();
@@ -365,13 +375,14 @@ public class CachingTransportTests
     public async Task RecordsDiscardedEventOnNonTransientExceptions()
     {
         // Arrange
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             Debug = true,
             CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem,
             ClientReportRecorder = Substitute.For<IClientReportRecorder>()
         };
 
@@ -397,13 +408,14 @@ public class CachingTransportTests
     public async Task RoundtripsClientReports()
     {
         // Arrange
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             Debug = true,
-            CacheDirectoryPath = cacheDirectory.Path
+            CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem
         };
 
         var timestamp = DateTimeOffset.UtcNow;
@@ -443,13 +455,14 @@ public class CachingTransportTests
     public async Task RestoresDiscardedEventCounts()
     {
         // Arrange
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             Debug = true,
-            CacheDirectoryPath = cacheDirectory.Path
+            CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem
         };
 
         var recorder = (ClientReportRecorder) options.ClientReportRecorder;
@@ -496,13 +509,14 @@ public class CachingTransportTests
     public async Task TestNetworkException(Exception exception)
     {
         // Arrange
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             Debug = true,
-            CacheDirectoryPath = cacheDirectory.Path
+            CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem
         };
 
         var receivedException = new Exception();
@@ -535,7 +549,7 @@ public class CachingTransportTests
 
         // Assert
         Assert.Equal(exception, receivedException);
-        Assert.True(Directory.EnumerateFiles(cacheDirectory.Path, "*", SearchOption.AllDirectories).Any());
+        Assert.True(_fileSystem.EnumerateFiles(cacheDirectory.Path, "*", SearchOption.AllDirectories).Any());
     }
 
     [Fact]
@@ -547,13 +561,14 @@ public class CachingTransportTests
         listener.WaitForNetworkOnlineAsync(Arg.Any<CancellationToken>())
             .Throws(new Exception("We should not be waiting for the network status if we know it's online."));
 
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             Debug = true,
             CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem,
             NetworkStatusListener = listener
         };
 
@@ -584,13 +599,14 @@ public class CachingTransportTests
                 return Task.Delay(Timeout.Infinite, callInfo.Arg<CancellationToken>());
             });
 
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             Debug = true,
             CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem,
             NetworkStatusListener = listener
         };
 
@@ -638,13 +654,14 @@ public class CachingTransportTests
                 return Task.CompletedTask;
             });
 
-        using var cacheDirectory = new TempDirectory();
+        using var cacheDirectory = new TempDirectory(_fileSystem);
         var options = new SentryOptions
         {
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             Debug = true,
             CacheDirectoryPath = cacheDirectory.Path,
+            FileSystem = _fileSystem,
             NetworkStatusListener = listener
         };
 

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -762,8 +762,10 @@ public class SentryClientTests
     [Fact]
     public void Ctor_WrapsCustomTransportWhenCachePathOnOptions()
     {
-        using var cacheDirectory = new TempDirectory();
+        var fileSystem = new FakeFileSystem();
+        using var cacheDirectory = new TempDirectory(fileSystem);
         _fixture.SentryOptions.CacheDirectoryPath = cacheDirectory.Path;
+        _fixture.SentryOptions.FileSystem = fileSystem;
         _fixture.SentryOptions.Dsn = ValidDsn;
         _fixture.SentryOptions.Transport = new FakeTransport();
 
@@ -776,8 +778,10 @@ public class SentryClientTests
     [Fact]
     public async Task SentryClient_WithCachingTransport_RecordsDiscardedEvents()
     {
-        using var cacheDirectory = new TempDirectory();
+        var fileSystem = new FakeFileSystem();
+        using var cacheDirectory = new TempDirectory(fileSystem);
         _fixture.SentryOptions.CacheDirectoryPath = cacheDirectory.Path;
+        _fixture.SentryOptions.FileSystem = fileSystem;
         _fixture.SentryOptions.Dsn = ValidDsn;
 
         var innerTransport = Substitute.For<ITransport>();


### PR DESCRIPTION
Adds a simple wrapper for file i/o operations use by the caching transport.

In tests, uses a fake implementation that wraps the in-memory mock filesystem provided by https://github.com/TestableIO/System.IO.Abstractions. (use in tests only - no dependency added to Sentry)

This removes the timing variability caused by disk access that some of our tests were flaky on, such as `Init_WithCache_BlocksUntilExistingCacheIsFlushed`.   I made some other minor changes to that test also.  I think we can re-enable it in CI now.

#skip-changelog
