### PR TITLE
Fix issues with envelope deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Ignore null Context values ([#1942](https://github.com/getsentry/sentry-dotnet/pull/1942))
 - Tags should not differ based on current culture ([#1949](https://github.com/getsentry/sentry-dotnet/pull/1949))
 - Always recalculate payload length ([#1957](https://github.com/getsentry/sentry-dotnet/pull/1957))
+- Fix issues with envelope deserialization ([#1965](https://github.com/getsentry/sentry-dotnet/pull/1965))
 
 ## 3.21.0
 

--- a/src/Sentry/Internal/Extensions/StreamExtensions.cs
+++ b/src/Sentry/Internal/Extensions/StreamExtensions.cs
@@ -84,9 +84,9 @@ namespace Sentry.Internal.Extensions
         // pre-creating this buffer leads to an optimized path when writing
         private static readonly byte[] NewlineBuffer = {(byte)'\n'};
 
-        public static async Task WriteNewlineAsync(this Stream stream, CancellationToken cancellationToken = default) =>
+        public static Task WriteNewlineAsync(this Stream stream, CancellationToken cancellationToken = default) =>
 #pragma warning disable CA1835 // the byte-array implementation of WriteAsync is more direct than using ReadOnlyMemory<byte>
-            await stream.WriteAsync(NewlineBuffer, 0, 1, cancellationToken).ConfigureAwait(false);
+            stream.WriteAsync(NewlineBuffer, 0, 1, cancellationToken);
 #pragma warning restore CA1835
 
         public static void WriteNewline(this Stream stream) => stream.Write(NewlineBuffer, 0, 1);

--- a/src/Sentry/Internal/Extensions/StreamExtensions.cs
+++ b/src/Sentry/Internal/Extensions/StreamExtensions.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,15 +7,60 @@ namespace Sentry.Internal.Extensions
 {
     internal static class StreamExtensions
     {
-        public static async IAsyncEnumerable<byte> ReadAllBytesAsync(
+        public static async Task<byte[]> ReadLineAsync(
             this Stream stream,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
+            // This approach avoids reading one byte at a time.
+
+            const int size = 128;
+            using var buffer = new PooledBuffer<byte>(size);
+
+            using var result = new MemoryStream(capacity: size);
+
+            var overreach = 0;
+            var found = false;
+            while (!found)
+            {
+                var bytesRead = await stream.ReadAsync(buffer.Array, 0, size, cancellationToken).ConfigureAwait(false);
+                if (bytesRead <= 0)
+                {
+                    break;
+                }
+
+                for (var i = 0; i < bytesRead; i++)
+                {
+                    if (buffer.Array[i] != '\n')
+                    {
+                        continue;
+                    }
+
+                    found = true;
+                    overreach = bytesRead - i - 1;
+                    bytesRead = i;
+                    break;
+                }
+
+                result.Write(buffer.Array, 0, bytesRead);
+            }
+
+            stream.Position -= overreach;
+            return result.ToArray();
+        }
+
+        public static async Task SkipNewlinesAsync(this Stream stream, CancellationToken cancellationToken = default)
+        {
+            // We probably have very few newline characters to skip, so reading one byte at a time is fine here.
+
             using var buffer = new PooledBuffer<byte>(1);
 
             while (await stream.ReadAsync(buffer.Array, 0, 1, cancellationToken).ConfigureAwait(false) > 0)
             {
-                yield return buffer.Array[0];
+                if (buffer.Array[0] != '\n')
+                {
+                    stream.Position--;
+                    return;
+                }
             }
         }
 

--- a/src/Sentry/Protocol/Envelopes/Envelope.cs
+++ b/src/Sentry/Protocol/Envelopes/Envelope.cs
@@ -97,13 +97,13 @@ namespace Sentry.Protocol.Envelopes
         {
             // Header
             await SerializeHeaderAsync(stream, logger, clock, cancellationToken).ConfigureAwait(false);
-            await stream.WriteByteAsync((byte)'\n', cancellationToken).ConfigureAwait(false);
+            await stream.WriteNewlineAsync(cancellationToken).ConfigureAwait(false);
 
             // Items
             foreach (var item in Items)
             {
                 await item.SerializeAsync(stream, logger, cancellationToken).ConfigureAwait(false);
-                await stream.WriteByteAsync((byte)'\n', cancellationToken).ConfigureAwait(false);
+                await stream.WriteNewlineAsync(cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -115,13 +115,13 @@ namespace Sentry.Protocol.Envelopes
         {
             // Header
             SerializeHeader(stream, logger, clock);
-            stream.WriteByte((byte)'\n');
+            stream.WriteNewline();
 
             // Items
             foreach (var item in Items)
             {
                 item.Serialize(stream, logger);
-                stream.WriteByte((byte)'\n');
+                stream.WriteNewline();
             }
         }
 

--- a/src/Sentry/Protocol/Envelopes/Envelope.cs
+++ b/src/Sentry/Protocol/Envelopes/Envelope.cs
@@ -277,23 +277,10 @@ namespace Sentry.Protocol.Envelopes
             Stream stream,
             CancellationToken cancellationToken = default)
         {
-            var buffer = new List<byte>();
-
-            var prevByte = default(int);
-            await foreach (var curByte in stream.ReadAllBytesAsync(cancellationToken).ConfigureAwait(false))
-            {
-                // Break if found an unescaped newline
-                if (curByte == '\n' && prevByte != '\\')
-                {
-                    break;
-                }
-
-                buffer.Add(curByte);
-                prevByte = curByte;
-            }
+            var buffer = await stream.ReadLineAsync(cancellationToken).ConfigureAwait(false);
 
             var header =
-                Json.Parse(buffer.ToArray(), JsonExtensions.GetDictionaryOrNull)
+                Json.Parse(buffer, JsonExtensions.GetDictionaryOrNull)
                 ?? throw new InvalidOperationException("Envelope header is malformed.");
 
             // The sent_at header should not be included in the result

--- a/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
@@ -147,7 +147,7 @@ namespace Sentry.Protocol.Envelopes
                 var headerWithLength = Header.ToDictionary();
                 headerWithLength[LengthKey] = payloadBuffer.Length;
                 await SerializeHeaderAsync(stream, headerWithLength, logger, cancellationToken).ConfigureAwait(false);
-                await stream.WriteByteAsync((byte)'\n', cancellationToken).ConfigureAwait(false);
+                await stream.WriteNewlineAsync( cancellationToken).ConfigureAwait(false);
 
                 // Payload
                 await payloadBuffer.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
@@ -167,7 +167,7 @@ namespace Sentry.Protocol.Envelopes
             var headerWithLength = Header.ToDictionary();
             headerWithLength[LengthKey] = payloadBuffer.Length;
             SerializeHeader(stream, headerWithLength, logger);
-            stream.WriteByte((byte)'\n');
+            stream.WriteNewline();
 
             // Payload
             payloadBuffer.CopyTo(stream);

--- a/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
@@ -98,11 +98,7 @@ namespace Sentry.Protocol.Envelopes
             CancellationToken cancellationToken)
         {
             var writer = new Utf8JsonWriter(stream);
-#if NET461 || NETSTANDARD2_0
-            using (writer)
-#else
             await using (writer.ConfigureAwait(false))
-#endif
             {
                 writer.WriteDictionaryValue(header, logger);
                 await writer.FlushAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
@@ -138,7 +138,7 @@ namespace Sentry.Protocol.Envelopes
                 var headerWithLength = Header.ToDictionary();
                 headerWithLength[LengthKey] = payloadBuffer.Length;
                 await SerializeHeaderAsync(stream, headerWithLength, logger, cancellationToken).ConfigureAwait(false);
-                await stream.WriteNewlineAsync( cancellationToken).ConfigureAwait(false);
+                await stream.WriteNewlineAsync(cancellationToken).ConfigureAwait(false);
 
                 // Payload
                 await payloadBuffer.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Improves deserialization by reading the envelope header line in a buffer instead of streaming one character at a time, which should hopefully fix #1963.

Also makes a few other optimizations in nearby code for both serialization and deserialization.

No new tests because we already have a lot of tests that validate it works correctly.