### PR TITLE
Some test fixes

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
     <!-- Workaround the fact that http doesnt exist in earlier frameworks -->
-    <Using Remove="System.Net.Http"/>
-    <Using Remove="System.Net.Http.Json"/>
+    <Using Remove="System.Net.Http" />
+    <Using Remove="System.Net.Http.Json" />
   </ItemGroup>
 </Project>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Using Include="Sentry"/>
-    <Using Include="Sentry.Extensibility"/>
-    <Using Include="System.Diagnostics"/>
+    <Using Include="Sentry" />
+    <Using Include="Sentry.Extensibility" />
+    <Using Include="System.Diagnostics" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!--Automatic upward search ends when first file found. From here we need to manually import parent props/targets
         https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build -->
-  <Import Project="..\Directory.Build.props"/>
+  <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
     <!--Generate xml docs for all projects under 'src'-->
@@ -54,13 +54,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)..\.assets\sentry-nuget.png" Pack="true" PackagePath=""/>
-    <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath=""/>
+    <None Include="$(MSBuildThisFileDirectory)..\.assets\sentry-nuget.png" Pack="true" PackagePath="" />
+    <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>
     <!-- Used to pull the CHANGELOG.md into the NuGet package Release Notes section -->
-    <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" Condition="'$(Configuration)' != 'Debug'"/>
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" Condition="'$(Configuration)' != 'Debug'" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Sentry/buildTransitive/Sentry.props
+++ b/src/Sentry/buildTransitive/Sentry.props
@@ -24,10 +24,10 @@
                        OutputFile="$(SentryAttributesFilePath)">
       <Output Condition="$(Language) != 'F#'"
               TaskParameter="OutputFile"
-              ItemName="Compile"/>
+              ItemName="Compile" />
       <Output Condition="$(Language) == 'F#'"
               TaskParameter="OutputFile"
-              ItemName="CompileBefore"/>
+              ItemName="CompileBefore" />
       <Output TaskParameter="OutputFile"
               ItemName="FileWrites" />
     </WriteCodeFragment>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -24,22 +24,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="Sentry"/>
-    <Using Include="Sentry.Extensibility"/>
-    <Using Include="Sentry.Infrastructure"/>
-    <Using Include="Sentry.Internal"/>
-    <Using Include="Sentry.Reflection"/>
-    <Using Include="Sentry.Protocol"/>
-    <Using Include="Sentry.Protocol.Envelopes"/>
-    <Using Include="Sentry.Integrations"/>
-    <Using Include="Sentry.Internal.Extensions"/>
-    <Using Include="System.Text"/>
-    <Using Include="Xunit"/>
-    <Using Include="Xunit.Abstractions"/>
-    <Using Include="FluentAssertions"/>
-    <Using Include="NSubstitute"/>
-    <Using Include="NSubstitute.Core"/>
-    <Using Include="NSubstitute.ReturnsExtensions"/>
+    <Using Include="Sentry" />
+    <Using Include="Sentry.Extensibility" />
+    <Using Include="Sentry.Infrastructure" />
+    <Using Include="Sentry.Internal" />
+    <Using Include="Sentry.Reflection" />
+    <Using Include="Sentry.Protocol" />
+    <Using Include="Sentry.Protocol.Envelopes" />
+    <Using Include="Sentry.Integrations" />
+    <Using Include="Sentry.Internal.Extensions" />
+    <Using Include="System.Text" />
+    <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
+    <Using Include="FluentAssertions" />
+    <Using Include="NSubstitute" />
+    <Using Include="NSubstitute.Core" />
+    <Using Include="NSubstitute.ReturnsExtensions" />
     <Using Include="Sentry.DsnSamples" Static="True" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />

--- a/test/Sentry.AspNetCore.Tests/Sentry.AspNetCore.Tests.csproj
+++ b/test/Sentry.AspNetCore.Tests/Sentry.AspNetCore.Tests.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0"/>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.7" />
     <PackageReference Include="Verify.AspNetCore" Version="1.5.0" />
   </ItemGroup>

--- a/test/Sentry.AspNetCore.Tests/VersioningTests.cs
+++ b/test/Sentry.AspNetCore.Tests/VersioningTests.cs
@@ -31,6 +31,9 @@ public class VersioningTests
                 o.Transport = transport;
                 o.Debug = true;
                 o.DiagnosticLogger = _logger;
