### PR TITLE
Increase timeout on test

### DIFF
--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -257,7 +257,7 @@ public class SentrySdkTests : IDisposable
         const int numEnvelopes = 5;
 
         // Set the delay for the transport here.  If the test becomes flaky, increase the timeout.
-        var processingDelayPerEnvelope = TimeSpan.FromMilliseconds(100);
+        var processingDelayPerEnvelope = TimeSpan.FromMilliseconds(200);
 
         // Arrange
         var fileSystem = new FakeFileSystem();


### PR DESCRIPTION
This one is still a bit flaky, even though it doesn't hit the disk anymore.  Let's give it just a bit more delay time.

#skip-changelog