### PR TITLE
Update Sentry Android SDK to version 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Features
 
 - Added 'integrations' to SdkVersion ([#1820](https://github.com/getsentry/sentry-dotnet/pull/1820))
+- Updated Sentry Android SDK to version 6.3.0 ([#1826](https://github.com/getsentry/sentry-dotnet/pull/1826))
 
 ## 3.20.1
 

--- a/src/Sentry/Android/Sentry.Android.props
+++ b/src/Sentry/Android/Sentry.Android.props
@@ -4,7 +4,7 @@
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <!-- BG8605 and BG8606 happen because there's a missing androidx.lifecycle dependency, but we don't need it here.  (The native Android Sentry SDK will use it if it exists.) -->
     <NoWarn>$(NoWarn);BG8605;BG8606</NoWarn>
-    <SentryAndroidSdkVersion>6.0.0</SentryAndroidSdkVersion>
+    <SentryAndroidSdkVersion>6.3.0</SentryAndroidSdkVersion>
     <SentryAndroidSdkDirectory>$(BaseIntermediateOutputPath)sdks\Sentry\Android\$(SentryAndroidSdkVersion)\</SentryAndroidSdkDirectory>
     <LangVersion>10</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>

--- a/src/Sentry/Android/Sentry.Android.props
+++ b/src/Sentry/Android/Sentry.Android.props
@@ -5,7 +5,7 @@
     <!-- BG8605 and BG8606 happen because there's a missing androidx.lifecycle dependency, but we don't need it here.  (The native Android Sentry SDK will use it if it exists.) -->
     <NoWarn>$(NoWarn);BG8605;BG8606</NoWarn>
     <SentryAndroidSdkVersion>6.0.0</SentryAndroidSdkVersion>
-    <AndroidLibsDirectory>$(BaseIntermediateOutputPath)\libs\Android\</AndroidLibsDirectory>
+    <SentryAndroidSdkDirectory>$(BaseIntermediateOutputPath)sdks\Sentry\Android\$(SentryAndroidSdkVersion)\</SentryAndroidSdkDirectory>
     <LangVersion>10</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
@@ -14,9 +14,9 @@
     <None Remove="Android\Transforms\*.xml" />
     <TransformFile Include="Android\Transforms\*.xml" />
     <!-- TODO: How to add JavaDocPaths for each package? -->
-    <AndroidLibrary Include="$(AndroidLibsDirectory)sentry-$(SentryAndroidSdkVersion).jar" />
-    <AndroidLibrary Include="$(AndroidLibsDirectory)sentry-android-core-$(SentryAndroidSdkVersion).aar" />
-    <AndroidLibrary Include="$(AndroidLibsDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).aar" />
+    <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-$(SentryAndroidSdkVersion).jar" />
+    <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-android-core-$(SentryAndroidSdkVersion).aar" />
+    <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).aar" />
   </ItemGroup>
 
   <ItemGroup>
@@ -44,21 +44,21 @@
   </ItemGroup>
 
   <Target Name="DownloadSentryAndroidSdk" BeforeTargets="CollectPackageReferences">
-    <DownloadFile SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-core/$(SentryAndroidSdkVersion)/sentry-android-core-$(SentryAndroidSdkVersion).aar"
-      DestinationFolder="$(AndroidLibsDirectory)"
-      Condition="!Exists('$(AndroidLibsDirectory)sentry-android-core-$(SentryAndroidSdkVersion).aar')">
-      <Output TaskParameter="DownloadedFile" ItemName="None" />
-    </DownloadFile>
-    <DownloadFile SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-ndk/$(SentryAndroidSdkVersion)/sentry-android-ndk-$(SentryAndroidSdkVersion).aar"
-      DestinationFolder="$(AndroidLibsDirectory)"
-      Condition="!Exists('$(AndroidLibsDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).aar')">
-      <Output TaskParameter="DownloadedFile" ItemName="None" />
-    </DownloadFile>
-    <DownloadFile SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry/$(SentryAndroidSdkVersion)/sentry-$(SentryAndroidSdkVersion).jar"
-      DestinationFolder="$(AndroidLibsDirectory)"
-      Condition="!Exists('$(AndroidLibsDirectory)sentry-$(SentryAndroidSdkVersion).jar')">
-      <Output TaskParameter="DownloadedFile" ItemName="None" />
-    </DownloadFile>
+    <DownloadFile
+      SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-core/$(SentryAndroidSdkVersion)/sentry-android-core-$(SentryAndroidSdkVersion).aar"
+      DestinationFolder="$(SentryAndroidSdkDirectory)"
+      Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-android-core-$(SentryAndroidSdkVersion).aar')"
+    />
+    <DownloadFile
+      SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-ndk/$(SentryAndroidSdkVersion)/sentry-android-ndk-$(SentryAndroidSdkVersion).aar"
+      DestinationFolder="$(SentryAndroidSdkDirectory)"
+      Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).aar')"
+    />
+    <DownloadFile
+      SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry/$(SentryAndroidSdkVersion)/sentry-$(SentryAndroidSdkVersion).jar"
+      DestinationFolder="$(SentryAndroidSdkDirectory)"
+      Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-$(SentryAndroidSdkVersion).jar')"
+    />
   </Target>
 
 </Project>

--- a/src/Sentry/Android/Sentry.Android.props
+++ b/src/Sentry/Android/Sentry.Android.props
@@ -48,16 +48,19 @@
       SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-core/$(SentryAndroidSdkVersion)/sentry-android-core-$(SentryAndroidSdkVersion).aar"
       DestinationFolder="$(SentryAndroidSdkDirectory)"
       Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-android-core-$(SentryAndroidSdkVersion).aar')"
+      Retries="3"
     />
     <DownloadFile
       SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-ndk/$(SentryAndroidSdkVersion)/sentry-android-ndk-$(SentryAndroidSdkVersion).aar"
       DestinationFolder="$(SentryAndroidSdkDirectory)"
       Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).aar')"
+      Retries="3"
     />
     <DownloadFile
       SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry/$(SentryAndroidSdkVersion)/sentry-$(SentryAndroidSdkVersion).jar"
       DestinationFolder="$(SentryAndroidSdkDirectory)"
       Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-$(SentryAndroidSdkVersion).jar')"
+      Retries="3"
     />
   </Target>
 

--- a/src/Sentry/Android/Transforms/Metadata.xml
+++ b/src/Sentry/Android/Transforms/Metadata.xml
@@ -44,7 +44,7 @@
 
   <!-- These constants need a different name than their class to avoid CS0542 compilation errors. -->
   <attr path="/api/package[@name='io.sentry']/class[@name='SentryTraceHeader']/field[@name='SENTRY_TRACE_HEADER']" name="managedName">SentryTraceHeaderName</attr>
-  <attr path="/api/package[@name='io.sentry']/class[@name='TraceStateHeader']/field[@name='TRACE_STATE_HEADER']" name="managedName">TraceStateHeaderName</attr>
+  <attr path="/api/package[@name='io.sentry']/class[@name='BaggageHeader']/field[@name='BAGGAGE_HEADER']" name="managedName">BaggageHeaderName</attr>
 
   <!-- Fix visibility of this type, for use in AndroidEventProcessor.cs -->
   <attr path="/api/package[@name='io.sentry.android.core']/class[@name='DefaultAndroidEventProcessor']" name="visibility">internal</attr>


### PR DESCRIPTION
- Updated to current version of the Sentry Android SDK
- Updated transforms to resolve warnings
- Added parameter to retry download of the SDK up to 3 times (using the default 5 seconds delay between on failure)
- Changed some paths and variables to align with coming changes for iOS bindings