### PR TITLE
WIP: Add .NET 7 to test projects

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -10,6 +10,16 @@ runs:
         echo "DOTNET_CLI_TELEMETRY_OPTOUT=1" >> $GITHUB_ENV
         echo "DOTNET_NOLOGO=1" >> $GITHUB_ENV
 
+    - name: Install .NET 7 SDK
+      uses: actions/setup-dotnet@v2
+      env:
+        # Prevent setup-dotnet action from stepping on pre-installed dotnet SDKs on Ubuntu and Windows (doesn't happen on macOS)
+        DOTNET_INSTALL_DIR: ${{ runner.os == 'Linux' && '/usr/share/dotnet' || runner.os == 'Windows' && 'C:\Program Files\dotnet' || '' }}
+      with:
+        dotnet-version: 7.0.x
+        include-prerelease: true
+        # All other versions of .NET we need are pre-installed on the GitHub Actions virtual images.
+
     - name: Dependency Caching
       uses: actions/cache@v3
       if: runner.os != 'Windows' # Cache is too slow on Windows to be useful.  See https://github.com/actions/cache/issues/752

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
+    "version": "7.0.100-rc.1.22431.12",
     "rollForward": "latestMinor",
-    "allowPrerelease": false
+    "allowPrerelease": true
   }
 }

--- a/test/Sentry.AspNetCore.Grpc.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.AspNetCore.Grpc.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1,0 +1,50 @@
+﻿namespace Sentry.AspNetCore.Grpc
+{
+    public class DefaultProtobufRequestPayloadExtractor : Sentry.AspNetCore.Grpc.IProtobufRequestPayloadExtractor
+    {
+        public DefaultProtobufRequestPayloadExtractor() { }
+        public Google.Protobuf.IMessage ExtractPayload<TRequest>(Sentry.AspNetCore.Grpc.IProtobufRequest<TRequest> request)
+            where TRequest :  class, Google.Protobuf.IMessage { }
+    }
+    public interface IProtobufRequestPayloadExtractor
+    {
+        Google.Protobuf.IMessage? ExtractPayload<TRequest>(Sentry.AspNetCore.Grpc.IProtobufRequest<TRequest> request)
+            where TRequest :  class, Google.Protobuf.IMessage;
+    }
+    public interface IProtobufRequest<TRequest>
+    {
+        long? ContentLength { get; }
+        TRequest Request { get; }
+    }
+    public class ProtobufRequestExtractionDispatcher : Sentry.AspNetCore.Grpc.IProtobufRequestPayloadExtractor
+    {
+        public ProtobufRequestExtractionDispatcher(System.Collections.Generic.IEnumerable<Sentry.AspNetCore.Grpc.IProtobufRequestPayloadExtractor> extractors, Sentry.SentryOptions options, System.Func<Sentry.Extensibility.RequestSize> sizeSwitch) { }
+        public Google.Protobuf.IMessage? ExtractPayload<TRequest>(Sentry.AspNetCore.Grpc.IProtobufRequest<TRequest> request)
+            where TRequest :  class, Google.Protobuf.IMessage { }
+    }
+    public static class ScopeExtensions
+    {
+        public static void Populate<TRequest>(this Sentry.Scope scope, Grpc.Core.ServerCallContext context, TRequest? request, Sentry.AspNetCore.SentryAspNetCoreOptions options)
+            where TRequest :  class { }
+    }
+    public static class SentryBuilderExtensions
+    {
+        public static Sentry.AspNetCore.ISentryBuilder AddGrpc(this Sentry.AspNetCore.ISentryBuilder builder) { }
+    }
+    public class SentryGrpcInterceptor : Grpc.Core.Interceptors.Interceptor
+    {
+        public SentryGrpcInterceptor(System.Func<Sentry.IHub> hubAccessor, Microsoft.Extensions.Options.IOptions<Sentry.AspNetCore.SentryAspNetCoreOptions> options) { }
+        public override System.Threading.Tasks.Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(Grpc.Core.IAsyncStreamReader<TRequest> requestStream, Grpc.Core.ServerCallContext context, Grpc.Core.ClientStreamingServerMethod<TRequest, TResponse> continuation)
+            where TRequest :  class
+            where TResponse :  class { }
+        public override System.Threading.Tasks.Task DuplexStreamingServerHandler<TRequest, TResponse>(Grpc.Core.IAsyncStreamReader<TRequest> requestStream, Grpc.Core.IServerStreamWriter<TResponse> responseStream, Grpc.Core.ServerCallContext context, Grpc.Core.DuplexStreamingServerMethod<TRequest, TResponse> continuation)
+            where TRequest :  class
+            where TResponse :  class { }
+        public override System.Threading.Tasks.Task ServerStreamingServerHandler<TRequest, TResponse>(TRequest request, Grpc.Core.IServerStreamWriter<TResponse> responseStream, Grpc.Core.ServerCallContext context, Grpc.Core.ServerStreamingServerMethod<TRequest, TResponse> continuation)
+            where TRequest :  class
+            where TResponse :  class { }
+        public override System.Threading.Tasks.Task<TResponse> UnaryServerHandler<TRequest, TResponse>(TRequest request, Grpc.Core.ServerCallContext context, Grpc.Core.UnaryServerMethod<TRequest, TResponse> continuation)
+            where TRequest :  class
+            where TResponse :  class { }
+    }
+}

--- a/test/Sentry.AspNetCore.Grpc.Tests/Sentry.AspNetCore.Grpc.Tests.csproj
+++ b/test/Sentry.AspNetCore.Grpc.Tests/Sentry.AspNetCore.Grpc.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.47.0" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.47.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.49.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.49.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1,0 +1,72 @@
+﻿namespace Microsoft.AspNetCore.Builder
+{
+    public static class SentryTracingMiddlewareExtensions { }
+}
+namespace Microsoft.AspNetCore.Hosting
+{
+    public static class SentryWebHostBuilderExtensions { }
+}
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ServiceCollectionExtensions { }
+}
+namespace Sentry.AspNetCore
+{
+    public interface ISentryBuilder
+    {
+        Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
+    }
+    public interface IUserFactory
+    {
+        Sentry.User? Create(Microsoft.AspNetCore.Http.HttpContext context);
+    }
+    public static class SamplingExtensions
+    {
+        public static Microsoft.AspNetCore.Http.HttpContext? TryGetHttpContext(this Sentry.TransactionSamplingContext samplingContext) { }
+        public static string? TryGetHttpMethod(this Sentry.TransactionSamplingContext samplingContext) { }
+        public static string? TryGetHttpPath(this Sentry.TransactionSamplingContext samplingContext) { }
+        public static string? TryGetHttpRoute(this Sentry.TransactionSamplingContext samplingContext) { }
+    }
+    public static class ScopeExtensions
+    {
+        public static void Populate(this Sentry.Scope scope, System.Diagnostics.Activity activity) { }
+        public static void Populate(this Sentry.Scope scope, Microsoft.AspNetCore.Http.HttpContext context, Sentry.AspNetCore.SentryAspNetCoreOptions options) { }
+    }
+    [Microsoft.Extensions.Logging.ProviderAlias("Sentry")]
+    public class SentryAspNetCoreLoggerProvider : Sentry.Extensions.Logging.SentryLoggerProvider
+    {
+        public SentryAspNetCoreLoggerProvider(Microsoft.Extensions.Options.IOptions<Sentry.AspNetCore.SentryAspNetCoreOptions> options, Sentry.IHub hub) { }
+    }
+    public class SentryAspNetCoreOptions : Sentry.Extensions.Logging.SentryLoggingOptions
+    {
+        public SentryAspNetCoreOptions() { }
+        public bool AdjustStandardEnvironmentNameCasing { get; set; }
+        public bool FlushOnCompletedRequest { get; set; }
+        public System.TimeSpan FlushTimeout { get; set; }
+        public bool IncludeActivityData { get; set; }
+        public Sentry.Extensibility.RequestSize MaxRequestBodySize { get; set; }
+        public Sentry.AspNetCore.TransactionNameProvider? TransactionNameProvider { get; set; }
+    }
+    public class SentryAspNetCoreOptionsSetup : Microsoft.Extensions.Options.ConfigureFromConfigurationOptions<Sentry.AspNetCore.SentryAspNetCoreOptions>
+    {
+        public SentryAspNetCoreOptionsSetup(Microsoft.Extensions.Logging.Configuration.ILoggerProviderConfiguration<Sentry.AspNetCore.SentryAspNetCoreLoggerProvider> providerConfiguration) { }
+        [System.Obsolete("Use constructor with no IHostingEnvironment")]
+        public SentryAspNetCoreOptionsSetup(Microsoft.Extensions.Logging.Configuration.ILoggerProviderConfiguration<Sentry.AspNetCore.SentryAspNetCoreLoggerProvider> providerConfiguration, Microsoft.AspNetCore.Hosting.IWebHostEnvironment hostingEnvironment) { }
+        public override void Configure(Sentry.AspNetCore.SentryAspNetCoreOptions options) { }
+    }
+    public static class SentryBuilderExtensions
+    {
+        public static Sentry.AspNetCore.ISentryBuilder AddSentryOptions(this Sentry.AspNetCore.ISentryBuilder builder, System.Action<Sentry.AspNetCore.SentryAspNetCoreOptions>? configureOptions) { }
+    }
+    public class SentryStartupFilter : Microsoft.AspNetCore.Hosting.IStartupFilter
+    {
+        public SentryStartupFilter() { }
+        public System.Action<Microsoft.AspNetCore.Builder.IApplicationBuilder> Configure(System.Action<Microsoft.AspNetCore.Builder.IApplicationBuilder> next) { }
+    }
+    public class SentryTunnelMiddleware : Microsoft.AspNetCore.Http.IMiddleware
+    {
+        public SentryTunnelMiddleware(string[] allowedHosts) { }
+        public System.Threading.Tasks.Task InvokeAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
+    }
+    public delegate string? TransactionNameProvider(Microsoft.AspNetCore.Http.HttpContext context);
+}

--- a/test/Sentry.AspNetCore.Tests/ModuleInit.cs
+++ b/test/Sentry.AspNetCore.Tests/ModuleInit.cs
@@ -1,4 +1,4 @@
-#if NET6_0
+#if NET6_0_OR_GREATER
 
 using System.Runtime.CompilerServices;
 

--- a/test/Sentry.AspNetCore.Tests/Sentry.AspNetCore.Tests.csproj
+++ b/test/Sentry.AspNetCore.Tests/Sentry.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +21,13 @@
   <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.8" />
+    <PackageReference Include="Verify.AspNetCore" Version="1.5.0" />
+    <PackageReference Include="Verify.Http" Version="2.5.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.0-rc.1.22427.2" />
     <PackageReference Include="Verify.AspNetCore" Version="1.5.0" />
     <PackageReference Include="Verify.Http" Version="2.5.0" />
   </ItemGroup>

--- a/test/Sentry.AspNetCore.Tests/WebIntegrationTests.cs
+++ b/test/Sentry.AspNetCore.Tests/WebIntegrationTests.cs
@@ -1,4 +1,4 @@
-#if NET6_0
+#if NET6_0_OR_GREATER
 
 using System.Net.Http;
 using Microsoft.AspNetCore.Builder;

--- a/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
@@ -1,8 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net48</TargetFrameworks>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0-rc.1.22426.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0-rc.1.22426.7" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />

--- a/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
+++ b/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
@@ -1,8 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net48</TargetFrameworks>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0-rc.1.22426.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0-rc.1.22426.7" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />

