### PR TITLE
Fix iOS sample build failure

### DIFF
--- a/samples/Sentry.Samples.Ios/Entitlements.plist
+++ b/samples/Sentry.Samples.Ios/Entitlements.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-    <dict>
-    </dict>
-</plist>

--- a/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
+++ b/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
-    <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Fixes: `Could not find any available provisioning profiles for Sentry.Samples.Ios on iOS.` seen here:

https://github.com/getsentry/sentry-dotnet/actions/runs/3097582515/jobs/5014421309#step:5:121

#skip-changelog