### PR TITLE
Update Sentry Android SDK to version 6.4.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Features
 
 - `SentryOptions.AttachStackTrace` is now enabled by default. ([#1907](https://github.com/getsentry/sentry-dotnet/pull/1907))
+- Update Sentry Android SDK to version 6.4.1 ([#1911](https://github.com/getsentry/sentry-dotnet/pull/1911))
 
 ## 3.21.0
 

--- a/src/Sentry/Platforms/Android/Sentry.Android.props
+++ b/src/Sentry/Platforms/Android/Sentry.Android.props
@@ -4,7 +4,7 @@
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <!-- BG8605 and BG8606 happen because there's a missing androidx.lifecycle dependency, but we don't need it here.  (The native Android Sentry SDK will use it if it exists.) -->
     <NoWarn>$(NoWarn);BG8605;BG8606</NoWarn>
-    <SentryAndroidSdkVersion>6.3.0</SentryAndroidSdkVersion>
+    <SentryAndroidSdkVersion>6.4.1</SentryAndroidSdkVersion>
     <SentryAndroidSdkDirectory>$(BaseIntermediateOutputPath)sdks\Sentry\Android\$(SentryAndroidSdkVersion)\</SentryAndroidSdkDirectory>
     <LangVersion>10</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>

--- a/src/Sentry/Platforms/Android/SentryOptions.cs
+++ b/src/Sentry/Platforms/Android/SentryOptions.cs
@@ -137,10 +137,10 @@ public partial class SentryOptions
         public bool EnableUserInteractionTracing { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets the interval for profiling traces, when enabled with <see cref="ProfilingEnabled"/>.
-        /// The default value is 10 milliseconds.
+        /// Deprecated.
         /// </summary>
-        public TimeSpan ProfilingTracesInterval { get; set; } = TimeSpan.FromMilliseconds(10);
+        [Obsolete("This property is deprecated and ignored.")]
+        public TimeSpan ProfilingTracesInterval { get; set; }
 
 
         // ---------- From SentryOptions.java ----------
@@ -197,9 +197,19 @@ public partial class SentryOptions
         /// <summary>
         /// Gets or sets if profiling is enabled for transactions.
         /// The default value is <c>false</c> (disabled).
-        /// See also <see cref="ProfilingTracesInterval"/>.
         /// </summary>
-        public bool ProfilingEnabled { get; set; } = false;
+        [Obsolete("Use ProfilesSampleRate instead")]
+        public bool ProfilingEnabled
+        {
+            get => (ProfilesSampleRate ?? 0.0) > 0.0;
+            set => ProfilesSampleRate = value ? 1.0 : null;
+        }
+
+        /// <summary>
+        /// Gets or sets the profiling sample rate, between 0.0 and 1.0.
+        /// The default value is <c>null</c> (disabled).
+        /// </summary>
+        public double? ProfilesSampleRate { get; set; }
 
         /// <summary>
         /// Gets or sets the read timeout on the HTTP connection used by Java when sending data to Sentry.

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -136,7 +136,6 @@ public static partial class SentrySdk
                 o.EnableSystemEventBreadcrumbs = options.Android.EnableSystemEventBreadcrumbs;
                 o.EnableUserInteractionBreadcrumbs = options.Android.EnableUserInteractionBreadcrumbs;
                 o.EnableUserInteractionTracing = options.Android.EnableUserInteractionTracing;
-                o.ProfilingTracesIntervalMillis = (int)options.Android.ProfilingTracesInterval.TotalMilliseconds;
 
                 // These options are in Java.SentryOptions but not ours
                 o.AttachThreads = options.Android.AttachThreads;
@@ -144,7 +143,7 @@ public static partial class SentrySdk
                 o.EnableNdk = options.Android.EnableNdk;
                 o.EnableShutdownHook = options.Android.EnableShutdownHook;
                 o.EnableUncaughtExceptionHandler = options.Android.EnableUncaughtExceptionHandler;
-                o.ProfilingEnabled = options.Android.ProfilingEnabled;
+                o.ProfilesSampleRate = (JavaDouble?)options.Android.ProfilesSampleRate;
                 o.PrintUncaughtStackTrace = options.Android.PrintUncaughtStackTrace;
                 o.ReadTimeoutMillis = (int)options.Android.ReadTimeout.TotalMilliseconds;
 


### PR DESCRIPTION
Updates the embedded Sentry Android SDK to the latest version, 6.4.1, including corresponding changes in options.