### PR TITLE
Use URL path in transaction names instead of "Unknown Route"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Update Sentry Android SDK to version 6.4.1 ([#1911](https://github.com/getsentry/sentry-dotnet/pull/1911))
 - Update Sentry Cocoa SDK to version 7.24.1 ([#1912](https://github.com/getsentry/sentry-dotnet/pull/1912))
 - Add TransactionNameSource annotation ([#1910](https://github.com/getsentry/sentry-dotnet/pull/1910))
+- Use URL path in transaction names instead of "Unknown Route" ([#1919](https://github.com/getsentry/sentry-dotnet/pull/1919))
 
 ## Fixes
 

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -23,15 +23,11 @@ namespace Sentry.AspNetCore.Extensions
                 return formattedRoute;
             }
 #endif
-            if (LegacyRouteFormat(context) is { } legacyFormat)
-            {
-                return legacyFormat;
-            }
-
-            var sentryRouteName = context.Features.Get<TransactionNameProvider>();
-
-            return sentryRouteName?.Invoke(context);
+            return LegacyRouteFormat(context);
         }
+
+        public static string? TryGetCustomTransactionName(this HttpContext context) =>
+            context.Features.Get<TransactionNameProvider>()?.Invoke(context);
 
         // Internal for testing.
         internal static string? NewRouteFormat(string? routePattern, HttpContext context)

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -162,7 +162,7 @@ namespace Sentry.AspNetCore.Extensions
 
             var method = context.Request.Method.ToUpperInvariant();
 
-            // e.g. "GET /pets/1"
+            // e.g. "GET /pets/{id}"
             return $"{method} {route}";
         }
     }

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptions.cs
@@ -55,7 +55,8 @@ public class SentryAspNetCoreOptions : SentryLoggingOptions
     /// The strategy to define the name of a transaction based on the <see cref="HttpContext"/>.
     /// </summary>
     /// <remarks>
-    /// The SDK can name transactions automatically when using MVC or Endpoint Routing. In other cases, like when serving static files, it will fallback to Unknown Route. This hook allows custom code to define a transaction name given a <see cref="HttpContext"/>.
+    /// The SDK can name transactions automatically when using MVC or Endpoint Routing. In other cases, like when serving static files, it will fallback to the URL path.
+    /// This hook allows custom code to define a transaction name given a <see cref="HttpContext"/>.
     /// </remarks>
     public TransactionNameProvider? TransactionNameProvider { get; set; }
 

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -12,7 +12,6 @@ namespace Sentry.AspNetCore
     /// </summary>
     internal class SentryTracingMiddleware
     {
-        internal const string UnknownRouteTransactionName = "Unknown Route";
         private const string OperationName = "http.server";
 
         private readonly RequestDelegate _next;
@@ -161,10 +160,15 @@ namespace Sentry.AspNetCore
 
                     var status = SpanStatusConverter.FromHttpStatusCode(context.Response.StatusCode);
 
-                    // If no Name was found for Transaction, fallback to UnknownRoute name.
+                    // If no Name was found for Transaction, then we don't have the route.
+                    // Fallback to the URL path.
                     if (transaction.Name == string.Empty)
                     {
-                        transaction.Name = UnknownRouteTransactionName;
+                        // e.g. "GET /pets/1"
+                        var method = context.Request.Method.ToUpperInvariant();
+                        var path = context.Request.Path;
+                        transaction.Name = $"{method} {path}";
+                        ((TransactionTracer)transaction).NameSource = TransactionNameSource.Url;
                     }
 
                     if (exception is null)

--- a/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
@@ -211,12 +211,11 @@ public class HttpContextExtensionsTests
     {
         // Arrange
         var expectedName = "abc";
-        TransactionNameProvider sentryRouteName = _ => expectedName;
         var httpContext = Fixture.GetSut();
-        httpContext.Features.Set(sentryRouteName);
+        httpContext.Features.Set((TransactionNameProvider) (_ => expectedName));
 
         // Act
-        var filteredRoute = httpContext.TryGetRouteTemplate();
+        var filteredRoute = httpContext.TryGetCustomTransactionName();
 
         // Assert
         Assert.Equal(expectedName, filteredRoute);

--- a/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
@@ -354,7 +354,7 @@ public class SentryTracingMiddlewareTests
     }
 
     [Fact]
-    public async Task Transaction_TransactionNameProviderSetUnset_UnknownTransactionNameSet()
+    public async Task Transaction_TransactionNameProviderSetUnset_TransactionNameSetToUrlPath()
     {
         // Arrange
         Transaction transaction = null;
@@ -391,8 +391,8 @@ public class SentryTracingMiddlewareTests
 
         // Assert
         transaction.Should().NotBeNull();
-        transaction.Name.Should().Be("Unknown Route");
-        transaction.NameSource.Should().Be(TransactionNameSource.Route);
+        transaction.Name.Should().Be("GET /person/13.bmp");
+        transaction.NameSource.Should().Be(TransactionNameSource.Url);
     }
 }
 

--- a/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
@@ -350,7 +350,7 @@ public class SentryTracingMiddlewareTests
         // Assert
         transaction.Should().NotBeNull();
         transaction.Name.Should().Be($"GET {expectedName}");
-        transaction.NameSource.Should().Be(TransactionNameSource.Route);
+        transaction.NameSource.Should().Be(TransactionNameSource.Custom);
     }
 
     [Fact]

--- a/test/Sentry.AspNetCore.Tests/WebIntegrationTests.PreFlightIgnoresTransaction.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/WebIntegrationTests.PreFlightIgnoresTransaction.verified.txt
@@ -23,8 +23,8 @@
   Payloads: [
     {
       Source: {
-        Name: Unknown Route,
-        NameSource: Route,
+        Name: OPTIONS /Target,
+        NameSource: Url,
         Platform: csharp,
         Operation: http.server,
         Description: ,


### PR DESCRIPTION
Now that we have `TransactionNameSource` (see #1910), we no longer need to send "Unknown Route" if we can't identify the route for a web request.  Instead, we'll use the URL path, and set `TransactionNameSource.Url`.

Also, if the route is set via `SentryAspNetCoreOptions.TransactionNameProvider`, then we'll continue to use that - but will set `TransactionNameSource.Custom`.

Only when we've actually got a *route* should we set `TransactionNameSource.Route`.