--- a/test/Sentry.EntityFramework.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.EntityFramework.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1,0 +1,45 @@
+﻿namespace Sentry.EntityFramework.ErrorProcessors
+{
+    public class DbConcurrencyExceptionProcessor : Sentry.Extensibility.SentryEventExceptionProcessor<System.Data.DBConcurrencyException>
+    {
+        public DbConcurrencyExceptionProcessor() { }
+        protected override void ProcessException(System.Data.DBConcurrencyException exception, Sentry.SentryEvent sentryEvent) { }
+    }
+    public class DbEntityValidationExceptionProcessor : Sentry.Extensibility.SentryEventExceptionProcessor<System.Data.Entity.Validation.DbEntityValidationException>
+    {
+        public DbEntityValidationExceptionProcessor() { }
+        protected override void ProcessException(System.Data.Entity.Validation.DbEntityValidationException exception, Sentry.SentryEvent sentryEvent) { }
+    }
+}
+namespace Sentry.EntityFramework
+{
+    public interface IQueryLogger
+    {
+        void Log(string text, Sentry.BreadcrumbLevel level = -1);
+    }
+    public class SentryCommandInterceptor : System.Data.Entity.Infrastructure.Interception.IDbCommandInterceptor, System.Data.Entity.Infrastructure.Interception.IDbInterceptor
+    {
+        public SentryCommandInterceptor(Sentry.EntityFramework.IQueryLogger queryLogger) { }
+        public virtual void Log<T>(System.Data.Common.DbCommand command, System.Data.Entity.Infrastructure.Interception.DbCommandInterceptionContext<T> interceptionContext) { }
+        public void NonQueryExecuted(System.Data.Common.DbCommand command, System.Data.Entity.Infrastructure.Interception.DbCommandInterceptionContext<int> interceptionContext) { }
+        public void NonQueryExecuting(System.Data.Common.DbCommand command, System.Data.Entity.Infrastructure.Interception.DbCommandInterceptionContext<int> interceptionContext) { }
+        public void ReaderExecuted(System.Data.Common.DbCommand command, System.Data.Entity.Infrastructure.Interception.DbCommandInterceptionContext<System.Data.Common.DbDataReader> interceptionContext) { }
+        public void ReaderExecuting(System.Data.Common.DbCommand command, System.Data.Entity.Infrastructure.Interception.DbCommandInterceptionContext<System.Data.Common.DbDataReader> interceptionContext) { }
+        public void ScalarExecuted(System.Data.Common.DbCommand command, System.Data.Entity.Infrastructure.Interception.DbCommandInterceptionContext<object> interceptionContext) { }
+        public void ScalarExecuting(System.Data.Common.DbCommand command, System.Data.Entity.Infrastructure.Interception.DbCommandInterceptionContext<object> interceptionContext) { }
+    }
+    public static class SentryDatabaseLogging
+    {
+        [System.Obsolete("This method is called automatically by options.AddEntityFramework. This method wi" +
+            "ll be removed in future versions.")]
+        public static Sentry.EntityFramework.SentryCommandInterceptor? UseBreadcrumbs(Sentry.EntityFramework.IQueryLogger? logger = null) { }
+    }
+}
+namespace Sentry
+{
+    public static class SentryOptionsExtensions
+    {
+        public static Sentry.SentryOptions AddEntityFramework(this Sentry.SentryOptions sentryOptions) { }
+        public static void DisableDbInterceptionIntegration(this Sentry.SentryOptions options) { }
+    }
+}

--- a/test/Sentry.EntityFramework.Tests/Sentry.EntityFramework.Tests.csproj
+++ b/test/Sentry.EntityFramework.Tests/Sentry.EntityFramework.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <!-- Running these tests on Mono fail -->

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1,0 +1,51 @@
+﻿namespace Microsoft.Extensions.Logging
+{
+    public static class LoggingBuilderExtensions { }
+    public static class SentryLoggerFactoryExtensions { }
+}
+namespace Sentry.Extensions.Logging
+{
+    public class DelegateLogEntryFilter : Sentry.Extensions.Logging.ILogEntryFilter
+    {
+        public DelegateLogEntryFilter(System.Func<string, Microsoft.Extensions.Logging.LogLevel, Microsoft.Extensions.Logging.EventId, System.Exception?, bool> filter) { }
+        public bool Filter(string categoryName, Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, System.Exception? exception) { }
+    }
+    public interface ILogEntryFilter
+    {
+        bool Filter(string categoryName, Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, System.Exception? exception);
+    }
+    public class MelDiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    {
+        public MelDiagnosticLogger(Microsoft.Extensions.Logging.ILogger<Sentry.ISentryClient> logger, Sentry.SentryLevel level) { }
+        public bool IsEnabled(Sentry.SentryLevel level) { }
+        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+    }
+    [Microsoft.Extensions.Logging.ProviderAlias("Sentry")]
+    public class SentryLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, System.IDisposable
+    {
+        public SentryLoggerProvider(Microsoft.Extensions.Options.IOptions<Sentry.Extensions.Logging.SentryLoggingOptions> options, Sentry.IHub hub) { }
+        public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName) { }
+        public void Dispose() { }
+    }
+    public class SentryLoggingOptions : Sentry.SentryOptions
+    {
+        public SentryLoggingOptions() { }
+        public bool InitializeSdk { get; set; }
+        public Microsoft.Extensions.Logging.LogLevel MinimumBreadcrumbLevel { get; set; }
+        public Microsoft.Extensions.Logging.LogLevel MinimumEventLevel { get; set; }
+        public void ConfigureScope(System.Action<Sentry.Scope> action) { }
+    }
+    public static class SentryLoggingOptionsExtensions
+    {
+        public static void AddLogEntryFilter(this Sentry.Extensions.Logging.SentryLoggingOptions options, Sentry.Extensions.Logging.ILogEntryFilter filter) { }
+        public static void AddLogEntryFilter(this Sentry.Extensions.Logging.SentryLoggingOptions options, System.Func<string, Microsoft.Extensions.Logging.LogLevel, Microsoft.Extensions.Logging.EventId, System.Exception?, bool> filter) { }
+    }
+}
+namespace Sentry.Extensions.Logging.Extensions.DependencyInjection
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddSentry<TOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+            where TOptions : Sentry.Extensions.Logging.SentryLoggingOptions, new () { }
+    }
+}

--- a/test/Sentry.Extensions.Logging.Tests/Sentry.Extensions.Logging.Tests.csproj
+++ b/test/Sentry.Extensions.Logging.Tests/Sentry.Extensions.Logging.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net48;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net48;net6.0-android</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">10.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>

