### PR TITLE
Misc cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -185,6 +185,7 @@ csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
+resharper_wrap_object_and_collection_initializer_style = chop_always
 
 # Declaring a local variable as const
 dotnet_diagnostic.RCS1118.severity = silent

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -29,6 +29,8 @@ namespace Sentry.Internal
         private int _isEnabled = 1;
         public bool IsEnabled => _isEnabled == 1;
 
+        internal SentryOptions Options => _options;
+
         internal Hub(
             SentryOptions options,
             ISentryClient? client = null,

--- a/src/Sentry/PlatformAbstractions/FrameworkInfo.NetFx.cs
+++ b/src/Sentry/PlatformAbstractions/FrameworkInfo.NetFx.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Win32;
+using Sentry.Extensibility;
 
 namespace Sentry.PlatformAbstractions
 {
@@ -177,8 +178,16 @@ namespace Sentry.PlatformAbstractions
             return ndpKey?.GetInt("Release");
         }
 
-        private static Version? GetNetFxVersionFromRelease(int release) =>
-            NetFxReleaseVersionMap.TryGetValue(release, out var version) ? Version.Parse(version) : null;
+        private static Version? GetNetFxVersionFromRelease(int release)
+        {
+            if (NetFxReleaseVersionMap.TryGetValue(release, out var version))
+            {
+                return Version.Parse(version);
+            }
+
+            SentrySdk.CurrentOptions?.LogWarning("Could not determine .NET Framework version for release {0}.", release);
+            return null;
+        }
     }
 }
 

--- a/src/Sentry/PlatformAbstractions/FrameworkInfo.NetStandard.cs
+++ b/src/Sentry/PlatformAbstractions/FrameworkInfo.NetStandard.cs
@@ -1,4 +1,4 @@
-#if !NET461
+#if !NETFRAMEWORK
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Sentry/PlatformAbstractions/FrameworkInstallation.cs
+++ b/src/Sentry/PlatformAbstractions/FrameworkInstallation.cs
@@ -16,6 +16,7 @@ namespace Sentry.PlatformAbstractions
         /// v2.0.50727, v3.5, v4.0
         /// </example>
         public string? ShortName { get; set; }
+
         /// <summary>
         /// Version
         /// </summary>
@@ -23,6 +24,7 @@ namespace Sentry.PlatformAbstractions
         /// 2.0.50727.4927, 3.0.30729.4926, 3.5.30729.4926
         /// </example>
         public Version? Version { get; set; }
+
         /// <summary>
         /// Service pack number, if any
         /// </summary>
@@ -30,12 +32,14 @@ namespace Sentry.PlatformAbstractions
         /// Only relevant prior to .NET 4
         /// </remarks>
         public int? ServicePack { get; set; }
+
         /// <summary>
         /// Type of Framework profile
         /// </summary>
         /// <remarks>Only relevant for .NET 3.5 and 4.0</remarks>
         /// <seealso href="https://docs.microsoft.com/en-us/dotnet/framework/deployment/client-profile"/>
         public FrameworkProfile? Profile { get; set; }
+
         /// <summary>
         ///  A .NET Framework release key
         /// </summary>
@@ -67,6 +71,7 @@ namespace Sentry.PlatformAbstractions
         /// The .NET Client Profile is a subset of the .NET Framework
         /// </summary>
         Client,
+
         /// <summary>
         /// The full .NET Framework
         /// </summary>

