### PR TITLE
Update bundled Android SDK to version 6.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Update bundled Android SDK to version 6.5.0 ([#1984](https://github.com/getsentry/sentry-dotnet/pull/1984))
+
 ## Fixes
 
 - Split Android and Cocoa bindings into separate projects ([#1983](https://github.com/getsentry/sentry-dotnet/pull/1983))

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -4,7 +4,7 @@
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <!-- BG8605 and BG8606 happen because there's a missing androidx.lifecycle dependency, but we don't need it here.  (The native Android Sentry SDK will use it if it exists.) -->
     <NoWarn>$(NoWarn);BG8605;BG8606</NoWarn>
-    <SentryAndroidSdkVersion>6.4.1</SentryAndroidSdkVersion>
+    <SentryAndroidSdkVersion>6.5.0</SentryAndroidSdkVersion>
     <SentryAndroidSdkDirectory>$(BaseIntermediateOutputPath)sdks\Sentry\Android\$(SentryAndroidSdkVersion)\</SentryAndroidSdkDirectory>
     <Description>.NET Bindings for the Sentry Android SDK</Description>
   </PropertyGroup>

--- a/src/Sentry.Bindings.Android/Transforms/Metadata.xml
+++ b/src/Sentry.Bindings.Android/Transforms/Metadata.xml
@@ -14,24 +14,24 @@
   <attr path="/api/package/interface[@visibility='public']" name="visibility">internal</attr>
 
   <!-- Assign .NET namespaces for all Java packages imported -->
-  <attr path="/api/package[@name='io.sentry']" name="managedName">Sentry.Java</attr>
-  <attr path="/api/package[@name='io.sentry.android.core']" name="managedName">Sentry.Android</attr>
-  <attr path="/api/package[@name='io.sentry.android.core.internal.gestures']" name="managedName">Sentry.Android.Internal.Gestures</attr>
-  <attr path="/api/package[@name='io.sentry.android.core.internal.util']" name="managedName">Sentry.Android.Internal.Util</attr>
-  <attr path="/api/package[@name='io.sentry.android.ndk']" name="managedName">Sentry.Android.Ndk</attr>
-  <attr path="/api/package[@name='io.sentry.android.supplemental']" name="managedName">Sentry.Android.Supplemental</attr>
-  <attr path="/api/package[@name='io.sentry.cache']" name="managedName">Sentry.Java.Cache</attr>
-  <attr path="/api/package[@name='io.sentry.clientreport']" name="managedName">Sentry.Java.ClientReport</attr>
-  <attr path="/api/package[@name='io.sentry.config']" name="managedName">Sentry.Java.Configuration</attr>
-  <attr path="/api/package[@name='io.sentry.exception']" name="managedName">Sentry.Java.Exception</attr>
-  <attr path="/api/package[@name='io.sentry.hints']" name="managedName">Sentry.Java.Hints</attr>
-  <attr path="/api/package[@name='io.sentry.instrumentation.file']" name="managedName">Sentry.Java.Instrumentation.File</attr>
-  <attr path="/api/package[@name='io.sentry.transport']" name="managedName">Sentry.Java.Transport</attr>
-  <attr path="/api/package[@name='io.sentry.protocol']" name="managedName">Sentry.Java.Protocol</attr>
-  <attr path="/api/package[@name='io.sentry.util']" name="managedName">Sentry.Java.Util</attr>
-  <attr path="/api/package[@name='io.sentry.vendor']" name="managedName">Sentry.Java.Vendor</attr>
-  <attr path="/api/package[@name='io.sentry.vendor.gson.stream']" name="managedName">Sentry.Java.Vendor.Gson.Stream</attr>
-  <attr path="/api/package[@name='io.sentry.vendor.gson.internal.bind.util']" name="managedName">Sentry.Java.Vendor.Gson.Internal.Bind.Util</attr>
+  <attr path="/api/package[@name='io.sentry']" name="managedName">Sentry.JavaSdk</attr>
+  <attr path="/api/package[@name='io.sentry.android.core']" name="managedName">Sentry.JavaSdk.Android.Core</attr>
+  <attr path="/api/package[@name='io.sentry.android.core.internal.gestures']" name="managedName">Sentry.JavaSdk.Android.Core.Internal.Gestures</attr>
+  <attr path="/api/package[@name='io.sentry.android.core.internal.util']" name="managedName">Sentry.JavaSdk.Android.Core.Internal.Util</attr>
+  <attr path="/api/package[@name='io.sentry.android.ndk']" name="managedName">Sentry.JavaSdk.Android.Ndk</attr>
+  <attr path="/api/package[@name='io.sentry.android.supplemental']" name="managedName">Sentry.JavaSdk.Android.Supplemental</attr>
+  <attr path="/api/package[@name='io.sentry.cache']" name="managedName">Sentry.JavaSdk.Cache</attr>
+  <attr path="/api/package[@name='io.sentry.clientreport']" name="managedName">Sentry.JavaSdk.ClientReport</attr>
+  <attr path="/api/package[@name='io.sentry.config']" name="managedName">Sentry.JavaSdk.Config</attr>
+  <attr path="/api/package[@name='io.sentry.exception']" name="managedName">Sentry.JavaSdk.Exception</attr>
+  <attr path="/api/package[@name='io.sentry.hints']" name="managedName">Sentry.JavaSdk.Hints</attr>
+  <attr path="/api/package[@name='io.sentry.instrumentation.file']" name="managedName">Sentry.JavaSdk.Instrumentation.File</attr>
+  <attr path="/api/package[@name='io.sentry.transport']" name="managedName">Sentry.JavaSdk.Transport</attr>
+  <attr path="/api/package[@name='io.sentry.protocol']" name="managedName">Sentry.JavaSdk.Protocol</attr>
+  <attr path="/api/package[@name='io.sentry.util']" name="managedName">Sentry.JavaSdk.Util</attr>
+  <attr path="/api/package[@name='io.sentry.vendor']" name="managedName">Sentry.JavaSdk.Vendor</attr>
+  <attr path="/api/package[@name='io.sentry.vendor.gson.stream']" name="managedName">Sentry.JavaSdk.Vendor.Gson.Stream</attr>
+  <attr path="/api/package[@name='io.sentry.vendor.gson.internal.bind.util']" name="managedName">Sentry.JavaSdk.Vendor.Gson.Internal.Bind.Util</attr>
 
   <!--
     These properties have conflicts that create BG8401 warnings ("Skipping '...' due to a duplicate field or property name.")

--- a/src/Sentry/Platforms/Android/AndroidEventProcessor.cs
+++ b/src/Sentry/Platforms/Android/AndroidEventProcessor.cs
@@ -1,12 +1,13 @@
 using Sentry.Android.Extensions;
 using Sentry.Extensibility;
+using Sentry.JavaSdk.Android.Core;
 
 namespace Sentry.Android;
 
 internal class AndroidEventProcessor : ISentryEventProcessor, IDisposable
 {
-    private readonly Java.IEventProcessor? _androidProcessor;
-    private readonly Java.Hint _hint = new();
+    private readonly JavaSdk.IEventProcessor? _androidProcessor;
+    private readonly JavaSdk.Hint _hint = new();
 
     public AndroidEventProcessor(SentryAndroidOptions androidOptions)
     {
@@ -14,7 +15,7 @@ internal class AndroidEventProcessor : ISentryEventProcessor, IDisposable
         // NOTE: This approach avoids hardcoding the class name (which could be obfuscated by proguard)
         _androidProcessor = androidOptions.EventProcessors.OfType<JavaObject>()
             .Where(o => o.Class == JavaClass.FromType(typeof(DefaultAndroidEventProcessor)))
-            .Cast<Java.IEventProcessor>()
+            .Cast<JavaSdk.IEventProcessor>()
             .FirstOrDefault();
 
         // TODO: This would be cleaner, but doesn't compile. Figure out why.
@@ -36,7 +37,7 @@ internal class AndroidEventProcessor : ISentryEventProcessor, IDisposable
 
             // Run a fake event through the Android processor, so we can get context info from the Android SDK.
             // We'll want to do this every time, so that all information is current. (ex: device orientation)
-            using var e = new Java.SentryEvent();
+            using var e = new JavaSdk.SentryEvent();
             androidProcessor.Process(e, _hint);
 
             // Copy what we need to the managed event

--- a/src/Sentry/Platforms/Android/AndroidScopeObserver.cs
+++ b/src/Sentry/Platforms/Android/AndroidScopeObserver.cs
@@ -22,7 +22,7 @@ internal sealed class AndroidScopeObserver : IScopeObserver
         try
         {
             var b = breadcrumb.ToJavaBreadcrumb();
-            Java.Sentry.AddBreadcrumb(b);
+            JavaSdk.Sentry.AddBreadcrumb(b);
         }
         finally
         {
@@ -42,14 +42,14 @@ internal sealed class AndroidScopeObserver : IScopeObserver
 
             if (value is string s)
             {
-                Java.Sentry.SetExtra(key, s);
+                JavaSdk.Sentry.SetExtra(key, s);
                 return;
             }
 
             try
             {
                 var json = JsonSerializer.Serialize(value);
-                Java.Sentry.SetExtra(key, json);
+                JavaSdk.Sentry.SetExtra(key, json);
             }
             catch (Exception ex)
             {
@@ -66,7 +66,7 @@ internal sealed class AndroidScopeObserver : IScopeObserver
     {
         try
         {
-            Java.Sentry.SetTag(key, value);
+            JavaSdk.Sentry.SetTag(key, value);
         }
         finally
         {
@@ -78,7 +78,7 @@ internal sealed class AndroidScopeObserver : IScopeObserver
     {
         try
         {
-            Java.Sentry.RemoveTag(key);
+            JavaSdk.Sentry.RemoveTag(key);
         }
         finally
         {
@@ -91,7 +91,7 @@ internal sealed class AndroidScopeObserver : IScopeObserver
         try
         {
             var u = user?.ToJavaUser();
-            Java.Sentry.SetUser(u);
+            JavaSdk.Sentry.SetUser(u);
         }
         finally
         {

--- a/src/Sentry/Platforms/Android/Callbacks/BeforeBreadcrumbCallback.cs
+++ b/src/Sentry/Platforms/Android/Callbacks/BeforeBreadcrumbCallback.cs
@@ -2,7 +2,7 @@ using Sentry.Android.Extensions;
 
 namespace Sentry.Android.Callbacks;
 
-internal class BeforeBreadcrumbCallback : JavaObject, Java.SentryOptions.IBeforeBreadcrumbCallback
+internal class BeforeBreadcrumbCallback : JavaObject, JavaSdk.SentryOptions.IBeforeBreadcrumbCallback
 {
     private readonly Func<Breadcrumb, Breadcrumb?> _beforeBreadcrumb;
 
@@ -11,7 +11,7 @@ internal class BeforeBreadcrumbCallback : JavaObject, Java.SentryOptions.IBefore
         _beforeBreadcrumb = beforeBreadcrumb;
     }
 
-    public Java.Breadcrumb? Execute(Java.Breadcrumb b, Java.Hint h)
+    public JavaSdk.Breadcrumb? Execute(JavaSdk.Breadcrumb b, JavaSdk.Hint h)
     {
         // Note: Hint is unused due to:
         // https://github.com/getsentry/sentry-dotnet/issues/1469

--- a/src/Sentry/Platforms/Android/Callbacks/BeforeSendCallback.cs
+++ b/src/Sentry/Platforms/Android/Callbacks/BeforeSendCallback.cs
@@ -3,23 +3,23 @@ using Sentry.Extensibility;
 
 namespace Sentry.Android.Callbacks;
 
-internal class BeforeSendCallback : JavaObject, Java.SentryOptions.IBeforeSendCallback
+internal class BeforeSendCallback : JavaObject, JavaSdk.SentryOptions.IBeforeSendCallback
 {
     private readonly Func<SentryEvent, SentryEvent?> _beforeSend;
     private readonly SentryOptions _options;
-    private readonly Java.SentryOptions _javaOptions;
+    private readonly JavaSdk.SentryOptions _javaOptions;
 
     public BeforeSendCallback(
         Func<SentryEvent, SentryEvent?> beforeSend,
         SentryOptions options,
-        Java.SentryOptions javaOptions)
+        JavaSdk.SentryOptions javaOptions)
     {
         _beforeSend = beforeSend;
         _options = options;
         _javaOptions = javaOptions;
     }
 
-    public Java.SentryEvent? Execute(Java.SentryEvent e, Java.Hint h)
+    public JavaSdk.SentryEvent? Execute(JavaSdk.SentryEvent e, JavaSdk.Hint h)
     {
         // Note: Hint is unused due to:
         // https://github.com/getsentry/sentry-dotnet/issues/1469

--- a/src/Sentry/Platforms/Android/Callbacks/OptionsConfigurationCallback.cs
+++ b/src/Sentry/Platforms/Android/Callbacks/OptionsConfigurationCallback.cs
@@ -1,6 +1,8 @@
+using Sentry.JavaSdk.Android.Core;
+
 namespace Sentry.Android.Callbacks;
 
-internal class OptionsConfigurationCallback : JavaObject, Java.Sentry.IOptionsConfiguration
+internal class OptionsConfigurationCallback : JavaObject, JavaSdk.Sentry.IOptionsConfiguration
 {
     private readonly Action<SentryAndroidOptions> _configureOptions;
 

--- a/src/Sentry/Platforms/Android/Callbacks/TracesSamplerCallback.cs
+++ b/src/Sentry/Platforms/Android/Callbacks/TracesSamplerCallback.cs
@@ -2,7 +2,7 @@ using Sentry.Android.Extensions;
 
 namespace Sentry.Android.Callbacks;
 
-internal class TracesSamplerCallback : JavaObject, Java.SentryOptions.ITracesSamplerCallback
+internal class TracesSamplerCallback : JavaObject, JavaSdk.SentryOptions.ITracesSamplerCallback
 {
     private readonly Func<TransactionSamplingContext, double?> _tracesSampler;
 
@@ -11,7 +11,7 @@ internal class TracesSamplerCallback : JavaObject, Java.SentryOptions.ITracesSam
         _tracesSampler = tracesSampler;
     }
 
-    public JavaDouble? Sample(Java.SamplingContext c)
+    public JavaDouble? Sample(JavaSdk.SamplingContext c)
     {
         var context = c.ToTransactionSamplingContext();
         return (JavaDouble?)_tracesSampler.Invoke(context);

--- a/src/Sentry/Platforms/Android/Extensions/BreadcrumbExtensions.cs
+++ b/src/Sentry/Platforms/Android/Extensions/BreadcrumbExtensions.cs
@@ -2,7 +2,7 @@ namespace Sentry.Android.Extensions;
 
 internal static class BreadcrumbExtensions
 {
-    public static Breadcrumb ToBreadcrumb(this Java.Breadcrumb breadcrumb)
+    public static Breadcrumb ToBreadcrumb(this JavaSdk.Breadcrumb breadcrumb)
     {
         var data = breadcrumb.Data
             .WorkaroundKeyIteratorBug()
@@ -16,9 +16,9 @@ internal static class BreadcrumbExtensions
             breadcrumb.Level?.ToBreadcrumbLevel() ?? default);
     }
 
-    public static Java.Breadcrumb ToJavaBreadcrumb(this Breadcrumb breadcrumb)
+    public static JavaSdk.Breadcrumb ToJavaBreadcrumb(this Breadcrumb breadcrumb)
     {
-        var javaBreadcrumb = new Java.Breadcrumb(breadcrumb.Timestamp.ToJavaDate())
+        var javaBreadcrumb = new JavaSdk.Breadcrumb(breadcrumb.Timestamp.ToJavaDate())
         {
             Message = breadcrumb.Message,
             Type = breadcrumb.Type,

--- a/src/Sentry/Platforms/Android/Extensions/DeviceExtensions.cs
+++ b/src/Sentry/Platforms/Android/Extensions/DeviceExtensions.cs
@@ -22,7 +22,7 @@ internal static class DeviceExtensions
         }
     }
 
-    public static void ApplyFromSentryAndroidSdk(this Device device, Java.Protocol.Device d)
+    public static void ApplyFromSentryAndroidSdk(this Device device, JavaSdk.Protocol.Device d)
     {
         // We already have these above
         // device.Manufacturer ??= d.Manufacturer;
@@ -66,7 +66,7 @@ internal static class DeviceExtensions
 
     }
 
-    public static DeviceOrientation ToDeviceOrientation(this Java.Protocol.Device.DeviceOrientation orientation) =>
+    public static DeviceOrientation ToDeviceOrientation(this JavaSdk.Protocol.Device.DeviceOrientation orientation) =>
         orientation.Name() switch
         {
             "PORTRAIT" => DeviceOrientation.Portrait,

--- a/src/Sentry/Platforms/Android/Extensions/EnumExtensions.cs
+++ b/src/Sentry/Platforms/Android/Extensions/EnumExtensions.cs
@@ -2,7 +2,7 @@ namespace Sentry.Android.Extensions;
 
 internal static class EnumExtensions
 {
-    public static SentryLevel ToSentryLevel(this Java.SentryLevel level) =>
+    public static SentryLevel ToSentryLevel(this JavaSdk.SentryLevel level) =>
         level.Name() switch
         {
             "DEBUG" => SentryLevel.Debug,
@@ -13,18 +13,18 @@ internal static class EnumExtensions
             _ => throw new ArgumentOutOfRangeException(nameof(level), level.Name(), message: default)
         };
 
-    public static Java.SentryLevel ToJavaSentryLevel(this SentryLevel level) =>
+    public static JavaSdk.SentryLevel ToJavaSentryLevel(this SentryLevel level) =>
         level switch
         {
-            SentryLevel.Debug => Java.SentryLevel.Debug!,
-            SentryLevel.Info => Java.SentryLevel.Info!,
-            SentryLevel.Warning => Java.SentryLevel.Warning!,
-            SentryLevel.Error => Java.SentryLevel.Error!,
-            SentryLevel.Fatal => Java.SentryLevel.Fatal!,
+            SentryLevel.Debug => JavaSdk.SentryLevel.Debug!,
+            SentryLevel.Info => JavaSdk.SentryLevel.Info!,
+            SentryLevel.Warning => JavaSdk.SentryLevel.Warning!,
+            SentryLevel.Error => JavaSdk.SentryLevel.Error!,
+            SentryLevel.Fatal => JavaSdk.SentryLevel.Fatal!,
             _ => throw new ArgumentOutOfRangeException(nameof(level), level, message: default)
         };
 
-    public static BreadcrumbLevel ToBreadcrumbLevel(this Java.SentryLevel level) =>
+    public static BreadcrumbLevel ToBreadcrumbLevel(this JavaSdk.SentryLevel level) =>
         level.Name() switch
         {
             "DEBUG" => BreadcrumbLevel.Debug,
@@ -35,18 +35,18 @@ internal static class EnumExtensions
             _ => throw new ArgumentOutOfRangeException(nameof(level), level.Name(), message: default)
         };
 
-    public static Java.SentryLevel ToJavaSentryLevel(this BreadcrumbLevel level) =>
+    public static JavaSdk.SentryLevel ToJavaSentryLevel(this BreadcrumbLevel level) =>
         level switch
         {
-            BreadcrumbLevel.Debug => Java.SentryLevel.Debug!,
-            BreadcrumbLevel.Info => Java.SentryLevel.Info!,
-            BreadcrumbLevel.Warning => Java.SentryLevel.Warning!,
-            BreadcrumbLevel.Error => Java.SentryLevel.Error!,
-            BreadcrumbLevel.Critical => Java.SentryLevel.Fatal!,
+            BreadcrumbLevel.Debug => JavaSdk.SentryLevel.Debug!,
+            BreadcrumbLevel.Info => JavaSdk.SentryLevel.Info!,
+            BreadcrumbLevel.Warning => JavaSdk.SentryLevel.Warning!,
+            BreadcrumbLevel.Error => JavaSdk.SentryLevel.Error!,
+            BreadcrumbLevel.Critical => JavaSdk.SentryLevel.Fatal!,
             _ => throw new ArgumentOutOfRangeException(nameof(level), level, message: default)
         };
 
-    public static SpanStatus ToSpanStatus(this Java.SpanStatus status) =>
+    public static SpanStatus ToSpanStatus(this JavaSdk.SpanStatus status) =>
         status.Name() switch
         {
             "OK" => SpanStatus.Ok,
@@ -70,30 +70,30 @@ internal static class EnumExtensions
             _ => throw new ArgumentOutOfRangeException(nameof(status), status.Name(), message: default)
         };
 
-    public static Java.SpanStatus ToJavaSpanStatus(this SpanStatus status) =>
+    public static JavaSdk.SpanStatus ToJavaSpanStatus(this SpanStatus status) =>
         status switch
         {
-            SpanStatus.Ok => Java.SpanStatus.Ok!,
-            SpanStatus.Cancelled => Java.SpanStatus.Cancelled!,
-            SpanStatus.InternalError => Java.SpanStatus.InternalError!,
-            SpanStatus.UnknownError => Java.SpanStatus.UnknownError!,
-            SpanStatus.InvalidArgument => Java.SpanStatus.InvalidArgument!,
-            SpanStatus.DeadlineExceeded => Java.SpanStatus.DeadlineExceeded!,
-            SpanStatus.NotFound => Java.SpanStatus.NotFound!,
-            SpanStatus.AlreadyExists => Java.SpanStatus.AlreadyExists!,
-            SpanStatus.PermissionDenied => Java.SpanStatus.PermissionDenied!,
-            SpanStatus.ResourceExhausted => Java.SpanStatus.ResourceExhausted!,
-            SpanStatus.FailedPrecondition => Java.SpanStatus.FailedPrecondition!,
-            SpanStatus.Aborted => Java.SpanStatus.Aborted!,
-            SpanStatus.OutOfRange => Java.SpanStatus.OutOfRange!,
-            SpanStatus.Unimplemented => Java.SpanStatus.Unimplemented!,
-            SpanStatus.Unavailable => Java.SpanStatus.Unavailable!,
-            SpanStatus.DataLoss => Java.SpanStatus.DataLoss!,
-            SpanStatus.Unauthenticated => Java.SpanStatus.Unauthenticated!,
+            SpanStatus.Ok => JavaSdk.SpanStatus.Ok!,
+            SpanStatus.Cancelled => JavaSdk.SpanStatus.Cancelled!,
+            SpanStatus.InternalError => JavaSdk.SpanStatus.InternalError!,
+            SpanStatus.UnknownError => JavaSdk.SpanStatus.UnknownError!,
+            SpanStatus.InvalidArgument => JavaSdk.SpanStatus.InvalidArgument!,
+            SpanStatus.DeadlineExceeded => JavaSdk.SpanStatus.DeadlineExceeded!,
+            SpanStatus.NotFound => JavaSdk.SpanStatus.NotFound!,
+            SpanStatus.AlreadyExists => JavaSdk.SpanStatus.AlreadyExists!,
+            SpanStatus.PermissionDenied => JavaSdk.SpanStatus.PermissionDenied!,
+            SpanStatus.ResourceExhausted => JavaSdk.SpanStatus.ResourceExhausted!,
+            SpanStatus.FailedPrecondition => JavaSdk.SpanStatus.FailedPrecondition!,
+            SpanStatus.Aborted => JavaSdk.SpanStatus.Aborted!,
+            SpanStatus.OutOfRange => JavaSdk.SpanStatus.OutOfRange!,
+            SpanStatus.Unimplemented => JavaSdk.SpanStatus.Unimplemented!,
+            SpanStatus.Unavailable => JavaSdk.SpanStatus.Unavailable!,
+            SpanStatus.DataLoss => JavaSdk.SpanStatus.DataLoss!,
+            SpanStatus.Unauthenticated => JavaSdk.SpanStatus.Unauthenticated!,
             _ => throw new ArgumentOutOfRangeException(nameof(status), status, message: default)
         };
 
-    public static TransactionNameSource ToTransactionNameSource(this Java.Protocol.TransactionNameSource source) =>
+    public static TransactionNameSource ToTransactionNameSource(this JavaSdk.Protocol.TransactionNameSource source) =>
         source.Name() switch
         {
             "CUSTOM" => TransactionNameSource.Custom,
@@ -104,14 +104,14 @@ internal static class EnumExtensions
             _ => throw new ArgumentOutOfRangeException(nameof(source), source.Name(), message: default)
         };
 
-    public static Java.Protocol.TransactionNameSource ToJavaTransactionNameSource(this TransactionNameSource source) =>
+    public static JavaSdk.Protocol.TransactionNameSource ToJavaTransactionNameSource(this TransactionNameSource source) =>
         source switch
         {
-            TransactionNameSource.Custom => Java.Protocol.TransactionNameSource.Custom!,
-            TransactionNameSource.Url => Java.Protocol.TransactionNameSource.Url!,
-            TransactionNameSource.Route => Java.Protocol.TransactionNameSource.Route!,
-            TransactionNameSource.View => Java.Protocol.TransactionNameSource.View!,
-            TransactionNameSource.Task => Java.Protocol.TransactionNameSource.Task!,
+            TransactionNameSource.Custom => JavaSdk.Protocol.TransactionNameSource.Custom!,
+            TransactionNameSource.Url => JavaSdk.Protocol.TransactionNameSource.Url!,
+            TransactionNameSource.Route => JavaSdk.Protocol.TransactionNameSource.Route!,
+            TransactionNameSource.View => JavaSdk.Protocol.TransactionNameSource.View!,
+            TransactionNameSource.Task => JavaSdk.Protocol.TransactionNameSource.Task!,
             _ => throw new ArgumentOutOfRangeException(nameof(source), source, message: default)
         };
 }

--- a/src/Sentry/Platforms/Android/Extensions/MiscExtensions.cs
+++ b/src/Sentry/Platforms/Android/Extensions/MiscExtensions.cs
@@ -2,11 +2,11 @@ namespace Sentry.Android.Extensions;
 
 internal static class MiscExtensions
 {
-    public static SentryId ToSentryId(this Java.Protocol.SentryId sentryId) => new(Guid.Parse(sentryId.ToString()));
+    public static SentryId ToSentryId(this JavaSdk.Protocol.SentryId sentryId) => new(Guid.Parse(sentryId.ToString()));
 
-    public static Java.Protocol.SentryId ToJavaSentryId(this SentryId sentryId) => new(sentryId.ToString());
+    public static JavaSdk.Protocol.SentryId ToJavaSentryId(this SentryId sentryId) => new(sentryId.ToString());
 
-    public static SpanId ToSpanId(this Java.SpanId spanId) => new(spanId.ToString());
+    public static SpanId ToSpanId(this JavaSdk.SpanId spanId) => new(spanId.ToString());
 
-    public static Java.SpanId ToJavaSpanId(this SpanId spanId) => new(spanId.ToString());
+    public static JavaSdk.SpanId ToJavaSpanId(this SpanId spanId) => new(spanId.ToString());
 }

--- a/src/Sentry/Platforms/Android/Extensions/OperatingSystemExtensions.cs
+++ b/src/Sentry/Platforms/Android/Extensions/OperatingSystemExtensions.cs
@@ -25,7 +25,7 @@ internal static class OperatingSystemExtensions
         // operatingSystem.RawDescription is already set in Enricher.cs
     }
 
-    public static void ApplyFromSentryAndroidSdk(this OperatingSystem operatingSystem, Java.Protocol.OperatingSystem os)
+    public static void ApplyFromSentryAndroidSdk(this OperatingSystem operatingSystem, JavaSdk.Protocol.OperatingSystem os)
     {
         // We already have everything above, except the Rooted flag.
         // The Android SDK figures this out in RootChecker.java

--- a/src/Sentry/Platforms/Android/Extensions/SamplingContextExtensions.cs
+++ b/src/Sentry/Platforms/Android/Extensions/SamplingContextExtensions.cs
@@ -6,7 +6,7 @@ internal static class SamplingContextExtensions
 {
     private static readonly Dictionary<string, object?> EmptyObjectDictionary = new();
 
-    public static TransactionSamplingContext ToTransactionSamplingContext(this Java.SamplingContext context)
+    public static TransactionSamplingContext ToTransactionSamplingContext(this JavaSdk.SamplingContext context)
     {
         var transactionContext = new TransactionContextFacade(context.TransactionContext);
 

--- a/src/Sentry/Platforms/Android/Extensions/SentryEventExtensions.cs
+++ b/src/Sentry/Platforms/Android/Extensions/SentryEventExtensions.cs
@@ -9,7 +9,7 @@ internal static class SentryEventExtensions
      * then deserializing back to an object on the other side.  It is not expected to be performant, as this code is only
      * used when a BeforeSend option is set, and then only when an event is captured by the Java SDK (which should be
      * relatively rare).
-     * 
+     *
      * This approach avoids having to write to/from methods for the entire object graph.  However, it's also important to
      * recognize that there's not necessarily a one-to-one mapping available on all objects (even through serialization)
      * between the two SDKs, so some optional details may be lost when roundtripping.  That's generally OK, as this is
@@ -17,11 +17,11 @@ internal static class SentryEventExtensions
      * updating the objects on either side.
      */
 
-    public static SentryEvent ToSentryEvent(this Java.SentryEvent sentryEvent, Java.SentryOptions javaOptions)
+    public static SentryEvent ToSentryEvent(this JavaSdk.SentryEvent sentryEvent, JavaSdk.SentryOptions javaOptions)
     {
         using var stream = new MemoryStream();
         using var streamWriter = new JavaOutputStreamWriter(stream);
-        using var jsonWriter = new Java.JsonObjectWriter(streamWriter, javaOptions.MaxDepth);
+        using var jsonWriter = new JavaSdk.JsonObjectWriter(streamWriter, javaOptions.MaxDepth);
         sentryEvent.Serialize(jsonWriter, javaOptions.Logger);
         jsonWriter.Flush();
         stream.Seek(0, SeekOrigin.Begin);
@@ -30,7 +30,7 @@ internal static class SentryEventExtensions
         return SentryEvent.FromJson(json.RootElement, sentryEvent.Throwable);
     }
 
-    public static Java.SentryEvent ToJavaSentryEvent(this SentryEvent sentryEvent, SentryOptions options, Java.SentryOptions javaOptions)
+    public static JavaSdk.SentryEvent ToJavaSentryEvent(this SentryEvent sentryEvent, SentryOptions options, JavaSdk.SentryOptions javaOptions)
     {
         using var stream = new MemoryStream();
         using var jsonWriter = new Utf8JsonWriter(stream);
@@ -39,8 +39,8 @@ internal static class SentryEventExtensions
         stream.Seek(0, SeekOrigin.Begin);
 
         using var streamReader = new JavaInputStreamReader(stream);
-        using var jsonReader = new Java.JsonObjectReader(streamReader);
-        using var deserializer = new Java.SentryEvent.Deserializer();
+        using var jsonReader = new JavaSdk.JsonObjectReader(streamReader);
+        using var deserializer = new JavaSdk.SentryEvent.Deserializer();
         return deserializer.Deserialize(jsonReader, javaOptions.Logger);
     }
 }

--- a/src/Sentry/Platforms/Android/Extensions/UserExtensions.cs
+++ b/src/Sentry/Platforms/Android/Extensions/UserExtensions.cs
@@ -7,7 +7,7 @@ internal static class UserExtensions
     private static readonly IDictionary<string, string> EmptyDictionary =
         new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
 
-    public static User ToUser(this Java.Protocol.User user) =>
+    public static User ToUser(this JavaSdk.Protocol.User user) =>
         new()
         {
             Email = user.Email,
@@ -17,7 +17,7 @@ internal static class UserExtensions
             Other = user.Others ?? EmptyDictionary
         };
 
-    public static Java.Protocol.User ToJavaUser(this User user) =>
+    public static JavaSdk.Protocol.User ToJavaUser(this User user) =>
         new()
         {
             Email = user.Email,

--- a/src/Sentry/Platforms/Android/Extensions/UserExtensions.cs
+++ b/src/Sentry/Platforms/Android/Extensions/UserExtensions.cs
@@ -14,7 +14,8 @@ internal static class UserExtensions
             Id = user.Id,
             IpAddress = user.IpAddress,
             Username = user.Username,
-            Other = user.Others ?? EmptyDictionary
+            Segment = user.Segment,
+            Other = user.Data ?? EmptyDictionary
         };
 
     public static JavaSdk.Protocol.User ToJavaUser(this User user) =>
@@ -24,6 +25,7 @@ internal static class UserExtensions
             Id = user.Id,
             IpAddress = user.IpAddress,
             Username = user.Username,
-            Others = user.Other.Count == 0 ? null : user.Other
+            Segment = user.Segment,
+            Data = user.Other.Count == 0 ? null : user.Other
         };
 }

--- a/src/Sentry/Platforms/Android/Facades/TransactionContextFacade.cs
+++ b/src/Sentry/Platforms/Android/Facades/TransactionContextFacade.cs
@@ -4,9 +4,9 @@ namespace Sentry.Android.Facades;
 
 internal class TransactionContextFacade : ITransactionContext
 {
-    private readonly Java.TransactionContext _context;
+    private readonly JavaSdk.TransactionContext _context;
 
-    internal TransactionContextFacade(Java.TransactionContext context)
+    internal TransactionContextFacade(JavaSdk.TransactionContext context)
     {
         _context = context;
     }

--- a/src/Sentry/Platforms/Android/JavaLogger.cs
+++ b/src/Sentry/Platforms/Android/JavaLogger.cs
@@ -2,22 +2,22 @@ using Sentry.Android.Extensions;
 
 namespace Sentry.Android;
 
-internal class JavaLogger : JavaObject, Java.ILogger
+internal class JavaLogger : JavaObject, JavaSdk.ILogger
 {
     private readonly SentryOptions _options;
 
     public JavaLogger(SentryOptions options) => _options = options;
 
-    public void Log(Java.SentryLevel level, string message, JavaObject[]? args) =>
+    public void Log(JavaSdk.SentryLevel level, string message, JavaObject[]? args) =>
         _options.DiagnosticLogger?.Log(level.ToSentryLevel(), "Android: " + FormatJavaString(message, args));
 
-    public void Log(Java.SentryLevel level, string message, Throwable? throwable) =>
+    public void Log(JavaSdk.SentryLevel level, string message, Throwable? throwable) =>
         _options.DiagnosticLogger?.Log(level.ToSentryLevel(), "Android: " + message, throwable);
 
-    public void Log(Java.SentryLevel level, Throwable? throwable, string message, params JavaObject[]? args) =>
+    public void Log(JavaSdk.SentryLevel level, Throwable? throwable, string message, params JavaObject[]? args) =>
         _options.DiagnosticLogger?.Log(level.ToSentryLevel(), "Android: " + FormatJavaString(message, args), throwable);
 
-    public bool IsEnabled(Java.SentryLevel? level) =>
+    public bool IsEnabled(JavaSdk.SentryLevel? level) =>
         level != null && _options.DiagnosticLogger?.IsEnabled(level.ToSentryLevel()) == true;
 
     private static string FormatJavaString(string s, JavaObject[]? args) => args is null ? s : JavaString.Format(s, args);

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -3,6 +3,7 @@ using Android.OS;
 using Sentry.Android;
 using Sentry.Android.Callbacks;
 using Sentry.Android.Extensions;
+using Sentry.JavaSdk.Android.Core;
 using Sentry.Protocol;
 
 // ReSharper disable once CheckNamespace
@@ -93,7 +94,7 @@ public static partial class SentrySdk
                 if (options.HttpProxy is System.Net.WebProxy proxy)
                 {
                     var creds = proxy.Credentials as System.Net.NetworkCredential;
-                    o.SetProxy(new Java.SentryOptions.Proxy
+                    o.SetProxy(new JavaSdk.SentryOptions.Proxy
                     {
                         Host = proxy.Address?.Host,
                         Port = proxy.Address?.Port.ToString(CultureInfo.InvariantCulture),
@@ -166,7 +167,7 @@ public static partial class SentrySdk
 
         // Set options for the managed SDK that depend on the Android SDK. (The user will not be able to modify these.)
         options.AddEventProcessor(new AndroidEventProcessor(androidOptions!));
-        options.CrashedLastRun = () => Java.Sentry.IsCrashedLastRun()?.BooleanValue() is true;
+        options.CrashedLastRun = () => JavaSdk.Sentry.IsCrashedLastRun()?.BooleanValue() is true;
         options.EnableScopeSync = true;
         options.ScopeObserver = new AndroidScopeObserver(options);
 

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -503,11 +503,11 @@ namespace Sentry
 
 #if ANDROID
                 case CrashType.Java:
-                    Sentry.Android.Supplemental.Buggy.ThrowRuntimeException(msg);
+                    JavaSdk.Android.Supplemental.Buggy.ThrowRuntimeException(msg);
                     break;
 
                 case CrashType.JavaBackgroundThread:
-                    Sentry.Android.Supplemental.Buggy.ThrowRuntimeExceptionOnBackgroundThread(msg);
+                    JavaSdk.Android.Supplemental.Buggy.ThrowRuntimeExceptionOnBackgroundThread(msg);
                     break;
 
                 case CrashType.Native:


### PR DESCRIPTION
- Bumped the Android SDK to 6.5.0.
- Changed the internal namespace to fix a conflict.
- Added `User.Segment` to the conversion methods, and fixed an obsoletion warning.