### PR TITLE
Use background thread for device tests

### DIFF
--- a/test/MauiTestUtils/DeviceTests.Runners/HeadlessRunner/Android/MauiTestActivity.cs
+++ b/test/MauiTestUtils/DeviceTests.Runners/HeadlessRunner/Android/MauiTestActivity.cs
@@ -11,24 +11,28 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
     {
         public TaskCompletionSource<Bundle> TaskCompletionSource { get; } = new TaskCompletionSource<Bundle>();
 
-        protected override async void OnCreate(Bundle? savedInstanceState)
+        protected override void OnCreate(Bundle? savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
 
-            try
+            // Do the work on the background thread to avoid a keyDispatchingTimedOut ANR
+            Task.Run(async () =>
             {
-                var runner = MauiTestInstrumentation.Current.Services.GetRequiredService<HeadlessTestRunner>();
+                try
+                {
+                    var runner = MauiTestInstrumentation.Current.Services.GetRequiredService<HeadlessTestRunner>();
 
-                var bundle = await runner.RunTestsAsync();
+                    var bundle = await runner.RunTestsAsync();
 
-                TaskCompletionSource.TrySetResult(bundle);
-            }
-            catch (Exception ex)
-            {
-                TaskCompletionSource.TrySetException(ex);
-            }
+                    TaskCompletionSource.TrySetResult(bundle);
+                }
+                catch (Exception ex)
+                {
+                    TaskCompletionSource.TrySetException(ex);
+                }
 
-            Finish();
+                Finish();
+            });
         }
     }
 }


### PR DESCRIPTION
This is an attempt to fix the `keyDispatchingTimedOut` ANR described in #1927

#skip-changelog