### PR TITLE
Add and use serialization and dictionary extensions

### DIFF
--- a/src/Sentry/Platforms/iOS/Extensions/BreadcrumbExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/BreadcrumbExtensions.cs
@@ -1,43 +1,26 @@
+using Sentry.Extensibility;
+
 namespace Sentry.iOS.Extensions;
 
 internal static class BreadcrumbExtensions
 {
-    public static Breadcrumb ToBreadcrumb(this SentryCocoa.SentryBreadcrumb breadcrumb)
-    {
-        var items = breadcrumb.Data as IEnumerable<KeyValuePair<NSString, NSObject?>>;
-        var data = items?.ToDictionary(
-            x => (string)x.Key,
-            x => x.Value?.ToString() ?? "");
-
-        return new Breadcrumb(
+    public static Breadcrumb ToBreadcrumb(this SentryCocoa.SentryBreadcrumb breadcrumb, IDiagnosticLogger? logger) =>
+        new(
             breadcrumb.Timestamp?.ToDateTimeOffset(),
             breadcrumb.Message,
             breadcrumb.Type,
-            data,
+            breadcrumb.Data.ToNullableStringDictionary(logger),
             breadcrumb.Category,
             breadcrumb.Level.ToBreadcrumbLevel());
-    }
 
-    public static SentryCocoa.SentryBreadcrumb ToCocoaBreadcrumb(this Breadcrumb breadcrumb)
-    {
-        NSDictionary<NSString, NSObject>? data = null;
-        if (breadcrumb.Data is { } breadcrumbData)
-        {
-            data = new NSDictionary<NSString, NSObject>();
-            foreach (var item in breadcrumbData)
-            {
-                data[item.Key] = NSObject.FromObject(item.Value);
-            }
-        }
-
-        return new SentryCocoa.SentryBreadcrumb
+    public static SentryCocoa.SentryBreadcrumb ToCocoaBreadcrumb(this Breadcrumb breadcrumb) =>
+        new()
         {
             Timestamp = breadcrumb.Timestamp.ToNSDate(),
             Message = breadcrumb.Message,
             Type = breadcrumb.Type,
-            Data = data,
+            Data = breadcrumb.Data?.ToNullableNSDictionary(),
             Category = breadcrumb.Category ?? "",
             Level = breadcrumb.Level.ToCocoaSentryLevel()
         };
-    }
 }

--- a/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
@@ -78,7 +78,7 @@ internal static class CocoaExtensions
         IDiagnosticLogger? logger = null)
         where TValue : NSObject
     {
-        if (dict is null || dict.Length == 0)
+        if (dict is null || dict.Count == 0)
         {
             return null;
         }

--- a/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
@@ -106,13 +106,10 @@ internal static class CocoaExtensions
     }
 
     public static NSDictionary<NSString, NSObject>? ToNullableNSDictionary<TValue>(
-        this ICollection<KeyValuePair<string, TValue>> dict)
-    {
-        if (dict.Count == 0)
-        {
-            return null;
-        }
+        this ICollection<KeyValuePair<string, TValue>> dict) =>
+        dict.Count == 0 ? null : dict.ToNSDictionary();
 
-        return dict.ToNSDictionary();
-    }
+    public static NSDictionary<NSString, NSObject>? ToNullableNSDictionary<TValue>(
+        this IReadOnlyCollection<KeyValuePair<string, TValue>> dict) =>
+        dict.Count == 0 ? null : dict.ToNSDictionary();
 }

