### PR TITLE
Fix reported error count on a crashed session update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Tags should not differ based on current culture ([#1949](https://github.com/getsentry/sentry-dotnet/pull/1949))
 - Always recalculate payload length ([#1957](https://github.com/getsentry/sentry-dotnet/pull/1957))
 - Fix issues with envelope deserialization ([#1965](https://github.com/getsentry/sentry-dotnet/pull/1965))
+- Fix reported error count on a crashed session update ([#1972](https://github.com/getsentry/sentry-dotnet/pull/1972))
 
 ## 3.21.0
 

--- a/src/Sentry/GlobalSessionManager.cs
+++ b/src/Sentry/GlobalSessionManager.cs
@@ -361,7 +361,7 @@ namespace Sentry
         {
             if (status == SessionEndStatus.Crashed)
             {
-                // This just increments the errors count, as crashed sessions should report a count of 1 per:
+                // increments the errors count, as crashed sessions should report a count of 1 per:
                 // https://develop.sentry.dev/sdk/sessions/#session-update-payload
                 session.ReportError();
             }

--- a/src/Sentry/GlobalSessionManager.cs
+++ b/src/Sentry/GlobalSessionManager.cs
@@ -359,6 +359,13 @@ namespace Sentry
 
         private SessionUpdate EndSession(Session session, DateTimeOffset timestamp, SessionEndStatus status)
         {
+            if (status == SessionEndStatus.Crashed)
+            {
+                // This just increments the errors count, as crashed sessions should report a count of 1 per:
+                // https://develop.sentry.dev/sdk/sessions/#session-update-payload
+                session.ReportError();
+            }
+
             AddSessionBreadcrumb("Ending Sentry Session");
             _options.LogInfo("Ended session (SID: {0}; DID: {1}) with status '{2}'.",
                 session.Id, session.DistinctId, status);

--- a/test/Sentry.Tests/GlobalSessionManagerTests.cs
+++ b/test/Sentry.Tests/GlobalSessionManagerTests.cs
@@ -166,7 +166,7 @@ public class GlobalSessionManagerTests : IDisposable
     }
 
     [Fact]
-    public void EndSession_ActiveSessionExists_EndsSession()
+    public void EndSession_ActiveSessionExists_ExitedStatus_EndsSession()
     {
         // Arrange
         var sut = _fixture.GetSut();
@@ -180,6 +180,25 @@ public class GlobalSessionManagerTests : IDisposable
         // Assert
         session.Should().NotBeNull();
         sessionUpdate?.EndStatus.Should().Be(SessionEndStatus.Exited);
+        sessionUpdate?.ErrorCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void EndSession_ActiveSessionExists_CrashedStatus_EndsSession()
+    {
+        // Arrange
+        var sut = _fixture.GetSut();
+
+        sut.StartSession();
+        var session = sut.CurrentSession;
+
+        // Act
+        var sessionUpdate = sut.EndSession(SessionEndStatus.Crashed);
+
+        // Assert
+        session.Should().NotBeNull();
+        sessionUpdate?.EndStatus.Should().Be(SessionEndStatus.Crashed);
+        sessionUpdate?.ErrorCount.Should().Be(1);
     }
 
     [Fact]


### PR DESCRIPTION
From https://develop.sentry.dev/sdk/sessions/#session-update-payload

![image](https://user-images.githubusercontent.com/1396388/194438522-fee6bdf7-9150-4610-8512-da8f02fb1f4a.png)

> "It's important that this counter is also incremented when a session goes to crashed. (eg: the crash itself is always an error as well)."

This PR does that.

> "Ingest should force errors to 1 if not set or 0."

If that's already happening on the back-end, I believe this doesn't really fix anything in particular, but should still be done for correctness.