+
+                // Disable process exit flush to resolve "There is no currently active test." errors.
+                o.DisableAppDomainProcessExitFlush();
             })
             .ConfigureServices(services =>
             {

--- a/test/Sentry.EntityFramework.Tests/SentryQueryPerformanceListenerTests.cs
+++ b/test/Sentry.EntityFramework.Tests/SentryQueryPerformanceListenerTests.cs
@@ -39,6 +39,12 @@ public class SentryQueryPerformanceListenerTests
     }
 
     private readonly Fixture _fixture = new();
+    private readonly IDiagnosticLogger _logger;
+
+    public SentryQueryPerformanceListenerTests(ITestOutputHelper output)
+    {
+        _logger = Substitute.ForPartsOf<TestOutputDiagnosticLogger>(output, SentryLevel.Debug);
+    }
 
     [Theory]
     [InlineData(DbScalarKey)]
@@ -221,12 +227,11 @@ public class SentryQueryPerformanceListenerTests
         // Arrange
         var hub = _fixture.Hub;
         hub.GetSpan().ReturnsNull();
-        var logger = Substitute.For<ITestOutputHelper>();
 
         var options = new SentryOptions
         {
             Debug = true,
-            DiagnosticLogger = new TestOutputDiagnosticLogger(logger)
+            DiagnosticLogger = _logger
         };
 
         var listener = new SentryQueryPerformanceListener(hub, options);
@@ -235,6 +240,6 @@ public class SentryQueryPerformanceListenerTests
         listener.ScalarExecuted(Substitute.For<DbCommand>(), Substitute.For<DbCommandInterceptionContext<object>>());
 
         // Assert
-        logger.Received(0).WriteLine(Arg.Any<string>());
+        _logger.DidNotReceiveWithAnyArgs().Log(default, default!);
     }
 }

--- a/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,0 +1,13 @@
+﻿[assembly: System.CLSCompliant(true)]
+namespace Sentry.Log4Net
+{
+    public class SentryAppender : log4net.Appender.AppenderSkeleton
+    {
+        public SentryAppender() { }
+        public string? Dsn { get; set; }
+        public string? Environment { get; set; }
+        public bool SendIdentity { get; set; }
+        protected override void Append(log4net.Core.LoggingEvent loggingEvent) { }
+        protected override void OnClose() { }
+    }
+}

--- a/test/Sentry.Log4Net.Tests/Sentry.Log4Net.Tests.csproj
+++ b/test/Sentry.Log4Net.Tests/Sentry.Log4Net.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Sentry.Testing/TestOutputDiagnosticLogger.cs
+++ b/test/Sentry.Testing/TestOutputDiagnosticLogger.cs
@@ -13,6 +13,9 @@ public class TestOutputDiagnosticLogger : IDiagnosticLogger
     private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
     private readonly string _testName;
 
+    private static readonly FieldInfo TestFieldInfo = typeof(TestOutputHelper)
+        .GetField("test", BindingFlags.Instance | BindingFlags.NonPublic);
+
     public IEnumerable<LogEntry> Entries => _entries;
 
     public bool HasErrorOrFatal => _entries
@@ -33,11 +36,7 @@ public class TestOutputDiagnosticLogger : IDiagnosticLogger
         _testOutputHelper = testOutputHelper;
         _minimumLevel = minimumLevel;
 
-        var test = _testOutputHelper
-            .GetType()
-            .GetField("test", BindingFlags.Instance | BindingFlags.NonPublic)?
-            .GetValue(_testOutputHelper)
-            as ITest;
+        var test = TestFieldInfo.GetValue(_testOutputHelper) as ITest;
         _testName = test?.DisplayName;
     }
 

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -306,6 +306,9 @@ public class HubTests
             DiagnosticLogger = logger
         };
 
+        // Disable process exit flush to resolve "There is no currently active test." errors.
+        options.DisableAppDomainProcessExitFlush();
+
         try
         {
             using var hub = new Hub(options);

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -322,6 +322,9 @@ public class SentrySdkTests : IDisposable
 
             using var _ = SentrySdk.Init(o =>
             {
+                // Disable process exit flush to resolve "There is no currently active test." errors.
+                o.DisableAppDomainProcessExitFlush();
+
                 o.Dsn = ValidDsn;
                 o.Debug = true;
                 o.DiagnosticLogger = _logger;


### PR DESCRIPTION
Found a few tests that were passing, but would throw an `InvalidOperationException` with message:
```
"Error: There is no currently active test."
```

This was most visible in the test runner output on VS 2022 for Mac, but was occurring regardless of runner, just not always visible depending how log output was collected.

- Updated the `TestOutputDiagnosticLogger` to swallow such exceptions and just write them to stderr, along with info to debug.
- That pointed me at three tests that were trying to log from the AppDomain process exit integration.  Fixed by setting `options.DisableAppDomainProcessExitFlush()` in the three tests that were failing.

Incidentally, two of those tests have been problematic with regard to flakiness, and have been blocking #1811.  I'll try that again after this merges.
 
Also:

- Found that our Log4Net tests were missing the `net6.0` target, so added that.
- Fixed some whitespace around self-closing tags in project files, just because VS for Mac kept wanting to add them and it was annoying.
- Found two EntityFramework tests that were mocking `ITestOutputLogger`, failing the reflection I needed to use to get the test name in the output helper.  Updated those to use a real test output logger.

#skip-changelog