--- a/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
@@ -78,8 +78,12 @@ internal static class CocoaExtensions
         IDiagnosticLogger? logger = null)
         where TValue : NSObject
     {
-        var d = dict?.ToStringDictionary(logger);
-        return d?.Count is null or 0 ? null : d;
+        if (dict is null || dict.Length == 0)
+        {
+            return null;
+        }
+
+        return dict.ToStringDictionary(logger);
     }
 
     public static NSDictionary<NSString, NSObject> ToNSDictionary<TValue>(

--- a/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
@@ -1,3 +1,6 @@
+using Sentry.Extensibility;
+using SentryCocoa;
+
 namespace Sentry.iOS.Extensions;
 
 internal static class CocoaExtensions
@@ -5,4 +8,96 @@ internal static class CocoaExtensions
     public static DateTimeOffset ToDateTimeOffset(this NSDate timestamp) => new((DateTime)timestamp);
 
     public static NSDate ToNSDate(this DateTimeOffset timestamp) => (NSDate)timestamp.UtcDateTime;
+
+    public static string? ToJsonString(this NSObject? obj, IDiagnosticLogger? logger = null)
+    {
+        if (obj == null)
+        {
+            return null;
+        }
+
+        if (obj is ISentrySerializable serializable)
+        {
+            // For types that implement Sentry Cocoa's SentrySerializable protocol (interface),
+            // We should call that first, and then serialize the result to JSON later.
+            obj = serializable.Serialize();
+        }
+
+        // Now we will use Apple's JSON Serialization functions.
+        // See https://developer.apple.com/documentation/foundation/nsjsonserialization
+
+        if (!NSJsonSerialization.IsValidJSONObject(obj))
+        {
+            logger?.LogWarning("Cannot serialize a {0} directly to JSON", obj.GetType().Name);
+            return null;
+        }
+
+        try
+        {
+            using var data = NSJsonSerialization.Serialize(obj, 0, out _);
+            return data.ToString();
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError("Error serializing {0} to JSON", ex, obj.GetType().Name);
+            return null;
+        }
+    }
+
+    public static Dictionary<string, string> ToStringDictionary<TValue>(
+        this NSDictionary<NSString, TValue>? dict,
+        IDiagnosticLogger? logger = null)
+        where TValue : NSObject
+    {
+        if (dict == null)
+        {
+            return new Dictionary<string, string>();
+        }
+
+        var result = new Dictionary<string, string>(capacity: (int)dict.Count);
+        foreach (var key in dict.Keys)
+        {
+            var value = dict[key];
+            if (value is NSString s)
+            {
+                result.Add(key, s);
+            }
+            else if (value.ToJsonString(logger) is { } json)
+            {
+                result.Add(key, json);
+            }
+
+            // Skip null values, including anything that couldn't be serialized
+        }
+
+        return result;
+    }
+
+    public static Dictionary<string, string>? ToNullableStringDictionary<TValue>(
+        this NSDictionary<NSString, TValue>? dict,
+        IDiagnosticLogger? logger = null)
+        where TValue : NSObject
+    {
+        var d = dict?.ToStringDictionary(logger);
+        return d?.Count is null or 0 ? null : d;
+    }
+
+    public static NSDictionary<NSString, NSObject> ToNSDictionary<TValue>(
+        this IEnumerable<KeyValuePair<string, TValue>> dict)
+    {
+        var result = new NSDictionary<NSString, NSObject>();
+        foreach (var item in dict)
+        {
+            result[item.Key] = NSObject.FromObject(item.Value);
+        }
+
+        return result;
+    }
+
+    public static NSDictionary<NSString, NSObject>? ToNullableNSDictionary<TValue>(
+        this IEnumerable<KeyValuePair<string, TValue>> dict)
+    {
+        var d = dict.ToNSDictionary();
+        return d.Count == 0 ? null : d;
+    }
 }

--- a/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
@@ -88,7 +88,11 @@ internal static class CocoaExtensions
         var result = new NSDictionary<NSString, NSObject>();
         foreach (var item in dict)
         {
-            result[item.Key] = NSObject.FromObject(item.Value);
+            // skip null values, but add others as NSObject
+            if (item.Value is { } value)
+            {
+                result[item.Key] = NSObject.FromObject(value);
+            }
         }
 
         return result;

