### PR TITLE
Test output cleanup

### DIFF
--- a/src/Sentry.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/ApplicationBuilderExtensions.cs
@@ -32,7 +32,8 @@ internal static class ApplicationBuilderExtensions
         var options = app.ApplicationServices.GetService<IOptions<SentryAspNetCoreOptions>>();
         if (options?.Value is { } o)
         {
-            if (o.Debug && (o.DiagnosticLogger == null || o.DiagnosticLogger.GetType() == typeof(ConsoleDiagnosticLogger)))
+            if (o.Debug && (o.DiagnosticLogger is null or ConsoleDiagnosticLogger ||
+                            o.DiagnosticLogger.GetType().Name == "TestOutputDiagnosticLogger"))
             {
                 var logger = app.ApplicationServices.GetRequiredService<ILogger<ISentryClient>>();
                 o.DiagnosticLogger = new MelDiagnosticLogger(logger, o.DiagnosticLevel);

--- a/src/Sentry/Internal/SentryScopeManager.cs
+++ b/src/Sentry/Internal/SentryScopeManager.cs
@@ -42,14 +42,12 @@ namespace Sentry.Internal
 
         public void ConfigureScope(Action<Scope>? configureScope)
         {
-            _options.LogDebug("Configuring the scope.");
             var scope = GetCurrent();
             configureScope?.Invoke(scope.Key);
         }
 
         public Task ConfigureScopeAsync(Func<Scope, Task>? configureScope)
         {
-            _options.LogDebug("Configuring the scope asynchronously.");
             var scope = GetCurrent();
             return configureScope?.Invoke(scope.Key) ?? Task.CompletedTask;
         }

--- a/test/Sentry.AspNetCore.Tests/IntegrationMockedBackgroundWorker.cs
+++ b/test/Sentry.AspNetCore.Tests/IntegrationMockedBackgroundWorker.cs
@@ -22,7 +22,7 @@ public class IntegrationMockedBackgroundWorker : SentrySdkTestFixture
 
     public IntegrationMockedBackgroundWorker()
     {
-        ConfigureWehHost = builder =>
+        ConfigureWebHost = builder =>
         {
             _ = builder.UseSentry(options =>
             {
@@ -242,7 +242,7 @@ public class IntegrationMockedBackgroundWorker : SentrySdkTestFixture
     [Fact]
     public void AllSettingsViaJson()
     {
-        ConfigureWehHost = b =>
+        ConfigureWebHost = b =>
         {
             _ = b.ConfigureAppConfiguration(c =>
             {

--- a/test/Sentry.AspNetCore.Tests/IntegrationMockedBackgroundWorker.cs
+++ b/test/Sentry.AspNetCore.Tests/IntegrationMockedBackgroundWorker.cs
@@ -20,7 +20,7 @@ public class IntegrationMockedBackgroundWorker : SentrySdkTestFixture
     private IBackgroundWorker Worker { get; set; } = Substitute.For<IBackgroundWorker>();
     protected Action<SentryAspNetCoreOptions> Configure;
 
-    public IntegrationMockedBackgroundWorker()
+    public IntegrationMockedBackgroundWorker(ITestOutputHelper output)
     {
         ConfigureWebHost = builder =>
         {
@@ -28,6 +28,7 @@ public class IntegrationMockedBackgroundWorker : SentrySdkTestFixture
             {
                 options.Dsn = ValidDsn;
                 options.BackgroundWorker = Worker;
+                options.DiagnosticLogger = new TestOutputDiagnosticLogger(output);
 
                 Configure?.Invoke(options);
             });

--- a/test/Sentry.AspNetCore.Tests/SentrySdkTestFixture.cs
+++ b/test/Sentry.AspNetCore.Tests/SentrySdkTestFixture.cs
@@ -15,7 +15,7 @@ public abstract class SentrySdkTestFixture : IDisposable
 
     public Action<IServiceCollection> ConfigureServices { get; set; }
     public Action<IApplicationBuilder> ConfigureApp { get; set; }
-    public Action<IWebHostBuilder> ConfigureWehHost { get; set; }
+    public Action<IWebHostBuilder> ConfigureWebHost { get; set; }
 
     public LastExceptionFilter LastExceptionFilter { get; private set; }
 
@@ -61,7 +61,7 @@ public abstract class SentrySdkTestFixture : IDisposable
             });
         });
 
-        ConfigureWehHost?.Invoke(builder);
+        ConfigureWebHost?.Invoke(builder);
         ConfigureBuilder(builder);
 
         TestServer = new TestServer(builder);

--- a/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.cs
+++ b/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.cs
@@ -96,7 +96,7 @@ public class SentryMauiAppBuilderExtensionsTests
         // Act
         var chainedBuilder = builder.UseSentry(options =>
         {
-            options.Debug = true;
+            options.Release = "test";
         });
 
         using var app = builder.Build();
@@ -106,7 +106,7 @@ public class SentryMauiAppBuilderExtensionsTests
         Assert.Same(builder, chainedBuilder);
         Assert.True(SentrySdk.IsEnabled);
         Assert.Equal(ValidDsn, options.Dsn);
-        Assert.True(options.Debug);
+        Assert.Equal("test", options.Release);
     }
 
     [Fact]

--- a/test/Sentry.Tests/EventProcessorTests.cs
+++ b/test/Sentry.Tests/EventProcessorTests.cs
@@ -1,8 +1,17 @@
-﻿namespace Sentry.Tests;
+using Sentry.Testing;
+
+namespace Sentry.Tests;
 
 [UsesVerify]
 public class EventProcessorTests
 {
+    private readonly TestOutputDiagnosticLogger _logger;
+
+    public EventProcessorTests(ITestOutputHelper output)
+    {
+        _logger = new TestOutputDiagnosticLogger(output);
+    }
+
     [Fact]
     public async Task Simple()
     {
@@ -71,12 +80,13 @@ public class EventProcessorTests
         public SentryEvent Process(SentryEvent @event) => null;
     }
 
-    private static SentryOptions Options(RecordingTransport transport) =>
+    private SentryOptions Options(ITransport transport) =>
         new()
         {
             TracesSampleRate = 1,
             Debug = true,
             Transport = transport,
             Dsn = ValidDsn,
+            DiagnosticLogger = _logger
         };
 }

--- a/test/Sentry.Tests/TransactionProcessorTests.cs
+++ b/test/Sentry.Tests/TransactionProcessorTests.cs
@@ -1,8 +1,17 @@
-﻿namespace Sentry.Tests;
+using Sentry.Testing;
+
+namespace Sentry.Tests;
 
 [UsesVerify]
 public class TransactionProcessorTests
 {
+    private readonly TestOutputDiagnosticLogger _logger;
+
+    public TransactionProcessorTests(ITestOutputHelper output)
+    {
+        _logger = new TestOutputDiagnosticLogger(output);
+    }
+
     [Fact]
     public async Task Simple()
     {
@@ -37,11 +46,7 @@ public class TransactionProcessorTests
     public void SampledOut()
     {
         var transport = Substitute.For<ITransport>();
-        var options = new SentryOptions
-        {
-            Transport = transport,
-            Dsn = ValidDsn
-        };
+        var options = Options(transport);
         var processor = new TrackingProcessor();
         options.AddTransactionProcessor(processor);
         var transaction = new Transaction("name", "operation")
@@ -90,12 +95,13 @@ public class TransactionProcessorTests
             null;
     }
 
-    private static SentryOptions Options(RecordingTransport transport) =>
+    private SentryOptions Options(ITransport transport) =>
         new()
         {
             TracesSampleRate = 1,
             Debug = true,
             Transport = transport,
             Dsn = ValidDsn,
+            DiagnosticLogger = _logger
         };
 }


### PR DESCRIPTION
This does two things:
- Ensures tests don't log debug output to the console.  It's noisy and fills up our log files even on success.
- Stops logging "Configuring the scope" messages, as most debug output contains dozens of them and they're not very useful.

#skip-changelog