--- a/test/Sentry.Google.Cloud.Functions.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Google.Cloud.Functions.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1,0 +1,10 @@
+﻿namespace Google.Cloud.Functions.Framework
+{
+    public class SentryStartup : Google.Cloud.Functions.Hosting.FunctionsStartup
+    {
+        public SentryStartup() { }
+        public override void Configure(Microsoft.AspNetCore.Hosting.WebHostBuilderContext context, Microsoft.AspNetCore.Builder.IApplicationBuilder app) { }
+        public override void ConfigureLogging(Microsoft.AspNetCore.Hosting.WebHostBuilderContext context, Microsoft.Extensions.Logging.ILoggingBuilder logging) { }
+        public override void ConfigureServices(Microsoft.AspNetCore.Hosting.WebHostBuilderContext context, Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+    }
+}

--- a/test/Sentry.Google.Cloud.Functions.Tests/Sentry.Google.Cloud.Functions.Tests.csproj
+++ b/test/Sentry.Google.Cloud.Functions.Tests/Sentry.Google.Cloud.Functions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1,0 +1,13 @@
+﻿[assembly: System.CLSCompliant(true)]
+namespace Sentry.Log4Net
+{
+    public class SentryAppender : log4net.Appender.AppenderSkeleton
+    {
+        public SentryAppender() { }
+        public string? Dsn { get; set; }
+        public string? Environment { get; set; }
+        public bool SendIdentity { get; set; }
+        protected override void Append(log4net.Core.LoggingEvent loggingEvent) { }
+        protected override void OnClose() { }
+    }
+}

--- a/test/Sentry.Log4Net.Tests/Sentry.Log4Net.Tests.csproj
+++ b/test/Sentry.Log4Net.Tests/Sentry.Log4Net.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Sentry.NLog.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.NLog.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1,0 +1,83 @@
+﻿[assembly: System.CLSCompliant(true)]
+namespace NLog
+{
+    public static class ConfigurationExtensions
+    {
+        public static NLog.Config.LoggingConfiguration AddSentry(this NLog.Config.LoggingConfiguration configuration, System.Action<Sentry.NLog.SentryNLogOptions>? optionsConfig = null) { }
+        public static NLog.Config.LoggingConfiguration AddSentry(this NLog.Config.LoggingConfiguration configuration, string? dsn, System.Action<Sentry.NLog.SentryNLogOptions>? optionsConfig = null) { }
+        public static NLog.Config.LoggingConfiguration AddSentry(this NLog.Config.LoggingConfiguration configuration, string? dsn, string targetName, System.Action<Sentry.NLog.SentryNLogOptions>? optionsConfig = null) { }
+        public static void AddTag(this Sentry.NLog.SentryNLogOptions options, string name, NLog.Layouts.Layout layout) { }
+    }
+}
+namespace Sentry.NLog
+{
+    [NLog.Config.NLogConfigurationItem]
+    public class SentryNLogOptions : Sentry.SentryOptions
+    {
+        public SentryNLogOptions() { }
+        [NLog.Config.NLogConfigurationIgnoreProperty]
+        public NLog.Layouts.Layout? BreadcrumbCategoryLayout { get; set; }
+        [NLog.Config.NLogConfigurationIgnoreProperty]
+        public NLog.Layouts.Layout? BreadcrumbLayout { get; set; }
+        [NLog.Config.NLogConfigurationIgnoreProperty]
+        public NLog.Layouts.Layout? DsnLayout { get; set; }
+        [NLog.Config.NLogConfigurationIgnoreProperty]
+        public NLog.Layouts.Layout? EnvironmentLayout { get; set; }
+        public System.TimeSpan FlushTimeout { get; set; }
+        public bool IgnoreEventsWithNoException { get; set; }
+        public bool IncludeEventDataOnBreadcrumbs { get; set; }
+        public bool IncludeEventPropertiesAsTags { get; set; }
+        public bool InitializeSdk { get; set; }
+        [NLog.Config.NLogConfigurationIgnoreProperty]
+        public NLog.Layouts.Layout? Layout { get; set; }
+        public NLog.LogLevel? MinimumBreadcrumbLevel { get; set; }
+        public NLog.LogLevel? MinimumEventLevel { get; set; }
+        [NLog.Config.NLogConfigurationIgnoreProperty]
+        public NLog.Layouts.Layout? ReleaseLayout { get; set; }
+        public int ShutdownTimeoutSeconds { get; set; }
+        [NLog.Config.NLogConfigurationIgnoreProperty]
+        public System.Collections.Generic.IList<NLog.Targets.TargetPropertyWithContext> Tags { get; }
+        [NLog.Config.NLogConfigurationIgnoreProperty]
+        public Sentry.NLog.SentryNLogUser? User { get; set; }
+    }
+    [NLog.Config.NLogConfigurationItem]
+    public class SentryNLogUser
+    {
+        public SentryNLogUser() { }
+        public NLog.Layouts.Layout? Email { get; set; }
+        public NLog.Layouts.Layout? Id { get; set; }
+        public NLog.Layouts.Layout? IpAddress { get; set; }
+        [NLog.Config.ArrayParameter(typeof(NLog.Targets.TargetPropertyWithContext?), "other")]
+        public System.Collections.Generic.IList<NLog.Targets.TargetPropertyWithContext>? Other { get; }
+        public NLog.Layouts.Layout? Segment { get; set; }
+        public NLog.Layouts.Layout? Username { get; set; }
+    }
+    [NLog.Targets.Target("Sentry")]
+    public sealed class SentryTarget : NLog.Targets.TargetWithContext
+    {
+        public SentryTarget() { }
+        public SentryTarget(Sentry.NLog.SentryNLogOptions options) { }
+        public NLog.Layouts.Layout? BreadcrumbCategory { get; set; }
+        public NLog.Layouts.Layout? BreadcrumbLayout { get; set; }
+        public NLog.Layouts.Layout? Dsn { get; set; }
+        public NLog.Layouts.Layout? Environment { get; set; }
+        public int FlushTimeoutSeconds { get; set; }
+        public bool IgnoreEventsWithNoException { get; set; }
+        public bool IncludeEventDataOnBreadcrumbs { get; set; }
+        public bool IncludeEventPropertiesAsTags { get; set; }
+        public bool InitializeSdk { get; set; }
+        public string MinimumBreadcrumbLevel { get; set; }
+        public string MinimumEventLevel { get; set; }
+        [NLog.Config.Advanced]
+        public Sentry.NLog.SentryNLogOptions Options { get; }
+        public NLog.Layouts.Layout? Release { get; set; }
+        public int ShutdownTimeoutSeconds { get; set; }
+        [NLog.Config.ArrayParameter(typeof(NLog.Targets.TargetPropertyWithContext), "tag")]
+        public System.Collections.Generic.IList<NLog.Targets.TargetPropertyWithContext> Tags { get; }
+        public Sentry.NLog.SentryNLogUser? User { get; set; }
+        protected override void CloseTarget() { }
+        protected override void FlushAsync(NLog.Common.AsyncContinuation asyncContinuation) { }
+        protected override void InitializeTarget() { }
+        protected override void Write(NLog.LogEventInfo logEvent) { }
+    }
+}

--- a/test/Sentry.NLog.Tests/Sentry.NLog.Tests.csproj
+++ b/test/Sentry.NLog.Tests/Sentry.NLog.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1,0 +1,72 @@
+﻿[assembly: System.CLSCompliant(true)]
+namespace Sentry.Serilog
+{
+    public class SentrySerilogOptions : Sentry.SentryOptions
+    {
+        public SentrySerilogOptions() { }
+        public System.IFormatProvider? FormatProvider { get; set; }
+        public bool InitializeSdk { get; set; }
+        public Serilog.Events.LogEventLevel MinimumBreadcrumbLevel { get; set; }
+        public Serilog.Events.LogEventLevel MinimumEventLevel { get; set; }
+        public Serilog.Formatting.ITextFormatter? TextFormatter { get; set; }
+    }
+}
+namespace Serilog
+{
+    public static class SentrySinkExtensions
+    {
+        public static void ConfigureSentrySerilogOptions(
+                    Sentry.Serilog.SentrySerilogOptions sentrySerilogOptions,
+                    string? dsn = null,
+                    Serilog.Events.LogEventLevel? minimumEventLevel = default,
+                    Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default,
+                    System.IFormatProvider? formatProvider = null,
+                    Serilog.Formatting.ITextFormatter? textFormatter = null,
+                    bool? sendDefaultPii = default,
+                    bool? isEnvironmentUser = default,
+                    string? serverName = null,
+                    bool? attachStackTrace = default,
+                    int? maxBreadcrumbs = default,
+                    float? sampleRate = default,
+                    string? release = null,
+                    string? environment = null,
+                    int? maxQueueItems = default,
+                    System.TimeSpan? shutdownTimeout = default,
+                    System.Net.DecompressionMethods? decompressionMethods = default,
+                    System.IO.Compression.CompressionLevel? requestBodyCompressionLevel = default,
+                    bool? requestBodyCompressionBuffered = default,
+                    bool? debug = default,
+                    Sentry.SentryLevel? diagnosticLevel = default,
+                    bool? reportAssemblies = default,
+                    Sentry.DeduplicateMode? deduplicateMode = default,
+                    bool? initializeSdk = default,
+                    System.Collections.Generic.Dictionary<string, string>? defaultTags = null) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
+        public static Serilog.LoggerConfiguration Sentry(
+                    this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,
+                    string? dsn = null,
+                    Serilog.Events.LogEventLevel minimumBreadcrumbLevel = 2,
+                    Serilog.Events.LogEventLevel minimumEventLevel = 4,
+                    System.IFormatProvider? formatProvider = null,
+                    Serilog.Formatting.ITextFormatter? textFormatter = null,
+                    bool? sendDefaultPii = default,
+                    bool? isEnvironmentUser = default,
+                    string? serverName = null,
+                    bool? attachStackTrace = default,
+                    int? maxBreadcrumbs = default,
+                    float? sampleRate = default,
+                    string? release = null,
+                    string? environment = null,
+                    int? maxQueueItems = default,
+                    System.TimeSpan? shutdownTimeout = default,
+                    System.Net.DecompressionMethods? decompressionMethods = default,
+                    System.IO.Compression.CompressionLevel? requestBodyCompressionLevel = default,
+                    bool? requestBodyCompressionBuffered = default,
+                    bool? debug = default,
+                    Sentry.SentryLevel? diagnosticLevel = default,
+                    bool? reportAssemblies = default,
+                    Sentry.DeduplicateMode? deduplicateMode = default,
+                    bool? initializeSdk = default,
+                    System.Collections.Generic.Dictionary<string, string>? defaultTags = null) { }
+    }
+}

--- a/test/Sentry.Serilog.Tests/Sentry.Serilog.Tests.csproj
+++ b/test/Sentry.Serilog.Tests/Sentry.Serilog.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Sentry.Testing.CrashableApp/Sentry.Testing.CrashableApp.csproj
+++ b/test/Sentry.Testing.CrashableApp/Sentry.Testing.CrashableApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Sentry.Testing/Sentry.Testing.csproj
+++ b/test/Sentry.Testing/Sentry.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1,0 +1,1471 @@
+﻿[assembly: System.CLSCompliant(true)]
+namespace Sentry
+{
+    [System.Diagnostics.DebuggerDisplay("{FileName}")]
+    public class Attachment
+    {
+        public Attachment(Sentry.AttachmentType type, Sentry.IAttachmentContent content, string fileName, string? contentType) { }
+        public Sentry.IAttachmentContent Content { get; }
+        public string? ContentType { get; }
+        public string FileName { get; }
+        public Sentry.AttachmentType Type { get; }
+    }
+    public enum AttachmentType
+    {
+        Default = 0,
+        Minidump = 1,
+        AppleCrashReport = 2,
+        UnrealContext = 3,
+        UnrealLogs = 4,
+    }
+    [System.Diagnostics.DebuggerDisplay("Message: {Message}, Type: {Type}")]
+    public sealed class Breadcrumb : Sentry.IJsonSerializable
+    {
+        public Breadcrumb(string message, string type, System.Collections.Generic.IReadOnlyDictionary<string, string>? data = null, string? category = null, Sentry.BreadcrumbLevel level = 0) { }
+        public string? Category { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string>? Data { get; }
+        public Sentry.BreadcrumbLevel Level { get; }
+        public string? Message { get; }
+        public System.DateTimeOffset Timestamp { get; }
+        public string? Type { get; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Breadcrumb FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public enum BreadcrumbLevel
+    {
+        [System.Runtime.Serialization.EnumMember(Value="debug")]
+        Debug = -1,
+        [System.Runtime.Serialization.EnumMember(Value="info")]
+        Info = 0,
+        [System.Runtime.Serialization.EnumMember(Value="warning")]
+        Warning = 1,
+        [System.Runtime.Serialization.EnumMember(Value="error")]
+        Error = 2,
+        [System.Runtime.Serialization.EnumMember(Value="critical")]
+        Critical = 3,
+    }
+    public class ByteAttachmentContent : Sentry.IAttachmentContent
+    {
+        public ByteAttachmentContent(byte[] bytes) { }
+        public System.IO.Stream GetStream() { }
+    }
+    public static class Constants
+    {
+        public const int DefaultMaxBreadcrumbs = 100;
+        public const string DisableSdkDsnValue = "";
+        public const string Platform = "csharp";
+        public const int ProtocolVersion = 7;
+    }
+    public sealed class Contexts : System.Collections.Concurrent.ConcurrentDictionary<string, object>, Sentry.IJsonSerializable
+    {
+        public Contexts() { }
+        public Sentry.Protocol.App App { get; }
+        public Sentry.Protocol.Browser Browser { get; }
+        public Sentry.Protocol.Device Device { get; }
+        public Sentry.Protocol.Gpu Gpu { get; }
+        public Sentry.Protocol.OperatingSystem OperatingSystem { get; }
+        public Sentry.Protocol.Runtime Runtime { get; }
+        public Sentry.Protocol.Trace Trace { get; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Contexts FromJson(System.Text.Json.JsonElement json) { }
+    }
+    [System.Obsolete("WARNING: This method deliberately causes a crash, and should not be used in a rea" +
+        "l application.")]
+    public enum CrashType
+    {
+        Managed = 0,
+        ManagedBackgroundThread = 1,
+    }
+    public sealed class DebugImage : Sentry.IJsonSerializable
+    {
+        public DebugImage() { }
+        public string? CodeFile { get; set; }
+        public string? CodeId { get; set; }
+        public string? DebugFile { get; set; }
+        public string? DebugId { get; set; }
+        public string? ImageAddress { get; set; }
+        public long? ImageSize { get; set; }
+        public string? Type { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.DebugImage FromJson(System.Text.Json.JsonElement json) { }
+    }
+    [System.Flags]
+    public enum DeduplicateMode
+    {
+        SameEvent = 1,
+        SameExceptionInstance = 2,
+        InnerException = 4,
+        AggregateException = 8,
+        All = 2147483647,
+    }
+    public class DefaultSentryScopeStateProcessor : Sentry.ISentryScopeStateProcessor
+    {
+        public DefaultSentryScopeStateProcessor() { }
+        public void Apply(Sentry.Scope scope, object state) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Assembly)]
+    public class DsnAttribute : System.Attribute
+    {
+        public DsnAttribute(string dsn) { }
+        public string Dsn { get; }
+    }
+    public static class EventLikeExtensions
+    {
+        public static bool HasUser(this Sentry.IEventLike eventLike) { }
+        public static void SetFingerprint(this Sentry.IEventLike eventLike, System.Collections.Generic.IEnumerable<string> fingerprint) { }
+        public static void SetFingerprint(this Sentry.IEventLike eventLike, params string[] fingerprint) { }
+    }
+    public class FileAttachmentContent : Sentry.IAttachmentContent
+    {
+        public FileAttachmentContent(string filePath) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously) { }
+        public System.IO.Stream GetStream() { }
+    }
+    public static class HasBreadcrumbsExtensions
+    {
+        public static void AddBreadcrumb(this Sentry.IHasBreadcrumbs hasBreadcrumbs, string message, string? category, string? type, System.ValueTuple<string, string>? dataPair = default, Sentry.BreadcrumbLevel level = 0) { }
+        public static void AddBreadcrumb(this Sentry.IHasBreadcrumbs hasBreadcrumbs, string message, string? category = null, string? type = null, System.Collections.Generic.IReadOnlyDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
+        public static void AddBreadcrumb(this Sentry.IHasBreadcrumbs hasBreadcrumbs, System.DateTimeOffset? timestamp, string message, string? category = null, string? type = null, System.Collections.Generic.IReadOnlyDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
+    }
+    public static class HasExtraExtensions
+    {
+        public static void SetExtras(this Sentry.IHasExtra hasExtra, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>> values) { }
+    }
+    public static class HasTagsExtensions
+    {
+        public static void SetTags(this Sentry.IHasTags hasTags, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> tags) { }
+    }
+    public static class HubExtensions
+    {
+        public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
+        public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
+        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureMessage(this Sentry.IHub hub, string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
+        public static void LockScope(this Sentry.IHub hub) { }
+        public static System.IDisposable PushAndLockScope(this Sentry.IHub hub) { }
+        public static Sentry.ITransaction StartTransaction(this Sentry.IHub hub, Sentry.ITransactionContext context) { }
+        public static Sentry.ITransaction StartTransaction(this Sentry.IHub hub, string name, string operation) { }
+        public static Sentry.ITransaction StartTransaction(this Sentry.IHub hub, string name, string operation, Sentry.SentryTraceHeader traceHeader) { }
+        public static Sentry.ITransaction StartTransaction(this Sentry.IHub hub, string name, string operation, string? description) { }
+        public static void UnlockScope(this Sentry.IHub hub) { }
+    }
+    public interface IAttachmentContent
+    {
+        System.IO.Stream GetStream();
+    }
+    public interface IEventLike : Sentry.IHasBreadcrumbs, Sentry.IHasExtra, Sentry.IHasTags
+    {
+        Sentry.Contexts Contexts { get; set; }
+        string? Environment { get; set; }
+        System.Collections.Generic.IReadOnlyList<string> Fingerprint { get; set; }
+        Sentry.SentryLevel? Level { get; set; }
+        string? Platform { get; set; }
+        string? Release { get; set; }
+        Sentry.Request Request { get; set; }
+        Sentry.SdkVersion Sdk { get; }
+        string? TransactionName { get; set; }
+        Sentry.User User { get; set; }
+    }
+    public interface IHasBreadcrumbs
+    {
+        System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
+        void AddBreadcrumb(Sentry.Breadcrumb breadcrumb);
+    }
+    public interface IHasExtra
+    {
+        System.Collections.Generic.IReadOnlyDictionary<string, object?> Extra { get; }
+        void SetExtra(string key, object? value);
+    }
+    public interface IHasTags
+    {
+        System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
+        void SetTag(string key, string value);
+        void UnsetTag(string key);
+    }
+    public interface IHasTransactionNameSource
+    {
+        Sentry.TransactionNameSource NameSource { get; }
+    }
+    public interface IHub : Sentry.ISentryClient, Sentry.ISentryScopeManager
+    {
+        Sentry.SentryId LastEventId { get; }
+        void BindException(System.Exception exception, Sentry.ISpan span);
+        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope);
+        void EndSession(Sentry.SessionEndStatus status = 0);
+        Sentry.ISpan? GetSpan();
+        Sentry.SentryTraceHeader? GetTraceHeader();
+        void PauseSession();
+        void ResumeSession();
+        void StartSession();
+        Sentry.ITransaction StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext);
+    }
+    public interface IJsonSerializable
+    {
+        void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger);
+    }
+    public interface IScopeObserver
+    {
+        void AddBreadcrumb(Sentry.Breadcrumb breadcrumb);
+        void SetExtra(string key, object? value);
+        void SetTag(string key, string value);
+        void SetUser(Sentry.User? user);
+        void UnsetTag(string key);
+    }
+    public interface ISentryClient
+    {
+        bool IsEnabled { get; }
+        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null);
+        void CaptureSession(Sentry.SessionUpdate sessionUpdate);
+        void CaptureTransaction(Sentry.Transaction transaction);
+        void CaptureUserFeedback(Sentry.UserFeedback userFeedback);
+        System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
+    public interface ISentryScopeManager
+    {
+        void BindClient(Sentry.ISentryClient client);
+        void ConfigureScope(System.Action<Sentry.Scope> configureScope);
+        System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope);
+        System.IDisposable PushScope();
+        System.IDisposable PushScope<TState>(TState state);
+        void WithScope(System.Action<Sentry.Scope> scopeCallback);
+    }
+    public interface ISentryScopeStateProcessor
+    {
+        void Apply(Sentry.Scope scope, object state);
+    }
+    public interface ISession
+    {
+        string? DistinctId { get; }
+        string? Environment { get; }
+        int ErrorCount { get; }
+        Sentry.SentryId Id { get; }
+        string? IpAddress { get; }
+        string Release { get; }
+        System.DateTimeOffset StartTimestamp { get; }
+        string? UserAgent { get; }
+    }
+    public interface ISpan : Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISpanContext, Sentry.ISpanData, Sentry.Protocol.ITraceContext
+    {
+        new string? Description { get; set; }
+        new string Operation { get; set; }
+        new Sentry.SpanStatus? Status { get; set; }
+        void Finish();
+        void Finish(Sentry.SpanStatus status);
+        void Finish(System.Exception exception);
+        void Finish(System.Exception exception, Sentry.SpanStatus status);
+        Sentry.ISpan StartChild(string operation);
+    }
+    public interface ISpanContext : Sentry.Protocol.ITraceContext { }
+    public interface ISpanData : Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISpanContext, Sentry.Protocol.ITraceContext
+    {
+        System.DateTimeOffset? EndTimestamp { get; }
+        bool IsFinished { get; }
+        System.DateTimeOffset StartTimestamp { get; }
+        Sentry.SentryTraceHeader GetTraceHeader();
+    }
+    public interface ITransaction : Sentry.IEventLike, Sentry.IHasBreadcrumbs, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISpan, Sentry.ISpanContext, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
+    {
+        new bool? IsParentSampled { get; set; }
+        new string Name { get; set; }
+        System.Collections.Generic.IReadOnlyCollection<Sentry.ISpan> Spans { get; }
+        Sentry.ISpan? GetLastActiveSpan();
+    }
+    public interface ITransactionContext : Sentry.ISpanContext, Sentry.Protocol.ITraceContext
+    {
+        bool? IsParentSampled { get; }
+        string Name { get; }
+    }
+    public interface ITransactionData : Sentry.IEventLike, Sentry.IHasBreadcrumbs, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISpanContext, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.Protocol.ITraceContext { }
+    public sealed class Package : Sentry.IJsonSerializable
+    {
+        public Package(string name, string version) { }
+        public string Name { get; }
+        public string Version { get; }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Package FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public enum ReportAssembliesMode
+    {
+        None = 0,
+        Version = 1,
+        InformationalVersion = 2,
+    }
+    public sealed class Request : Sentry.IJsonSerializable
+    {
+        public Request() { }
+        public string? Cookies { get; set; }
+        public object? Data { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Env { get; }
+        public System.Collections.Generic.IDictionary<string, string> Headers { get; }
+        public string? Method { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Other { get; }
+        public string? QueryString { get; set; }
+        public string? Url { get; set; }
+        public Sentry.Request Clone() { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Request FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public class Scope : Sentry.IEventLike, Sentry.IHasBreadcrumbs, Sentry.IHasExtra, Sentry.IHasTags
+    {
+        public Scope(Sentry.SentryOptions? options) { }
+        public System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment> Attachments { get; }
+        public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
+        public Sentry.Contexts Contexts { get; set; }
+        public string? Distribution { get; set; }
+        public string? Environment { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Extra { get; }
+        public System.Collections.Generic.IReadOnlyList<string> Fingerprint { get; set; }
+        public Sentry.SentryLevel? Level { get; set; }
+        public string? Platform { get; set; }
+        public string? Release { get; set; }
+        public Sentry.Request Request { get; set; }
+        public Sentry.SdkVersion Sdk { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
+        public Sentry.ITransaction? Transaction { get; set; }
+        public string? TransactionName { get; set; }
+        public Sentry.User User { get; set; }
+        public void AddAttachment(Sentry.Attachment attachment) { }
+        public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb) { }
+        public void Apply(Sentry.IEventLike other) { }
+        public void Apply(Sentry.Scope other) { }
+        public void Apply(object state) { }
+        public void ClearAttachments() { }
+        public Sentry.Scope Clone() { }
+        public Sentry.ISpan? GetSpan() { }
+        public void SetExtra(string key, object? value) { }
+        public void SetTag(string key, string value) { }
+        public void UnsetTag(string key) { }
+    }
+    public static class ScopeExtensions
+    {
+        public static void AddAttachment(this Sentry.Scope scope, string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
+        public static void AddAttachment(this Sentry.Scope scope, byte[] data, string fileName, Sentry.AttachmentType type = 0, string? contentType = null) { }
+        public static void AddAttachment(this Sentry.Scope scope, System.IO.Stream stream, string fileName, Sentry.AttachmentType type = 0, string? contentType = null) { }
+        public static void AddEventProcessor(this Sentry.Scope scope, Sentry.Extensibility.ISentryEventProcessor processor) { }
+        public static void AddEventProcessor(this Sentry.Scope scope, System.Func<Sentry.SentryEvent, Sentry.SentryEvent> processor) { }
+        public static void AddEventProcessors(this Sentry.Scope scope, System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventProcessor> processors) { }
+        public static void AddExceptionProcessor(this Sentry.Scope scope, Sentry.Extensibility.ISentryEventExceptionProcessor processor) { }
+        public static void AddExceptionProcessors(this Sentry.Scope scope, System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventExceptionProcessor> processors) { }
+        public static void AddTransactionProcessor(this Sentry.Scope scope, Sentry.Extensibility.ISentryTransactionProcessor processor) { }
+        public static void AddTransactionProcessor(this Sentry.Scope scope, System.Func<Sentry.Transaction, Sentry.Transaction?> processor) { }
+        public static void AddTransactionProcessors(this Sentry.Scope scope, System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryTransactionProcessor> processors) { }
+        public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventProcessor> GetAllEventProcessors(this Sentry.Scope scope) { }
+        public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventExceptionProcessor> GetAllExceptionProcessors(this Sentry.Scope scope) { }
+        public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryTransactionProcessor> GetAllTransactionProcessors(this Sentry.Scope scope) { }
+    }
+    public sealed class SdkVersion : Sentry.IJsonSerializable
+    {
+        public SdkVersion() { }
+        public string? Name { get; set; }
+        public System.Collections.Generic.IEnumerable<Sentry.Package> Packages { get; }
+        public string? Version { get; set; }
+        public void AddIntegration(string integration) { }
+        public void AddPackage(string name, string version) { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SdkVersion FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public class SentryClient : Sentry.ISentryClient, System.IDisposable
+    {
+        public SentryClient(Sentry.SentryOptions options) { }
+        public bool IsEnabled { get; }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null) { }
+        public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
+        public void CaptureTransaction(Sentry.Transaction transaction) { }
+        public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
+        [System.Obsolete("Sentry client should not be explicitly disposed of. This method will be removed i" +
+            "n version 4.")]
+        public void Dispose() { }
+        public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
+    }
+    public static class SentryClientExtensions
+    {
+        public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex) { }
+        public static Sentry.SentryId CaptureMessage(this Sentry.ISentryClient client, string message, Sentry.SentryLevel level = 1) { }
+        public static void CaptureUserFeedback(this Sentry.ISentryClient client, Sentry.SentryId eventId, string email, string comments, string? name = null) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("{GetType().Name,nq}: {EventId,nq}")]
+    public sealed class SentryEvent : Sentry.IEventLike, Sentry.IHasBreadcrumbs, Sentry.IHasExtra, Sentry.IHasTags, Sentry.IJsonSerializable
+    {
+        public SentryEvent() { }
+        public SentryEvent(System.Exception? exception) { }
+        public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
+        public Sentry.Contexts Contexts { get; set; }
+        public System.Collections.Generic.List<Sentry.DebugImage>? DebugImages { get; set; }
+        public string? Distribution { get; set; }
+        public string? Environment { get; set; }
+        public Sentry.SentryId EventId { get; }
+        public System.Exception? Exception { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Extra { get; }
+        public System.Collections.Generic.IReadOnlyList<string> Fingerprint { get; set; }
+        public Sentry.SentryLevel? Level { get; set; }
+        public string? Logger { get; set; }
+        public Sentry.SentryMessage? Message { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Modules { get; }
+        public string? Platform { get; set; }
+        public string? Release { get; set; }
+        public Sentry.Request Request { get; set; }
+        public Sentry.SdkVersion Sdk { get; }
+        public System.Collections.Generic.IEnumerable<Sentry.Protocol.SentryException>? SentryExceptions { get; set; }
+        public System.Collections.Generic.IEnumerable<Sentry.SentryThread>? SentryThreads { get; set; }
+        public string? ServerName { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
+        public System.DateTimeOffset Timestamp { get; }
+        public string? TransactionName { get; set; }
+        public Sentry.User User { get; set; }
+        public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb) { }
+        public void SetExtra(string key, object? value) { }
+        public void SetTag(string key, string value) { }
+        public void UnsetTag(string key) { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryEvent FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public class SentryHttpMessageHandler : System.Net.Http.DelegatingHandler
+    {
+        public SentryHttpMessageHandler() { }
+        public SentryHttpMessageHandler(Sentry.IHub hub) { }
+        public SentryHttpMessageHandler(System.Net.Http.HttpMessageHandler innerHandler) { }
+        public SentryHttpMessageHandler(System.Net.Http.HttpMessageHandler innerHandler, Sentry.IHub hub) { }
+        protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { }
+    }
+    public readonly struct SentryId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SentryId>
+    {
+        public static readonly Sentry.SentryId Empty;
+        public SentryId(System.Guid guid) { }
+        public bool Equals(Sentry.SentryId other) { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public override string ToString() { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryId Create() { }
+        public static Sentry.SentryId FromJson(System.Text.Json.JsonElement json) { }
+        public static Sentry.SentryId Parse(string value) { }
+        public static System.Guid op_Implicit(Sentry.SentryId sentryId) { }
+        public static Sentry.SentryId op_Implicit(System.Guid guid) { }
+        public static bool operator !=(Sentry.SentryId left, Sentry.SentryId right) { }
+        public static bool operator ==(Sentry.SentryId left, Sentry.SentryId right) { }
+    }
+    public enum SentryLevel : short
+    {
+        [System.Runtime.Serialization.EnumMember(Value="debug")]
+        Debug = 0,
+        [System.Runtime.Serialization.EnumMember(Value="info")]
+        Info = 1,
+        [System.Runtime.Serialization.EnumMember(Value="warning")]
+        Warning = 2,
+        [System.Runtime.Serialization.EnumMember(Value="error")]
+        Error = 3,
+        [System.Runtime.Serialization.EnumMember(Value="fatal")]
+        Fatal = 4,
+    }
+    public sealed class SentryMessage : Sentry.IJsonSerializable
+    {
+        public SentryMessage() { }
+        public string? Formatted { get; set; }
+        public string? Message { get; set; }
+        public System.Collections.Generic.IEnumerable<object>? Params { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryMessage FromJson(System.Text.Json.JsonElement json) { }
+        public static Sentry.SentryMessage op_Implicit(string? message) { }
+    }
+    public class SentryOptions
+    {
+        public SentryOptions() { }
+        public bool AttachStacktrace { get; set; }
+        public bool AutoSessionTracking { get; set; }
+        public System.TimeSpan AutoSessionTrackingInterval { get; set; }
+        public Sentry.Extensibility.IBackgroundWorker? BackgroundWorker { get; set; }
+        public System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?>? BeforeBreadcrumb { get; set; }
+        public System.Func<Sentry.SentryEvent, Sentry.SentryEvent?>? BeforeSend { get; set; }
+        public string? CacheDirectoryPath { get; set; }
+        public System.Action<System.Net.Http.HttpClient>? ConfigureClient { get; set; }
+        public System.Func<bool>? CrashedLastRun { get; set; }
+        public System.Func<System.Net.Http.HttpClientHandler>? CreateHttpClientHandler { get; set; }
+        public bool Debug { get; set; }
+        public System.Net.DecompressionMethods DecompressionMethods { get; set; }
+        public Sentry.DeduplicateMode DeduplicateMode { get; set; }
+        public System.Collections.Generic.Dictionary<string, string> DefaultTags { get; }
+        public Sentry.StartupTimeDetectionMode DetectStartupTime { get; set; }
+        public Sentry.SentryLevel DiagnosticLevel { get; set; }
+        public Sentry.Extensibility.IDiagnosticLogger? DiagnosticLogger { get; set; }
+        public string? Distribution { get; set; }
+        public string? Dsn { get; set; }
+        public bool EnableScopeSync { get; set; }
+        public string? Environment { get; set; }
+        public System.Net.IWebProxy? HttpProxy { get; set; }
+        public System.TimeSpan InitCacheFlushTimeout { get; set; }
+        public bool IsEnvironmentUser { get; set; }
+        public bool IsGlobalModeEnabled { get; set; }
+        public bool KeepAggregateException { get; set; }
+        public long MaxAttachmentSize { get; set; }
+        public int MaxBreadcrumbs { get; set; }
+        public int MaxCacheItems { get; set; }
+        public int MaxQueueItems { get; set; }
+        public Sentry.Extensibility.INetworkStatusListener? NetworkStatusListener { get; set; }
+        public string? Release { get; set; }
+        [System.Obsolete("Use ReportAssembliesMode instead", false)]
+        public bool ReportAssemblies { get; set; }
+        public Sentry.ReportAssembliesMode ReportAssembliesMode { get; set; }
+        public bool RequestBodyCompressionBuffered { get; set; }
+        public System.IO.Compression.CompressionLevel RequestBodyCompressionLevel { get; set; }
+        public float? SampleRate { get; set; }
+        public Sentry.IScopeObserver? ScopeObserver { get; set; }
+        public bool SendClientReports { get; set; }
+        public bool SendDefaultPii { get; set; }
+        public Sentry.ISentryScopeStateProcessor SentryScopeStateProcessor { get; set; }
+        public string? ServerName { get; set; }
+        public System.TimeSpan ShutdownTimeout { get; set; }
+        public Sentry.StackTraceMode StackTraceMode { get; set; }
+        public double TracesSampleRate { get; set; }
+        public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
+        public Sentry.Extensibility.ITransport? Transport { get; set; }
+        public bool UseAsyncFileIO { get; set; }
+        public void AddJsonConverter(System.Text.Json.Serialization.JsonConverter converter) { }
+    }
+    public static class SentryOptionsExtensions
+    {
+        public static void AddEventProcessor(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryEventProcessor processor) { }
+        public static void AddEventProcessorProvider(this Sentry.SentryOptions options, System.Func<System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventProcessor>> processorProvider) { }
+        public static void AddEventProcessors(this Sentry.SentryOptions options, System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventProcessor> processors) { }
+        public static void AddExceptionFilter(this Sentry.SentryOptions options, Sentry.Extensibility.IExceptionFilter exceptionFilter) { }
+        public static void AddExceptionFilterForType<TException>(this Sentry.SentryOptions options)
+            where TException : System.Exception { }
+        public static void AddExceptionProcessor(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryEventExceptionProcessor processor) { }
+        public static void AddExceptionProcessorProvider(this Sentry.SentryOptions options, System.Func<System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventExceptionProcessor>> processorProvider) { }
+        public static void AddExceptionProcessors(this Sentry.SentryOptions options, System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventExceptionProcessor> processors) { }
+        public static void AddInAppExclude(this Sentry.SentryOptions options, string prefix) { }
+        public static void AddInAppInclude(this Sentry.SentryOptions options, string prefix) { }
+        public static void AddIntegration(this Sentry.SentryOptions options, Sentry.Integrations.ISdkIntegration integration) { }
+        public static void AddTransactionProcessor(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryTransactionProcessor processor) { }
+        public static void AddTransactionProcessorProvider(this Sentry.SentryOptions options, System.Func<System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryTransactionProcessor>> processorProvider) { }
+        public static void AddTransactionProcessors(this Sentry.SentryOptions options, System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryTransactionProcessor> processors) { }
+        public static void ApplyDefaultTags(this Sentry.SentryOptions options, Sentry.IHasTags hasTags) { }
+        public static void DisableAppDomainProcessExitFlush(this Sentry.SentryOptions options) { }
+        public static void DisableAppDomainUnhandledExceptionCapture(this Sentry.SentryOptions options) { }
+        public static void DisableDiagnosticSourceIntegration(this Sentry.SentryOptions options) { }
+        public static void DisableDuplicateEventDetection(this Sentry.SentryOptions options) { }
+        public static void DisableTaskUnobservedTaskExceptionCapture(this Sentry.SentryOptions options) { }
+        public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventProcessor> GetAllEventProcessors(this Sentry.SentryOptions options) { }
+        public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventExceptionProcessor> GetAllExceptionProcessors(this Sentry.SentryOptions options) { }
+        public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryTransactionProcessor> GetAllTransactionProcessors(this Sentry.SentryOptions options) { }
+        public static void RemoveIntegration<TIntegration>(this Sentry.SentryOptions options)
+            where TIntegration : Sentry.Integrations.ISdkIntegration { }
+        public static Sentry.SentryOptions UseStackTraceFactory(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryStackTraceFactory sentryStackTraceFactory) { }
+    }
+    public static class SentrySdk
+    {
+        public static bool IsEnabled { get; }
+        public static Sentry.SentryId LastEventId { get; }
+        public static void AddBreadcrumb(string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
+        public static void AddBreadcrumb(Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
+        public static void BindClient(Sentry.ISentryClient client) { }
+        public static void BindException(System.Exception exception, Sentry.ISpan span) { }
+        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt) { }
+        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope) { }
+        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureMessage(string message, Sentry.SentryLevel level = 1) { }
+        public static Sentry.SentryId CaptureMessage(string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
+        public static void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static void CaptureTransaction(Sentry.Transaction transaction) { }
+        public static void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
+        public static void CaptureUserFeedback(Sentry.SentryId eventId, string email, string comments, string? name = null) { }
+        [System.Obsolete("WARNING: This method deliberately causes a crash, and should not be used in a rea" +
+            "l application.")]
+        public static void CauseCrash(Sentry.CrashType crashType) { }
+        public static void Close() { }
+        public static void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
+        public static System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
+        public static void EndSession(Sentry.SessionEndStatus status = 0) { }
+        public static System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
+        public static Sentry.ISpan? GetSpan() { }
+        public static Sentry.SentryTraceHeader? GetTraceHeader() { }
+        public static System.IDisposable Init() { }
+        public static System.IDisposable Init(Sentry.SentryOptions options) { }
+        public static System.IDisposable Init(System.Action<Sentry.SentryOptions>? configureOptions) { }
+        public static System.IDisposable Init(string? dsn) { }
+        public static void PauseSession() { }
+        public static System.IDisposable PushScope() { }
+        public static System.IDisposable PushScope<TState>(TState state) { }
+        public static void ResumeSession() { }
+        public static void StartSession() { }
+        public static Sentry.ITransaction StartTransaction(Sentry.ITransactionContext context) { }
+        public static Sentry.ITransaction StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
+        public static Sentry.ITransaction StartTransaction(string name, string operation) { }
+        public static Sentry.ITransaction StartTransaction(string name, string operation, Sentry.SentryTraceHeader traceHeader) { }
+        public static Sentry.ITransaction StartTransaction(string name, string operation, string? description) { }
+        [System.Obsolete("This method is deprecated in favor of overloads of CaptureEvent, CaptureMessage a" +
+            "nd CaptureException that provide a callback to a configurable scope.")]
+        public static void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
+    }
+    public sealed class SentryStackFrame : Sentry.IJsonSerializable
+    {
+        public SentryStackFrame() { }
+        public string? AbsolutePath { get; set; }
+        public string? AddressMode { get; set; }
+        public int? ColumnNumber { get; set; }
+        public string? ContextLine { get; set; }
+        public string? FileName { get; set; }
+        public System.Collections.Generic.IList<int> FramesOmitted { get; }
+        public string? Function { get; set; }
+        public long ImageAddress { get; set; }
+        public bool? InApp { get; set; }
+        public string? InstructionAddress { get; set; }
+        public long? InstructionOffset { get; set; }
+        public int? LineNumber { get; set; }
+        public string? Module { get; set; }
+        public string? Package { get; set; }
+        public string? Platform { get; set; }
+        public System.Collections.Generic.IList<string> PostContext { get; }
+        public System.Collections.Generic.IList<string> PreContext { get; }
+        public long? SymbolAddress { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Vars { get; }
+        public void ConfigureAppFrame(Sentry.SentryOptions options) { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryStackFrame FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class SentryStackTrace : Sentry.IJsonSerializable
+    {
+        public SentryStackTrace() { }
+        public System.Collections.Generic.IList<Sentry.SentryStackFrame> Frames { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryStackTrace FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class SentryThread : Sentry.IJsonSerializable
+    {
+        public SentryThread() { }
+        public bool? Crashed { get; set; }
+        public bool? Current { get; set; }
+        public int? Id { get; set; }
+        public string? Name { get; set; }
+        public Sentry.SentryStackTrace? Stacktrace { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryThread FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public class SentryTraceHeader
+    {
+        public SentryTraceHeader(Sentry.SentryId traceId, Sentry.SpanId spanSpanId, bool? isSampled) { }
+        public bool? IsSampled { get; }
+        public Sentry.SpanId SpanId { get; }
+        public Sentry.SentryId TraceId { get; }
+        public override string ToString() { }
+        public static Sentry.SentryTraceHeader Parse(string value) { }
+    }
+    public sealed class SentryValues<T> : Sentry.IJsonSerializable
+    {
+        public SentryValues(System.Collections.Generic.IEnumerable<T>? values) { }
+        public System.Collections.Generic.IEnumerable<T> Values { get; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+    }
+    public class Session : Sentry.ISession
+    {
+        public Session(string? distinctId, string release, string? environment) { }
+        public string? DistinctId { get; }
+        public string? Environment { get; }
+        public int ErrorCount { get; }
+        public Sentry.SentryId Id { get; }
+        public string? IpAddress { get; }
+        public string Release { get; }
+        public System.DateTimeOffset StartTimestamp { get; }
+        public string? UserAgent { get; }
+        public void ReportError() { }
+    }
+    public enum SessionEndStatus
+    {
+        Exited = 0,
+        Crashed = 1,
+        Abnormal = 2,
+    }
+    public class SessionUpdate : Sentry.IJsonSerializable, Sentry.ISession
+    {
+        public SessionUpdate(Sentry.SessionUpdate sessionUpdate, bool isInitial) { }
+        public SessionUpdate(Sentry.SessionUpdate sessionUpdate, bool isInitial, Sentry.SessionEndStatus? endStatus) { }
+        public SessionUpdate(Sentry.ISession session, bool isInitial, System.DateTimeOffset timestamp, int sequenceNumber, Sentry.SessionEndStatus? endStatus) { }
+        public SessionUpdate(Sentry.SentryId id, string? distinctId, System.DateTimeOffset startTimestamp, string release, string? environment, string? ipAddress, string? userAgent, int errorCount, bool isInitial, System.DateTimeOffset timestamp, int sequenceNumber, Sentry.SessionEndStatus? endStatus) { }
+        public string? DistinctId { get; }
+        public System.TimeSpan Duration { get; }
+        public Sentry.SessionEndStatus? EndStatus { get; }
+        public string? Environment { get; }
+        public int ErrorCount { get; }
+        public Sentry.SentryId Id { get; }
+        public string? IpAddress { get; }
+        public bool IsInitial { get; }
+        public string Release { get; }
+        public int SequenceNumber { get; }
+        public System.DateTimeOffset StartTimestamp { get; }
+        public System.DateTimeOffset Timestamp { get; }
+        public string? UserAgent { get; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SessionUpdate FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public class Span : Sentry.IHasExtra, Sentry.IHasTags, Sentry.IJsonSerializable, Sentry.ISpanContext, Sentry.ISpanData, Sentry.Protocol.ITraceContext
+    {
+        public Span(Sentry.ISpan tracer) { }
+        public Span(Sentry.SpanId? parentSpanId, string operation) { }
+        public string? Description { get; set; }
+        public System.DateTimeOffset? EndTimestamp { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Extra { get; }
+        public bool IsFinished { get; }
+        public bool? IsSampled { get; }
+        public string Operation { get; set; }
+        public Sentry.SpanId? ParentSpanId { get; }
+        public Sentry.SpanId SpanId { get; }
+        public System.DateTimeOffset StartTimestamp { get; }
+        public Sentry.SpanStatus? Status { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
+        public Sentry.SentryId TraceId { get; }
+        public Sentry.SentryTraceHeader GetTraceHeader() { }
+        public void SetExtra(string key, object? value) { }
+        public void SetTag(string key, string value) { }
+        public void UnsetTag(string key) { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Span FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public class SpanContext : Sentry.ISpanContext, Sentry.Protocol.ITraceContext
+    {
+        public SpanContext(Sentry.SpanId spanId, Sentry.SpanId? parentSpanId, Sentry.SentryId traceId, string operation, string? description, Sentry.SpanStatus? status, bool? isSampled) { }
+        public string? Description { get; }
+        public bool? IsSampled { get; }
+        public string Operation { get; }
+        public Sentry.SpanId? ParentSpanId { get; }
+        public Sentry.SpanId SpanId { get; }
+        public Sentry.SpanStatus? Status { get; }
+        public Sentry.SentryId TraceId { get; }
+    }
+    public static class SpanExtensions
+    {
+        public static Sentry.ISpan StartChild(this Sentry.ISpan span, string operation, string? description) { }
+    }
+    public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>
+    {
+        public static readonly Sentry.SpanId Empty;
+        public SpanId(string value) { }
+        public bool Equals(Sentry.SpanId other) { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public override string ToString() { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
+        public static Sentry.SpanId Create() { }
+        public static Sentry.SpanId FromJson(System.Text.Json.JsonElement json) { }
+        public static Sentry.SpanId Parse(string value) { }
+        public static string op_Implicit(Sentry.SpanId id) { }
+        public static bool operator !=(Sentry.SpanId left, Sentry.SpanId right) { }
+        public static bool operator ==(Sentry.SpanId left, Sentry.SpanId right) { }
+    }
+    public enum SpanStatus
+    {
+        Ok = 0,
+        DeadlineExceeded = 1,
+        Unauthenticated = 2,
+        PermissionDenied = 3,
+        NotFound = 4,
+        ResourceExhausted = 5,
+        InvalidArgument = 6,
+        Unimplemented = 7,
+        Unavailable = 8,
+        InternalError = 9,
+        UnknownError = 10,
+        Cancelled = 11,
+        AlreadyExists = 12,
+        FailedPrecondition = 13,
+        Aborted = 14,
+        OutOfRange = 15,
+        DataLoss = 16,
+    }
+    public class SpanTracer : Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISpan, Sentry.ISpanContext, Sentry.ISpanData, Sentry.Protocol.ITraceContext
+    {
+        public SpanTracer(Sentry.IHub hub, Sentry.TransactionTracer transaction, Sentry.SpanId? parentSpanId, Sentry.SentryId traceId, string operation) { }
+        public string? Description { get; set; }
+        public System.DateTimeOffset? EndTimestamp { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Extra { get; }
+        public bool IsFinished { get; }
+        public bool? IsSampled { get; }
+        public string Operation { get; set; }
+        public Sentry.SpanId? ParentSpanId { get; }
+        public Sentry.SpanId SpanId { get; }
+        public System.DateTimeOffset StartTimestamp { get; }
+        public Sentry.SpanStatus? Status { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
+        public Sentry.SentryId TraceId { get; }
+        public void Finish() { }
+        public void Finish(Sentry.SpanStatus status) { }
+        public void Finish(System.Exception exception) { }
+        public void Finish(System.Exception exception, Sentry.SpanStatus status) { }
+        public Sentry.SentryTraceHeader GetTraceHeader() { }
+        public void SetExtra(string key, object? value) { }
+        public void SetTag(string key, string value) { }
+        public Sentry.ISpan StartChild(string operation) { }
+        public void UnsetTag(string key) { }
+    }
+    public enum StackTraceMode
+    {
+        Original = 0,
+        Enhanced = 1,
+    }
+    public enum StartupTimeDetectionMode
+    {
+        None = 0,
+        Fast = 1,
+        Best = 2,
+    }
+    public class StreamAttachmentContent : Sentry.IAttachmentContent
+    {
+        public StreamAttachmentContent(System.IO.Stream stream) { }
+        public System.IO.Stream GetStream() { }
+    }
+    public class Transaction : Sentry.IEventLike, Sentry.IHasBreadcrumbs, Sentry.IHasExtra, Sentry.IHasTags, Sentry.IHasTransactionNameSource, Sentry.IJsonSerializable, Sentry.ISpanContext, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
+    {
+        public Transaction(Sentry.ITransaction tracer) { }
+        public Transaction(string name, string operation) { }
+        public Transaction(string name, string operation, Sentry.TransactionNameSource nameSource) { }
+        public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
+        public Sentry.Contexts Contexts { get; set; }
+        public string? Description { get; set; }
+        public string? Distribution { get; set; }
+        public System.DateTimeOffset? EndTimestamp { get; }
+        public string? Environment { get; set; }
+        public Sentry.SentryId EventId { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Extra { get; }
+        public System.Collections.Generic.IReadOnlyList<string> Fingerprint { get; set; }
+        public bool IsFinished { get; }
+        public bool? IsParentSampled { get; set; }
+        public bool? IsSampled { get; }
+        public Sentry.SentryLevel? Level { get; set; }
+        public string Name { get; }
+        public Sentry.TransactionNameSource NameSource { get; }
+        public string Operation { get; }
+        public Sentry.SpanId? ParentSpanId { get; }
+        public string? Platform { get; set; }
+        public string? Release { get; set; }
+        public Sentry.Request Request { get; set; }
+        public Sentry.SdkVersion Sdk { get; }
+        public Sentry.SpanId SpanId { get; }
+        public System.Collections.Generic.IReadOnlyCollection<Sentry.Span> Spans { get; }
+        public System.DateTimeOffset StartTimestamp { get; }
+        public Sentry.SpanStatus? Status { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
+        public Sentry.SentryId TraceId { get; }
+        public Sentry.User User { get; set; }
+        public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb) { }
+        public Sentry.SentryTraceHeader GetTraceHeader() { }
+        public void SetExtra(string key, object? value) { }
+        public void SetTag(string key, string value) { }
+        public void UnsetTag(string key) { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Transaction FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public class TransactionContext : Sentry.SpanContext, Sentry.IHasTransactionNameSource, Sentry.ISpanContext, Sentry.ITransactionContext, Sentry.Protocol.ITraceContext
+    {
+        public TransactionContext(string name, string operation) { }
+        public TransactionContext(string name, string operation, Sentry.SentryTraceHeader traceHeader) { }
+        public TransactionContext(string name, string operation, Sentry.TransactionNameSource nameSource) { }
+        public TransactionContext(string name, string operation, bool? isSampled) { }
+        public TransactionContext(string name, string operation, Sentry.SentryTraceHeader traceHeader, Sentry.TransactionNameSource nameSource) { }
+        public TransactionContext(Sentry.SpanId? parentSpanId, Sentry.SentryId traceId, string name, string operation, bool? isParentSampled) { }
+        public TransactionContext(Sentry.SpanId spanId, Sentry.SpanId? parentSpanId, Sentry.SentryId traceId, string name, string operation, string? description, Sentry.SpanStatus? status, bool? isSampled, bool? isParentSampled) { }
+        public TransactionContext(Sentry.SpanId spanId, Sentry.SpanId? parentSpanId, Sentry.SentryId traceId, string name, string operation, string? description, Sentry.SpanStatus? status, bool? isSampled, bool? isParentSampled, Sentry.TransactionNameSource nameSource) { }
+        public bool? IsParentSampled { get; }
+        public string Name { get; }
+        public Sentry.TransactionNameSource NameSource { get; }
+    }
+    public enum TransactionNameSource
+    {
+        Custom = 0,
+        Url = 1,
+        Route = 2,
+        View = 3,
+        Component = 4,
+        Task = 5,
+    }
+    public class TransactionSamplingContext
+    {
+        public TransactionSamplingContext(Sentry.ITransactionContext transactionContext, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> CustomSamplingContext { get; }
+        public Sentry.ITransactionContext TransactionContext { get; }
+    }
+    public class TransactionTracer : Sentry.IEventLike, Sentry.IHasBreadcrumbs, Sentry.IHasExtra, Sentry.IHasTags, Sentry.IHasTransactionNameSource, Sentry.ISpan, Sentry.ISpanContext, Sentry.ISpanData, Sentry.ITransaction, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
+    {
+        public TransactionTracer(Sentry.IHub hub, Sentry.ITransactionContext context) { }
+        public TransactionTracer(Sentry.IHub hub, string name, string operation) { }
+        public TransactionTracer(Sentry.IHub hub, string name, string operation, Sentry.TransactionNameSource nameSource) { }
+        public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
+        public Sentry.Contexts Contexts { get; set; }
+        public string? Description { get; set; }
+        public string? Distribution { get; set; }
+        public System.DateTimeOffset? EndTimestamp { get; }
+        public string? Environment { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Extra { get; }
+        public System.Collections.Generic.IReadOnlyList<string> Fingerprint { get; set; }
+        public bool IsFinished { get; }
+        public bool? IsParentSampled { get; set; }
+        public bool? IsSampled { get; }
+        public Sentry.SentryLevel? Level { get; set; }
+        public string Name { get; set; }
+        public Sentry.TransactionNameSource NameSource { get; set; }
+        public string Operation { get; set; }
+        public Sentry.SpanId? ParentSpanId { get; }
+        public string? Platform { get; set; }
+        public string? Release { get; set; }
+        public Sentry.Request Request { get; set; }
+        public Sentry.SdkVersion Sdk { get; }
+        public Sentry.SpanId SpanId { get; }
+        public System.Collections.Generic.IReadOnlyCollection<Sentry.ISpan> Spans { get; }
+        public System.DateTimeOffset StartTimestamp { get; }
+        public Sentry.SpanStatus? Status { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
+        public Sentry.SentryId TraceId { get; }
+        public Sentry.User User { get; set; }
+        public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb) { }
+        public void Finish() { }
+        public void Finish(Sentry.SpanStatus status) { }
+        public void Finish(System.Exception exception) { }
+        public void Finish(System.Exception exception, Sentry.SpanStatus status) { }
+        public Sentry.ISpan? GetLastActiveSpan() { }
+        public Sentry.SentryTraceHeader GetTraceHeader() { }
+        public void SetExtra(string key, object? value) { }
+        public void SetTag(string key, string value) { }
+        public Sentry.ISpan StartChild(string operation) { }
+        public void UnsetTag(string key) { }
+    }
+    public sealed class User : Sentry.IJsonSerializable
+    {
+        public User() { }
+        public string? Email { get; set; }
+        public string? Id { get; set; }
+        public string? IpAddress { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Other { get; set; }
+        public string? Segment { get; set; }
+        public string? Username { get; set; }
+        public Sentry.User Clone() { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
+        public static Sentry.User FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class UserFeedback : Sentry.IJsonSerializable
+    {
+        public UserFeedback(Sentry.SentryId eventId, string? name, string? email, string? comments) { }
+        public string? Comments { get; }
+        public string? Email { get; }
+        public Sentry.SentryId EventId { get; }
+        public string? Name { get; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.UserFeedback FromJson(System.Text.Json.JsonElement json) { }
+    }
+}
+namespace Sentry.Extensibility
+{
+    public abstract class BaseRequestPayloadExtractor : Sentry.Extensibility.IRequestPayloadExtractor
+    {
+        protected BaseRequestPayloadExtractor() { }
+        protected abstract object? DoExtractPayLoad(Sentry.Extensibility.IHttpRequest request);
+        public object? ExtractPayload(Sentry.Extensibility.IHttpRequest request) { }
+        protected abstract bool IsSupported(Sentry.Extensibility.IHttpRequest request);
+    }
+    public class DefaultRequestPayloadExtractor : Sentry.Extensibility.BaseRequestPayloadExtractor
+    {
+        public DefaultRequestPayloadExtractor() { }
+        protected override object? DoExtractPayLoad(Sentry.Extensibility.IHttpRequest request) { }
+        protected override bool IsSupported(Sentry.Extensibility.IHttpRequest request) { }
+    }
+    public static class DiagnosticLoggerExtensions
+    {
+        public static void LogDebug(this Sentry.Extensibility.IDiagnosticLogger logger, string message) { }
+        public static void LogDebug<TArg>(this Sentry.Extensibility.IDiagnosticLogger logger, string message, TArg arg) { }
+        public static void LogDebug<TArg, TArg2>(this Sentry.Extensibility.IDiagnosticLogger logger, string message, TArg arg, TArg2 arg2) { }
+        public static void LogError(this Sentry.Extensibility.IDiagnosticLogger logger, string message, System.Exception? exception = null) { }
+        public static void LogError<TArg>(this Sentry.Extensibility.IDiagnosticLogger logger, string message, System.Exception exception, TArg arg) { }
+        public static void LogError<TArg, TArg2>(this Sentry.Extensibility.IDiagnosticLogger logger, string message, System.Exception exception, TArg arg, TArg2 arg2) { }
+        public static void LogError<TArg, TArg2, TArg3>(this Sentry.Extensibility.IDiagnosticLogger logger, System.Exception exception, string message, TArg arg, TArg2 arg2, TArg3 arg3) { }
+        public static void LogError<TArg, TArg2, TArg3, TArg4>(this Sentry.Extensibility.IDiagnosticLogger logger, string message, System.Exception exception, TArg arg, TArg2 arg2, TArg3 arg3, TArg4 arg4) { }
+        public static void LogFatal(this Sentry.Extensibility.IDiagnosticLogger logger, string message, System.Exception? exception = null) { }
+        public static void LogInfo(this Sentry.Extensibility.IDiagnosticLogger logger, string message) { }
+        public static void LogInfo<TArg>(this Sentry.Extensibility.IDiagnosticLogger logger, string message, TArg arg) { }
+        public static void LogInfo<TArg, TArg2>(this Sentry.Extensibility.IDiagnosticLogger logger, string message, TArg arg, TArg2 arg2) { }
+        public static void LogInfo<TArg, TArg2, TArg3>(this Sentry.Extensibility.IDiagnosticLogger logger, string message, TArg arg, TArg2 arg2, TArg3 arg3) { }
+        public static void LogWarning(this Sentry.Extensibility.IDiagnosticLogger logger, string message) { }
+        public static void LogWarning<TArg>(this Sentry.Extensibility.IDiagnosticLogger logger, string message, TArg arg) { }
+        public static void LogWarning<TArg, TArg2>(this Sentry.Extensibility.IDiagnosticLogger logger, string message, TArg arg, TArg2 arg2) { }
+    }
+    public class DisabledHub : Sentry.IHub, Sentry.ISentryClient, Sentry.ISentryScopeManager, System.IDisposable
+    {
+        public static readonly Sentry.Extensibility.DisabledHub Instance;
+        public bool IsEnabled { get; }
+        public Sentry.SentryId LastEventId { get; }
+        public void BindClient(Sentry.ISentryClient client) { }
+        public void BindException(System.Exception exception, Sentry.ISpan span) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
+        public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
+        public void CaptureTransaction(Sentry.Transaction transaction) { }
+        public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
+        public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
+        public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
+        public void Dispose() { }
+        public void EndSession(Sentry.SessionEndStatus status = 0) { }
+        public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
+        public Sentry.ISpan? GetSpan() { }
+        public Sentry.SentryTraceHeader? GetTraceHeader() { }
+        public void PauseSession() { }
+        public System.IDisposable PushScope() { }
+        public System.IDisposable PushScope<TState>(TState state) { }
+        public void ResumeSession() { }
+        public void StartSession() { }
+        public Sentry.ITransaction StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
+        public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
+    }
+    public class FormRequestPayloadExtractor : Sentry.Extensibility.BaseRequestPayloadExtractor
+    {
+        public FormRequestPayloadExtractor() { }
+        protected override object? DoExtractPayLoad(Sentry.Extensibility.IHttpRequest request) { }
+        protected override bool IsSupported(Sentry.Extensibility.IHttpRequest request) { }
+    }
+    public sealed class HubAdapter : Sentry.IHub, Sentry.ISentryClient, Sentry.ISentryScopeManager
+    {
+        public static readonly Sentry.Extensibility.HubAdapter Instance;
+        public bool IsEnabled { get; }
+        public Sentry.SentryId LastEventId { get; }
+        public void AddBreadcrumb(string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
+        public void AddBreadcrumb(Sentry.Infrastructure.ISystemClock clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
+        public void BindClient(Sentry.ISentryClient client) { }
+        public void BindException(System.Exception exception, Sentry.ISpan span) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
+        public Sentry.SentryId CaptureException(System.Exception exception) { }
+        public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
+        public void CaptureTransaction(Sentry.Transaction transaction) { }
+        public void CaptureUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+        public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
+        public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
+        public void EndSession(Sentry.SessionEndStatus status = 0) { }
+        public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
+        public Sentry.ISpan? GetSpan() { }
+        public Sentry.SentryTraceHeader? GetTraceHeader() { }
+        public void PauseSession() { }
+        public System.IDisposable PushScope() { }
+        public System.IDisposable PushScope<TState>(TState state) { }
+        public void ResumeSession() { }
+        public void StartSession() { }
+        public Sentry.ITransaction StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
+        [System.Obsolete("This method is deprecated in favor of overloads of CaptureEvent, CaptureMessage a" +
+            "nd CaptureException that provide a callback to a configurable scope.")]
+        public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
+    }
+    public interface IBackgroundWorker
+    {
+        int QueuedItems { get; }
+        bool EnqueueEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
+        System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
+    public interface IDiagnosticLogger
+    {
+        bool IsEnabled(Sentry.SentryLevel level);
+        void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args);
+    }
+    public interface IExceptionFilter
+    {
+        bool Filter(System.Exception ex);
+    }
+    public interface IHttpRequest
+    {
+        System.IO.Stream? Body { get; }
+        long? ContentLength { get; }
+        string? ContentType { get; }
+        System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, System.Collections.Generic.IEnumerable<string>>>? Form { get; }
+    }
+    public interface INetworkStatusListener
+    {
+        bool Online { get; }
+        System.Threading.Tasks.Task WaitForNetworkOnlineAsync(System.Threading.CancellationToken cancellationToken);
+    }
+    public interface IRequestPayloadExtractor
+    {
+        object? ExtractPayload(Sentry.Extensibility.IHttpRequest request);
+    }
+    public interface ISentryEventExceptionProcessor
+    {
+        void Process(System.Exception exception, Sentry.SentryEvent sentryEvent);
+    }
+    public interface ISentryEventProcessor
+    {
+        Sentry.SentryEvent? Process(Sentry.SentryEvent @event);
+    }
+    public interface ISentryStackTraceFactory
+    {
+        Sentry.SentryStackTrace? Create(System.Exception? exception = null);
+    }
+    public interface ISentryTransactionProcessor
+    {
+        Sentry.Transaction? Process(Sentry.Transaction transaction);
+    }
+    public interface ITransport
+    {
+        System.Threading.Tasks.Task SendEnvelopeAsync(Sentry.Protocol.Envelopes.Envelope envelope, System.Threading.CancellationToken cancellationToken = default);
+    }
+    public class RequestBodyExtractionDispatcher : Sentry.Extensibility.IRequestPayloadExtractor
+    {
+        public RequestBodyExtractionDispatcher(System.Collections.Generic.IEnumerable<Sentry.Extensibility.IRequestPayloadExtractor> extractors, Sentry.SentryOptions options, System.Func<Sentry.Extensibility.RequestSize> sizeSwitch) { }
+        public object? ExtractPayload(Sentry.Extensibility.IHttpRequest request) { }
+    }
+    public enum RequestSize
+    {
+        None = 0,
+        Small = 1,
+        Medium = 2,
+        Always = 3,
+    }
+    public abstract class SentryEventExceptionProcessor<TException> : Sentry.Extensibility.ISentryEventExceptionProcessor
+        where TException : System.Exception
+    {
+        protected SentryEventExceptionProcessor() { }
+        public void Process(System.Exception? exception, Sentry.SentryEvent sentryEvent) { }
+        protected abstract void ProcessException(TException exception, Sentry.SentryEvent sentryEvent);
+    }
+    public class SentryStackTraceFactory : Sentry.Extensibility.ISentryStackTraceFactory
+    {
+        public SentryStackTraceFactory(Sentry.SentryOptions options) { }
+        public virtual Sentry.SentryStackTrace? Create(System.Exception? exception = null) { }
+        protected virtual Sentry.SentryStackFrame CreateFrame(System.Diagnostics.StackFrame stackFrame, bool isCurrentStackTrace) { }
+        protected virtual System.Diagnostics.StackTrace CreateStackTrace(System.Exception? exception) { }
+        protected virtual System.Reflection.MethodBase? GetMethod(System.Diagnostics.StackFrame stackFrame) { }
+        protected Sentry.SentryStackFrame InternalCreateFrame(System.Diagnostics.StackFrame stackFrame, bool demangle) { }
+    }
+}
+namespace Sentry.Http
+{
+    public abstract class HttpTransportBase
+    {
+        protected HttpTransportBase(Sentry.SentryOptions options, System.Func<string, string?>? getEnvironmentVariable = null, Sentry.Infrastructure.ISystemClock? clock = null) { }
+        protected System.Net.Http.HttpRequestMessage CreateRequest(Sentry.Protocol.Envelopes.Envelope envelope) { }
+        protected void HandleResponse(System.Net.Http.HttpResponseMessage response, Sentry.Protocol.Envelopes.Envelope envelope) { }
+        protected System.Threading.Tasks.Task HandleResponseAsync(System.Net.Http.HttpResponseMessage response, Sentry.Protocol.Envelopes.Envelope envelope, System.Threading.CancellationToken cancellationToken) { }
+        protected Sentry.Protocol.Envelopes.Envelope ProcessEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
+        protected System.IO.Stream ReadStreamFromHttpContent(System.Net.Http.HttpContent content) { }
+    }
+    public interface ISentryHttpClientFactory
+    {
+        System.Net.Http.HttpClient Create(Sentry.SentryOptions options);
+    }
+}
+namespace Sentry.Infrastructure
+{
+    public class ConsoleDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
+    {
+        public ConsoleDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
+        protected override void LogMessage(string message) { }
+    }
+    [System.Obsolete("Logger doesn\'t work outside of Sentry SDK. Please use TraceDiagnosticLogger inste" +
+        "ad")]
+    public class DebugDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
+    {
+        public DebugDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
+        protected override void LogMessage(string message) { }
+    }
+    public abstract class DiagnosticLogger : Sentry.Extensibility.IDiagnosticLogger
+    {
+        protected DiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
+        public bool IsEnabled(Sentry.SentryLevel level) { }
+        public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
+        protected abstract void LogMessage(string message);
+    }
+    public interface ISystemClock
+    {
+        System.DateTimeOffset GetUtcNow();
+    }
+    public sealed class SystemClock : Sentry.Infrastructure.ISystemClock
+    {
+        public static readonly Sentry.Infrastructure.SystemClock Clock;
+        [System.Obsolete("This constructor will become private in a future major version. Use the `SystemCl" +
+            "ock.Clock` singleton instead.")]
+        public SystemClock() { }
+        public System.DateTimeOffset GetUtcNow() { }
+    }
+    public class TraceDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
+    {
+        public TraceDiagnosticLogger(Sentry.SentryLevel minimalLevel) { }
+        protected override void LogMessage(string message) { }
+    }
+}
+namespace Sentry.Integrations
+{
+    public interface ISdkIntegration
+    {
+        void Register(Sentry.IHub hub, Sentry.SentryOptions options);
+    }
+}
+namespace Sentry.PlatformAbstractions
+{
+    public static class FrameworkInfo
+    {
+        public static System.Collections.Generic.IReadOnlyDictionary<int, string> NetFxReleaseVersionMap { get; }
+        public static System.Collections.Generic.IEnumerable<Sentry.PlatformAbstractions.FrameworkInstallation> GetInstallations() { }
+        public static Sentry.PlatformAbstractions.FrameworkInstallation? GetLatest(int clr) { }
+    }
+    public class FrameworkInstallation
+    {
+        public FrameworkInstallation() { }
+        public Sentry.PlatformAbstractions.FrameworkProfile? Profile { get; set; }
+        public int? Release { get; set; }
+        public int? ServicePack { get; set; }
+        public string? ShortName { get; set; }
+        public System.Version? Version { get; set; }
+        public override string ToString() { }
+    }
+    public enum FrameworkProfile
+    {
+        Client = 0,
+        Full = 1,
+    }
+    public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
+    {
+        public Runtime(string? name = null, string? version = null, string? raw = null, string? identifier = null) { }
+        [set: System.Obsolete("This setter is nonfunctional, and will be removed in a future version.")]
+        public string? Identifier { get; set; }
+        public string? Name { get; }
+        public string? Raw { get; }
+        public string? Version { get; }
+        public static Sentry.PlatformAbstractions.Runtime Current { get; }
+        public bool Equals(Sentry.PlatformAbstractions.Runtime? other) { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public override string? ToString() { }
+    }
+    public static class RuntimeExtensions
+    {
+        public static bool IsMono(this Sentry.PlatformAbstractions.Runtime runtime) { }
+        public static bool IsNetCore(this Sentry.PlatformAbstractions.Runtime runtime) { }
+        public static bool IsNetFx(this Sentry.PlatformAbstractions.Runtime runtime) { }
+    }
+}
+namespace Sentry.Protocol
+{
+    public sealed class App : Sentry.IJsonSerializable
+    {
+        public const string Type = "app";
+        public App() { }
+        public string? Build { get; set; }
+        public string? BuildType { get; set; }
+        public string? Hash { get; set; }
+        public string? Identifier { get; set; }
+        public string? Name { get; set; }
+        public System.DateTimeOffset? StartTime { get; set; }
+        public string? Version { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
+        public static Sentry.Protocol.App FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class Browser : Sentry.IJsonSerializable
+    {
+        public const string Type = "browser";
+        public Browser() { }
+        public string? Name { get; set; }
+        public string? Version { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
+        public static Sentry.Protocol.Browser FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class Device : Sentry.IJsonSerializable
+    {
+        public const string Type = "device";
+        public Device() { }
+        public string? Architecture { get; set; }
+        public short? BatteryLevel { get; set; }
+        public string? BatteryStatus { get; set; }
+        public System.DateTimeOffset? BootTime { get; set; }
+        public string? Brand { get; set; }
+        public string? CpuDescription { get; set; }
+        public string? DeviceType { get; set; }
+        public string? DeviceUniqueIdentifier { get; set; }
+        public long? ExternalFreeStorage { get; set; }
+        public long? ExternalStorageSize { get; set; }
+        public string? Family { get; set; }
+        public long? FreeMemory { get; set; }
+        public long? FreeStorage { get; set; }
+        public bool? IsCharging { get; set; }
+        public bool? IsOnline { get; set; }
+        public bool? LowMemory { get; set; }
+        public string? Manufacturer { get; set; }
+        public long? MemorySize { get; set; }
+        public string? Model { get; set; }
+        public string? ModelId { get; set; }
+        public string? Name { get; set; }
+        public Sentry.Protocol.DeviceOrientation? Orientation { get; set; }
+        public int? ProcessorCount { get; set; }
+        public int? ProcessorFrequency { get; set; }
+        public float? ScreenDensity { get; set; }
+        public int? ScreenDpi { get; set; }
+        public string? ScreenResolution { get; set; }
+        public bool? Simulator { get; set; }
+        public long? StorageSize { get; set; }
+        public bool? SupportsAccelerometer { get; set; }
+        public bool? SupportsAudio { get; set; }
+        public bool? SupportsGyroscope { get; set; }
+        public bool? SupportsLocationService { get; set; }
+        public bool? SupportsVibration { get; set; }
+        public System.TimeZoneInfo? Timezone { get; set; }
+        public long? UsableMemory { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
+        public static Sentry.Protocol.Device FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public enum DeviceOrientation
+    {
+        [System.Runtime.Serialization.EnumMember(Value="portrait")]
+        Portrait = 0,
+        [System.Runtime.Serialization.EnumMember(Value="landscape")]
+        Landscape = 1,
+    }
+    public sealed class Gpu : Sentry.IJsonSerializable
+    {
+        public const string Type = "gpu";
+        public Gpu() { }
+        public string? ApiType { get; set; }
+        public string? GraphicsShaderLevel { get; set; }
+        public int? Id { get; set; }
+        public int? MaxTextureSize { get; set; }
+        public int? MemorySize { get; set; }
+        public bool? MultiThreadedRendering { get; set; }
+        public string? Name { get; set; }
+        public string? NpotSupport { get; set; }
+        public bool? SupportsComputeShaders { get; set; }
+        public bool? SupportsDrawCallInstancing { get; set; }
+        public bool? SupportsGeometryShaders { get; set; }
+        public bool? SupportsRayTracing { get; set; }
+        public string? VendorId { get; set; }
+        public string? VendorName { get; set; }
+        public string? Version { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
+        public static Sentry.Protocol.Gpu FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public interface ITraceContext
+    {
+        string? Description { get; }
+        bool? IsSampled { get; }
+        string Operation { get; }
+        Sentry.SpanId? ParentSpanId { get; }
+        Sentry.SpanId SpanId { get; }
+        Sentry.SpanStatus? Status { get; }
+        Sentry.SentryId TraceId { get; }
+    }
+    public sealed class Mechanism : Sentry.IJsonSerializable
+    {
+        public static readonly string HandledKey;
+        public static readonly string MechanismKey;
+        public Mechanism() { }
+        public System.Collections.Generic.IDictionary<string, object> Data { get; }
+        public string? Description { get; set; }
+        public bool? Handled { get; set; }
+        public string? HelpLink { get; set; }
+        public System.Collections.Generic.IDictionary<string, object> Meta { get; }
+        public string? Type { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Protocol.Mechanism FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class OperatingSystem : Sentry.IJsonSerializable
+    {
+        public const string Type = "os";
+        public OperatingSystem() { }
+        public string? Build { get; set; }
+        public string? KernelVersion { get; set; }
+        public string? Name { get; set; }
+        public string? RawDescription { get; set; }
+        public bool? Rooted { get; set; }
+        public string? Version { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
+        public static Sentry.Protocol.OperatingSystem FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class Runtime : Sentry.IJsonSerializable
+    {
+        public const string Type = "runtime";
+        public Runtime() { }
+        public string? Build { get; set; }
+        public string? Identifier { get; set; }
+        public string? Name { get; set; }
+        public string? RawDescription { get; set; }
+        public string? Version { get; set; }
+        [System.Obsolete("This method will be made internal in a future version.")]
+        public Sentry.Protocol.Runtime Clone() { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
+        public static Sentry.Protocol.Runtime FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class SentryException : Sentry.IJsonSerializable
+    {
+        public SentryException() { }
+        public System.Collections.Generic.IDictionary<string, object?> Data { get; }
+        public Sentry.Protocol.Mechanism? Mechanism { get; set; }
+        public string? Module { get; set; }
+        public Sentry.SentryStackTrace? Stacktrace { get; set; }
+        public int ThreadId { get; set; }
+        public string? Type { get; set; }
+        public string? Value { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Protocol.SentryException FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public class Trace : Sentry.IJsonSerializable, Sentry.Protocol.ITraceContext
+    {
+        public const string Type = "trace";
+        public Trace() { }
+        public string? Description { get; set; }
+        public bool? IsSampled { get; }
+        public string Operation { get; set; }
+        public Sentry.SpanId? ParentSpanId { get; set; }
+        public Sentry.SpanId SpanId { get; set; }
+        public Sentry.SpanStatus? Status { get; set; }
+        public Sentry.SentryId TraceId { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Protocol.Trace FromJson(System.Text.Json.JsonElement json) { }
+    }
+}
+namespace Sentry.Protocol.Envelopes
+{
+    public sealed class Envelope : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public Envelope(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> items) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public System.Collections.Generic.IReadOnlyList<Sentry.Protocol.Envelopes.EnvelopeItem> Items { get; }
+        public void Dispose() { }
+        public void Serialize(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public Sentry.SentryId? TryGetEventId() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.Envelope> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
+    {
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
+        public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
+        public void Dispose() { }
+        public void Serialize(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
+        public string? TryGetFileName() { }
+        public long? TryGetLength() { }
+        public string? TryGetType() { }
+        public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.EnvelopeItem> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.Attachment attachment) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromEvent(Sentry.SentryEvent @event) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromSession(Sentry.SessionUpdate sessionUpdate) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromTransaction(Sentry.Transaction transaction) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
+    }
+    public interface ISerializable
+    {
+        void Serialize(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger);
+        System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default);
+    }
+}
+namespace Sentry.Reflection
+{
+    [System.Obsolete("Should not be public. This method will be removed in version 4.")]
+    public static class AssemblyExtensions
+    {
+        public static Sentry.SdkVersion GetNameAndVersion(this System.Reflection.Assembly asm) { }
+    }
+}
+public static class SentryExceptionExtensions
+{
+    public static void AddSentryContext(this System.Exception ex, string name, System.Collections.Generic.IReadOnlyDictionary<string, object> data) { }
+    public static void AddSentryTag(this System.Exception ex, string name, string value) { }
+    public static System.Collections.Generic.IEnumerable<System.Exception> EnumerateChainedExceptions(this System.Exception exception, Sentry.SentryOptions options) { }
+}

--- a/test/Sentry.Tests/Internals/MemoryInfoTests.WriteTo.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/Internals/MemoryInfoTests.WriteTo.DotNet7_0.verified.txt
@@ -1,0 +1,19 @@
+﻿{
+  allocated_bytes: 1,
+  compacted: true,
+  concurrent: false,
+  finalization_pending_count: 12,
+  fragmented_bytes: 2,
+  heap_size_bytes: 3,
+  high_memory_load_threshold_bytes: 4,
+  index: 11,
+  memory_load_bytes: 6,
+  pause_durations: [
+    1000
+  ],
+  pause_time_percentage: 10,
+  pinned_objects_count: 9,
+  promoted_bytes: 8,
+  total_available_memory_bytes: 5,
+  total_committed_bytes: 7
+}

--- a/test/Sentry.Tests/Sentry.Tests.csproj
+++ b/test/Sentry.Tests/Sentry.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net48;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net48;net6.0-android</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">10.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>


### PR DESCRIPTION
Per #1676, start testing on .NET 7 RC1.

No changes to targets of any Sentry libraries yet.

#skip-changelog