### PR TITLE
Set default `Release` and `Distribution` for iOS and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add Mac Catalyst target ([#1848](https://github.com/getsentry/sentry-dotnet/pull/1848))
 - Add `Distribution` properties ([#1851](https://github.com/getsentry/sentry-dotnet/pull/1851))
 - Add and configure options for the iOS SDK ([#1849](https://github.com/getsentry/sentry-dotnet/pull/1849))
+- Set default `Release` and `Distribution` for iOS and Android ([#1856](https://github.com/getsentry/sentry-dotnet/pull/1856))
 
 ### Fixes
 

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -18,6 +18,10 @@ public static partial class SentrySdk
         options.AutoSessionTracking = true;
         options.IsGlobalModeEnabled = true;
 
+        // Set default release and distribution
+        options.Release ??= GetDefaultReleaseString();
+        options.Distribution ??= GetDefaultDistributionString();
+
         // "Best" mode throws platform not supported exception.  Use "Fast" mode instead.
         options.DetectStartupTime = StartupTimeDetectionMode.Fast;
 
@@ -174,4 +178,17 @@ public static partial class SentrySdk
 
         // TODO: Pause/Resume
     }
+
+    private static string GetDefaultReleaseString()
+    {
+        var packageName = GetBundleValue("CFBundleIdentifier");
+        var packageVersion = GetBundleValue("CFBundleShortVersionString");
+        var buildVersion = GetBundleValue("CFBundleVersion");
+
+        return $"{packageName}@{packageVersion}+{buildVersion}";
+    }
+
+    private static string GetDefaultDistributionString() => GetBundleValue("CFBundleVersion");
+
+    private static string GetBundleValue(string key) => NSBundle.MainBundle.ObjectForInfoDictionary(key).ToString();
 }


### PR DESCRIPTION
Sets the default `Release` and `Distribution` values for iOS and Android.

Example:
- Release: `"myapp@1.2.3+456"`
- Distribution: `"456"`

This copies the behavior from the Sentry iOS and Android SDKs.