### PR TITLE
Update github actions

### DIFF
--- a/.github/actions/buildnative/action.yml
+++ b/.github/actions/buildnative/action.yml
@@ -8,13 +8,9 @@ runs:
       shell: bash
       run: echo "JAVA_HOME_11=$JAVA_HOME_11_X64" >> $GITHUB_ENV
 
-    - name: Setup Homebrew
-      if: runner.os != 'Windows'
-      uses: Homebrew/actions/setup-homebrew@b1bdd59d7f4eadb1ae600d5d79b8aeeb4eabe17a
-
     - name: Install Ninja
       shell: bash
-      run: ${{ runner.os == 'Windows' && 'choco' || 'brew' }} install ninja
+      run: ${{ runner.os == 'macOS' && 'brew install ninja' || runner.os == 'Windows' && 'choco install ninja' || 'sudo apt-get install ninja-build' }}
 
     - name: Build C Project
       if: runner.os == 'Linux' || runner.os == 'macOS'

--- a/.github/actions/buildnative/action.yml
+++ b/.github/actions/buildnative/action.yml
@@ -9,7 +9,8 @@ runs:
       run: echo "JAVA_HOME_11=$JAVA_HOME_11_X64" >> $GITHUB_ENV
 
     - name: Install Ninja
-      uses: seanmiddleditch/gha-setup-ninja@master
+      shell: bash
+      run: ${{ runner.os == 'macOS' && 'brew install ninja' || runner.os == 'Windows' && 'choco install ninja' || runner.os == 'Linux' && 'sudo apt-get install ninja-build' || '' }}
 
     - name: Build C Project
       if: runner.os == 'Linux' || runner.os == 'macOS'

--- a/.github/actions/buildnative/action.yml
+++ b/.github/actions/buildnative/action.yml
@@ -10,7 +10,7 @@ runs:
 
     - name: Install Ninja
       shell: bash
-      run: ${{ runner.os == 'macOS' && 'brew install ninja' || runner.os == 'Windows' && 'choco install ninja' || runner.os == 'Linux' && 'sudo apt-get install ninja-build' || '' }}
+      run: ${{ runner.os == 'Windows' && 'choco' || 'brew' }} install ninja
 
     - name: Build C Project
       if: runner.os == 'Linux' || runner.os == 'macOS'

--- a/.github/actions/buildnative/action.yml
+++ b/.github/actions/buildnative/action.yml
@@ -8,6 +8,10 @@ runs:
       shell: bash
       run: echo "JAVA_HOME_11=$JAVA_HOME_11_X64" >> $GITHUB_ENV
 
+    - name: Setup Homebrew
+      if: runner.os != 'Windows'
+      uses: Homebrew/actions/setup-homebrew@b1bdd59d7f4eadb1ae600d5d79b8aeeb4eabe17a
+
     - name: Install Ninja
       shell: bash
       run: ${{ runner.os == 'Windows' && 'choco' || 'brew' }} install ninja

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -21,9 +21,6 @@ runs:
     - name: Install .NET 6 SDK
       uses: actions/setup-dotnet@v3
       if: runner.os == 'Windows'
-      env:
-        # Prevent setup-dotnet action from stepping on pre-installed dotnet SDKs
-        DOTNET_INSTALL_DIR: C:\Program Files\dotnet
       with:
         dotnet-version: 6.x.x
 

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -42,7 +42,7 @@ jobs:
     needs: [build]
     name: Run Android API-${{ matrix.api-level }} Test
     # MacOS is required for the emulator, per https://github.com/ReactiveCircus/android-emulator-runner/blob/main/README.md
-    # We use macos-12 because macos-latest will soon point their anyway, per https://github.com/actions/runner-images/issues/6384
+    # We use macos-12 because macos-latest will soon point there anyway, per https://github.com/actions/runner-images/issues/6384
     runs-on: macos-12
     strategy:
       fail-fast: false

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -41,7 +41,9 @@ jobs:
   android:
     needs: [build]
     name: Run Android API-${{ matrix.api-level }} Test
-    runs-on: macos-latest # MacOS is required for the emulator, per https://github.com/ReactiveCircus/android-emulator-runner/blob/main/README.md
+    # MacOS is required for the emulator, per https://github.com/ReactiveCircus/android-emulator-runner/blob/main/README.md
+    # We use macos-12 because macos-latest will soon point their anyway, per https://github.com/actions/runner-images/issues/6384
+    runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:
@@ -59,13 +61,16 @@ jobs:
           name: device-test-android
           path: bin
 
-      - name: Install xharness
+      - name: Install XHarness
         run: dotnet tool install Microsoft.DotNet.XHarness.CLI --global --version "1.*-*"
 
-      # Cached AVD setup per https://github.com/ReactiveCircus/android-emulator-runner/blob/main/README.md
+      - name: Install Intel HAXM
+        run: brew install --cask intel-haxm
 
-      - name: Gradle cache
+      - name: Setup Gradle
         uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # pin@v2
+
+      # Cached AVD setup per https://github.com/ReactiveCircus/android-emulator-runner/blob/main/README.md
 
       - name: AVD cache
         uses: actions/cache@v3
@@ -74,12 +79,12 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+          key: avd-hwaccel-${{ matrix.api-level }}
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         timeout-minutes: 30
-        uses: reactivecircus/android-emulator-runner@d7b53ddc6e44254e1f4cf4a6ad67345837027a66 # pin@v2
+        uses: reactivecircus/android-emulator-runner@50986b1464923454c95e261820bc626f38490ec0 # pin@v2
         with:
           api-level: ${{ matrix.api-level }}
           # We don't need the Google APIs, but the default images are not available for 32+
@@ -88,13 +93,13 @@ jobs:
           ram-size: 2048M
           arch: x86_64
           disk-size: 4096M
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-window -accel on -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run Tests
         timeout-minutes: 30
-        uses: reactivecircus/android-emulator-runner@d7b53ddc6e44254e1f4cf4a6ad67345837027a66 # pin@v2
+        uses: reactivecircus/android-emulator-runner@50986b1464923454c95e261820bc626f38490ec0 # pin@v2
         with:
           api-level: ${{ matrix.api-level }}
           # We don't need the Google APIs, but the default images are not available for 32+
@@ -103,7 +108,7 @@ jobs:
           ram-size: 2048M
           arch: x86_64
           disk-size: 4096M
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-snapshot-save -no-window -accel on -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: xharness android test --output-directory=./test_output --app=bin/io.sentry.dotnet.maui.device.testapp-Signed.apk --package-name=io.sentry.dotnet.maui.device.testapp
 

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -29,7 +29,7 @@ jobs:
 
       # We only need to restore to check for vulnerable packages
       - name: Restore .NET Dependencies
-        run: dotnet restore --nologo
+        run: dotnet restore Sentry-CI-Build-${{ runner.os }}.slnf --nologo
 
       # The dotnet list package command doesn't change its exit code on detection, so tee to a file and scan it
       # See https://github.com/NuGet/Home/issues/11315#issuecomment-1243055173


### PR DESCRIPTION
A few improvements to our GitHub Actions workflows:

- Install Ninja directly (via brew, choco, or apt-get), as the action we were previously using appears to be not getting updates and is giving a node12 warning
- Remove `DOTNET_INSTALL_DIR` from the .NET install action, as it's no longer needed with v3
- Update the device tests to run on macos-12, use the latest android emulator action, and install/use HAXM
- Fix the broken restore in the vulnerabilities check workflow


#skip-changelog