### PR TITLE
Only bind the Cocoa SDK on OSX

### DIFF
--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -31,7 +31,7 @@
     <NativeReference Include="$(SentryCocoaFramework)" Kind="Framework" />
   </ItemGroup>
 
-  <Target Name="DownloadSentryCocoaSdk" BeforeTargets="CollectPackageReferences">
+  <Target Name="DownloadSentryCocoaSdk" BeforeTargets="CollectPackageReferences" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
 
     <!-- TODO: Uncomment to download official version from GitHub once we have fixed https://github.com/getsentry/sentry-cocoa/issues/2031 -->
     <!-- <DownloadFile


### PR DESCRIPTION
The build fails when trying to build the entire `Sentry.sln` on Windows.  This fixes it by skipping the custom target during the restore phase if not on OSX.

#skip-changelog