--- a/src/Sentry/PlatformAbstractions/FrameworkInstallationExtensions.cs
+++ b/src/Sentry/PlatformAbstractions/FrameworkInstallationExtensions.cs
@@ -2,7 +2,7 @@ namespace Sentry.PlatformAbstractions
 {
     internal static class FrameworkInstallationExtensions
     {
-        internal static string? GetVersionNumber(this FrameworkInstallation frameworkInstall)
+        internal static string? GetVersionNumber(this FrameworkInstallation? frameworkInstall)
             => frameworkInstall?.ShortName
                 ?? (frameworkInstall?.Version != null ? $"v{frameworkInstall.Version}" : null);
     }

--- a/src/Sentry/PlatformAbstractions/RuntimeExtensions.cs
+++ b/src/Sentry/PlatformAbstractions/RuntimeExtensions.cs
@@ -15,12 +15,14 @@ namespace Sentry.PlatformAbstractions
         /// <param name="runtime">The runtime instance to check.</param>
         /// <returns>True if it's .NET Framework, otherwise false.</returns>
         public static bool IsNetFx(this Runtime runtime) => runtime.IsRuntime(".NET Framework");
+
         /// <summary>
-        /// Is the runtime instance .NET Core.
+        /// Is the runtime instance .NET Core (or .NET).
         /// </summary>
         /// <param name="runtime">The runtime instance to check.</param>
-        /// <returns>True if it's .NET Core, otherwise false.</returns>
-        public static bool IsNetCore(this Runtime runtime) => runtime.IsRuntime(".NET Core");
+        /// <returns>True if it's .NET Core (or .NET), otherwise false.</returns>
+        public static bool IsNetCore(this Runtime runtime) => runtime.IsRuntime(".NET Core") || runtime.IsRuntime(".NET");
+
         /// <summary>
         /// Is the runtime instance Mono.
         /// </summary>

--- a/src/Sentry/PlatformAbstractions/RuntimeInfo.cs
+++ b/src/Sentry/PlatformAbstractions/RuntimeInfo.cs
@@ -19,30 +19,32 @@ namespace Sentry.PlatformAbstractions
         {
             var runtime = GetFromRuntimeInformation();
             runtime ??= GetFromMonoRuntime();
-
             runtime ??= GetFromEnvironmentVariable();
-            return runtime;
+            return runtime.WithAdditionalProperties();
         }
 
-        internal static void SetAdditionalParameters(Runtime runtime)
+        internal static Runtime WithAdditionalProperties(this Runtime runtime)
         {
-#if NET461
-            SetNetFxReleaseAndVersion(runtime);
+#if NETFRAMEWORK
+            GetNetFxInstallationAndVersion(runtime, out var inst, out var ver);
+            var version = runtime.Version ?? ver;
+            var installation = runtime.FrameworkInstallation ?? inst;
+            return new Runtime(runtime.Name, version, installation, runtime.Raw);
+#elif NET5_0_OR_GREATER
+            var version = runtime.Version ?? GetNetCoreVersion(runtime);
+            var identifier = runtime.Identifier ?? GetRuntimeIdentifier(runtime);
+            return new Runtime(runtime.Name, version, runtime.Raw, identifier);
 #else
-            SetNetCoreVersion(runtime);
-#endif
-#if NET5_0_OR_GREATER
-            SetRuntimeIdentifier(runtime);
+            var version = runtime.Version ?? GetNetCoreVersion(runtime);
+            return new Runtime(runtime.Name, version, runtime.Raw);
 #endif
         }
 
-        internal static Runtime? Parse(string rawRuntimeDescription, string? name = null)
+        internal static Runtime? Parse(string? rawRuntimeDescription, string? name = null)
         {
             if (rawRuntimeDescription == null)
             {
-                return name == null
-                    ? null
-                    : new Runtime(name);
+                return name == null ? null : new Runtime(name);
             }
 
             var match = RuntimeParseRegex.Match(rawRuntimeDescription);
@@ -57,68 +59,76 @@ namespace Sentry.PlatformAbstractions
             return new Runtime(name, raw: rawRuntimeDescription);
         }
 
-#if NET461
-        internal static void SetNetFxReleaseAndVersion(Runtime runtime)
+#if NETFRAMEWORK
+        internal static void GetNetFxInstallationAndVersion(
+            Runtime runtime,
+            out FrameworkInstallation? frameworkInstallation,
+            out string? version)
         {
-            if (runtime?.IsNetFx() == true)
+            if (runtime.IsNetFx() != true)
             {
-                var latest = FrameworkInfo.GetLatest(Environment.Version.Major);
+                frameworkInstallation = null;
+                version = null;
+                return;
+            }
 
-                runtime.FrameworkInstallation = latest;
-                if (latest.Version?.Major < 4)
-                {
-                    // prior to 4, user-friendly versions are always 2 digit: 1.0, 1.1, 2.0, 3.0, 3.5
-                    runtime.Version = latest.ServicePack == null
-                        ? $"{latest.Version.Major}.{latest.Version.Minor}"
-                        : $"{latest.Version.Major}.{latest.Version.Minor} SP {latest.ServicePack}";
-                }
-                else
-                {
-                    runtime.Version = latest.Version?.ToString();
-                }
+            frameworkInstallation = FrameworkInfo.GetLatest(Environment.Version.Major);
+
+            if (frameworkInstallation?.Version?.Major < 4)
+            {
+                // prior to 4, user-friendly versions are always 2 digit: 1.0, 1.1, 2.0, 3.0, 3.5
+                version = frameworkInstallation.ServicePack == null
+                    ? $"{frameworkInstallation.Version.Major}.{frameworkInstallation.Version.Minor}"
+                    : $"{frameworkInstallation.Version.Major}.{frameworkInstallation.Version.Minor} SP {frameworkInstallation.ServicePack}";
+            }
+            else
+            {
+                version = frameworkInstallation?.Version?.ToString();
             }
         }
-#endif
-
-#if !NET461
-        // Known issue on Docker: https://github.com/dotnet/BenchmarkDotNet/issues/448#issuecomment-361027977
-        internal static void SetNetCoreVersion(Runtime runtime)
-        {
-            if (runtime.IsNetCore())
-            {
-                // https://github.com/dotnet/BenchmarkDotNet/issues/448#issuecomment-308424100
-                var assembly = typeof(System.Runtime.GCSettings).GetTypeInfo().Assembly;
-#if NETCOREAPP3_0_OR_GREATER
-                var assemblyPath = assembly.Location.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
 #else
-                var assemblyPath = assembly.CodeBase.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
-#endif
-                var netCoreAppIndex = Array.IndexOf(assemblyPath, "Microsoft.NETCore.App");
-                if (netCoreAppIndex > 0
-                    && netCoreAppIndex < assemblyPath.Length - 2)
-                {
-                    runtime.Version = assemblyPath[netCoreAppIndex + 1];
-                }
+        // Known issue on Docker: https://github.com/dotnet/BenchmarkDotNet/issues/448#issuecomment-361027977
+        private static string? GetNetCoreVersion(Runtime runtime)
+        {
+            if (!runtime.IsNetCore())
+            {
+                return null;
             }
+
+            // https://github.com/dotnet/BenchmarkDotNet/issues/448#issuecomment-308424100
+            var assembly = typeof(System.Runtime.GCSettings).GetTypeInfo().Assembly;
+#if NETCOREAPP3_0_OR_GREATER
+            var assemblyPath = assembly.Location;
+#else
+            var assemblyPath = assembly.CodeBase;
+#endif
+            var parts = assemblyPath.Split(new[] {'/', '\\'}, StringSplitOptions.RemoveEmptyEntries);
+            var netCoreAppIndex = Array.IndexOf(parts, "Microsoft.NETCore.App");
+            if (netCoreAppIndex > 0 && netCoreAppIndex < parts.Length - 2)
+            {
+                return parts[netCoreAppIndex + 1];
+            }
+
+            return null;
         }
 #endif
 
 #if NET5_0_OR_GREATER
-        internal static void SetRuntimeIdentifier(Runtime runtime)
+        internal static string? GetRuntimeIdentifier(Runtime runtime)
         {
             try
             {
-                runtime.Identifier = RuntimeInformation.RuntimeIdentifier;
+                return RuntimeInformation.RuntimeIdentifier;
             }
             catch
             {
+                return null;
             }
         }
 #endif
 
-        internal static Runtime? GetFromRuntimeInformation()
+        private static Runtime? GetFromRuntimeInformation()
         {
-            string frameworkDescription;
             try
             {
                 // Preferred API: netstandard2.0
@@ -126,17 +136,16 @@ namespace Sentry.PlatformAbstractions
                 // https://github.com/mono/mono/blob/90b49aa3aebb594e0409341f9dca63b74f9df52e/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs
                 // e.g: .NET Framework 4.7.2633.0, .NET Native, WebAssembly
                 // Note: this throws on some Unity IL2CPP versions
-                frameworkDescription = RuntimeInformation.FrameworkDescription;
+                var frameworkDescription = RuntimeInformation.FrameworkDescription;
+                return Parse(frameworkDescription);
             }
             catch
             {
                 return null;
             }
-
-            return Parse(frameworkDescription);
         }
 
-        internal static Runtime? GetFromMonoRuntime()
+        private static Runtime? GetFromMonoRuntime()
             => Type.GetType("Mono.Runtime", false)
                 ?.GetMethod("GetDisplayName", BindingFlags.NonPublic | BindingFlags.Static)
                 ?.Invoke(null, null) is string monoVersion
@@ -150,7 +159,7 @@ namespace Sentry.PlatformAbstractions
                 : null;
 
         // This should really only be used on .NET 1.0, 1.1, 2.0, 3.0, 3.5 and 4.0
-        internal static Runtime GetFromEnvironmentVariable()
+        private static Runtime GetFromEnvironmentVariable()
         {
             // Environment.Version: NET Framework 4, 4.5, 4.5.1, 4.5.2 = 4.0.30319.xxxxx
             // .NET Framework 4.6, 4.6.1, 4.6.2, 4.7, 4.7.1 =  4.0.30319.42000

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -22,6 +22,8 @@ namespace Sentry
     {
         private static IHub _hub = DisabledHub.Instance;
 
+        internal static SentryOptions? CurrentOptions => _hub is Hub hub ? hub.Options;
+
         /// <summary>
         /// Last event id recorded in the current scope.
         /// </summary>

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -22,7 +22,7 @@ namespace Sentry
     {
         private static IHub _hub = DisabledHub.Instance;
 
-        internal static SentryOptions? CurrentOptions => _hub is Hub hub ? hub.Options;
+        internal static SentryOptions? CurrentOptions => _hub is Hub hub ? hub.Options : null;
 
         /// <summary>
         /// Last event id recorded in the current scope.

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -1184,6 +1184,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
     {
         public Runtime(string? name = null, string? version = null, string? raw = null, string? identifier = null) { }
+        [set: System.Obsolete("This setter is nonfunctional, and will be removed in a future version.")]
         public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core2_1.verified.txt
@@ -1181,15 +1181,15 @@ namespace Sentry.PlatformAbstractions
         Client = 0,
         Full = 1,
     }
-    public class Runtime
+    public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
     {
-        public Runtime(string? name = null, string? version = null, string? raw = null) { }
+        public Runtime(string? name = null, string? version = null, string? raw = null, string? identifier = null) { }
         public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
         public static Sentry.PlatformAbstractions.Runtime Current { get; }
-        public bool Equals(Sentry.PlatformAbstractions.Runtime other) { }
+        public bool Equals(Sentry.PlatformAbstractions.Runtime? other) { }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string? ToString() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -1184,6 +1184,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
     {
         public Runtime(string? name = null, string? version = null, string? raw = null, string? identifier = null) { }
+        [set: System.Obsolete("This setter is nonfunctional, and will be removed in a future version.")]
         public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_0.verified.txt
@@ -1181,15 +1181,15 @@ namespace Sentry.PlatformAbstractions
         Client = 0,
         Full = 1,
     }
-    public class Runtime
+    public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
     {
-        public Runtime(string? name = null, string? version = null, string? raw = null) { }
+        public Runtime(string? name = null, string? version = null, string? raw = null, string? identifier = null) { }
         public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
         public static Sentry.PlatformAbstractions.Runtime Current { get; }
-        public bool Equals(Sentry.PlatformAbstractions.Runtime other) { }
+        public bool Equals(Sentry.PlatformAbstractions.Runtime? other) { }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string? ToString() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1182,15 +1182,15 @@ namespace Sentry.PlatformAbstractions
         Client = 0,
         Full = 1,
     }
-    public class Runtime
+    public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
     {
-        public Runtime(string? name = null, string? version = null, string? raw = null) { }
+        public Runtime(string? name = null, string? version = null, string? raw = null, string? identifier = null) { }
         public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
         public static Sentry.PlatformAbstractions.Runtime Current { get; }
-        public bool Equals(Sentry.PlatformAbstractions.Runtime other) { }
+        public bool Equals(Sentry.PlatformAbstractions.Runtime? other) { }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string? ToString() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1185,6 +1185,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
     {
         public Runtime(string? name = null, string? version = null, string? raw = null, string? identifier = null) { }
+        [set: System.Obsolete("This setter is nonfunctional, and will be removed in a future version.")]
         public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1181,16 +1181,16 @@ namespace Sentry.PlatformAbstractions
         Client = 0,
         Full = 1,
     }
-    public class Runtime
+    public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
     {
         public Runtime(string? name = null, string? version = null, Sentry.PlatformAbstractions.FrameworkInstallation? frameworkInstallation = null, string? raw = null) { }
-        public Sentry.PlatformAbstractions.FrameworkInstallation FrameworkInstallation { get; }
+        public Sentry.PlatformAbstractions.FrameworkInstallation? FrameworkInstallation { get; }
         public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
         public static Sentry.PlatformAbstractions.Runtime Current { get; }
-        public bool Equals(Sentry.PlatformAbstractions.Runtime other) { }
+        public bool Equals(Sentry.PlatformAbstractions.Runtime? other) { }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string? ToString() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_6.verified.txt
@@ -1185,6 +1185,7 @@ namespace Sentry.PlatformAbstractions
     {
         public Runtime(string? name = null, string? version = null, Sentry.PlatformAbstractions.FrameworkInstallation? frameworkInstallation = null, string? raw = null) { }
         public Sentry.PlatformAbstractions.FrameworkInstallation? FrameworkInstallation { get; }
+        [set: System.Obsolete("This setter is nonfunctional, and will be removed in a future version.")]
         public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1182,15 +1182,15 @@ namespace Sentry.PlatformAbstractions
         Client = 0,
         Full = 1,
     }
-    public class Runtime
+    public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
     {
-        public Runtime(string? name = null, string? version = null, string? raw = null) { }
+        public Runtime(string? name = null, string? version = null, string? raw = null, string? identifier = null) { }
         public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
         public static Sentry.PlatformAbstractions.Runtime Current { get; }
-        public bool Equals(Sentry.PlatformAbstractions.Runtime other) { }
+        public bool Equals(Sentry.PlatformAbstractions.Runtime? other) { }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string? ToString() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet5_0.verified.txt
@@ -1185,6 +1185,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
     {
         public Runtime(string? name = null, string? version = null, string? raw = null, string? identifier = null) { }
+        [set: System.Obsolete("This setter is nonfunctional, and will be removed in a future version.")]
         public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1182,15 +1182,15 @@ namespace Sentry.PlatformAbstractions
         Client = 0,
         Full = 1,
     }
-    public class Runtime
+    public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
     {
-        public Runtime(string? name = null, string? version = null, string? raw = null) { }
+        public Runtime(string? name = null, string? version = null, string? raw = null, string? identifier = null) { }
         public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }
         public static Sentry.PlatformAbstractions.Runtime Current { get; }
-        public bool Equals(Sentry.PlatformAbstractions.Runtime other) { }
+        public bool Equals(Sentry.PlatformAbstractions.Runtime? other) { }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string? ToString() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1185,6 +1185,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
     {
         public Runtime(string? name = null, string? version = null, string? raw = null, string? identifier = null) { }
+        [set: System.Obsolete("This setter is nonfunctional, and will be removed in a future version.")]
         public string? Identifier { get; set; }
         public string? Name { get; }
         public string? Raw { get; }

--- a/test/Sentry.Tests/PlatformAbstractions/FrameworkInstallationExtensionsTests.cs
+++ b/test/Sentry.Tests/PlatformAbstractions/FrameworkInstallationExtensionsTests.cs
@@ -9,7 +9,9 @@ public class FrameworkInstallationExtensionsTests
     {
         //Arrange
         FrameworkInstallation frameworkInstallation = null;
+
         //Act
+        // ReSharper disable once ExpressionIsAlwaysNull
         var version = frameworkInstallation.GetVersionNumber();
 
         //Assert

--- a/test/Sentry.Tests/PlatformAbstractions/NetFxInstallationsEventProcessorTests.cs
+++ b/test/Sentry.Tests/PlatformAbstractions/NetFxInstallationsEventProcessorTests.cs
@@ -44,7 +44,7 @@ public class NetFxInstallationsEventProcessorTests
         _ = sut.Process(@event);
 
         //Assert
-        var dictionary = @event.Contexts[NetFxInstallationsEventProcessor.NetFxInstallationsKey] as Dictionary<string, string>;
+        var dictionary = (Dictionary<string, string>) @event.Contexts[NetFxInstallationsEventProcessor.NetFxInstallationsKey];
         foreach (var item in installationList)
         {
             Assert.Contains($"\"{item.GetVersionNumber()}\"", dictionary[$"{NetFxInstallationsEventProcessor.NetFxInstallationsKey} {item.Profile}"]);


### PR DESCRIPTION
While working on #1885, I noticed that the classes under `PlatformAbstractions` had a lot of code analysis warnings.  This PR addresses that.

Also, I thought it would be a good idea to log a warning if we encounter an unknown NetFX release number.  This would have made fixing #1885 a lot easier, so will help in the future.

In order to log the warning, I also added an internal `SentrySdk.CurrentOptions` property that uses the options from the current hub.  That seemed better than refactoring the whole thing to pass options or a logger all the way down.  I think it will be useful elsewhere also.

#skip-changelog