### PR TITLE
ci: update and pin GHA to commit hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,42 +19,42 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-12]
 
     steps:
-        - name: Checkout
-          uses: actions/checkout@v3
-          with:
-            submodules: recursive
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-        - name: Setup Environment
-          uses: ./.github/actions/environment
+      - name: Setup Environment
+        uses: ./.github/actions/environment
 
-        - name: Build Native Dependencies
-          uses: ./.github/actions/buildnative
+      - name: Build Native Dependencies
+        uses: ./.github/actions/buildnative
 
-        - name: Build
-          run: dotnet build -c Release --nologo /p:CopyLocalLockFileAssemblies=true
+      - name: Build
+        run: dotnet build -c Release --nologo /p:CopyLocalLockFileAssemblies=true
 
-        - name: Test
-          run: dotnet test -c Release --no-build --nologo -l GitHubActions -l "trx;LogFilePrefix=testresults_${{ runner.os }}"
+      - name: Test
+        run: dotnet test -c Release --no-build --nologo -l GitHubActions -l "trx;LogFilePrefix=testresults_${{ runner.os }}"
 
-        - name: Pack
-          # Only pack in one build environment.  We'll use macOS so we can build for ios/maccatalyst targets
-          if: startsWith(matrix.os, 'macos')
-          run: dotnet pack -c Release --no-build --nologo
+      - name: Pack
+        # Only pack in one build environment.  We'll use macOS so we can build for ios/maccatalyst targets
+        if: startsWith(matrix.os, 'macos')
+        run: dotnet pack -c Release --no-build --nologo
 
-        - name: Upload Verify Results
-          if: failure()
-          uses: actions/upload-artifact@v3
-          with:
-            name: verify-test-results
-            path: |
-              **/*.received.*
+      - name: Upload Verify Results
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: verify-test-results
+          path: |
+            **/*.received.*
 
-        - name: Archive Artifacts
-          # only archive on macos since we only pack on macos. See Pack step.
-          if: startsWith(matrix.os, 'macos')
-          uses: actions/upload-artifact@v3
-          with:
-            name: ${{ github.sha }}
-            if-no-files-found: error
-            path: |
-              ${{ github.workspace }}/src/**/Release/*.nupkg
+      - name: Archive Artifacts
+        # only archive on macos since we only pack on macos. See Pack step.
+        if: startsWith(matrix.os, 'macos')
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.sha }}
+          if-no-files-found: error
+          path: |
+            ${{ github.workspace }}/src/**/Release/*.nupkg

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,21 +18,21 @@ jobs:
       fail-fast: false
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        submodules: recursive
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-    - name: Setup Environment
-      uses: ./.github/actions/environment
+      - name: Setup Environment
+        uses: ./.github/actions/environment
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: csharp
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e0e5ded33cabb451ae0a9768fc7b0410bad9ad44 # pin@v2
+        with:
+          languages: csharp
 
-    - name: Build
-      run: dotnet build --nologo
+      - name: Build
+        run: dotnet build --nologo
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e0e5ded33cabb451ae0a9768fc7b0410bad9ad44 # pin@v2

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -11,35 +11,35 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-        - name: Checkout
-          uses: actions/checkout@v3
-          with:
-            submodules: recursive
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-        - name: Setup Environment
-          uses: ./.github/actions/environment
+      - name: Setup Environment
+        uses: ./.github/actions/environment
 
-        - name: Build Native Dependencies
-          uses: ./.github/actions/buildnative
+      - name: Build Native Dependencies
+        uses: ./.github/actions/buildnative
 
-        - name: Build Android Test App
-          run: dotnet build -c Release -f net6.0-android test/Sentry.Maui.Device.TestApp
+      - name: Build Android Test App
+        run: dotnet build -c Release -f net6.0-android test/Sentry.Maui.Device.TestApp
 
-        - name: Upload Android Test App
-          uses: actions/upload-artifact@v3
-          with:
-            name: device-test-android
-            if-no-files-found: error
-            path: test/Sentry.Maui.Device.TestApp/bin/Release/net6.0-android/io.sentry.dotnet.maui.device.testapp-Signed.apk
+      - name: Upload Android Test App
+        uses: actions/upload-artifact@v3
+        with:
+          name: device-test-android
+          if-no-files-found: error
+          path: test/Sentry.Maui.Device.TestApp/bin/Release/net6.0-android/io.sentry.dotnet.maui.device.testapp-Signed.apk
 
   android:
     needs: [build]
     name: Run Android API-${{ matrix.api-level }} Test
-    runs-on: macos-latest  # MacOS is required for the emulator, per https://github.com/ReactiveCircus/android-emulator-runner/blob/main/README.md
+    runs-on: macos-latest # MacOS is required for the emulator, per https://github.com/ReactiveCircus/android-emulator-runner/blob/main/README.md
     strategy:
       fail-fast: false
       matrix:
-        api-level: [27,28,29,30,31,32,33]
+        api-level: [27, 28, 29, 30, 31, 32, 33]
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
@@ -58,7 +58,7 @@ jobs:
 
       - name: Test
         timeout-minutes: 30
-        uses: reactivecircus/android-emulator-runner@d7b53ddc6e44254e1f4cf4a6ad67345837027a66
+        uses: reactivecircus/android-emulator-runner@d7b53ddc6e44254e1f4cf4a6ad67345837027a66 # pin@v2
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.api-level >= 32 && 'google_apis' || 'default' }} # We don't need the Google APIs, but the default images are not available for 32+
@@ -76,7 +76,7 @@ jobs:
         shell: pwsh
 
       - name: Upload results
-        if:  success() || failure()
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: device-test-android-${{ matrix.api-level }}-results

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: nikeee/docfx-action@b9c2cf92e3b4aa06878a1410833a8828b4bdcd26
+      - uses: nikeee/docfx-action@b9c2cf92e3b4aa06878a1410833a8828b4bdcd26 # pin@v1.0.0
         name: Build Documentation
         with:
           args: docs/docfx.json
-      - uses: peaceiris/actions-gh-pages@v3
+      - uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305 # pin@v3
         name: Publish to GitHub Pages
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -26,4 +26,3 @@ jobs:
         with:
           name: docs
           path: docs/_site
-

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     # once a day
-    - cron:  '0 0 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
   List-vulnerable-packages:
@@ -18,19 +18,18 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-12]
 
     steps:
-        - name: Checkout
-          uses: actions/checkout@v3
-          with:
-            submodules: recursive
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-        - name: Setup Environment
-          uses: ./.github/actions/environment
+      - name: Setup Environment
+        uses: ./.github/actions/environment
 
-# Everything above here is the same as the main build.
-# We only need to restore to check for vulnerable packages
+      # Everything above here is the same as the main build.
+      # We only need to restore to check for vulnerable packages
+      - name: Restore dependencies
+        run: dotnet restore
 
-        - name: Restore dependencies
-          run: dotnet restore
-
-        - name: List vulnerable packages
-          run: dotnet list package --vulnerable --include-transitive
+      - name: List vulnerable packages
+        run: dotnet list package --vulnerable --include-transitive


### PR DESCRIPTION
Used `Get-ChildItem . -Filter *.yml | Foreach-Object { pin-github-action --allow 'actions/*,getsentry/*' $_.FullName }` and manually reverted the most disturbing formatting changes it's making (line breaks on long lines)...

There should be no need to do this again + new PRs will automatically get a failure through Danger.

#skip-changelog