### PR TITLE
Misc fixes for iOS

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.300",
+    "version": "6.0.400",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }

--- a/samples/Sentry.Samples.Ios/AppDelegate.cs
+++ b/samples/Sentry.Samples.Ios/AppDelegate.cs
@@ -23,11 +23,18 @@ public class AppDelegate : UIApplicationDelegate
         // create a new window instance based on the screen size
         Window = new UIWindow(UIScreen.MainScreen.Bounds);
 
+        // determine the background color for the view (SystemBackground requires iOS >= 13.0)
+        var backgroundColor = UIDevice.CurrentDevice.CheckSystemVersion(13, 0)
+#pragma warning disable CA1416
+            ? UIColor.SystemBackground
+#pragma warning restore CA1416
+            : UIColor.White;
+
         // create a UIViewController with a single UILabel
         var vc = new UIViewController();
         vc.View!.AddSubview(new UILabel(Window!.Frame)
         {
-            BackgroundColor = UIColor.SystemBackground,
+            BackgroundColor = backgroundColor,
             TextAlignment = UITextAlignment.Center,
             Text = "Hello, iOS!",
             AutoresizingMask = UIViewAutoresizing.All,

--- a/samples/Sentry.Samples.Ios/Info.plist
+++ b/samples/Sentry.Samples.Ios/Info.plist
@@ -5,7 +5,7 @@
     <key>CFBundleDisplayName</key>
     <string>Sentry.Samples.Ios</string>
     <key>CFBundleIdentifier</key>
-    <string>com.companyname.Sentry.Samples.Ios</string>
+    <string>io.sentry.dotnet.samples.ios</string>
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
     <key>CFBundleVersion</key>

--- a/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
+++ b/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
-    <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
 

--- a/samples/Sentry.Samples.MacCatalyst/Info.plist
+++ b/samples/Sentry.Samples.MacCatalyst/Info.plist
@@ -5,7 +5,7 @@
     <key>CFBundleDisplayName</key>
     <string>Sentry.Samples.MacCatalyst</string>
     <key>CFBundleIdentifier</key>
-    <string>com.companyname.Sentry.Samples.MacCatalyst</string>
+    <string>io.sentry.dotnet.samples.maccatalyst</string>
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
     <key>CFBundleVersion</key>

--- a/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
+++ b/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
@@ -26,8 +26,8 @@
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
 
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>

--- a/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
+++ b/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
@@ -19,7 +19,7 @@
     <ApplicationTitle>Sentry.Samples.Maui</ApplicationTitle>
 
     <!-- App Identifier -->
-    <ApplicationId>io.sentry.samples.maui</ApplicationId>
+    <ApplicationId>io.sentry.dotnet.samples.maui</ApplicationId>
     <ApplicationIdGuid>52a4f672-a7ff-471e-bc74-fd81d6e28e53</ApplicationIdGuid>
 
     <!-- Versions -->

--- a/src/Sentry.Maui/Sentry.Maui.csproj
+++ b/src/Sentry.Maui/Sentry.Maui.csproj
@@ -30,11 +30,10 @@
 
     <!--
       As long as we are using platform-specific targets, we have to set some default supported versions.
-      TODO: These are the same ones used in the MAUI sample app.  Investigate if we can/should go lower.
     -->
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sentry/Platforms/iOS/Bindings/ApiDefinitions.cs
+++ b/src/Sentry/Platforms/iOS/Bindings/ApiDefinitions.cs
@@ -64,7 +64,7 @@ interface Constants
 // delegate void SentryOnAppStartMeasurementAvailable ([NullAllowed] SentryAppStartMeasurement arg0);
 
 // @interface PrivateSentrySDKOnly : NSObject
-[BaseType (typeof(NSObject))]
+[BaseType (typeof(NSObject), Name="PrivateSentrySDKOnly")]
 [Internal]
 interface PrivateSentrySdkOnly
 {
@@ -1389,7 +1389,7 @@ interface SentryNSError : SentrySerializable
 }
 
 // @interface SentrySDK : NSObject
-[BaseType (typeof(NSObject))]
+[BaseType (typeof(NSObject), Name="SentrySDK")]
 [DisableDefaultCtor]
 [Internal]
 interface SentrySdk

--- a/src/Sentry/Platforms/iOS/Sentry.iOS.props
+++ b/src/Sentry/Platforms/iOS/Sentry.iOS.props
@@ -55,15 +55,4 @@
     />
   </Target>
 
-  <!--
-    Workaround for https://github.com/dotnet/msbuild/issues/4584 needed when packing in 6.0.3xx
-    Remove when 6.0.4xx is released, and bump SDK version global.json.
-  -->
-  <Target Name="RemoveInvalidManifest" AfterTargets="BuiltProjectOutputGroup">
-    <ItemGroup Condition="!Exists('$(OutDir)$(_DeploymentTargetApplicationManifestFileName)')">
-      <BuiltProjectOutputGroupOutput Remove="$([System.IO.Path]::GetFullPath('$(OutDir)$(_DeploymentTargetApplicationManifestFileName)'))" />
-    </ItemGroup>
-  </Target>
-
-
 </Project>


### PR DESCRIPTION
- Lower the required iOS platform version to 10.0
- Lower the required MacCatalyst platform version to 13.1
- Updated some sample code to work with the lower targets
- Updated the bundle identifiers for the sample apps
- Fix some binding issues related to case-sensitivity of class names
- Update to .NET SDK 6.0.400

#skip-changelog