### PR TITLE
Update Sentry Cocoa SDK to 7.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `SentryOptions.AttachStackTrace` is now enabled by default. ([#1907](https://github.com/getsentry/sentry-dotnet/pull/1907))
 - Update Sentry Android SDK to version 6.4.1 ([#1911](https://github.com/getsentry/sentry-dotnet/pull/1911))
+- Update Sentry Cocoa SDK to version 7.24.1 ([#1912](https://github.com/getsentry/sentry-dotnet/pull/1912))
 
 ## 3.21.0
 

--- a/src/Sentry/Platforms/iOS/Bindings/ApiDefinitions.cs
+++ b/src/Sentry/Platforms/iOS/Bindings/ApiDefinitions.cs
@@ -813,6 +813,10 @@ interface SentryOptions
     [Export ("enabled")]
     bool Enabled { get; set; }
 
+	// @property (assign, nonatomic) BOOL enableCrashHandler;
+	[Export ("enableCrashHandler")]
+	bool EnableCrashHandler { get; set; }
+
     // @property (assign, nonatomic) NSUInteger maxBreadcrumbs;
     [Export ("maxBreadcrumbs")]
     nuint MaxBreadcrumbs { get; set; }
@@ -894,6 +898,10 @@ interface SentryOptions
     [Export ("attachScreenshot")]
     bool AttachScreenshot { get; set; }
 
+	// @property (assign, nonatomic) BOOL attachViewHierarchy;
+	[Export ("attachViewHierarchy")]
+	bool AttachViewHierarchy { get; set; }
+
     // @property (assign, nonatomic) BOOL enableUserInteractionTracing;
     [Export ("enableUserInteractionTracing")]
     bool EnableUserInteractionTracing { get; set; }
@@ -954,7 +962,19 @@ interface SentryOptions
     [Export ("enableCoreDataTracking")]
     bool EnableCoreDataTracking { get; set; }
 
-    // @property (assign, nonatomic) BOOL enableProfiling;
+	// @property (nonatomic, strong) NSNumber * _Nullable profilesSampleRate;
+	[NullAllowed, Export ("profilesSampleRate", ArgumentSemantic.Strong)]
+	NSNumber ProfilesSampleRate { get; set; }
+
+	// @property (nonatomic) SentryTracesSamplerCallback _Nullable profilesSampler;
+	[NullAllowed, Export ("profilesSampler", ArgumentSemantic.Assign)]
+	Func<SentrySamplingContext, NSNumber?> ProfilesSampler { get; set; }
+
+	// @property (readonly, assign, nonatomic) BOOL isProfilingEnabled;
+	[Export ("isProfilingEnabled")]
+	bool IsProfilingEnabled { get; }
+
+	// @property (assign, nonatomic) BOOL enableProfiling __attribute__((deprecated("Use profilesSampleRate or profilesSampler instead. This property will be removed in a future version of the SDK")));
     [Export ("enableProfiling")]
     bool EnableProfiling { get; set; }
 
@@ -981,10 +1001,10 @@ interface SentryOptions
 [Internal]
 interface SentryIntegrationProtocol
 {
-    // @required -(void)installWithOptions:(SentryOptions * _Nonnull)options;
+	// @required -(BOOL)installWithOptions:(SentryOptions * _Nonnull)options;
     [Abstract]
     [Export ("installWithOptions:")]
-    void InstallWithOptions (SentryOptions options);
+	bool InstallWithOptions (SentryOptions options);
 
     // @optional -(void)uninstall;
     [Export ("uninstall")]
@@ -1168,10 +1188,6 @@ interface SentryHub
     [Export ("endSessionWithTimestamp:")]
     void EndSessionWithTimestamp (NSDate timestamp);
 
-    // // @property (nonatomic, strong) NSMutableArray<NSObject<SentryIntegrationProtocol> *> * _Nonnull installedIntegrations;
-    // [Export ("installedIntegrations", ArgumentSemantic.Strong)]
-    // NSMutableArray<SentryIntegrationProtocol> InstalledIntegrations { get; set; }
-
     // -(SentryId * _Nonnull)captureEvent:(SentryEvent * _Nonnull)event __attribute__((swift_name("capture(event:)")));
     [Export ("captureEvent:")]
     SentryId CaptureEvent (SentryEvent @event);
@@ -1252,10 +1268,9 @@ interface SentryHub
     [Export ("bindClient:")]
     void BindClient ([NullAllowed] SentryClient client);
 
-    // -(id _Nullable)getIntegration:(NSString * _Nonnull)integrationName;
-    [Export ("getIntegration:")]
-    [return: NullAllowed]
-    NSObject GetIntegration (string integrationName);
+	// -(BOOL)hasIntegration:(NSString * _Nonnull)integrationName;
+	[Export ("hasIntegration:")]
+	bool HasIntegration (string integrationName);
 
     // -(BOOL)isIntegrationInstalled:(Class _Nonnull)integrationClass;
     [Export ("isIntegrationInstalled:")]
@@ -1945,6 +1960,10 @@ interface SentryTransactionContext
     [Export ("name")]
     string Name { get; }
 
+	// @property (readonly, nonatomic) SentryTransactionNameSource nameSource;
+	[Export ("nameSource")]
+	SentryTransactionNameSource NameSource { get; }
+
     // @property (nonatomic) SentrySampleDecision parentSampled;
     [Export ("parentSampled", ArgumentSemantic.Assign)]
     SentrySampleDecision ParentSampled { get; set; }
@@ -1971,8 +1990,8 @@ interface SentryTransactionContext
 [Internal]
 interface SentryUser : SentrySerializable //, INSCopying
 {
-    // @property (copy, atomic) NSString * _Nonnull userId;
-    [Export ("userId")]
+	// @property (copy, atomic) NSString * _Nullable userId;
+	[NullAllowed, Export ("userId")]
     string UserId { get; set; }
 
     // @property (copy, atomic) NSString * _Nullable email;

--- a/src/Sentry/Platforms/iOS/Bindings/README.md
+++ b/src/Sentry/Platforms/iOS/Bindings/README.md
@@ -1,4 +1,11 @@
-The files in this folder aren't "normal" C# files, but rather they are [Xamarin Objective-C bindings][1].  They were originally generated with [Objective Sharpie][2].  However, they are not purely auto-generated.  Several modifications have been made:
+The files in this folder aren't "normal" C# files, but rather they are [Xamarin Objective-C bindings][1].
+They were originally generated with [Objective Sharpie][2], using the following command:
+
+```
+sharpie bind <path to sentry-cocoa sdk root>/Sentry.xcodeproj -sdk iphoneos
+```
+
+However, the files are not purely auto-generated.  Several modifications have been made:
 
 - Everything has been made internal, either via the `internal` keyword, or the `[Internal]` binding attribute.
 - Named delegates have been replaced with `Func<T>` or `Action<T>` to work around https://github.com/xamarin/xamarin-macios/issues/15299

--- a/src/Sentry/Platforms/iOS/Bindings/StructsAndEnums.cs
+++ b/src/Sentry/Platforms/iOS/Bindings/StructsAndEnums.cs
@@ -23,6 +23,26 @@ internal enum SentryLevel : ulong
 }
 
 [Native]
+internal enum SentryPermissionStatus : long
+{
+	Unknown = 0,
+	Granted,
+	Partial,
+	Denied
+}
+
+[Native]
+internal enum SentryTransactionNameSource : long
+{
+	Custom = 0,
+	Url,
+	Route,
+	View,
+	Component,
+	Task
+}
+
+[Native]
 internal enum SentryAppStartType : ulong
 {
     Warm,

--- a/src/Sentry/Platforms/iOS/Extensions/UserExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/UserExtensions.cs
@@ -19,18 +19,11 @@ internal static class UserExtensions
         var cocoaUser = new SentryCocoa.SentryUser
         {
             Email = user.Email,
+            UserId = user.Id,
             IpAddress = user.IpAddress,
             Username = user.Username,
             Data = user.Other.ToNullableNSDictionary()
         };
-
-        // Leave a null User ID uninitialized since it is optional.
-        // It should be nullable in the Sentry Cocoa SDK, but isn't currently.
-        // See: https://github.com/getsentry/sentry-cocoa/issues/2035
-        if (user.Id != null)
-        {
-            cocoaUser.UserId = user.Id;
-        }
 
         return cocoaUser;
     }

--- a/src/Sentry/Platforms/iOS/Sentry.iOS.props
+++ b/src/Sentry/Platforms/iOS/Sentry.iOS.props
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <SentryCocoaSdkVersion>7.23.0</SentryCocoaSdkVersion>
+    <SentryCocoaSdkVersion>7.24.1</SentryCocoaSdkVersion>
     <SentryCocoaSdkDirectory>$(BaseIntermediateOutputPath)sdks\Sentry\Cocoa\$(SentryCocoaSdkVersion)\</SentryCocoaSdkDirectory>
     <SentryCocoaFramework>$(SentryCocoaSdkDirectory)Carthage\Build\Sentry.xcframework</SentryCocoaFramework>
 


### PR DESCRIPTION
Updates the embedded Sentry Cocoa SDK to the latest version, 7.24.1