### PR TITLE
Obsolete AdjustStandardEnvironmentNameCasing with workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix logging loop with Serilog sentry ([#1828](https://github.com/getsentry/sentry-dotnet/pull/1828))
 - Skip attachment if stream is empty ([#1854](https://github.com/getsentry/sentry-dotnet/pull/1854))
 - Allow some mobile options to be modified from defaults ([#1857](https://github.com/getsentry/sentry-dotnet/pull/1857))
+- Obsolete AdjustStandardEnvironmentNameCasing with workaround ([#1860](https://github.com/getsentry/sentry-dotnet/pull/1860))
 
 ## 3.20.1
 

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
@@ -60,10 +60,12 @@ public class SentryAspNetCoreOptions : SentryLoggingOptions
     /// The default .NET Core environment names include Production, Development and Staging (note Pascal casing), whereas Sentry prefers
     /// to have its environment setting be all lower case.
     /// </remarks>
-    [Obsolete(@"Not supported via code. Instead set the value in appsettings.json:
-   ""Sentry"": {
-    ""AdjustStandardEnvironmentNameCasing"": false
-  }")]
+    [Obsolete(@"Not supported via code.
+https://github.com/getsentry/sentry-dotnet/pull/1860
+Instead set the value in appsettings.json:
+""Sentry"": {
+  ""AdjustStandardEnvironmentNameCasing"": false
+}")]
     public bool AdjustStandardEnvironmentNameCasing { get; set; } = true;
 
     /// <summary>

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
@@ -60,6 +60,10 @@ public class SentryAspNetCoreOptions : SentryLoggingOptions
     /// The default .NET Core environment names include Production, Development and Staging (note Pascal casing), whereas Sentry prefers
     /// to have its environment setting be all lower case.
     /// </remarks>
+    [Obsolete(@"Not supported via code. Instead set the value in appsettings.json:
+   ""Sentry"": {
+    ""AdjustStandardEnvironmentNameCasing"": false
+  }")]
     public bool AdjustStandardEnvironmentNameCasing { get; set; } = true;
 
     /// <summary>

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
@@ -40,7 +40,9 @@ namespace Sentry.AspNetCore
             //       We only need to do anything here if nothing was found by the locator.
             if (options.SettingLocator.GetEnvironment(useDefaultIfNotFound: false) is null)
             {
+#pragma warning disable CS0618
                 if (!options.AdjustStandardEnvironmentNameCasing)
+#pragma warning restore CS0618
                 {
                     options.Environment = _hostingEnvironment.EnvironmentName;
                 }

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -40,6 +40,9 @@ namespace Sentry.AspNetCore
     public class SentryAspNetCoreOptions : Sentry.Extensions.Logging.SentryLoggingOptions
     {
         public SentryAspNetCoreOptions() { }
+        [System.Obsolete("Not supported via code.\\r\\nhttps://github.com/getsentry/sentry-dotnet/pull/1860\\r" +
+            "\\nInstead set the value in appsettings.json:\\r\\n\"Sentry\": {\\r\\n  \"AdjustStandard" +
+            "EnvironmentNameCasing\": false\\r\\n}")]
         public bool AdjustStandardEnvironmentNameCasing { get; set; }
         public bool FlushOnCompletedRequest { get; set; }
         public System.TimeSpan FlushTimeout { get; set; }

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -40,6 +40,9 @@ namespace Sentry.AspNetCore
     public class SentryAspNetCoreOptions : Sentry.Extensions.Logging.SentryLoggingOptions
     {
         public SentryAspNetCoreOptions() { }
+        [System.Obsolete("Not supported via code.\\r\\nhttps://github.com/getsentry/sentry-dotnet/pull/1860\\r" +
+            "\\nInstead set the value in appsettings.json:\\r\\n\"Sentry\": {\\r\\n  \"AdjustStandard" +
+            "EnvironmentNameCasing\": false\\r\\n}")]
         public bool AdjustStandardEnvironmentNameCasing { get; set; }
         public bool FlushOnCompletedRequest { get; set; }
         public System.TimeSpan FlushTimeout { get; set; }

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -40,6 +40,9 @@ namespace Sentry.AspNetCore
     public class SentryAspNetCoreOptions : Sentry.Extensions.Logging.SentryLoggingOptions
     {
         public SentryAspNetCoreOptions() { }
+        [System.Obsolete("Not supported via code.\\r\\nhttps://github.com/getsentry/sentry-dotnet/pull/1860\\r" +
+            "\\nInstead set the value in appsettings.json:\\r\\n\"Sentry\": {\\r\\n  \"AdjustStandard" +
+            "EnvironmentNameCasing\": false\\r\\n}")]
         public bool AdjustStandardEnvironmentNameCasing { get; set; }
         public bool FlushOnCompletedRequest { get; set; }
         public System.TimeSpan FlushTimeout { get; set; }

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -40,6 +40,9 @@ namespace Sentry.AspNetCore
     public class SentryAspNetCoreOptions : Sentry.Extensions.Logging.SentryLoggingOptions
     {
         public SentryAspNetCoreOptions() { }
+        [System.Obsolete("Not supported via code.\\r\\nhttps://github.com/getsentry/sentry-dotnet/pull/1860\\r" +
+            "\\nInstead set the value in appsettings.json:\\r\\n\"Sentry\": {\\r\\n  \"AdjustStandard" +
+            "EnvironmentNameCasing\": false\\r\\n}")]
         public bool AdjustStandardEnvironmentNameCasing { get; set; }
         public bool FlushOnCompletedRequest { get; set; }
         public System.TimeSpan FlushTimeout { get; set; }

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -40,6 +40,9 @@ namespace Sentry.AspNetCore
     public class SentryAspNetCoreOptions : Sentry.Extensions.Logging.SentryLoggingOptions
     {
         public SentryAspNetCoreOptions() { }
+        [System.Obsolete("Not supported via code.\\r\\nhttps://github.com/getsentry/sentry-dotnet/pull/1860\\r" +
+            "\\nInstead set the value in appsettings.json:\\r\\n\"Sentry\": {\\r\\n  \"AdjustStandard" +
+            "EnvironmentNameCasing\": false\\r\\n}")]
         public bool AdjustStandardEnvironmentNameCasing { get; set; }
         public bool FlushOnCompletedRequest { get; set; }
         public System.TimeSpan FlushTimeout { get; set; }

--- a/test/Sentry.AspNetCore.Tests/SentryAspNetCoreOptionsSetupTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryAspNetCoreOptionsSetupTests.cs
@@ -90,7 +90,9 @@ public class SentryAspNetCoreOptionsSetupTests
             hostingEnvironment);
 
         _target.Environment = environment;
+#pragma warning disable CS0618
         _target.AdjustStandardEnvironmentNameCasing = adjustStandardEnvironmentNameCasingSetting;
+#pragma warning restore CS0618
 
         // Act.
         sut.Configure(_target);


### PR DESCRIPTION
Resolves #1267

Doe to the order of executrion, setting `AdjustStandardEnvironmentNameCasing` via a callback is ignored.

```
 .ConfigureWebHostDefaults(webBuilder =>
  {
      webBuilder.UseSentry(o =>
      {
         // ignored
          o.AdjustStandardEnvironmentNameCasing = false;
      });

      webBuilder.UseStartup<Startup>();
  });
```

The current workaround is to set it in AppSettings

```
 "Sentry": {
    "AdjustStandardEnvironmentNameCasing": false
  }
```

Given the eventual fix is [to make sentry server side case insensitive for environment](https://github.com/getsentry/sentry/issues/6568), it it not worth investing in a fix for this client side. 

So instead obsolete `AdjustStandardEnvironmentNameCasing` with a message that pionts to the AppSettings workaround.

`AdjustStandardEnvironmentNameCasing` will then be removed in the major after https://github.com/getsentry/sentry/issues/6568 is resolved

