### PR TITLE
Update code docs on SentryOptions.Release

### DIFF
--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -246,9 +246,13 @@ namespace Sentry
         }
 
         /// <summary>
-        /// The release version of the application.
+        /// The release information for the application.
+        /// Can be anything, but generally should be either a semantic version string in the format
+        /// <c>package@version</c> or <c>package@version+build</c>, or a commit SHA from a version control system.
         /// </summary>
         /// <example>
+        /// MyApp@1.2.3
+        /// MyApp@1.2.3+foo
         /// 721e41770371db95eee98ca2707686226b993eda
         /// 14.1.16.32451
         /// </example>


### PR DESCRIPTION
As follow-up from a customer support question, clarify code docs about `SentryOptions.Release` to better match https://docs.sentry.io/platforms/dotnet/configuration/releases/

#skip-changelog