### PR TITLE
Fix flaky test

### DIFF
--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -315,6 +315,7 @@ public class HubTests
             };
 
             hub.CaptureEvent(evt);
+            await hub.FlushAsync(options.ShutdownTimeout);
 
             // Synchronizing in the tests to go through the caching and http transports
             await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(3)));

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -11,6 +11,13 @@ namespace Sentry.Tests;
 
 public class HubTests
 {
+    private readonly ITestOutputHelper _output;
+
+    public HubTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
     [Fact]
     public void PushScope_BreadcrumbWithinScope_NotVisibleOutside()
     {
@@ -279,8 +286,7 @@ public class HubTests
         var fileSystem = new FakeFileSystem();
         using var tempDirectory = offlineCaching ? new TempDirectory(fileSystem) : null;
 
-        var logger = Substitute.For<IDiagnosticLogger>();
-        logger.IsEnabled(SentryLevel.Error).Returns(true);
+        var logger = Substitute.ForPartsOf<TestOutputDiagnosticLogger>(_output, SentryLevel.Debug);
 
         var options = new SentryOptions
         {
@@ -294,7 +300,6 @@ public class HubTests
             // Not to send some session envelope
             AutoSessionTracking = false,
             Debug = true,
-            DiagnosticLevel = SentryLevel.Error,
             DiagnosticLogger = logger
         };
 


### PR DESCRIPTION
Attempt to fix flaky test

```
[xUnit.net 00:00:12.91]     Sentry.Tests.HubTests.CaptureEvent_NonSerializableContextAndOfflineCaching_CapturesEventWithContextKey(offlineCaching: True) [FAIL]

Error: Un-serializable context key should exist
Expected: True
Actual:   False

  Failed Sentry.Tests.HubTests.CaptureEvent_NonSerializableContextAndOfflineCaching_CapturesEventWithContextKey(offlineCaching: True) [6 s]
  Error Message:
   Un-serializable context key should exist
Expected: True
Actual:   False
  Stack Trace:
     at Sentry.Tests.HubTests.CaptureEvent_NonSerializableContextAndOfflineCaching_CapturesEventWithContextKey(Boolean offlineCaching) in /home/runner/work/sentry-dotnet/sentry-dotnet/test/Sentry.Tests/HubTests.cs:line 317
   at Sentry.Tests.HubTests.CaptureEvent_NonSerializableContextAndOfflineCaching_CapturesEventWithContextKey(Boolean offlineCaching) in /home/runner/work/sentry-dotnet/sentry-dotnet/test/Sentry.Tests/HubTests.cs:line 336
```

- Output the debug log to test output so if it fails again we will have more information
- Flush the hub before asserts.  I think this is the cause.

#skip-changelog