--- a/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
@@ -85,17 +85,20 @@ internal static class CocoaExtensions
     public static NSDictionary<NSString, NSObject> ToNSDictionary<TValue>(
         this IEnumerable<KeyValuePair<string, TValue>> dict)
     {
-        var result = new NSDictionary<NSString, NSObject>();
+        var d = new Dictionary<NSString, NSObject>();
         foreach (var item in dict)
         {
             // skip null values, but add others as NSObject
             if (item.Value is { } value)
             {
-                result[item.Key] = NSObject.FromObject(value);
+                d.Add((NSString)item.Key, NSObject.FromObject(value));
             }
         }
 
-        return result;
+        return NSDictionary<NSString, NSObject>
+            .FromObjectsAndKeys(
+                d.Values.ToArray(),
+                d.Keys.ToArray());
     }
 
     public static NSDictionary<NSString, NSObject>? ToNullableNSDictionary<TValue>(

--- a/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
@@ -106,9 +106,13 @@ internal static class CocoaExtensions
     }
 
     public static NSDictionary<NSString, NSObject>? ToNullableNSDictionary<TValue>(
-        this IEnumerable<KeyValuePair<string, TValue>> dict)
+        this ICollection<KeyValuePair<string, TValue>> dict)
     {
-        var d = dict.ToNSDictionary();
-        return d.Count == 0 ? null : d;
+        if (dict.Count == 0)
+        {
+            return null;
+        }
+
+        return dict.ToNSDictionary();
     }
 }

--- a/src/Sentry/Platforms/iOS/Extensions/UserExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/UserExtensions.cs
@@ -1,71 +1,27 @@
-using System.Collections.ObjectModel;
-using System.Text.Json;
+using Sentry.Extensibility;
 
 namespace Sentry.iOS.Extensions;
 
 internal static class UserExtensions
 {
-    private static readonly IDictionary<string, string> EmptyDictionary =
-        new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
-
-    public static User ToUser(this SentryCocoa.SentryUser user)
-    {
-        IDictionary<string, string>? otherData;
-        if (user.Data is not IDictionary<NSString, NSObject> data)
-        {
-            otherData = EmptyDictionary;
-        }
-        else
-        {
-            otherData = data
-                .ToDictionary(
-                    x => (string)x.Key,
-                    x =>
-                    {
-                        try
-                        {
-                            return JsonSerializer.Serialize(x.Value);
-                        }
-                        catch
-                        {
-                            // TODO: log error
-                            return "";
-                        }
-                    });
-        }
-
-        return new User
+    public static User ToUser(this SentryCocoa.SentryUser user, IDiagnosticLogger? logger = null) =>
+        new()
         {
             Email = user.Email,
             Id = user.UserId,
             IpAddress = user.IpAddress,
             Username = user.Username,
-            Other = otherData
+            Other = user.Data.ToStringDictionary(logger)
         };
-    }
 
     public static SentryCocoa.SentryUser ToCocoaUser(this User user)
     {
-        NSDictionary<NSString, NSObject>? userData;
-        if (user.Other.Count == 0)
-        {
-            userData = null;
-        }
-        else
-        {
-            userData = new NSDictionary<NSString, NSObject>();
-            foreach (var item in user.Other)
-            {
-                userData[item.Key] = NSObject.FromObject(item.Value);
-            }
-        }
-
         var cocoaUser = new SentryCocoa.SentryUser
         {
             Email = user.Email,
             IpAddress = user.IpAddress,
             Username = user.Username,
-            Data = userData
+            Data = user.Other.ToNullableNSDictionary()
         };
 
         // Leave a null User ID uninitialized since it is optional.

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -58,7 +58,8 @@ public static partial class SentrySdk
             if (options.BeforeBreadcrumb is { } beforeBreadcrumb)
             {
                 // Note: Nullable return is allowed but delegate is generated incorrectly
-                o.BeforeBreadcrumb = b => beforeBreadcrumb(b.ToBreadcrumb())?.ToCocoaBreadcrumb()!;
+                o.BeforeBreadcrumb = b => beforeBreadcrumb(b.ToBreadcrumb(options.DiagnosticLogger))?
+                    .ToCocoaBreadcrumb()!;
             }
 
             // TOOD: Work on below (copied from Android)


### PR DESCRIPTION
Following up feedback on #1834 

- Uses Apple's `NSJsonSerialization` for JSON serialization of `NSObject` and derived types.
- Consolidates `NSDictionary` conversions into extension methods.

#skip-changelog