### PR TITLE
Support more types for message template tags in SentryLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Exception filters should consider child exceptions of an `AggregateException` ([#1924](https://github.com/getsentry/sentry-dotnet/pull/1924))
 - Add Blazor WASM detection to set IsGlobalModeEnabled to true ([#1931](https://github.com/getsentry/sentry-dotnet/pull/1931))
 - Respect Transaction.IsSampled in SqlListener ([#1933](https://github.com/getsentry/sentry-dotnet/pull/1933))
+- Support `long` for message template tags in SentryLogger ([#1945](https://github.com/getsentry/sentry-dotnet/pull/1945))
 
 ## 3.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Use URL path in transaction names instead of "Unknown Route" ([#1919](https://github.com/getsentry/sentry-dotnet/pull/1919))
 - Add `User.Segment` property ([#1920](https://github.com/getsentry/sentry-dotnet/pull/1920))
 - Add support for custom `JsonConverter`s ([#1934](https://github.com/getsentry/sentry-dotnet/pull/1934))
+- Support more types for message template tags in SentryLogger ([#1945](https://github.com/getsentry/sentry-dotnet/pull/1945))
 
 ## Fixes
 
@@ -20,7 +21,6 @@
 - Exception filters should consider child exceptions of an `AggregateException` ([#1924](https://github.com/getsentry/sentry-dotnet/pull/1924))
 - Add Blazor WASM detection to set IsGlobalModeEnabled to true ([#1931](https://github.com/getsentry/sentry-dotnet/pull/1931))
 - Respect Transaction.IsSampled in SqlListener ([#1933](https://github.com/getsentry/sentry-dotnet/pull/1933))
-- Support `long` for message template tags in SentryLogger ([#1945](https://github.com/getsentry/sentry-dotnet/pull/1945))
 
 ## 3.21.0
 

--- a/src/Sentry.Extensions.Logging/SentryLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryLogger.cs
@@ -77,6 +77,10 @@ internal sealed class SentryLogger : ILogger
                     {
                         @event.SetTag(property.Key, integerTagValue.ToString());
                     }
+                    else if (property.Value is long longIntegerValue)
+                    {
+                        @event.SetTag(property.Key, longIntegerValue.ToString());
+                    }
                     else if (property.Value is float floatTagValue)
                     {
                         @event.SetTag(property.Key, floatTagValue.ToString());

--- a/src/Sentry.Extensions.Logging/SentryLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryLogger.cs
@@ -89,7 +89,6 @@ internal sealed class SentryLogger : ILogger
                             {
                                 @event.SetTag(property.Key, property.Value.ToString()!);
                             }
-
                             break;
                         }
                     }

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
@@ -75,6 +75,7 @@ public class SentryLoggerTests
         {
             new("fooString", "bar"),
             new("fooInteger", 1234),
+            new("fooLong", 1234L),
             new("fooDouble", (double)1234),
             new("fooFloat", (float)1234.123),
             new("fooGuid", guidValue)
@@ -87,6 +88,7 @@ public class SentryLoggerTests
             .CaptureEvent(Arg.Is<SentryEvent>(
                 e => e.Tags["fooString"] == "bar" &&
                      e.Tags["fooInteger"] == "1234" &&
+                     e.Tags["fooLong"] == "1234" &&
                      e.Tags["fooDouble"] == "1234" &&
                      e.Tags["fooFloat"] == "1234.123" &&
                      e.Tags["fooGuid"] == guidValue.ToString()));

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
@@ -76,9 +76,11 @@ public class SentryLoggerTests
             new("fooString", "bar"),
             new("fooInteger", 1234),
             new("fooLong", 1234L),
+            new("fooUShort", (ushort)1234),
             new("fooDouble", (double)1234),
             new("fooFloat", (float)1234.123),
-            new("fooGuid", guidValue)
+            new("fooGuid", guidValue),
+            new("fooEnum", UriKind.Absolute) // any enum, just an example
         };
         var sut = _fixture.GetSut();
 
@@ -89,9 +91,11 @@ public class SentryLoggerTests
                 e => e.Tags["fooString"] == "bar" &&
                      e.Tags["fooInteger"] == "1234" &&
                      e.Tags["fooLong"] == "1234" &&
+                     e.Tags["fooUShort"] == "1234" &&
                      e.Tags["fooDouble"] == "1234" &&
                      e.Tags["fooFloat"] == "1234.123" &&
-                     e.Tags["fooGuid"] == guidValue.ToString()));
+                     e.Tags["fooGuid"] == guidValue.ToString() &&
+                     e.Tags["fooEnum"] == "Absolute"));
     }
 
     [Fact]


### PR DESCRIPTION
Adds support for all primitive types (long integers, etc.), and enums when converting objects to strings to be used for tags.  Applies to the `SentyLogger` used by `Sentry.Extensions.Logging` and packages that depend on it such as ASP.NET Core.