### PR TITLE
Deny app domains in tests on Mono only

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -10,10 +10,15 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- An attempt to use run netfx tests with Mono and .NET Core CLI https://github.com/xunit/xunit/issues/1357 -->
-    <!-- After strong name signing assemblies, only net462 target stopped working. Again xunit -noshadow seems to solve it: https://github.com/Microsoft/vstest/issues/1684 -->
+  <!-- configure xunit -->
+  <ItemGroup Condition="!$([MSBuild]::IsOSPlatform('windows'))">
     <Content Include="..\xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
+    <Content Include="..\xunit.runner.windows.json">
+      <Link>xunit.runner.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/test/xunit.runner.windows.json
+++ b/test/xunit.runner.windows.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "appDomain": "denied",
+  "shadowCopy": false,
 
   "// TODO:": "Re-enable parallelization (disabled due to test flakiness)",
   "parallelizeAssembly": false,


### PR DESCRIPTION
Reverts #1805 for non-Windows machines.  Should fix #1812 

#skip-changelog