### PR TITLE
Fix Sentry interfering with MAUI's focus events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix environment name casing issue ([#1861](https://github.com/getsentry/sentry-dotnet/pull/1861))
 - Null check HttpContext in SystemWebVersionLocator ([#1881](https://github.com/getsentry/sentry-dotnet/pull/1881))
 - Fix detection of .NET Framework 4.8.1 ([#1885](https://github.com/getsentry/sentry-dotnet/pull/1885))
+- Fix Sentry interfering with MAUI's focus events ([#1891](https://github.com/getsentry/sentry-dotnet/pull/1891))
 
 ## 3.20.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@
 - Fix environment name casing issue ([#1861](https://github.com/getsentry/sentry-dotnet/pull/1861))
 - Null check HttpContext in SystemWebVersionLocator ([#1881](https://github.com/getsentry/sentry-dotnet/pull/1881))
 - Fix detection of .NET Framework 4.8.1 ([#1885](https://github.com/getsentry/sentry-dotnet/pull/1885))
-- Fix Sentry interfering with MAUI's focus events ([#1891](https://github.com/getsentry/sentry-dotnet/pull/1891))
 - Flush caching transport with main flush ([#1890](https://github.com/getsentry/sentry-dotnet/pull/1890))
+- Fix Sentry interfering with MAUI's focus events ([#1891](https://github.com/getsentry/sentry-dotnet/pull/1891))
 
 ## 3.20.1
 

--- a/src/Sentry.Maui/Internal/MauiEventsBinder.cs
+++ b/src/Sentry.Maui/Internal/MauiEventsBinder.cs
@@ -347,8 +347,8 @@ internal class MauiEventsBinder : IMauiEventsBinder
         button.Clicked += (sender, _) =>
             _hub.AddBreadcrumbForEvent(_options, sender, nameof(Button.Clicked), UserType, UserActionCategory);
         button.Pressed += (sender, _) =>
-            _hub.AddBreadcrumbForEvent(_options, sender, nameof(Button.Pressed), UserType,UserActionCategory);
+            _hub.AddBreadcrumbForEvent(_options, sender, nameof(Button.Pressed), UserType, UserActionCategory);
         button.Released += (sender, _) =>
-            _hub.AddBreadcrumbForEvent(_options, sender, nameof(Button.Released), UserType,UserActionCategory);
+            _hub.AddBreadcrumbForEvent(_options, sender, nameof(Button.Released), UserType, UserActionCategory);
     }
 }

--- a/src/Sentry.Maui/Internal/MauiEventsBinder.cs
+++ b/src/Sentry.Maui/Internal/MauiEventsBinder.cs
@@ -28,6 +28,7 @@ internal class MauiEventsBinder : IMauiEventsBinder
     private static readonly HashSet<Type> ExplicitlyHandledTypes = new()
     {
         typeof(Element),
+        typeof(VisualElement),
         typeof(BindableObject),
         typeof(Application),
         typeof(Window),
@@ -61,6 +62,11 @@ internal class MauiEventsBinder : IMauiEventsBinder
         {
             // All elements have a set of common events we can hook
             BindElementEvents(e.Element);
+
+            if (e.Element is VisualElement visualElement)
+            {
+                BindVisualElementEvents(visualElement);
+            }
 
             // We'll use reflection to attach to other events
             // This allows us to attach to events from custom controls
@@ -261,6 +267,30 @@ internal class MauiEventsBinder : IMauiEventsBinder
         // NotifyPropertyChanged events are too noisy to be useful
         // element.PropertyChanging
         // element.PropertyChanged
+    }
+
+    private void BindVisualElementEvents(VisualElement element)
+    {
+        element.Focused += (sender, e) =>
+            _hub.AddBreadcrumbForEvent(_options, sender, nameof(VisualElement.Focused), SystemType, RenderingCategory);
+
+        element.Unfocused += (sender, e) =>
+            _hub.AddBreadcrumbForEvent(_options, sender, nameof(VisualElement.Unfocused), SystemType, RenderingCategory);
+
+        element.Loaded += (sender, e) =>
+            _hub.AddBreadcrumbForEvent(_options, sender, nameof(VisualElement.Loaded), SystemType, RenderingCategory);
+
+        element.Unloaded += (sender, e) =>
+            _hub.AddBreadcrumbForEvent(_options, sender, nameof(VisualElement.Unloaded), SystemType, RenderingCategory);
+
+        element.ChildrenReordered += (sender, e) =>
+            _hub.AddBreadcrumbForEvent(_options, sender, nameof(VisualElement.ChildrenReordered), SystemType, RenderingCategory);
+
+        element.MeasureInvalidated += (sender, e) =>
+            _hub.AddBreadcrumbForEvent(_options, sender, nameof(VisualElement.MeasureInvalidated), SystemType, RenderingCategory);
+
+        element.SizeChanged += (sender, e) =>
+            _hub.AddBreadcrumbForEvent(_options, sender, nameof(VisualElement.SizeChanged), SystemType, RenderingCategory);
     }
 
     private void BindShellEvents(Shell shell)

--- a/src/Sentry.Maui/Internal/MauiEventsBinder.cs
+++ b/src/Sentry.Maui/Internal/MauiEventsBinder.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
 using Microsoft.Extensions.Options;
@@ -125,6 +126,13 @@ internal class MauiEventsBinder : IMauiEventsBinder
         var events = elementType.GetEvents(BindingFlags.Instance | BindingFlags.Public);
         foreach (var eventInfo in events.Where(e => !ExplicitlyHandledTypes.Contains(e.DeclaringType!)))
         {
+            var browsable = eventInfo.GetCustomAttribute<EditorBrowsableAttribute>();
+            if (browsable != null && browsable.State != EditorBrowsableState.Always)
+            {
+                // These events are not meant for typical consumption.
+                continue;
+            }
+
             Action<object, object> handler = (sender, _) =>
             {
                 _hub.AddBreadcrumbForEvent(_options, sender, eventInfo.Name);


### PR DESCRIPTION
Fixes #1886

We were binding to [`Microsoft.Maui.Controls.VisualElement.FocusChangeRequested`](https://github.com/dotnet/maui/blob/a6aafd312c223543e27763183d2fc83f84587f14/src/Controls/src/Core/VisualElement.cs#L954) via reflection.  That particular event has a handler that requires setting `e.Result = true` in order to not block the focus request.  Unfortunately, the default is false (ouch!).

`FocusChangeRequested` is marked with `[EditorBrowsable(EditorBrowsableState.Never)]`, indicating it's not meant for public consumption.  We probably shouldn't have been attaching to it at all.

Fixed this in two ways:
- Changed the reflection-based event handler to not hook any events marked with `EditorBrowsable` (unless its param is `Always`)
- Added non-reflection-based event handlers for `VisualElement` so we can better control the specific events from that type.