### PR TITLE
add  --nologo to dotnet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,15 +28,15 @@ jobs:
           uses: ./.github/actions/environment
 
         - name: Build
-          run: dotnet build -c Release /p:CopyLocalLockFileAssemblies=true
+          run: dotnet build -c Release --nologo /p:CopyLocalLockFileAssemblies=true
 
         - name: Test
-          run: dotnet test -c Release --no-build -l GitHubActions -l "trx;LogFilePrefix=testresults_${{ runner.os }}"
+          run: dotnet test -c Release --no-build --nologo -l GitHubActions -l "trx;LogFilePrefix=testresults_${{ runner.os }}"
 
         - name: Pack
           # Only pack in one build environment.  We'll use macOS so we can build for ios/maccatalyst targets
           if: startsWith(matrix.os, 'macos')
-          run: dotnet pack -c Release --no-build
+          run: dotnet pack -c Release --no-build --nologo
 
         - name: Upload Verify Results
           if: failure()

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
         languages: csharp
 
     - name: Build
-      run: dotnet build
+      run: dotnet build --nologo
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
remove some of the noise when looking at test results in the logs

#skip-changelog