### PR TITLE
Stop using `server-os` and `server-runtime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix detection of .NET Framework 4.8.1 ([#1885](https://github.com/getsentry/sentry-dotnet/pull/1885))
 - Flush caching transport with main flush ([#1890](https://github.com/getsentry/sentry-dotnet/pull/1890))
 - Fix Sentry interfering with MAUI's focus events ([#1891](https://github.com/getsentry/sentry-dotnet/pull/1891))
+- Stop using `server-os` and `server-runtime` ([#1891](https://github.com/getsentry/sentry-dotnet/pull/1893))
 
 ## 3.20.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Fix detection of .NET Framework 4.8.1 ([#1885](https://github.com/getsentry/sentry-dotnet/pull/1885))
 - Flush caching transport with main flush ([#1890](https://github.com/getsentry/sentry-dotnet/pull/1890))
 - Fix Sentry interfering with MAUI's focus events ([#1891](https://github.com/getsentry/sentry-dotnet/pull/1891))
-- Stop using `server-os` and `server-runtime` ([#1891](https://github.com/getsentry/sentry-dotnet/pull/1893))
+- Stop using `server-os` and `server-runtime` ([#1893](https://github.com/getsentry/sentry-dotnet/pull/1893))
 
 ## 3.20.1
 

--- a/src/Sentry.AspNet/Internal/SystemWebRequestEventProcessor.cs
+++ b/src/Sentry.AspNet/Internal/SystemWebRequestEventProcessor.cs
@@ -1,7 +1,6 @@
 using System.Security.Claims;
 using System.Web;
 using Sentry.Extensibility;
-using Sentry.Protocol;
 using Sentry.Reflection;
 
 namespace Sentry.AspNet.Internal;
@@ -91,18 +90,6 @@ internal class SystemWebRequestEventProcessor : ISentryEventProcessor
         }
 
         @event.ServerName = Environment.MachineName;
-
-        // Move 'runtime' under key 'server-runtime' as User-Agent parsing done at
-        // Sentry will represent the client's
-        if (@event.Contexts.TryRemove(Runtime.Type, out var runtime))
-        {
-            @event.Contexts["server-runtime"] = runtime;
-        }
-
-        if (@event.Contexts.TryRemove(Protocol.OperatingSystem.Type, out var os))
-        {
-            @event.Contexts["server-os"] = os;
-        }
 
         var body = PayloadExtractor.ExtractPayload(new SystemWebHttpRequest(context.Request));
         if (body != null)

--- a/src/Sentry.AspNetCore/AspNetCoreEventProcessor.cs
+++ b/src/Sentry.AspNetCore/AspNetCoreEventProcessor.cs
@@ -1,6 +1,4 @@
 using Sentry.Extensibility;
-using Sentry.Protocol;
-using OperatingSystem = Sentry.Protocol.OperatingSystem;
 
 namespace Sentry.AspNetCore;
 
@@ -8,18 +6,6 @@ internal class AspNetCoreEventProcessor : ISentryEventProcessor
 {
     public SentryEvent Process(SentryEvent @event)
     {
-        // Move 'runtime' under key 'server-runtime' as User-Agent parsing done at
-        // Sentry will represent the client's
-        if (@event.Contexts.TryRemove(Runtime.Type, out var runtime))
-        {
-            @event.Contexts["server-runtime"] = runtime;
-        }
-
-        if (@event.Contexts.TryRemove(OperatingSystem.Type, out var os))
-        {
-            @event.Contexts["server-os"] = os;
-        }
-
         // Not PII as this is running on a server
         if (@event.ServerName == null)
         {

--- a/test/Sentry.AspNetCore.Tests/AspNetCoreEventProcessorTests.cs
+++ b/test/Sentry.AspNetCore.Tests/AspNetCoreEventProcessorTests.cs
@@ -1,5 +1,3 @@
-using OperatingSystem = Sentry.Protocol.OperatingSystem;
-
 namespace Sentry.AspNetCore.Tests;
 
 public class AspNetCoreEventProcessorTests
@@ -9,49 +7,6 @@ public class AspNetCoreEventProcessorTests
     public AspNetCoreEventProcessorTests()
     {
         _sut = new AspNetCoreEventProcessor();
-    }
-
-    [Fact]
-    public void Process_WithRuntime_MovesToServerRuntime()
-    {
-        var target = new SentryEvent();
-        var expected = target.Contexts.Runtime;
-
-        _ = _sut.Process(target);
-
-        Assert.Same(expected, target.Contexts["server-runtime"]);
-    }
-    [Fact]
-    public void Process_WithoutRuntime_NoServerRuntime()
-    {
-        var target = new SentryEvent();
-        _ = target.Contexts.TryRemove(Runtime.Type, out _);
-
-        _ = _sut.Process(target);
-
-        Assert.False(target.Contexts.ContainsKey("server-runtime"));
-    }
-
-    [Fact]
-    public void Process_WithOperatingSystem_MovesToServerOperatingSystem()
-    {
-        var target = new SentryEvent();
-        var expected = target.Contexts.OperatingSystem;
-
-        _ = _sut.Process(target);
-
-        Assert.Same(expected, target.Contexts["server-os"]);
-    }
-
-    [Fact]
-    public void Process_WithoutOperatingSystem_NoServerOperatingSystem()
-    {
-        var target = new SentryEvent();
-        _ = target.Contexts.TryRemove(OperatingSystem.Type, out _);
-
-        _ = _sut.Process(target);
-
-        Assert.False(target.Contexts.ContainsKey("server-os"));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1575

See https://github.com/getsentry/sentry-dotnet/issues/1575#issuecomment-1234667512 for details