### PR TITLE
Add retry to flaky test

### DIFF
--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -268,6 +268,17 @@ public class HubTests
     [InlineData(false)]
     public async Task CaptureEvent_NonSerializableContextAndOfflineCaching_CapturesEventWithContextKey(bool offlineCaching)
     {
+        // This test has proven to be flaky, so we'll retry it a few times.
+        // As long as it doesn't consistently fail, that should be good enough.
+        // TODO: The retry can be removed if we can confidently figure out the source of the flakiness.
+        await TestHelpers.RetryTestAsync(
+            maxAttempts: 3,
+            _output,
+            () => CapturesEventWithContextKey_Implementation(offlineCaching));
+    }
+
+    private async Task CapturesEventWithContextKey_Implementation(bool offlineCaching)
+    {
         var tcs = new TaskCompletionSource<bool>();
         var expectedMessage = Guid.NewGuid().ToString();
 
@@ -336,7 +347,6 @@ public class HubTests
                 "Failed to serialize object for property '{0}'. Original depth: {1}, current depth: {2}",
                 Arg.Any<InvalidDataException>(),
                 Arg.Any<object[]>());
-
         }
         finally
         {


### PR DESCRIPTION
We've fought this one before, but seeing it failing a lot now with device tests.

Let's just add some retry for now.

#skip-changelog