### PR TITLE
fix: Skip attachment if stream is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fix logging loop with NLog sentry ([#1824](https://github.com/getsentry/sentry-dotnet/pull/1824))
 - Fix logging loop with Serilog sentry ([#1828](https://github.com/getsentry/sentry-dotnet/pull/1828))
+- Skip attachment if stream is empty ([#1854](https://github.com/getsentry/sentry-dotnet/pull/1854))
 
 ## 3.20.1
 

--- a/src/Sentry/Envelopes/Envelope.cs
+++ b/src/Sentry/Envelopes/Envelope.cs
@@ -183,7 +183,7 @@ namespace Sentry.Protocol.Envelopes
                         // We pull the stream out here so we can length check
                         // to avoid adding an invalid attachment
                         var stream = attachment.Content.GetStream();
-                        if (stream.Length != 0)
+                        if (stream.TryGetLength() != 0)
                         {
                             items.Add(EnvelopeItem.FromAttachment(attachment, stream));
                         }

--- a/src/Sentry/Envelopes/Envelope.cs
+++ b/src/Sentry/Envelopes/Envelope.cs
@@ -180,14 +180,17 @@ namespace Sentry.Protocol.Envelopes
                 {
                     try
                     {
-                        var envelopeItem = EnvelopeItem.FromAttachment(attachment);
-                        if (envelopeItem is not null)
+                        // We pull the stream out here so we can length check
+                        // to avoid adding an invalid attachment
+                        var stream = attachment.Content.GetStream();
+                        if (stream.Length != 0)
                         {
-                            items.Add(envelopeItem);
+                            items.Add(EnvelopeItem.FromAttachment(attachment, stream));
                         }
                         else
                         {
-                            logger?.LogWarning("Did not add '{0}' to envelope. Stream might be empty.", attachment.FileName);
+                            logger?.LogWarning("Did not add '{0}' to envelope because the stream was empty.",
+                                attachment.FileName);
                         }
                     }
                     catch (Exception exception)

--- a/src/Sentry/Envelopes/Envelope.cs
+++ b/src/Sentry/Envelopes/Envelope.cs
@@ -180,7 +180,15 @@ namespace Sentry.Protocol.Envelopes
                 {
                     try
                     {
-                        items.Add(EnvelopeItem.FromAttachment(attachment));
+                        var envelopeItem = EnvelopeItem.FromAttachment(attachment);
+                        if (envelopeItem is not null)
+                        {
+                            items.Add(envelopeItem);
+                        }
+                        else
+                        {
+                            logger?.LogWarning("Did not add '{0}' to envelope. Stream might be empty.", attachment.FileName);
+                        }
                     }
                     catch (Exception exception)
                     {

--- a/src/Sentry/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Envelopes/EnvelopeItem.cs
@@ -259,9 +259,13 @@ namespace Sentry.Protocol.Envelopes
         /// <summary>
         /// Creates an <see cref="EnvelopeItem"/> from <paramref name="attachment"/>.
         /// </summary>
-        public static EnvelopeItem FromAttachment(Attachment attachment)
+        public static EnvelopeItem? FromAttachment(Attachment attachment)
         {
             var stream = attachment.Content.GetStream();
+            if (stream.Length == 0)
+            {
+                return null;
+            }
 
             var attachmentType = attachment.Type switch
             {

--- a/src/Sentry/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Envelopes/EnvelopeItem.cs
@@ -259,14 +259,14 @@ namespace Sentry.Protocol.Envelopes
         /// <summary>
         /// Creates an <see cref="EnvelopeItem"/> from <paramref name="attachment"/>.
         /// </summary>
-        public static EnvelopeItem? FromAttachment(Attachment attachment)
+        public static EnvelopeItem FromAttachment(Attachment attachment)
         {
             var stream = attachment.Content.GetStream();
-            if (stream.Length == 0)
-            {
-                return null;
-            }
+            return FromAttachment(attachment, stream);
+        }
 
+        internal static EnvelopeItem FromAttachment(Attachment attachment, Stream stream)
+        {
             var attachmentType = attachment.Type switch
             {
                 AttachmentType.Minidump => "event.minidump",

--- a/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
@@ -700,6 +700,20 @@ public class EnvelopeTests
     }
 
     [Fact]
+    public void FromEvent_EmptyAttachmentStream_DoesNotIncludeAttachment()
+    {
+        // Arrange
+        var attachment = new Attachment(default, new StreamAttachmentContent(new MemoryStream()), "Screenshot.jpg",
+            "image/jpg");
+
+        // Act
+        var envelope = Envelope.FromEvent(new SentryEvent(), attachments: new List<Attachment> { attachment });
+
+        // Assert
+        envelope.Items.Should().HaveCount(1);
+    }
+
+    [Fact]
     public async Task Serialization_RoundTrip_ReplacesSentAtHeader()
     {
         // Arrange

--- a/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
@@ -538,9 +538,11 @@ public class EnvelopeTests
             Sdk = new SdkVersion { Name = "SDK-test", Version = "1.0.0" }
         };
 
+        using var attachmentStream = new MemoryStream(new byte[] {1, 2, 3});
+
         var attachment = new Attachment(
             AttachmentType.Default,
-            new StreamAttachmentContent(Stream.Null),
+            new StreamAttachmentContent(attachmentStream),
             "file.txt",
             null);
 
@@ -573,9 +575,11 @@ public class EnvelopeTests
             Sdk = new SdkVersion { Name = "SDK-test", Version = "1.0.0" }
         };
 
+        using var attachmentStream = new MemoryStream(new byte[] {1, 2, 3});
+
         var attachment = new Attachment(
             AttachmentType.Default,
-            new StreamAttachmentContent(Stream.Null),
+            new StreamAttachmentContent(attachmentStream),
             "file.txt",
             null);
 

--- a/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
@@ -707,7 +707,10 @@ public class EnvelopeTests
     public void FromEvent_EmptyAttachmentStream_DoesNotIncludeAttachment()
     {
         // Arrange
-        var attachment = new Attachment(default, new StreamAttachmentContent(new MemoryStream()), "Screenshot.jpg",
+        var attachment = new Attachment(
+            default,
+            new StreamAttachmentContent(Stream.Null),
+            "Screenshot.jpg",
             "image/jpg");
 
         // Act


### PR DESCRIPTION
Background: In Unity, we attach a screenshot attachment to the scope so when `GetStream` gets called we return a MemoryStream. In some circumstances, i.e. on a background thread, we cannot actually capture the screen and we return an empty MemoryStream. 

To avoid adding an empty `EnvelopeItem` we check for it first and warn.