### PR TITLE
Reduce lock contention when sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Update Sentry Cocoa SDK to version 7.24.1 ([#1912](https://github.com/getsentry/sentry-dotnet/pull/1912))
 - Add TransactionNameSource annotation ([#1910](https://github.com/getsentry/sentry-dotnet/pull/1910))
 
+## Fixes
+
+- Reduce lock contention when sampling ([#1915](https://github.com/getsentry/sentry-dotnet/pull/1915))
+
 ## 3.21.0
 
 _Includes Sentry.Maui Preview 3_

--- a/src/Sentry/Internal/SynchronizedRandom.cs
+++ b/src/Sentry/Internal/SynchronizedRandom.cs
@@ -1,5 +1,9 @@
 using System;
 
+#if !NET6_0_OR_GREATER
+using System.Threading;
+#endif
+
 namespace Sentry.Internal
 {
     internal static class SynchronizedRandom
@@ -17,40 +21,13 @@ namespace Sentry.Internal
         public static double NextDouble() => Random.Shared.NextDouble();
         public static void NextBytes(byte[] bytes) => Random.Shared.NextBytes(bytes);
 #else
-        // TODO: ThreadLocal instance would avoid contention
-        private static readonly Random Random = new();
+        private static readonly AsyncLocal<Random> LocalRandom = new();
+        private static Random Random => LocalRandom.Value ??= new Random();
 
-        public static void NextBytes(byte[] bytes)
-        {
-            lock (Random)
-            {
-                Random.NextBytes(bytes);
-            }
-        }
-
-        public static double NextDouble()
-        {
-            lock (Random)
-            {
-                return Random.NextDouble();
-            }
-        }
-
-        public static int Next(int minValue, int maxValue)
-        {
-            lock (Random)
-            {
-                return Random.Next(minValue, maxValue);
-            }
-        }
-
-        public static int Next()
-        {
-            lock (Random)
-            {
-                return Random.Next();
-            }
-        }
+        public static void NextBytes(byte[] bytes) => Random.NextBytes(bytes);
+        public static double NextDouble() => Random.NextDouble();
+        public static int Next(int minValue, int maxValue) => Random.Next(minValue, maxValue);
+        public static int Next() => Random.Next();
 #endif
     }
 }


### PR DESCRIPTION
Resolves a TODO note, reducing lock contention when generating random numbers used for sampling.