### PR TITLE
Add and configure options for the iOS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Enable Scope Sync for iOS ([#1834](https://github.com/getsentry/sentry-dotnet/pull/1834))
 - Add API for deliberately crashing an app ([#1842](https://github.com/getsentry/sentry-dotnet/pull/1842))
 - Add Mac Catalyst target ([#1848](https://github.com/getsentry/sentry-dotnet/pull/1848))
+- Add and configure options for the iOS SDK ([#1849](https://github.com/getsentry/sentry-dotnet/pull/1849))
 
 ### Fixes
 

--- a/samples/Sentry.Samples.Maui/MainPage.xaml.cs
+++ b/samples/Sentry.Samples.Maui/MainPage.xaml.cs
@@ -56,7 +56,7 @@ public partial class MainPage
     {
         try
         {
-            SentrySdk.CauseCrash(CrashType.Managed);
+            throw new ApplicationException("This exception was thrown and captured manually, without crashing the app.");
         }
         catch (Exception ex)
         {

--- a/samples/Sentry.Samples.Maui/MainPage.xaml.cs
+++ b/samples/Sentry.Samples.Maui/MainPage.xaml.cs
@@ -8,10 +8,16 @@ public partial class MainPage
 {
     private readonly ILogger<MainPage> _logger;
 
-    int count = 0;
+    private int _count = 0;
 
     // NOTE: You can only inject an ILogger<T>, not a plain ILogger
     public MainPage(ILogger<MainPage> logger)
+    {
+        _logger = logger;
+        InitializeComponent();
+    }
+
+    protected override void OnAppearing()
     {
 #if !ANDROID
         JavaCrashBtn.IsVisible = false;
@@ -20,22 +26,25 @@ public partial class MainPage
 #if !(ANDROID || IOS || MACCATALYST)
         NativeCrashBtn.IsVisible = false;
 #endif
-        _logger = logger;
-        InitializeComponent();
+        base.OnAppearing();
     }
 
     private void OnCounterClicked(object sender, EventArgs e)
     {
-        count++;
+        _count++;
 
-        if (count == 1)
-            CounterBtn.Text = $"Clicked {count} time";
+        if (_count == 1)
+        {
+            CounterBtn.Text = $"Clicked {_count} time";
+        }
         else
-            CounterBtn.Text = $"Clicked {count} times";
+        {
+            CounterBtn.Text = $"Clicked {_count} times";
+        }
 
         SemanticScreenReader.Announce(CounterBtn.Text);
 
-        _logger.LogInformation("The button has been clicked {ClickCount} times", count);
+        _logger.LogInformation("The button has been clicked {ClickCount} times", _count);
     }
 
     private void OnUnhandledExceptionClicked(object sender, EventArgs e)

--- a/src/Sentry/Internal/Constants.cs
+++ b/src/Sentry/Internal/Constants.cs
@@ -35,6 +35,8 @@ namespace Sentry.Internal
         // See: https://github.com/getsentry/sentry-release-registry
 #if ANDROID
         public const string SdkName = "sentry.dotnet.android";
+#elif IOS || MACCATALYST
+        public const string SdkName = "sentry.dotnet.cocoa";
 #else
         public const string SdkName = "sentry.dotnet";
 #endif

--- a/src/Sentry/Internal/ProcessInfo.cs
+++ b/src/Sentry/Internal/ProcessInfo.cs
@@ -74,7 +74,6 @@ namespace Sentry.Internal
             {
 #if ANDROID || IOS || MACCATALYST
                 options.LogWarning("StartupTimeDetectionMode.Best is not available on this platform.  Using 'Fast' mode.");
-                return;
 #else
                 // StartupTime is set to UtcNow in this constructor.
                 // That's computationally cheap but not very precise.
@@ -99,7 +98,7 @@ namespace Sentry.Internal
             }
         }
 
-#if !ANDROID
+#if !(ANDROID || IOS || MACCATALYST)
         private static DateTimeOffset GetStartupTime()
         {
             using var proc = Process.GetCurrentProcess();

--- a/src/Sentry/Platforms/Android/Extensions/MiscExtensions.cs
+++ b/src/Sentry/Platforms/Android/Extensions/MiscExtensions.cs
@@ -1,6 +1,6 @@
 namespace Sentry.Android.Extensions;
 
-internal static class SMiscExtensions
+internal static class MiscExtensions
 {
     public static SentryId ToSentryId(this Java.Protocol.SentryId sentryId) => new(Guid.Parse(sentryId.ToString()));
 

--- a/src/Sentry/Platforms/Android/SentryOptions.cs
+++ b/src/Sentry/Platforms/Android/SentryOptions.cs
@@ -250,7 +250,7 @@ public partial class SentryOptions
         /// events that originate from the embedded Android SDK. The default value is <c>false</c> (disabled).
         /// </summary>
         /// <remarks>
-        /// This is an experimental feature and is imperefct, as the .NET SDK and the embedded Android SDK don't
+        /// This is an experimental feature and is imperfect, as the .NET SDK and the embedded Android SDK don't
         /// implement all of the same features that may be present in the event graph. Some optional elements may
         /// be stripped away during the roundtripping between the two SDKs.  Use with caution.
         /// </remarks>

--- a/src/Sentry/Platforms/Android/SentryOptions.cs
+++ b/src/Sentry/Platforms/Android/SentryOptions.cs
@@ -204,8 +204,8 @@ public partial class SentryOptions
 
         // ---------- Other ----------
 
-        internal string[]? InAppExclude { get; set; }
-        internal string[]? InAppInclude { get; set; }
+        internal List<string>? InAppExcludes { get; private set; }
+        internal List<string>? InAppIncludes { get; private set; }
 
         /// <summary>
         /// Add prefix to exclude from 'InApp' stacktrace list by the Android SDK.
@@ -218,10 +218,11 @@ public partial class SentryOptions
         /// <example>
         /// 'java.util.', 'org.apache.logging.log4j.'
         /// </example>
-        public void AddInAppExclude(string prefix) =>
-            InAppExclude = InAppExclude != null
-                ? InAppExclude.Concat(new[] { prefix }).ToArray()
-                : new[] { prefix };
+        public void AddInAppExclude(string prefix)
+        {
+            InAppExcludes ??= new List<string>();
+            InAppExcludes.Add(prefix);
+        }
 
         /// <summary>
         /// Add prefix to include as in 'InApp' stacktrace by the Android SDK.
@@ -234,10 +235,10 @@ public partial class SentryOptions
         /// <example>
         /// 'java.util.customcode.', 'io.sentry.samples.'
         /// </example>
-        public void AddInAppInclude(string prefix) =>
-            InAppInclude = InAppInclude != null
-                ? InAppInclude.Concat(new[] { prefix }).ToArray()
-                : new[] { prefix };
+        public void AddInAppInclude(string prefix){
+            InAppIncludes ??= new List<string>();
+            InAppIncludes.Add(prefix);
+        }
 
         /// <summary>
         /// Gets or sets a value that indicates if tracing features are enabled on the embedded Android SDK.

--- a/src/Sentry/Platforms/Android/SentryOptions.cs
+++ b/src/Sentry/Platforms/Android/SentryOptions.cs
@@ -33,7 +33,7 @@ public partial class SentryOptions
         /// <remarks>
         /// See https://docs.sentry.io/platforms/android/configuration/app-not-respond/
         /// </remarks>
-        public bool AnrReportInDebug { get; set; }
+        public bool AnrReportInDebug { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the ANR (Application Not Responding) timeout interval.
@@ -53,7 +53,7 @@ public partial class SentryOptions
         /// This feature is provided by the Sentry Android SDK and thus only works for Java-based errors.
         /// See https://docs.sentry.io/platforms/android/enriching-events/screenshots/
         /// </remarks>
-        public bool AttachScreenshot { get; set; }
+        public bool AttachScreenshot { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value that indicates if automatic breadcrumbs for <c>Activity</c> lifecycle events are
@@ -129,7 +129,7 @@ public partial class SentryOptions
         /// <remarks>
         /// See https://docs.sentry.io/platforms/android/performance/instrumentation/automatic-instrumentation/#user-interaction-instrumentation
         /// </remarks>
-        public bool EnableUserInteractionTracing { get; set; }
+        public bool EnableUserInteractionTracing { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the interval for profiling traces, when enabled with <see cref="ProfilingEnabled"/>.
@@ -144,7 +144,7 @@ public partial class SentryOptions
         /// Gets or sets a value that indicates if all the threads are automatically attached to all logged events.
         /// The default value is <c>false</c> (disabled).
         /// </summary>
-        public bool AttachThreads { get; set; }
+        public bool AttachThreads { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the connection timeout on the HTTP connection used by Java when sending data to Sentry.
@@ -152,14 +152,14 @@ public partial class SentryOptions
         /// </summary>
         public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
-        // TODO: Should we have this Distribution property on SentryOptions (with Release and Environment)?
         /// <summary>
-        /// Gets or sets the distribution.
+        /// Gets or sets the distribution of the application.
         /// </summary>
         /// <remarks>
-        /// See https://docs.sentry.io/platforms/java/guides/spring/configuration/#distribution
+        /// See "dist" in https://develop.sentry.dev/sdk/event-payloads/#optional-attributes
         /// </remarks>
-        public string? Distribution { get; set; }
+        // TODO: Should we have this property on the main SentryOptions (with Release and Environment)?
+        public string? Distribution { get; set; } = null;
 
         /// <summary>
         /// Gets or sets a value that indicates if the NDK (Android Native Development Kit) is enabled.
@@ -186,14 +186,14 @@ public partial class SentryOptions
         /// Gets or sets a value that indicates if uncaught Java errors will have their stack traces
         /// printed to the standard error stream. The default value is <c>false</c> (disabled).
         /// </summary>
-        public bool PrintUncaughtStackTrace { get; set; }
+        public bool PrintUncaughtStackTrace { get; set; } = false;
 
         /// <summary>
         /// Gets or sets if profiling is enabled for transactions.
         /// The default value is <c>false</c> (disabled).
         /// See also <see cref="ProfilingTracesInterval"/>.
         /// </summary>
-        public bool ProfilingEnabled { get; set; }
+        public bool ProfilingEnabled { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the read timeout on the HTTP connection used by Java when sending data to Sentry.
@@ -244,7 +244,7 @@ public partial class SentryOptions
         /// Gets or sets a value that indicates if tracing features are enabled on the embedded Android SDK.
         /// The default value is <c>false</c> (disabled).
         /// </summary>
-        public bool EnableAndroidSdkTracing { get; set; }
+        public bool EnableAndroidSdkTracing { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value that indicates if the <see cref="BeforeSend"/> callback will be invoked for
@@ -253,8 +253,8 @@ public partial class SentryOptions
         /// <remarks>
         /// This is an experimental feature and is imperfect, as the .NET SDK and the embedded Android SDK don't
         /// implement all of the same features that may be present in the event graph. Some optional elements may
-        /// be stripped away during the roundtripping between the two SDKs.  Use with caution.
+        /// be stripped away during the round-tripping between the two SDKs.  Use with caution.
         /// </remarks>
-        public bool EnableAndroidSdkBeforeSend { get; set; }
+        public bool EnableAndroidSdkBeforeSend { get; set; } = false;
     }
 }

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -157,8 +157,8 @@ public static partial class SentrySdk
                 o.ReadTimeoutMillis = (int)options.Android.ReadTimeout.TotalMilliseconds;
 
                 // In-App Excludes and Includes to be passed to the Android SDK
-                options.Android.InAppExclude?.ToList().ForEach(x => o.AddInAppExclude(x));
-                options.Android.InAppInclude?.ToList().ForEach(x => o.AddInAppInclude(x));
+                options.Android.InAppExcludes?.ForEach(x => o.AddInAppExclude(x));
+                options.Android.InAppIncludes?.ForEach(x => o.AddInAppInclude(x));
 
                 // These options are intentionally set and not exposed for modification
                 o.EnableExternalConfiguration = false;

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -94,11 +94,8 @@ public static partial class SentrySdk
                     o.CacheDirPath = Path.Combine(cacheDirectoryPath, "android");
                 }
 
-                var javaTags = o.Tags;
-                foreach (var tag in options.DefaultTags)
-                {
-                    javaTags.Add(tag);
-                }
+                // NOTE: Tags in options.DefaultTags should not be passed down, because we already call SetTag on each
+                //       one when sending events, which is relayed through the scope observer.
 
                 if (options.HttpProxy is System.Net.WebProxy proxy)
                 {

--- a/src/Sentry/Platforms/iOS/Bindings/ApiDefinitions.cs
+++ b/src/Sentry/Platforms/iOS/Bindings/ApiDefinitions.cs
@@ -66,7 +66,7 @@ interface Constants
 // @interface PrivateSentrySDKOnly : NSObject
 [BaseType (typeof(NSObject))]
 [Internal]
-interface PrivateSentrySDKOnly
+interface PrivateSentrySdkOnly
 {
     // +(void)storeEnvelope:(SentryEnvelope * _Nonnull)envelope;
     [Static]
@@ -117,12 +117,12 @@ interface PrivateSentrySDKOnly
     // @property (assign, nonatomic, class) BOOL appStartMeasurementHybridSDKMode;
     [Static]
     [Export ("appStartMeasurementHybridSDKMode")]
-    bool AppStartMeasurementHybridSDKMode { get; set; }
+    bool AppStartMeasurementHybridSdkMode { get; set; }
 
     // @property (assign, nonatomic, class) BOOL framesTrackingMeasurementHybridSDKMode;
     [Static]
     [Export ("framesTrackingMeasurementHybridSDKMode")]
-    bool FramesTrackingMeasurementHybridSDKMode { get; set; }
+    bool FramesTrackingMeasurementHybridSdkMode { get; set; }
 
     // @property (readonly, assign, nonatomic, class) BOOL isFramesTrackingRunning;
     [Static]
@@ -1392,7 +1392,7 @@ interface SentryNSError : SentrySerializable
 [BaseType (typeof(NSObject))]
 [DisableDefaultCtor]
 [Internal]
-interface SentrySDK
+interface SentrySdk
 {
     // @property (readonly, nonatomic, class) id<SentrySpan> _Nullable span;
     [Static]

--- a/src/Sentry/Platforms/iOS/Bindings/ApiDefinitions.cs
+++ b/src/Sentry/Platforms/iOS/Bindings/ApiDefinitions.cs
@@ -827,7 +827,7 @@ interface SentryOptions
 
     // @property (copy, nonatomic) SentryBeforeSendEventCallback _Nullable beforeSend;
     [NullAllowed, Export ("beforeSend", ArgumentSemantic.Copy)]
-    Func<SentryEvent, SentryEvent> BeforeSend { get; set; }
+    Func<SentryEvent?, SentryEvent> BeforeSend { get; set; }
 
     // @property (copy, nonatomic) SentryBeforeBreadcrumbCallback _Nullable beforeBreadcrumb;
     [NullAllowed, Export ("beforeBreadcrumb", ArgumentSemantic.Copy)]
@@ -916,7 +916,7 @@ interface SentryOptions
 
     // @property (nonatomic) SentryTracesSamplerCallback _Nullable tracesSampler;
     [NullAllowed, Export ("tracesSampler", ArgumentSemantic.Assign)]
-    Func<SentrySamplingContext, NSNumber> TracesSampler { get; set; }
+    Func<SentrySamplingContext, NSNumber?> TracesSampler { get; set; }
 
     // @property (readonly, assign, nonatomic) BOOL isTracingEnabled;
     [Export ("isTracingEnabled")]

--- a/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
@@ -11,6 +11,15 @@ internal static class CocoaExtensions
 
     public static string? ToJsonString(this NSObject? obj, IDiagnosticLogger? logger = null)
     {
+        using var data = obj.ToJsonData(logger);
+        return data?.ToString();
+    }
+
+    public static Stream? ToJsonStream(this NSObject? obj, IDiagnosticLogger? logger = null) =>
+        obj.ToJsonData(logger)?.AsStream();
+
+    private static NSData? ToJsonData(this NSObject? obj, IDiagnosticLogger? logger = null)
+    {
         if (obj == null)
         {
             return null;
@@ -34,8 +43,7 @@ internal static class CocoaExtensions
 
         try
         {
-            using var data = NSJsonSerialization.Serialize(obj, 0, out _);
-            return data.ToString();
+            return NSJsonSerialization.Serialize(obj, 0, out _);
         }
         catch (Exception ex)
         {
@@ -86,6 +94,61 @@ internal static class CocoaExtensions
         return dict.ToStringDictionary(logger);
     }
 
+    public static Dictionary<string, object?> ToObjectDictionary<TValue>(
+        this NSDictionary<NSString, TValue>? dict,
+        IDiagnosticLogger? logger = null)
+        where TValue : NSObject
+    {
+        if (dict == null)
+        {
+            return new Dictionary<string, object?>();
+        }
+
+        var result = new Dictionary<string, object?>(capacity: (int)dict.Count);
+        foreach (var key in dict.Keys)
+        {
+            var value = dict[key];
+            switch (value)
+            {
+                case null or NSNull:
+                    result.Add(key, null);
+                    break;
+                case NSString s:
+                    result.Add(key, s);
+                    break;
+                case NSNumber n:
+                    result.Add(key, n.ToObject());
+                    break;
+                default:
+                    if (value.ToJsonString(logger) is { } json)
+                    {
+                        result.Add(key, json);
+                    }
+                    else
+                    {
+                        logger?.LogWarning("Could not add value of type {0} to dictionary.", value.GetType());
+                    }
+
+                    break;
+            }
+        }
+
+        return result;
+    }
+
+    public static Dictionary<string, object?>? ToNullableObjectDictionary<TValue>(
+        this NSDictionary<NSString, TValue>? dict,
+        IDiagnosticLogger? logger = null)
+        where TValue : NSObject
+    {
+        if (dict is null || dict.Count == 0)
+        {
+            return null;
+        }
+
+        return dict.ToObjectDictionary(logger);
+    }
+
     public static NSDictionary<NSString, NSObject> ToNSDictionary<TValue>(
         this IEnumerable<KeyValuePair<string, TValue>> dict)
     {
@@ -112,4 +175,52 @@ internal static class CocoaExtensions
     public static NSDictionary<NSString, NSObject>? ToNullableNSDictionary<TValue>(
         this IReadOnlyCollection<KeyValuePair<string, TValue>> dict) =>
         dict.Count == 0 ? null : dict.ToNSDictionary();
+
+    /// <summary>
+    /// Converts an <see cref="NSNumber"/> to a .NET primitive data type and returns the result box in an <see cref="object"/>.
+    /// </summary>
+    /// <param name="n">The <see cref="NSNumber"/> to convert.</param>
+    /// <returns>An <see cref="object"/> that contains the number in its primitive type.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the number's <c>ObjCType</c> was unrecognized.</exception>
+    /// <remarks>
+    /// This method always returns a result that is compatible with its value, but does not always give the expected result.
+    /// Specifically:
+    /// <list type="bullet">
+    ///   <item><c>byte</c> returns <c>short</c></item>
+    ///   <item><c>ushort</c> return <c>int</c></item>
+    ///   <item><c>uint</c> returns <c>long</c></item>
+    ///   <item><c>ulong</c> returns <c>long</c> unless it's > <c>long.MaxValue</c></item>
+    ///   <item>n/nu types return more primitive types (ex. <c>nfloat</c> => <c>double</c>)</item>
+    /// </list>
+    /// Type encodings are listed here:
+    /// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
+    /// </remarks>
+    public static object ToObject(this NSNumber n)
+    {
+        if (n is NSDecimalNumber d)
+        {
+            // handle NSDecimalNumber type directly
+            return (decimal)d.NSDecimalValue;
+        }
+
+        return n.ObjCType switch
+        {
+            "c" when n.Class.Name == "__NSCFBoolean" => n.BoolValue, // ObjC bool
+            "c" => n.SByteValue, // signed char
+            "i" => n.Int32Value, // signed int
+            "s" => n.Int16Value, // signed short
+            "l" => n.Int32Value, // signed long (32 bit)
+            "q" => n.Int64Value, // signed long long (64 bit)
+            "C" => n.ByteValue, // unsigned char
+            "I" => n.UInt32Value, // unsigned int
+            "S" => n.UInt16Value, // unsigned short
+            "L" => n.UInt32Value, // unsigned long (32 bit)
+            "Q" => n.UInt64Value, // unsigned long long (64 bit)
+            "f" => n.FloatValue, // float
+            "d" => n.DoubleValue, // double
+            "B" => n.BoolValue, // C++ bool or C99 _Bool
+            _ => throw new ArgumentOutOfRangeException(nameof(n), n,
+                $"NSNumber \"{n.StringValue}\" has an unknown ObjCType \"{n.ObjCType}\" (Class: \"{n.Class.Name}\")")
+        };
+    }
 }

--- a/src/Sentry/Platforms/iOS/Extensions/EnumExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/EnumExtensions.cs
@@ -27,4 +27,70 @@ internal static class EnumExtensions
             BreadcrumbLevel.Critical => SentryCocoa.SentryLevel.Fatal,
             _ => throw new ArgumentOutOfRangeException(nameof(level), level, message: default)
         };
+
+    public static bool? ToNullableBoolean(this SentryCocoa.SentrySampleDecision decision) =>
+        decision switch
+        {
+            SentryCocoa.SentrySampleDecision.Yes => true,
+            SentryCocoa.SentrySampleDecision.No => false,
+            SentryCocoa.SentrySampleDecision.Undecided => null,
+            _ => throw new ArgumentOutOfRangeException(nameof(decision), decision, null)
+        };
+
+    public static SentryCocoa.SentrySampleDecision ToCocoaSampleDecision(this bool? decision) =>
+        decision switch
+        {
+            true => SentryCocoa.SentrySampleDecision.Yes,
+            false => SentryCocoa.SentrySampleDecision.No,
+            null => SentryCocoa.SentrySampleDecision.Undecided
+        };
+
+    public static SpanStatus? ToSpanStatus(this SentryCocoa.SentrySpanStatus status) =>
+        status switch
+        {
+            SentryCocoa.SentrySpanStatus.Undefined => null,
+            SentryCocoa.SentrySpanStatus.Ok => SpanStatus.Ok,
+            SentryCocoa.SentrySpanStatus.Cancelled => SpanStatus.Cancelled,
+            SentryCocoa.SentrySpanStatus.InternalError => SpanStatus.InternalError,
+            SentryCocoa.SentrySpanStatus.UnknownError => SpanStatus.UnknownError,
+            SentryCocoa.SentrySpanStatus.InvalidArgument => SpanStatus.InvalidArgument,
+            SentryCocoa.SentrySpanStatus.DeadlineExceeded => SpanStatus.DeadlineExceeded,
+            SentryCocoa.SentrySpanStatus.NotFound => SpanStatus.NotFound,
+            SentryCocoa.SentrySpanStatus.AlreadyExists => SpanStatus.AlreadyExists,
+            SentryCocoa.SentrySpanStatus.PermissionDenied => SpanStatus.PermissionDenied,
+            SentryCocoa.SentrySpanStatus.ResourceExhausted => SpanStatus.ResourceExhausted,
+            SentryCocoa.SentrySpanStatus.FailedPrecondition => SpanStatus.FailedPrecondition,
+            SentryCocoa.SentrySpanStatus.Aborted => SpanStatus.Aborted,
+            SentryCocoa.SentrySpanStatus.OutOfRange => SpanStatus.OutOfRange,
+            SentryCocoa.SentrySpanStatus.Unimplemented => SpanStatus.Unimplemented,
+            SentryCocoa.SentrySpanStatus.Unavailable => SpanStatus.Unavailable,
+            SentryCocoa.SentrySpanStatus.DataLoss => SpanStatus.DataLoss,
+            SentryCocoa.SentrySpanStatus.Unauthenticated => SpanStatus.Unauthenticated,
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status, message: default)
+        };
+
+    public static SentryCocoa.SentrySpanStatus ToCocoaSpanStatus(this SpanStatus? status) =>
+        status switch
+        {
+            null => SentryCocoa.SentrySpanStatus.Undefined,
+            SpanStatus.Ok => SentryCocoa.SentrySpanStatus.Ok,
+            SpanStatus.Cancelled => SentryCocoa.SentrySpanStatus.Cancelled,
+            SpanStatus.InternalError => SentryCocoa.SentrySpanStatus.InternalError,
+            SpanStatus.UnknownError => SentryCocoa.SentrySpanStatus.UnknownError,
+            SpanStatus.InvalidArgument => SentryCocoa.SentrySpanStatus.InvalidArgument,
+            SpanStatus.DeadlineExceeded => SentryCocoa.SentrySpanStatus.DeadlineExceeded,
+            SpanStatus.NotFound => SentryCocoa.SentrySpanStatus.NotFound,
+            SpanStatus.AlreadyExists => SentryCocoa.SentrySpanStatus.AlreadyExists,
+            SpanStatus.PermissionDenied => SentryCocoa.SentrySpanStatus.PermissionDenied,
+            SpanStatus.ResourceExhausted => SentryCocoa.SentrySpanStatus.ResourceExhausted,
+            SpanStatus.FailedPrecondition => SentryCocoa.SentrySpanStatus.FailedPrecondition,
+            SpanStatus.Aborted => SentryCocoa.SentrySpanStatus.Aborted,
+            SpanStatus.OutOfRange => SentryCocoa.SentrySpanStatus.OutOfRange,
+            SpanStatus.Unimplemented => SentryCocoa.SentrySpanStatus.Unimplemented,
+            SpanStatus.Unavailable => SentryCocoa.SentrySpanStatus.Unavailable,
+            SpanStatus.DataLoss => SentryCocoa.SentrySpanStatus.DataLoss,
+            SpanStatus.Unauthenticated => SentryCocoa.SentrySpanStatus.Unauthenticated,
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status, message: default)
+        };
+
 }

--- a/src/Sentry/Platforms/iOS/Extensions/MiscExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/MiscExtensions.cs
@@ -1,0 +1,12 @@
+namespace Sentry.iOS.Extensions;
+
+internal static class MiscExtensions
+{
+    public static SentryId ToSentryId(this SentryCocoa.SentryId sentryId) => new(Guid.Parse(sentryId.SentryIdString));
+
+    public static SentryCocoa.SentryId ToCocoaSentryId(this SentryId sentryId) => new(sentryId.ToString());
+
+    public static SpanId ToSpanId(this SentryCocoa.SentrySpanId spanId) => new(spanId.SentrySpanIdString);
+
+    public static SentryCocoa.SentrySpanId ToCocoaSpanId(this SpanId spanId) => new(spanId.ToString());
+}

--- a/src/Sentry/Platforms/iOS/Extensions/SamplingContextExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/SamplingContextExtensions.cs
@@ -1,0 +1,13 @@
+using Sentry.iOS.Facades;
+
+namespace Sentry.iOS.Extensions;
+
+internal static class SamplingContextExtensions
+{
+    public static TransactionSamplingContext ToTransactionSamplingContext(this SentryCocoa.SentrySamplingContext context)
+    {
+        var transactionContext = new TransactionContextFacade(context.TransactionContext);
+        var customSamplingContext = context.CustomSamplingContext.ToObjectDictionary();
+        return new TransactionSamplingContext(transactionContext, customSamplingContext);
+    }
+}

--- a/src/Sentry/Platforms/iOS/Extensions/SentryEventExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/SentryEventExtensions.cs
@@ -1,0 +1,45 @@
+// using Sentry.Extensibility;
+// using Sentry.Protocol.Envelopes;
+//
+// namespace Sentry.iOS.Extensions;
+//
+// internal static class SentryEventExtensions
+// {
+//     /*
+//      * These methods map between a SentryEvent and it's Cocoa counterpart by serializing as JSON into memory on one side,
+//      * then deserializing back to an object on the other side.  It is not expected to be performant, as this code is only
+//      * used when a BeforeSend option is set, and then only when an event is captured by the Cocoa SDK (which should be
+//      * relatively rare).
+//      *
+//      * This approach avoids having to write to/from methods for the entire object graph.  However, it's also important to
+//      * recognize that there's not necessarily a one-to-one mapping available on all objects (even through serialization)
+//      * between the two SDKs, so some optional details may be lost when roundtripping.  That's generally OK, as this is
+//      * still better than nothing.  If a specific part of the object graph becomes important to roundtrip, we can consider
+//      * updating the objects on either side.
+//      */
+//
+//     public static SentryEvent ToSentryEvent(this SentryCocoa.SentryEvent sentryEvent, SentryCocoa.SentryOptions cocoaOptions)
+//     {
+//         using var stream = sentryEvent.ToJsonStream()!;
+//         //stream.Seek(0, SeekOrigin.Begin); ??
+//
+//         using var json = JsonDocument.Parse(stream);
+//         var exception = sentryEvent.Error == null ? null : new NSErrorException(sentryEvent.Error);
+//         return SentryEvent.FromJson(json.RootElement, exception);
+//     }
+//
+//     public static SentryCocoa.SentryEvent ToCocoaSentryEvent(this SentryEvent sentryEvent, SentryOptions options, SentryCocoa.SentryOptions cocoaOptions)
+//     {
+//         var envelope = Envelope.FromEvent(sentryEvent);
+//
+//         using var stream = new MemoryStream();
+//         envelope.Serialize(stream, options.DiagnosticLogger);
+//         stream.Seek(0, SeekOrigin.Begin);
+//
+//         using var data = NSData.FromStream(stream)!;
+//         var cocoaEnvelope = SentryCocoa.PrivateSentrySDKOnly.EnvelopeWithData(data);
+//
+//         var cocoaEvent = (SentryCocoa.SentryEvent) cocoaEnvelope.Items[0];
+//         return cocoaEvent;
+//     }
+// }

--- a/src/Sentry/Platforms/iOS/Extensions/SentryEventExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/SentryEventExtensions.cs
@@ -18,7 +18,7 @@
 //      * updating the objects on either side.
 //      */
 //
-//     public static SentryEvent ToSentryEvent(this SentryCocoa.SentryEvent sentryEvent, SentryCocoa.SentryOptions cocoaOptions)
+//     public static SentryEvent ToSentryEvent(this SentryCocoa.SentryEvent sentryEvent, SentryCocoaOptions cocoaOptions)
 //     {
 //         using var stream = sentryEvent.ToJsonStream()!;
 //         //stream.Seek(0, SeekOrigin.Begin); ??
@@ -28,7 +28,7 @@
 //         return SentryEvent.FromJson(json.RootElement, exception);
 //     }
 //
-//     public static SentryCocoa.SentryEvent ToCocoaSentryEvent(this SentryEvent sentryEvent, SentryOptions options, SentryCocoa.SentryOptions cocoaOptions)
+//     public static SentryCocoa.SentryEvent ToCocoaSentryEvent(this SentryEvent sentryEvent, SentryOptions options, SentryCocoaOptions cocoaOptions)
 //     {
 //         var envelope = Envelope.FromEvent(sentryEvent);
 //

--- a/src/Sentry/Platforms/iOS/Facades/TransactionContextFacade.cs
+++ b/src/Sentry/Platforms/iOS/Facades/TransactionContextFacade.cs
@@ -1,0 +1,31 @@
+using Sentry.iOS.Extensions;
+
+namespace Sentry.iOS.Facades;
+
+internal class TransactionContextFacade : ITransactionContext
+{
+    private readonly SentryCocoa.SentryTransactionContext _context;
+
+    internal TransactionContextFacade(SentryCocoa.SentryTransactionContext context)
+    {
+        _context = context;
+    }
+
+    public string Name => _context.Name;
+
+    public bool? IsParentSampled => _context.ParentSampled.ToNullableBoolean();
+
+    public SpanId SpanId => _context.SpanId.ToSpanId();
+
+    public SpanId? ParentSpanId => _context.ParentSpanId?.ToSpanId();
+
+    public SentryId TraceId => _context.TraceId.ToSentryId();
+
+    public string Operation => _context.Operation;
+
+    public string? Description => _context.Description;
+
+    public SpanStatus? Status => _context.Status.ToSpanStatus();
+
+    public bool? IsSampled => _context.Sampled.ToNullableBoolean();
+}

--- a/src/Sentry/Platforms/iOS/IosEventProcessor.cs
+++ b/src/Sentry/Platforms/iOS/IosEventProcessor.cs
@@ -4,9 +4,9 @@ namespace Sentry.iOS;
 
 internal class IosEventProcessor : ISentryEventProcessor, IDisposable
 {
-    private readonly SentryCocoa.SentryOptions _options;
+    private readonly SentryCocoaOptions _options;
 
-    public IosEventProcessor(SentryCocoa.SentryOptions options)
+    public IosEventProcessor(SentryCocoaOptions options)
     {
         _options = options;
     }

--- a/src/Sentry/Platforms/iOS/IosEventProcessor.cs
+++ b/src/Sentry/Platforms/iOS/IosEventProcessor.cs
@@ -1,0 +1,24 @@
+using Sentry.Extensibility;
+
+namespace Sentry.iOS;
+
+internal class IosEventProcessor : ISentryEventProcessor, IDisposable
+{
+    private readonly SentryCocoa.SentryOptions _options;
+
+    public IosEventProcessor(SentryCocoa.SentryOptions options)
+    {
+        _options = options;
+    }
+
+    public SentryEvent Process(SentryEvent @event)
+    {
+        // TODO: Apply device/os context info
+
+        return @event;
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/Sentry/Platforms/iOS/IosScopeObserver.cs
+++ b/src/Sentry/Platforms/iOS/IosScopeObserver.cs
@@ -23,7 +23,7 @@ internal sealed class IosScopeObserver : IScopeObserver
         try
         {
             var b = breadcrumb.ToCocoaBreadcrumb();
-            SentryCocoa.SentrySDK.ConfigureScope(scope => scope.AddBreadcrumb(b));
+            SentryCocoa.SentrySdk.ConfigureScope(scope => scope.AddBreadcrumb(b));
         }
         finally
         {
@@ -43,7 +43,7 @@ internal sealed class IosScopeObserver : IScopeObserver
 
             if (value is string s)
             {
-                SentryCocoa.SentrySDK.ConfigureScope(scope =>
+                SentryCocoa.SentrySdk.ConfigureScope(scope =>
                     scope.SetExtraValue(NSObject.FromObject(s), key));
 
                 return;
@@ -52,7 +52,7 @@ internal sealed class IosScopeObserver : IScopeObserver
             try
             {
                 var json = JsonSerializer.Serialize(value);
-                SentryCocoa.SentrySDK.ConfigureScope(scope => scope.SetExtraValue(NSObject.FromObject(json), key));
+                SentryCocoa.SentrySdk.ConfigureScope(scope => scope.SetExtraValue(NSObject.FromObject(json), key));
             }
             catch (Exception ex)
             {
@@ -69,7 +69,7 @@ internal sealed class IosScopeObserver : IScopeObserver
     {
         try
         {
-            SentryCocoa.SentrySDK.ConfigureScope(scope => scope.SetTagValue(value, key));
+            SentryCocoa.SentrySdk.ConfigureScope(scope => scope.SetTagValue(value, key));
         }
         finally
         {
@@ -81,7 +81,7 @@ internal sealed class IosScopeObserver : IScopeObserver
     {
         try
         {
-            SentryCocoa.SentrySDK.ConfigureScope(scope => scope.RemoveTagForKey(key));
+            SentryCocoa.SentrySdk.ConfigureScope(scope => scope.RemoveTagForKey(key));
         }
         finally
         {
@@ -94,7 +94,7 @@ internal sealed class IosScopeObserver : IScopeObserver
         try
         {
             var u = user?.ToCocoaUser();
-            SentryCocoa.SentrySDK.ConfigureScope(scope => scope.SetUser(u));
+            SentryCocoa.SentrySdk.ConfigureScope(scope => scope.SetUser(u));
         }
         finally
         {

--- a/src/Sentry/Platforms/iOS/IosScopeObserver.cs
+++ b/src/Sentry/Platforms/iOS/IosScopeObserver.cs
@@ -23,7 +23,7 @@ internal sealed class IosScopeObserver : IScopeObserver
         try
         {
             var b = breadcrumb.ToCocoaBreadcrumb();
-            SentryCocoa.SentrySdk.ConfigureScope(scope => scope.AddBreadcrumb(b));
+            SentryCocoaSdk.ConfigureScope(scope => scope.AddBreadcrumb(b));
         }
         finally
         {
@@ -43,7 +43,7 @@ internal sealed class IosScopeObserver : IScopeObserver
 
             if (value is string s)
             {
-                SentryCocoa.SentrySdk.ConfigureScope(scope =>
+                SentryCocoaSdk.ConfigureScope(scope =>
                     scope.SetExtraValue(NSObject.FromObject(s), key));
 
                 return;
@@ -52,7 +52,7 @@ internal sealed class IosScopeObserver : IScopeObserver
             try
             {
                 var json = JsonSerializer.Serialize(value);
-                SentryCocoa.SentrySdk.ConfigureScope(scope => scope.SetExtraValue(NSObject.FromObject(json), key));
+                SentryCocoaSdk.ConfigureScope(scope => scope.SetExtraValue(NSObject.FromObject(json), key));
             }
             catch (Exception ex)
             {
@@ -69,7 +69,7 @@ internal sealed class IosScopeObserver : IScopeObserver
     {
         try
         {
-            SentryCocoa.SentrySdk.ConfigureScope(scope => scope.SetTagValue(value, key));
+            SentryCocoaSdk.ConfigureScope(scope => scope.SetTagValue(value, key));
         }
         finally
         {
@@ -81,7 +81,7 @@ internal sealed class IosScopeObserver : IScopeObserver
     {
         try
         {
-            SentryCocoa.SentrySdk.ConfigureScope(scope => scope.RemoveTagForKey(key));
+            SentryCocoaSdk.ConfigureScope(scope => scope.RemoveTagForKey(key));
         }
         finally
         {
@@ -94,7 +94,7 @@ internal sealed class IosScopeObserver : IScopeObserver
         try
         {
             var u = user?.ToCocoaUser();
-            SentryCocoa.SentrySdk.ConfigureScope(scope => scope.SetUser(u));
+            SentryCocoaSdk.ConfigureScope(scope => scope.SetUser(u));
         }
         finally
         {

--- a/src/Sentry/Platforms/iOS/Sentry.iOS.props
+++ b/src/Sentry/Platforms/iOS/Sentry.iOS.props
@@ -17,6 +17,7 @@
     <Using Include="System.Globalization" />
     <Using Include="System.Text.Json" />
     <Using Include="Foundation" />
+    <Using Include="SentryCocoa.SentryOptions" Alias="SentryCocoaOptions" />
     <Using Include="SentryCocoa.SentrySdk" Alias="SentryCocoaSdk" />
   </ItemGroup>
 

--- a/src/Sentry/Platforms/iOS/Sentry.iOS.props
+++ b/src/Sentry/Platforms/iOS/Sentry.iOS.props
@@ -17,6 +17,7 @@
     <Using Include="System.Globalization" />
     <Using Include="System.Text.Json" />
     <Using Include="Foundation" />
+    <Using Include="SentryCocoa.SentrySdk" Alias="SentryCocoaSdk" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Sentry/Platforms/iOS/Sentry.iOS.props
+++ b/src/Sentry/Platforms/iOS/Sentry.iOS.props
@@ -14,6 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="System.Globalization" />
+    <Using Include="System.Text.Json" />
     <Using Include="Foundation" />
   </ItemGroup>
 

--- a/src/Sentry/Platforms/iOS/SentryOptions.cs
+++ b/src/Sentry/Platforms/iOS/SentryOptions.cs
@@ -25,7 +25,6 @@ public partial class SentryOptions
         public bool EnableAppHangTracking { get; set; }
         public bool EnableAutoBreadcrumbTracking { get; set; }
         public bool EnableAutoPerformanceTracking { get; set; }
-        public bool EnableAutoSessionTracking { get; set; }
         public bool EnableCoreDataTracking { get; set; }
         public bool EnableFileIOTracking { get; set; }
         public bool EnableNetworkBreadcrumbs { get; set; }

--- a/src/Sentry/Platforms/iOS/SentryOptions.cs
+++ b/src/Sentry/Platforms/iOS/SentryOptions.cs
@@ -27,5 +27,16 @@ public partial class SentryOptions
         /// The default value is <c>false</c> (disabled).
         /// </summary>
         public bool EnableCocoaSdkTracing { get; set; }
+
+        // /// <summary>
+        // /// Gets or sets a value that indicates if the <see cref="BeforeSend"/> callback will be invoked for
+        // /// events that originate from the embedded Cocoa SDK. The default value is <c>false</c> (disabled).
+        // /// </summary>
+        // /// <remarks>
+        // /// This is an experimental feature and is imperfect, as the .NET SDK and the embedded Cocoa SDK don't
+        // /// implement all of the same features that may be present in the event graph. Some optional elements may
+        // /// be stripped away during the roundtripping between the two SDKs.  Use with caution.
+        // /// </remarks>
+        // public bool EnableCocoaSdkBeforeSend { get; set; }
     }
 }

--- a/src/Sentry/Platforms/iOS/SentryOptions.cs
+++ b/src/Sentry/Platforms/iOS/SentryOptions.cs
@@ -38,5 +38,38 @@ public partial class SentryOptions
         // /// be stripped away during the roundtripping between the two SDKs.  Use with caution.
         // /// </remarks>
         // public bool EnableCocoaSdkBeforeSend { get; set; }
+
+        // ---------- Other ----------
+
+        internal List<string>? InAppExcludes { get; private set; }
+        internal List<string>? InAppIncludes { get; private set; }
+
+        /// <summary>
+        /// Add prefix to exclude from 'InApp' stacktrace list by the Cocoa SDK.
+        /// Note that this uses iOS module names, not .NET namespaces.
+        /// </summary>
+        /// <param name="prefix">The string used to filter the stacktrace to be excluded from InApp.</param>
+        /// <remarks>
+        /// https://docs.sentry.io/platforms/apple/guides/ios/configuration/options/#in-app-exclude
+        /// </remarks>
+        public void AddInAppExclude(string prefix)
+        {
+            InAppExcludes ??= new List<string>();
+            InAppExcludes.Add(prefix);
+        }
+
+        /// <summary>
+        /// Add prefix to include as in 'InApp' stacktrace by the Cocoa SDK.
+        /// Note that this uses Cocoa package names, not .NET namespaces.
+        /// </summary>
+        /// <param name="prefix">The string used to filter the stacktrace to be included in InApp.</param>
+        /// <remarks>
+        /// See https://docs.sentry.io/platforms/apple/guides/ios/configuration/options/#in-app-include
+        /// </remarks>
+        public void AddInAppInclude(string prefix)
+        {
+            InAppIncludes ??= new List<string>();
+            InAppIncludes.Add(prefix);
+        }
     }
 }

--- a/src/Sentry/Platforms/iOS/SentryOptions.cs
+++ b/src/Sentry/Platforms/iOS/SentryOptions.cs
@@ -1,3 +1,5 @@
+using ObjCRuntime;
+
 // ReSharper disable once CheckNamespace
 namespace Sentry;
 
@@ -18,27 +20,193 @@ public partial class SentryOptions
 
         // ---------- From Cocoa's SentryOptions.h ----------
 
-        public bool AttachScreenshot { get; set; }
-        public TimeSpan AppHangTimeoutInterval { get; set; }
-        public TimeSpan IdleTimeout { get; set; }
-        public string? Distribution { get; set; }
-        public bool EnableAppHangTracking { get; set; }
-        public bool EnableAutoBreadcrumbTracking { get; set; }
-        public bool EnableAutoPerformanceTracking { get; set; }
-        public bool EnableCoreDataTracking { get; set; }
-        public bool EnableFileIOTracking { get; set; }
-        public bool EnableNetworkBreadcrumbs { get; set; }
-        public bool EnableNetworkTracking { get; set; }
-        public bool EnableOutOfMemoryTracking { get; set; }
-        public bool EnableProfiling { get; set; }
-        public bool EnableSwizzling { get; set; }
-        public bool EnableUIViewControllerTracking { get; set; }
-        public bool EnableUserInteractionTracing { get; set; }
-        public bool StitchAsyncCode { get; set; }
+        /// <summary>
+        /// Automatically attaches a screenshot when capturing an error or exception.
+        /// The default value is <c>false</c> (disabled).
+        /// </summary>
+        /// <remarks>
+        /// See https://docs.sentry.io/platforms/apple/guides/ios/configuration/options/#attach-screenshot
+        /// </remarks>
+        public bool AttachScreenshot { get; set; } = false;
 
-        // public Action<SentryEvent>? OnCrashedLastRun { get; set; }
+        /// <summary>
+        /// The minimum amount of time an app should be unresponsive to be classified as an App Hanging.
+        /// The actual amount may be a little longer.  Avoid using values lower than 100ms, which may cause a lot
+        /// of app hangs events being transmitted.
+        /// The default value is 2 seconds.
+        /// Requires setting <see cref="EnableAppHangTracking"/> to <c>true</c>.
+        /// </summary>
+        /// <remarks>
+        /// See https://docs.sentry.io/platforms/apple/configuration/app-hangs/
+        /// </remarks>
+        public TimeSpan AppHangTimeoutInterval { get; set; } = TimeSpan.FromSeconds(2);
 
-        public NSUrlSessionDelegate? UrlSessionDelegate { get; set; }
+        /// <summary>
+        /// How long an idle transaction waits for new children after all its child spans finished.
+        /// Only UI event transactions are idle transactions.
+        /// The default value is 3 seconds.
+        /// </summary>
+        /// <remarks>
+        /// See https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#user-interaction-instrumentation
+        /// </remarks>
+        public TimeSpan IdleTimeout { get; set; } = TimeSpan.FromSeconds(3);
+
+        /// <summary>
+        /// Gets or sets the distribution of the application.
+        /// </summary>
+        /// <remarks>
+        /// See "dist" in https://develop.sentry.dev/sdk/event-payloads/#optional-attributes
+        /// </remarks>
+        // TODO: Should we have this property on the main SentryOptions (with Release and Environment)?
+        public string? Distribution { get; set; } = null;
+
+        /// <summary>
+        /// When enabled, the SDK tracks when the application stops responding for a specific amount of
+        /// time defined by the <see cref="AppHangTimeoutInterval"/> option.
+        /// The default value is <c>false</c> (disabled).
+        /// </summary>
+        /// <remarks>
+        /// See https://docs.sentry.io/platforms/apple/configuration/app-hangs/
+        /// </remarks>
+        public bool EnableAppHangTracking { get; set; } = false;
+
+        /// <summary>
+        /// When enabled, the SDK adds breadcrumbs for various system events.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        /// <remarks>
+        /// See https://docs.sentry.io/platforms/apple/enriching-events/breadcrumbs/#automatic-breadcrumbs
+        /// </remarks>
+        public bool EnableAutoBreadcrumbTracking { get; set; } = true;
+
+        /// <summary>
+        /// When enabled, the SDK tracks performance for <see cref="UIViewController"/> subclasses and HTTP requests
+        /// automatically. It also measures the app start and slow and frozen frames.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        /// <remarks>
+        /// Performance Monitoring must be enabled for this option to take effect.
+        /// See: https://docs.sentry.io/platforms/apple/performance/
+        /// And: https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#opt-out
+        /// </remarks>
+        public bool EnableAutoPerformanceTracking { get; set; } = true;
+
+        /// <summary>
+        /// This feature is experimental.
+        /// When enabled, the SDK tracks the performance of Core Data operations.
+        /// It requires enabling performance monitoring.
+        /// The default value is <c>false</c> (disabled).
+        /// </summary>
+        /// <remarks>
+        /// Performance Monitoring must be enabled for this option to take effect.
+        /// See https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#core-data-instrumentation
+        /// </remarks>
+        public bool EnableCoreDataTracking { get; set; } = false;
+
+        /// <summary>
+        /// This feature is experimental.
+        /// When enabled, the SDK tracks performance for file IO reads and writes with <see cref="NSData"/>
+        /// if auto performance tracking and <see cref="EnableSwizzling"/> are enabled.
+        /// The default value is <c>false</c> (disabled).
+        /// </summary>
+        /// <remarks>
+        /// See https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#file-io-instrumentation
+        /// </remarks>
+        public bool EnableFileIOTracking { get; set; } = false;
+
+        /// <summary>
+        /// When enabled, the SDK adds breadcrumbs for each network request
+        /// if auto performance tracking and <see cref="EnableSwizzling"/> are enabled.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        public bool EnableNetworkBreadcrumbs { get; set; } = true;
+
+        /// <summary>
+        /// When enabled, the SDK adds breadcrumbs for HTTP requests and tracks performance for HTTP requests
+        /// if auto performance tracking and <see cref="EnableSwizzling"/> are enabled.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        /// <remarks>
+        /// https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#http-instrumentation
+        /// </remarks>
+        public bool EnableNetworkTracking { get; set; } = true;
+
+        /// <summary>
+        /// Whether to enable out of memory tracking or not.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        /// <remarks>
+        /// https://docs.sentry.io/platforms/apple/configuration/out-of-memory/
+        /// </remarks>
+        public bool EnableOutOfMemoryTracking { get; set; } = true;
+
+        /// <summary>
+        /// Whether the SDK should use swizzling or not.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        /// <remarks>
+        /// When turned off the following features are disabled: breadcrumbs for touch events and
+        /// navigation with <see cref="UIViewController"/>, automatic instrumentation for <see cref="UIViewController"/>,
+        /// automatic instrumentation for HTTP requests, automatic instrumentation for file IO with <see cref="NSData"/>,
+        /// and automatically added sentry-trace header to HTTP requests for distributed tracing.
+        /// See https://docs.sentry.io/platforms/apple/configuration/swizzling/
+        /// </remarks>
+        public bool EnableSwizzling { get; set; } = true;
+
+        /// <summary>
+        /// When enabled, the SDK tracks performance for <see cref="UIViewController"/> subclasses.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        /// <remarks>
+        /// See https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-instrumentation
+        /// </remarks>
+        public bool EnableUIViewControllerTracking { get; set; } = true;
+
+        /// <summary>
+        /// This feature is experimental.
+        /// When enabled, the SDK creates transactions for UI events like buttons clicks, switch toggles,
+        /// and other UI elements that uses <see cref="UIControl.SendAction(Selector, NSObject?, UIEvent?)"/>.
+        /// The default value is <c>false</c> (disabled).
+        /// </summary>
+        /// <remarks>
+        /// See https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#user-interaction-instrumentation
+        /// </remarks>
+        public bool EnableUserInteractionTracing { get; set; } = false;
+
+        /// <summary>
+        /// This feature is experimental.
+        /// Turning this feature on can have an impact on the grouping of your issues.
+        /// When enabled, the Cocoa SDK stitches stack traces of asynchronous code together.
+        /// This feature affects stack traces from native crashes only.
+        /// The default value is <c>false</c> (disabled).
+        /// </summary>
+        /// <remarks>
+        /// Official docs TBD.
+        /// See https://github.com/getsentry/sentry-docs/issues/5215
+        /// </remarks>
+        public bool StitchAsyncCode { get; set; } = false;
+
+        // /// <summary>
+        // /// This gets called shortly after the initialization of the SDK when the last program execution
+        // /// terminated with a crash. It is not guaranteed that this is called on the main thread.
+        // /// </summary>
+        // /// <remarks>
+        // /// This callback is only executed once during the entire run of the program to avoid
+        // /// multiple callbacks if there are multiple crash events to send. This can happen when the program
+        // /// terminates with a crash before the SDK can send the crash event.
+        // /// You can use <see cref="BeforeSend"/> if you prefer a callback for every event.
+        // /// See also https://docs.sentry.io/platforms/apple/enriching-events/user-feedback/
+        // /// </remarks>
+        // public Action<SentryEvent>? OnCrashedLastRun { get; set; } = null;
+
+        /// <summary>
+        /// When provided, this will be set as delegate on the <see cref="NSUrlSession"/> used for network
+        /// data-transfer tasks performed by the native Sentry Cocoa SDK.
+        /// </summary>
+        /// <remarks>
+        /// See https://github.com/getsentry/sentry-cocoa/issues/1168
+        /// </remarks>
+        public NSUrlSessionDelegate? UrlSessionDelegate { get; set; } = null;
 
 
         // ---------- Other ----------
@@ -47,7 +215,7 @@ public partial class SentryOptions
         /// Gets or sets a value that indicates if tracing features are enabled on the embedded Cocoa SDK.
         /// The default value is <c>false</c> (disabled).
         /// </summary>
-        public bool EnableCocoaSdkTracing { get; set; }
+        public bool EnableCocoaSdkTracing { get; set; } = false;
 
         // /// <summary>
         // /// Gets or sets a value that indicates if the <see cref="BeforeSend"/> callback will be invoked for
@@ -56,7 +224,7 @@ public partial class SentryOptions
         // /// <remarks>
         // /// This is an experimental feature and is imperfect, as the .NET SDK and the embedded Cocoa SDK don't
         // /// implement all of the same features that may be present in the event graph. Some optional elements may
-        // /// be stripped away during the roundtripping between the two SDKs.  Use with caution.
+        // /// be stripped away during the round-tripping between the two SDKs.  Use with caution.
         // /// </remarks>
         // public bool EnableCocoaSdkBeforeSend { get; set; }
 
@@ -69,7 +237,7 @@ public partial class SentryOptions
         /// </summary>
         /// <param name="prefix">The string used to filter the stacktrace to be excluded from InApp.</param>
         /// <remarks>
-        /// https://docs.sentry.io/platforms/apple/guides/ios/configuration/options/#in-app-exclude
+        /// https://docs.sentry.io/platforms/apple/configuration/options/#in-app-exclude
         /// </remarks>
         public void AddInAppExclude(string prefix)
         {
@@ -79,11 +247,11 @@ public partial class SentryOptions
 
         /// <summary>
         /// Add prefix to include as in 'InApp' stacktrace by the Cocoa SDK.
-        /// Note that this uses Cocoa package names, not .NET namespaces.
+        /// Note that this uses iOS package names, not .NET namespaces.
         /// </summary>
         /// <param name="prefix">The string used to filter the stacktrace to be included in InApp.</param>
         /// <remarks>
-        /// See https://docs.sentry.io/platforms/apple/guides/ios/configuration/options/#in-app-include
+        /// See https://docs.sentry.io/platforms/apple/configuration/options/#in-app-include
         /// </remarks>
         public void AddInAppInclude(string prefix)
         {

--- a/src/Sentry/Platforms/iOS/SentryOptions.cs
+++ b/src/Sentry/Platforms/iOS/SentryOptions.cs
@@ -37,6 +37,10 @@ public partial class SentryOptions
         public bool EnableUserInteractionTracing { get; set; }
         public bool StitchAsyncCode { get; set; }
 
+        // public Action<SentryEvent>? OnCrashedLastRun { get; set; }
+
+        public NSUrlSessionDelegate? UrlSessionDelegate { get; set; }
+
 
         // ---------- Other ----------
 

--- a/src/Sentry/Platforms/iOS/SentryOptions.cs
+++ b/src/Sentry/Platforms/iOS/SentryOptions.cs
@@ -16,6 +16,16 @@ public partial class SentryOptions
     {
         internal IosOptions() { }
 
+        // ---------- From Cocoa's SentryOptions.h ----------
+
         // TODO
+
+        // ---------- Other ----------
+
+        /// <summary>
+        /// Gets or sets a value that indicates if tracing features are enabled on the embedded Cocoa SDK.
+        /// The default value is <c>false</c> (disabled).
+        /// </summary>
+        public bool EnableCocoaSdkTracing { get; set; }
     }
 }

--- a/src/Sentry/Platforms/iOS/SentryOptions.cs
+++ b/src/Sentry/Platforms/iOS/SentryOptions.cs
@@ -18,7 +18,25 @@ public partial class SentryOptions
 
         // ---------- From Cocoa's SentryOptions.h ----------
 
-        // TODO
+        public bool AttachScreenshot { get; set; }
+        public TimeSpan AppHangTimeoutInterval { get; set; }
+        public TimeSpan IdleTimeout { get; set; }
+        public string? Distribution { get; set; }
+        public bool EnableAppHangTracking { get; set; }
+        public bool EnableAutoBreadcrumbTracking { get; set; }
+        public bool EnableAutoPerformanceTracking { get; set; }
+        public bool EnableAutoSessionTracking { get; set; }
+        public bool EnableCoreDataTracking { get; set; }
+        public bool EnableFileIOTracking { get; set; }
+        public bool EnableNetworkBreadcrumbs { get; set; }
+        public bool EnableNetworkTracking { get; set; }
+        public bool EnableOutOfMemoryTracking { get; set; }
+        public bool EnableProfiling { get; set; }
+        public bool EnableSwizzling { get; set; }
+        public bool EnableUIViewControllerTracking { get; set; }
+        public bool EnableUserInteractionTracing { get; set; }
+        public bool StitchAsyncCode { get; set; }
+
 
         // ---------- Other ----------
 
@@ -38,8 +56,6 @@ public partial class SentryOptions
         // /// be stripped away during the roundtripping between the two SDKs.  Use with caution.
         // /// </remarks>
         // public bool EnableCocoaSdkBeforeSend { get; set; }
-
-        // ---------- Other ----------
 
         internal List<string>? InAppExcludes { get; private set; }
         internal List<string>? InAppIncludes { get; private set; }

--- a/src/Sentry/Platforms/iOS/SentryOptions.cs
+++ b/src/Sentry/Platforms/iOS/SentryOptions.cs
@@ -6,14 +6,15 @@ public partial class SentryOptions
     /// <summary>
     /// Exposes additional options for the iOS platform.
     /// </summary>
-    public IOSOptions IOS { get; } = new();
+    // ReSharper disable once InconsistentNaming
+    public IosOptions iOS { get; } = new();
 
     /// <summary>
     /// Provides additional options for the iOS platform.
     /// </summary>
-    public class IOSOptions
+    public class IosOptions
     {
-        internal IOSOptions() { }
+        internal IosOptions() { }
 
         // TODO
     }

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -23,7 +23,7 @@ public static partial class SentrySdk
 
         // Now initialize the Cocoa SDK
         SentryCocoa.SentryOptions? cocoaOptions = null;
-        SentryCocoa.SentrySDK.StartWithConfigureOptions(o =>
+        SentryCocoa.SentrySdk.StartWithConfigureOptions(o =>
         {
             // Capture the Cocoa options reference on the outer scope
             cocoaOptions = o;
@@ -147,7 +147,7 @@ public static partial class SentrySdk
 
         // Set options for the managed SDK that depend on the Cocoa SDK
         options.AddEventProcessor(new IosEventProcessor(cocoaOptions!));
-        options.CrashedLastRun = () => SentryCocoa.SentrySDK.CrashedLastRun;
+        options.CrashedLastRun = () => SentryCocoa.SentrySdk.CrashedLastRun;
         options.EnableScopeSync = true;
         options.ScopeObserver = new IosScopeObserver(options);
 

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -128,7 +128,7 @@ public static partial class SentrySdk
         });
 
         // Set options for the managed SDK that depend on the Cocoa SDK
-        // options.AddEventProcessor(new CocoaEventProcessor(cocoaOptions!));
+        options.AddEventProcessor(new IosEventProcessor(cocoaOptions!));
         options.CrashedLastRun = () => SentryCocoa.SentrySDK.CrashedLastRun;
         options.EnableScopeSync = true;
         options.ScopeObserver = new IosScopeObserver(options);

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -118,10 +118,17 @@ public static partial class SentrySdk
             // o.Integrations
             // o.DefaultIntegrations
 
-
-            // // Don't capture managed exceptions in the native SDK, since we already capture them in the managed SDK
-            // o.AddIgnoredExceptionForType(JavaClass.ForName("android.runtime.JavaProxyThrowable"));
-
+            // NOTE
+            // When we have an unhandled managed exception, we send that to Sentry twice - once managed and once native.
+            // The managed exception is what a .NET developer would expect, and it is sent by the Sentry.NET SDK
+            // But we also get a native SIGABRT since it crashed the application, which is sent by the Sentry Cocoa SDK.
+            // This is partially due to our setting ObjCRuntime.MarshalManagedExceptionMode.UnwindNativeCode above.
+            //
+            // A similar thing happens on Android, which we exclude with:
+            //     o.AddIgnoredExceptionForType(JavaClass.ForName("android.runtime.JavaProxyThrowable"));
+            //
+            // TODO: How should we handle this for iOS?  We probably don't want to completely exclude SIGABRT
+            //
         });
 
         // Set options for the managed SDK that depend on the Cocoa SDK

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -95,7 +95,6 @@ public static partial class SentrySdk
             o.EnableAppHangTracking = options.iOS.EnableAppHangTracking;
             o.EnableAutoBreadcrumbTracking = options.iOS.EnableAutoBreadcrumbTracking;
             o.EnableAutoPerformanceTracking = options.iOS.EnableAutoPerformanceTracking;
-            o.EnableAutoSessionTracking = options.iOS.EnableAutoSessionTracking;
             o.EnableCoreDataTracking = options.iOS.EnableCoreDataTracking;
             o.EnableFileIOTracking = options.iOS.EnableFileIOTracking;
             o.EnableNetworkBreadcrumbs = options.iOS.EnableNetworkBreadcrumbs;

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -135,6 +135,11 @@ public static partial class SentrySdk
             //         o.EnableExternalConfiguration = false;
             //         o.EnableDeduplication = false;
             //         o.AttachServerName = false;
+
+            // In-App Excludes and Includes to be passed to the Cocoa SDK
+            options.iOS.InAppExcludes?.ForEach(x => o.AddInAppExclude(x));
+            options.iOS.InAppIncludes?.ForEach(x => o.AddInAppInclude(x));
+
             //
             //         // These options are intentionally not expose or modified
             //         //o.MaxRequestBodySize   // N/A for Android apps

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -74,11 +74,17 @@ public static partial class SentrySdk
                 }
             }
 
-            // TODO: Finish SentryEventExtensions to enable this
+            // TODO: Finish SentryEventExtensions to enable these
+            //
             // if (options.iOS.EnableCocoaSdkBeforeSend && options.BeforeSend is { } beforeSend)
             // {
             //     // Note: Nullable return is allowed but delegate is generated incorrectly
             //     o.BeforeSend = evt => beforeSend(evt.ToSentryEvent(o))?.ToCocoaSentryEvent(options, o)!;
+            // }
+            //
+            // if (options.iOS.OnCrashedLastRun is { } onCrashedLastRun)
+            // {
+            //     o.OnCrashedLastRun = evt => onCrashedLastRun(evt.ToSentryEvent(o));
             // }
 
             // These options are from Cocoa's SentryOptions
@@ -100,14 +106,18 @@ public static partial class SentrySdk
             o.EnableUIViewControllerTracking = options.iOS.EnableUIViewControllerTracking;
             o.EnableUserInteractionTracing = options.iOS.EnableUserInteractionTracing;
             o.StitchAsyncCode = options.iOS.StitchAsyncCode;
+            o.UrlSessionDelegate = options.iOS.UrlSessionDelegate;
 
             // In-App Excludes and Includes to be passed to the Cocoa SDK
             options.iOS.InAppExcludes?.ForEach(x => o.AddInAppExclude(x));
             options.iOS.InAppIncludes?.ForEach(x => o.AddInAppInclude(x));
 
             // These options are intentionally not expose or modified
-            // o.Enabled;
+            // o.Enabled
             // o.SdkInfo
+            // o.Integrations
+            // o.DefaultIntegrations
+
 
             // // Don't capture managed exceptions in the native SDK, since we already capture them in the managed SDK
             // o.AddIgnoredExceptionForType(JavaClass.ForName("android.runtime.JavaProxyThrowable"));

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -100,7 +100,6 @@ public static partial class SentrySdk
             o.EnableNetworkBreadcrumbs = options.iOS.EnableNetworkBreadcrumbs;
             o.EnableNetworkTracking = options.iOS.EnableNetworkTracking;
             o.EnableOutOfMemoryTracking = options.iOS.EnableOutOfMemoryTracking;
-            o.EnableProfiling = options.iOS.EnableProfiling;
             o.EnableSwizzling = options.iOS.EnableSwizzling;
             o.EnableUIViewControllerTracking = options.iOS.EnableUIViewControllerTracking;
             o.EnableUserInteractionTracing = options.iOS.EnableUserInteractionTracing;

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -116,6 +116,7 @@ public static partial class SentrySdk
             // o.SdkInfo
             // o.Integrations
             // o.DefaultIntegrations
+            // o.EnableProfiling  (deprecated)
 
             // When we have an unhandled managed exception, we send that to Sentry twice - once managed and once native.
             // The managed exception is what a .NET developer would expect, and it is sent by the Sentry.NET SDK

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -28,10 +28,6 @@ public static partial class SentrySdk
             // Capture the Cocoa options reference on the outer scope
             cocoaOptions = o;
 
-            // TODO: Equivalent of Android options?
-            // o.DistinctId
-            // o.EnableScopeSync
-
             // These options are copied over from our SentryOptions
             o.AttachStacktrace = options.AttachStacktrace;
             o.Debug = options.Debug;
@@ -39,17 +35,19 @@ public static partial class SentrySdk
             o.Dsn = options.Dsn;
             o.EnableAutoSessionTracking = options.AutoSessionTracking;
             o.Environment = options.Environment;
-            //o.FlushTimeoutMillis = (long)options.InitCacheFlushTimeout.TotalMilliseconds;
             o.MaxAttachmentSize = (nuint) options.MaxAttachmentSize;
             o.MaxBreadcrumbs = (nuint) options.MaxBreadcrumbs;
             o.MaxCacheItems = (nuint) options.MaxCacheItems;
-            // o.MaxQueueSize = options.MaxQueueItems;
             o.ReleaseName = options.Release;
             o.SampleRate = options.SampleRate;
             o.SendClientReports = options.SendClientReports;
             o.SendDefaultPii = options.SendDefaultPii;
             o.SessionTrackingIntervalMillis = (nuint) options.AutoSessionTrackingInterval.TotalMilliseconds;
-            // o.ShutdownTimeoutMillis = (long)options.ShutdownTimeout.TotalMilliseconds;
+
+            // These options are not available in the Sentry Cocoa SDK
+            // o.? = options.InitCacheFlushTimeout;
+            // o.? = options.MaxQueueItems;
+            // o.? = options.ShutdownTimeout;
 
             // NOTE: options.CacheDirectoryPath - No option for this in Sentry Cocoa, but caching is still enabled
             // https://github.com/getsentry/sentry-cocoa/issues/1051
@@ -76,77 +74,43 @@ public static partial class SentrySdk
                 }
             }
 
-            // TODO: Work on below (copied from Android implementation - needs updating)
-
+            // TODO: Finish SentryEventExtensions to enable this
             // if (options.iOS.EnableCocoaSdkBeforeSend && options.BeforeSend is { } beforeSend)
             // {
             //     // Note: Nullable return is allowed but delegate is generated incorrectly
             //     o.BeforeSend = evt => beforeSend(evt.ToSentryEvent(o))?.ToCocoaSentryEvent(options, o)!;
             // }
 
-            //
-            //         // These options we have behind feature flags
-            //         if (options.Android.EnableAndroidSdkTracing)
-            //         {
-            //             o.TracesSampleRate = (JavaDouble?)options.TracesSampleRate;
-            //
-            //             if (options.TracesSampler is { } tracesSampler)
-            //             {
-            //                 o.TracesSampler = new TracesSamplerCallback(tracesSampler);
-            //             }
-            //         }
-            //
-            //         if (options.Android.EnableAndroidSdkBeforeSend && options.BeforeSend is { } beforeSend)
-            //         {
-            //             o.BeforeSend = new BeforeSendCallback(beforeSend, options, o);
-            //         }
-            //
-            //         // These options are from SentrycocoaOptions
-            //         o.AttachScreenshot = options.Android.AttachScreenshot;
-            //         o.AnrEnabled = options.Android.AnrEnabled;
-            //         o.AnrReportInDebug = options.Android.AnrReportInDebug;
-            //         o.AnrTimeoutIntervalMillis = (long)options.Android.AnrTimeoutInterval.TotalMilliseconds;
-            //         o.EnableActivityLifecycleBreadcrumbs = options.Android.EnableActivityLifecycleBreadcrumbs;
-            //         o.EnableAutoActivityLifecycleTracing = options.Android.EnableAutoActivityLifecycleTracing;
-            //         o.EnableActivityLifecycleTracingAutoFinish = options.Android.EnableActivityLifecycleTracingAutoFinish;
-            //         o.EnableAppComponentBreadcrumbs = options.Android.EnableAppComponentBreadcrumbs;
-            //         o.EnableAppLifecycleBreadcrumbs = options.Android.EnableAppLifecycleBreadcrumbs;
-            //         o.EnableSystemEventBreadcrumbs = options.Android.EnableSystemEventBreadcrumbs;
-            //         o.EnableUserInteractionBreadcrumbs = options.Android.EnableUserInteractionBreadcrumbs;
-            //         o.EnableUserInteractionTracing = options.Android.EnableUserInteractionTracing;
-            //         o.ProfilingTracesIntervalMillis = (int)options.Android.ProfilingTracesInterval.TotalMilliseconds;
-            //
-            //         // These options are in Java.SentryOptions but not ours
-            //         o.AttachThreads = options.Android.AttachThreads;
-            //         o.ConnectionTimeoutMillis = (int)options.Android.ConnectionTimeout.TotalMilliseconds;
-            //         o.Dist = options.Android.Distribution;
-            //         o.EnableNdk = options.Android.EnableNdk;
-            //         o.EnableShutdownHook = options.Android.EnableShutdownHook;
-            //         o.EnableUncaughtExceptionHandler = options.Android.EnableUncaughtExceptionHandler;
-            //         o.ProfilingEnabled = options.Android.ProfilingEnabled;
-            //         o.PrintUncaughtStackTrace = options.Android.PrintUncaughtStackTrace;
-            //         o.ReadTimeoutMillis = (int)options.Android.ReadTimeout.TotalMilliseconds;
-            //
-            //         // In-App Excludes and Includes to be passed to the Android SDK
-            //         options.Android.InAppExclude?.ToList().ForEach(x => o.AddInAppExclude(x));
-            //         options.Android.InAppInclude?.ToList().ForEach(x => o.AddInAppInclude(x));
-            //
-            //         // These options are intentionally set and not exposed for modification
-            //         o.EnableExternalConfiguration = false;
-            //         o.EnableDeduplication = false;
-            //         o.AttachServerName = false;
+            // These options are from Cocoa's SentryOptions
+            o.AttachScreenshot = options.iOS.AttachScreenshot;
+            o.AppHangTimeoutInterval = options.iOS.AppHangTimeoutInterval.TotalSeconds;
+            o.IdleTimeout = options.iOS.IdleTimeout.TotalSeconds;
+            o.Dist = options.iOS.Distribution;
+            o.EnableAppHangTracking = options.iOS.EnableAppHangTracking;
+            o.EnableAutoBreadcrumbTracking = options.iOS.EnableAutoBreadcrumbTracking;
+            o.EnableAutoPerformanceTracking = options.iOS.EnableAutoPerformanceTracking;
+            o.EnableAutoSessionTracking = options.iOS.EnableAutoSessionTracking;
+            o.EnableCoreDataTracking = options.iOS.EnableCoreDataTracking;
+            o.EnableFileIOTracking = options.iOS.EnableFileIOTracking;
+            o.EnableNetworkBreadcrumbs = options.iOS.EnableNetworkBreadcrumbs;
+            o.EnableNetworkTracking = options.iOS.EnableNetworkTracking;
+            o.EnableOutOfMemoryTracking = options.iOS.EnableOutOfMemoryTracking;
+            o.EnableProfiling = options.iOS.EnableProfiling;
+            o.EnableSwizzling = options.iOS.EnableSwizzling;
+            o.EnableUIViewControllerTracking = options.iOS.EnableUIViewControllerTracking;
+            o.EnableUserInteractionTracing = options.iOS.EnableUserInteractionTracing;
+            o.StitchAsyncCode = options.iOS.StitchAsyncCode;
 
             // In-App Excludes and Includes to be passed to the Cocoa SDK
             options.iOS.InAppExcludes?.ForEach(x => o.AddInAppExclude(x));
             options.iOS.InAppIncludes?.ForEach(x => o.AddInAppInclude(x));
 
-            //
-            //         // These options are intentionally not expose or modified
-            //         //o.MaxRequestBodySize   // N/A for Android apps
-            //         //o.MaxSpans             // See https://github.com/getsentry/sentry-dotnet/discussions/1698
-            //
-            //         // Don't capture managed exceptions in the native SDK, since we already capture them in the managed SDK
-            //         o.AddIgnoredExceptionForType(JavaClass.ForName("android.runtime.JavaProxyThrowable"));
+            // These options are intentionally not expose or modified
+            // o.Enabled;
+            // o.SdkInfo
+
+            // // Don't capture managed exceptions in the native SDK, since we already capture them in the managed SDK
+            // o.AddIgnoredExceptionForType(JavaClass.ForName("android.runtime.JavaProxyThrowable"));
 
         });
 

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -78,6 +78,12 @@ public static partial class SentrySdk
 
             // TODO: Work on below (copied from Android implementation - needs updating)
 
+            // if (options.iOS.EnableCocoaSdkBeforeSend && options.BeforeSend is { } beforeSend)
+            // {
+            //     // Note: Nullable return is allowed but delegate is generated incorrectly
+            //     o.BeforeSend = evt => beforeSend(evt.ToSentryEvent(o))?.ToCocoaSentryEvent(options, o)!;
+            // }
+
             //
             //         // These options we have behind feature flags
             //         if (options.Android.EnableAndroidSdkTracing)

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -123,6 +123,8 @@ public static partial class SentrySdk
             // But we also get a native SIGABRT since it crashed the application, which is sent by the Sentry Cocoa SDK.
             // This is partially due to our setting ObjCRuntime.MarshalManagedExceptionMode.UnwindNativeCode above.
             // Thankfully, we can see Xamarin's unhandled exception handler on the stack trace, so we can filter them out.
+            // Here is the function that calls abort(), which we will use as a filter:
+            // https://github.com/xamarin/xamarin-macios/blob/c55fbdfef95028ba03d0f7a35aebca03bd76f852/runtime/runtime.m#L1114-L1122
             o.BeforeSend = evt =>
             {
                 // There should only be one exception on the event in this case

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -64,7 +64,19 @@ public static partial class SentrySdk
                     .ToCocoaBreadcrumb()!;
             }
 
-            // TOOD: Work on below (copied from Android)
+            // These options we have behind feature flags
+            if (options.iOS.EnableCocoaSdkTracing)
+            {
+                o.TracesSampleRate = options.TracesSampleRate;
+
+                if (options.TracesSampler is { } tracesSampler)
+                {
+                    // Note: Nullable return is allowed but delegate is generated incorrectly
+                    o.TracesSampler = context => tracesSampler(context.ToTransactionSamplingContext())!;
+                }
+            }
+
+            // TODO: Work on below (copied from Android implementation - needs updating)
 
             //
             //         // These options we have behind feature flags

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -54,7 +54,8 @@ public static partial class SentrySdk
             // NOTE: options.CacheDirectoryPath - No option for this in Sentry Cocoa, but caching is still enabled
             // https://github.com/getsentry/sentry-cocoa/issues/1051
 
-            // o.??? = options.DefaultTags
+            // NOTE: Tags in options.DefaultTags should not be passed down, because we already call SetTag on each
+            //       one when sending events, which is relayed through the scope observer.
 
             if (options.BeforeBreadcrumb is { } beforeBreadcrumb)
             {

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -23,7 +23,7 @@ public static partial class SentrySdk
 
         // Now initialize the Cocoa SDK
         SentryCocoa.SentryOptions? cocoaOptions = null;
-        SentryCocoa.SentrySdk.StartWithConfigureOptions(o =>
+        SentryCocoaSdk.StartWithConfigureOptions(o =>
         {
             // Capture the Cocoa options reference on the outer scope
             cocoaOptions = o;
@@ -147,7 +147,7 @@ public static partial class SentrySdk
 
         // Set options for the managed SDK that depend on the Cocoa SDK
         options.AddEventProcessor(new IosEventProcessor(cocoaOptions!));
-        options.CrashedLastRun = () => SentryCocoa.SentrySdk.CrashedLastRun;
+        options.CrashedLastRun = () => SentryCocoaSdk.CrashedLastRun;
         options.EnableScopeSync = true;
         options.ScopeObserver = new IosScopeObserver(options);
 

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -572,7 +572,7 @@ namespace Sentry
         /// </remarks>
         public TimeSpan AutoSessionTrackingInterval { get; set; } = TimeSpan.FromSeconds(30);
 
-#if ANDROID
+#if ANDROID || IOS || MACCATALYST
         /// <summary>
         /// Whether the SDK should start a session automatically when it's initialized and
         /// end the session when it's closed.

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -500,7 +500,7 @@ namespace Sentry
                     break;
 #elif IOS || MACCATALYST
                 case CrashType.Native:
-                    SentryCocoa.SentrySdk.Crash();
+                    SentryCocoaSdk.Crash();
                     break;
 #endif
                 default:

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -500,7 +500,7 @@ namespace Sentry
                     break;
 #elif IOS || MACCATALYST
                 case CrashType.Native:
-                    SentryCocoa.SentrySDK.Crash();
+                    SentryCocoa.SentrySdk.Crash();
                     break;
 #endif
                 default:


### PR DESCRIPTION
- Sets the default options for the Cocoa SDK
- Added several internal extension methods to deal with various mappings between .NET and Objective-C data types
- Connect `BeforeBreadcrumb` on the Cocoa SDK
- Prevented duplicate events on unhandled managed crash by filtering out the corresponding native SIGABRT event

A few minor fixes along the way:
- Fixed the MAUI sample app crashing on startup on iOS
- Updated some `#if` statements
- Fixed some typos
- Set defaults explicitly for the Android options
- Fixed a bug with `DefaultTags` being duplicated in the Android SDK
- Aliased a few common types

Next to do (separate PRs coming for these)
- Finish connecting `BeforeSend` and `OnCrashedLastRun`, both which need `SentryEvent` to/from working.
  - Started on this - code is commented out in this PR.
- Gather device and context info in `IosScopeObserver`
- Need to move the `Distribution` option into the main SDK. 