### PR TITLE
Update bundled Cocoa SDK to version 7.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Unreleased
 
 - Update bundled Android SDK to version 6.5.0 ([#1984](https://github.com/getsentry/sentry-dotnet/pull/1984))
+- Update bundled Cocoa SDK to version 7.28.0 ([#1988](https://github.com/getsentry/sentry-dotnet/pull/1988))
 
 ## Fixes
 

--- a/src/Sentry.Bindings.Cocoa/ApiDefinition.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinition.cs
@@ -94,6 +94,21 @@ interface PrivateSentrySdkOnly
     [Export ("setSdkName:andVersionString:")]
     void SetSdkName (string sdkName, string versionString);
 
+    // +(void)setSdkName:(NSString * _Nonnull)sdkName;
+    [Static]
+    [Export ("setSdkName:")]
+    void SetSdkName (string sdkName);
+
+    // +(NSString * _Nonnull)getSdkName;
+    [Static]
+    [Export ("getSdkName")]
+    string SdkName { get; }
+
+    // +(NSString * _Nonnull)getSdkVersionString;
+    [Static]
+    [Export ("getSdkVersionString")]
+    string SdkVersionString { get; }
+
     // @property (copy, nonatomic, class) SentryOnAppStartMeasurementAvailable _Nullable onAppStartMeasurementAvailable;
     [Static]
     [NullAllowed, Export ("onAppStartMeasurementAvailable", ArgumentSemantic.Copy)]
@@ -337,6 +352,10 @@ interface SentryClient
     // -(void)captureEnvelope:(SentryEnvelope * _Nonnull)envelope __attribute__((swift_name("capture(envelope:)")));
     [Export ("captureEnvelope:")]
     void CaptureEnvelope (SentryEnvelope envelope);
+
+    // -(void)flush:(NSTimeInterval)timeout __attribute__((swift_name("flush(timeout:)")));
+    [Export ("flush:")]
+    void Flush (double timeout);
 }
 
 // @interface SentryCrashExceptionApplication : NSObject
@@ -993,6 +1012,10 @@ interface SentryOptions
     // @property (assign, nonatomic) BOOL enableAutoBreadcrumbTracking;
     [Export ("enableAutoBreadcrumbTracking")]
     bool EnableAutoBreadcrumbTracking { get; set; }
+
+    // @property (retain, nonatomic) NSArray * _Nonnull tracePropagationTargets;
+    [Export ("tracePropagationTargets", ArgumentSemantic.Retain)]
+    NSObject[] TracePropagationTargets { get; set; }
 }
 
 // @protocol SentryIntegrationProtocol <NSObject>
@@ -1146,6 +1169,16 @@ interface SentrySpan : SentrySerializable
     [Export ("removeTagForKey:")]
     void RemoveTagForKey (string key);
 
+    // @required -(void)setMeasurement:(NSString * _Nonnull)name value:(NSNumber * _Nonnull)value __attribute__((swift_name("setMeasurement(name:value:)")));
+    [Abstract]
+    [Export ("setMeasurement:value:")]
+    void SetMeasurement (string name, NSNumber value);
+
+    // @required -(void)setMeasurement:(NSString * _Nonnull)name value:(NSNumber * _Nonnull)value unit:(SentryMeasurementUnit * _Nonnull)unit __attribute__((swift_name("setMeasurement(name:value:unit:)")));
+    [Abstract]
+    [Export ("setMeasurement:value:unit:")]
+    void SetMeasurement (string name, NSNumber value, SentryMeasurementUnit unit);
+
     // @required -(void)finish;
     [Abstract]
     [Export ("finish")]
@@ -1283,6 +1316,10 @@ interface SentryHub
     // -(void)captureEnvelope:(SentryEnvelope * _Nonnull)envelope __attribute__((swift_name("capture(envelope:)")));
     [Export ("captureEnvelope:")]
     void CaptureEnvelope (SentryEnvelope envelope);
+
+    // -(void)flush:(NSTimeInterval)timeout __attribute__((swift_name("flush(timeout:)")));
+    [Export ("flush:")]
+    void Flush (double timeout);
 }
 
 // @interface SentryId : NSObject
@@ -1306,6 +1343,167 @@ interface SentryId
     [Static]
     [Export ("empty", ArgumentSemantic.Strong)]
     SentryId Empty { get; }
+}
+
+// @interface SentryMeasurementUnit : NSObject <NSCopying>
+[BaseType (typeof(NSObject))]
+[DisableDefaultCtor]
+[Internal]
+interface SentryMeasurementUnit // : INSCopying
+{
+    // -(instancetype _Nonnull)initWithUnit:(NSString * _Nonnull)unit;
+    [Export ("initWithUnit:")]
+    NativeHandle Constructor (string unit);
+
+    // @property (readonly, copy) NSString * _Nonnull unit;
+    [Export ("unit")]
+    string Unit { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnit * _Nonnull none;
+    [Static]
+    [Export ("none", ArgumentSemantic.Copy)]
+    SentryMeasurementUnit None { get; }
+}
+
+// @interface SentryMeasurementUnitDuration : SentryMeasurementUnit
+[BaseType (typeof(SentryMeasurementUnit))]
+[DisableDefaultCtor]
+[Internal]
+interface SentryMeasurementUnitDuration
+{
+    // @property (readonly, copy, class) SentryMeasurementUnitDuration * _Nonnull nanosecond;
+    [Static]
+    [Export ("nanosecond", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitDuration Nanosecond { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitDuration * _Nonnull microsecond;
+    [Static]
+    [Export ("microsecond", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitDuration Microsecond { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitDuration * _Nonnull millisecond;
+    [Static]
+    [Export ("millisecond", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitDuration Millisecond { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitDuration * _Nonnull second;
+    [Static]
+    [Export ("second", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitDuration Second { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitDuration * _Nonnull minute;
+    [Static]
+    [Export ("minute", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitDuration Minute { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitDuration * _Nonnull hour;
+    [Static]
+    [Export ("hour", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitDuration Hour { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitDuration * _Nonnull day;
+    [Static]
+    [Export ("day", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitDuration Day { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitDuration * _Nonnull week;
+    [Static]
+    [Export ("week", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitDuration Week { get; }
+}
+
+// @interface SentryMeasurementUnitInformation : SentryMeasurementUnit
+[BaseType (typeof(SentryMeasurementUnit))]
+[DisableDefaultCtor]
+[Internal]
+interface SentryMeasurementUnitInformation
+{
+    // @property (readonly, copy, class) SentryMeasurementUnitInformation * _Nonnull bit;
+    [Static]
+    [Export ("bit", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitInformation Bit { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitInformation * _Nonnull byte;
+    [Static]
+    [Export ("byte", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitInformation Byte { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitInformation * _Nonnull kilobyte;
+    [Static]
+    [Export ("kilobyte", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitInformation Kilobyte { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitInformation * _Nonnull kibibyte;
+    [Static]
+    [Export ("kibibyte", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitInformation Kibibyte { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitInformation * _Nonnull megabyte;
+    [Static]
+    [Export ("megabyte", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitInformation Megabyte { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitInformation * _Nonnull mebibyte;
+    [Static]
+    [Export ("mebibyte", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitInformation Mebibyte { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitInformation * _Nonnull gigabyte;
+    [Static]
+    [Export ("gigabyte", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitInformation Gigabyte { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitInformation * _Nonnull gibibyte;
+    [Static]
+    [Export ("gibibyte", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitInformation Gibibyte { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitInformation * _Nonnull terabyte;
+    [Static]
+    [Export ("terabyte", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitInformation Terabyte { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitInformation * _Nonnull tebibyte;
+    [Static]
+    [Export ("tebibyte", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitInformation Tebibyte { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitInformation * _Nonnull petabyte;
+    [Static]
+    [Export ("petabyte", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitInformation Petabyte { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitInformation * _Nonnull pebibyte;
+    [Static]
+    [Export ("pebibyte", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitInformation Pebibyte { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitInformation * _Nonnull exabyte;
+    [Static]
+    [Export ("exabyte", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitInformation Exabyte { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitInformation * _Nonnull exbibyte;
+    [Static]
+    [Export ("exbibyte", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitInformation Exbibyte { get; }
+}
+
+// @interface SentryMeasurementUnitFraction : SentryMeasurementUnit
+[BaseType (typeof(SentryMeasurementUnit))]
+[DisableDefaultCtor]
+[Internal]
+interface SentryMeasurementUnitFraction
+{
+    // @property (readonly, copy, class) SentryMeasurementUnitFraction * _Nonnull ratio;
+    [Static]
+    [Export ("ratio", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitFraction Ratio { get; }
+
+    // @property (readonly, copy, class) SentryMeasurementUnitFraction * _Nonnull percent;
+    [Static]
+    [Export ("percent", ArgumentSemantic.Copy)]
+    SentryMeasurementUnitFraction Percent { get; }
 }
 
 // @interface SentryMechanism : NSObject <SentrySerializable>
@@ -1563,6 +1761,11 @@ interface SentrySdk
     [Static]
     [Export ("crash")]
     void Crash ();
+
+    // +(void)flush:(NSTimeInterval)timeout __attribute__((swift_name("flush(timeout:)")));
+    [Static]
+    [Export ("flush:")]
+    void Flush (double timeout);
 
     // +(void)close;
     [Static]
@@ -2005,6 +2208,10 @@ interface SentryUser : SentrySerializable //, INSCopying
     // @property (copy, atomic) NSString * _Nullable ipAddress;
     [NullAllowed, Export ("ipAddress")]
     string IpAddress { get; set; }
+
+    // @property (copy, atomic) NSString * _Nullable segment;
+    [NullAllowed, Export ("segment")]
+    string Segment { get; set; }
 
     // @property (atomic, strong) NSDictionary<NSString *,id> * _Nullable data;
     [NullAllowed, Export ("data", ArgumentSemantic.Strong)]

--- a/src/Sentry.Bindings.Cocoa/ApiDefinition.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinition.cs
@@ -2,7 +2,7 @@ using System;
 using Foundation;
 using ObjCRuntime;
 
-namespace SentryCocoa;
+namespace Sentry.CocoaSdk;
 
 [Static]
 [Internal]

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <SentryCocoaSdkVersion>7.24.1</SentryCocoaSdkVersion>
+    <SentryCocoaSdkVersion>7.28.0</SentryCocoaSdkVersion>
     <SentryCocoaSdkDirectory>$(BaseIntermediateOutputPath)sdks\Sentry\Cocoa\$(SentryCocoaSdkVersion)\</SentryCocoaSdkDirectory>
     <SentryCocoaFramework>$(SentryCocoaSdkDirectory)Carthage\Build\Sentry.xcframework</SentryCocoaFramework>
 

--- a/src/Sentry.Bindings.Cocoa/StructsAndEnums.cs
+++ b/src/Sentry.Bindings.Cocoa/StructsAndEnums.cs
@@ -1,6 +1,6 @@
 using ObjCRuntime;
 
-namespace SentryCocoa;
+namespace Sentry.CocoaSdk;
 
 [Native]
 internal enum SentryLogLevel : long

--- a/src/Sentry.Bindings.Cocoa/StructsAndEnums.cs
+++ b/src/Sentry.Bindings.Cocoa/StructsAndEnums.cs
@@ -25,21 +25,21 @@ internal enum SentryLevel : ulong
 [Native]
 internal enum SentryPermissionStatus : long
 {
-	Unknown = 0,
-	Granted,
-	Partial,
-	Denied
+    Unknown = 0,
+    Granted,
+    Partial,
+    Denied
 }
 
 [Native]
 internal enum SentryTransactionNameSource : long
 {
-	Custom = 0,
-	Url,
-	Route,
-	View,
-	Component,
-	Task
+    Custom = 0,
+    Url,
+    Route,
+    View,
+    Component,
+    Task
 }
 
 [Native]
@@ -66,12 +66,21 @@ internal enum SentryError : long
 
 // internal static class CFunctions
 // {
-// 	// extern NSError * _Nullable NSErrorFromSentryError (SentryError error, NSString * _Nonnull description) __attribute__((visibility("default")));
-// 	[DllImport ("__Internal")]
-// 	[Verify (PlatformInvoke)]
-//     [Internal]
-// 	[return: NullAllowed]
-// 	static extern NSError NSErrorFromSentryError (SentryError error, NSString description);
+//     // extern NSError * _Nullable NSErrorFromSentryError (SentryError error, NSString * _Nonnull description) __attribute__((visibility("default")));
+//     [DllImport ("__Internal")]
+//     [Verify (PlatformInvoke)]
+//     [return: NullAllowed]
+//     static extern NSError NSErrorFromSentryError (SentryError error, NSString description);
+
+//     // extern NSString * _Nonnull nameForSentrySampleDecision (SentrySampleDecision decision);
+//     [DllImport ("__Internal")]
+//     [Verify (PlatformInvoke)]
+//     static extern NSString nameForSentrySampleDecision (SentrySampleDecision decision);
+
+//     // extern NSString * _Nonnull nameForSentrySpanStatus (SentrySpanStatus status);
+//     [DllImport ("__Internal")]
+//     [Verify (PlatformInvoke)]
+//     static extern NSString nameForSentrySpanStatus (SentrySpanStatus status);
 // }
 
 [Native]

--- a/src/Sentry.Bindings.Cocoa/howtobuild.md
+++ b/src/Sentry.Bindings.Cocoa/howtobuild.md
@@ -1,0 +1,24 @@
+Due to https://github.com/getsentry/sentry-cocoa/issues/2031, we can't use the pre-built release of the Sentry-Cocoa SDK, or our build will fail due to lack of MacCatalyst output.
+
+To workaround, we need a custom build of Carthage, that has https://github.com/Carthage/Carthage/pull/3235 applied.
+- Clone the https://github.com/NachoSoto/Carthage fork, and switch to the xcframework-catalyst branch
+- run `make install` to install, which builds Carthage and installs it locally to `/usr/local/bin/carthage`.
+  - See https://github.com/Carthage/Carthage/blob/master/CONTRIBUTING.md#get-started
+
+Now go clone the https://github.com/getsentry/sentry-cocoa repo and do the following:
+- Checkout the version tag that you are building.  Example: `git checkout 7.28.0`
+- Run `make init`, per https://github.com/getsentry/sentry-cocoa/blob/master/CONTRIBUTING.md#setting-up-an-environment
+- Modify the `makefile`, editing the `build-xcframework` section to the following:
+    ```
+    build-xcframework:
+        @echo "--> Carthage: creating Sentry xcframework"
+        /usr/local/bin/carthage build --use-xcframeworks --no-skip-current --platform ios
+        /usr/local/bin/carthage build --use-xcframeworks --no-skip-current --platform macCatalyst
+        ditto -c -k -X --rsrc --keepParent Carthage Sentry.xcframework.zip
+    ```
+- Run `make build-xcframework`
+- Copy the resulting `Sentry.xcframework.zip` into the `sentry-dotnet` project at the `/lib` folder root
+- Rename it to include the version number (ex: `Sentry.xcframework.7.28.0.custombuild.zip), and delete the prior version zip.
+- Edit `Sentry.Bindings.Cocoa.csproj` to update `SentryCocoaSdkVersion`
+- If needed, update `StructsAndEnums.cs` and `ApiDefinition.cs` (see `sharpie.md` for details).
+- Run `dotnet build Sentry.Bindings.Cocoa.csproj` and resolve any warnings/errors before trying to use in the rest of the solution.

--- a/src/Sentry.Bindings.Cocoa/sharpie.md
+++ b/src/Sentry.Bindings.Cocoa/sharpie.md
@@ -9,6 +9,7 @@ However, the files are not purely auto-generated.  Several modifications have be
 
 - Everything has been made internal, either via the `internal` keyword, or the `[Internal]` binding attribute.
 - Named delegates have been replaced with `Func<T>` or `Action<T>` to work around https://github.com/xamarin/xamarin-macios/issues/15299
+- `INSCopying` interfaces have been commented out, to resolve nullability error
 - Items that Sharpie marked with `[Verify]` have been resolved, except for:
   - `NSErrorFromSentryError` and its containing class has been commented out, as we aren't using it presently and it needs verification
 

--- a/src/Sentry/Platforms/iOS/Extensions/BreadcrumbExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/BreadcrumbExtensions.cs
@@ -4,7 +4,7 @@ namespace Sentry.iOS.Extensions;
 
 internal static class BreadcrumbExtensions
 {
-    public static Breadcrumb ToBreadcrumb(this SentryCocoa.SentryBreadcrumb breadcrumb, IDiagnosticLogger? logger) =>
+    public static Breadcrumb ToBreadcrumb(this CocoaSdk.SentryBreadcrumb breadcrumb, IDiagnosticLogger? logger) =>
         new(
             breadcrumb.Timestamp?.ToDateTimeOffset(),
             breadcrumb.Message,
@@ -13,7 +13,7 @@ internal static class BreadcrumbExtensions
             breadcrumb.Category,
             breadcrumb.Level.ToBreadcrumbLevel());
 
-    public static SentryCocoa.SentryBreadcrumb ToCocoaBreadcrumb(this Breadcrumb breadcrumb) =>
+    public static CocoaSdk.SentryBreadcrumb ToCocoaBreadcrumb(this Breadcrumb breadcrumb) =>
         new()
         {
             Timestamp = breadcrumb.Timestamp.ToNSDate(),

--- a/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/CocoaExtensions.cs
@@ -1,5 +1,4 @@
 using Sentry.Extensibility;
-using SentryCocoa;
 
 namespace Sentry.iOS.Extensions;
 
@@ -25,7 +24,7 @@ internal static class CocoaExtensions
             return null;
         }
 
-        if (obj is ISentrySerializable serializable)
+        if (obj is CocoaSdk.ISentrySerializable serializable)
         {
             // For types that implement Sentry Cocoa's SentrySerializable protocol (interface),
             // We should call that first, and then serialize the result to JSON later.

--- a/src/Sentry/Platforms/iOS/Extensions/EnumExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/EnumExtensions.cs
@@ -3,99 +3,99 @@ namespace Sentry.iOS.Extensions;
 internal static class EnumExtensions
 {
     // These align, so we can just cast
-    public static SentryLevel ToSentryLevel(this SentryCocoa.SentryLevel level) => (SentryLevel)level;
-    public static SentryCocoa.SentryLevel ToCocoaSentryLevel(this SentryLevel level) => (SentryCocoa.SentryLevel)level;
+    public static SentryLevel ToSentryLevel(this CocoaSdk.SentryLevel level) => (SentryLevel)level;
+    public static CocoaSdk.SentryLevel ToCocoaSentryLevel(this SentryLevel level) => (CocoaSdk.SentryLevel)level;
 
-    public static BreadcrumbLevel ToBreadcrumbLevel(this SentryCocoa.SentryLevel level) =>
+    public static BreadcrumbLevel ToBreadcrumbLevel(this CocoaSdk.SentryLevel level) =>
         level switch
         {
-            SentryCocoa.SentryLevel.Debug => BreadcrumbLevel.Debug,
-            SentryCocoa.SentryLevel.Info => BreadcrumbLevel.Info,
-            SentryCocoa.SentryLevel.Warning => BreadcrumbLevel.Warning,
-            SentryCocoa.SentryLevel.Error => BreadcrumbLevel.Error,
-            SentryCocoa.SentryLevel.Fatal => BreadcrumbLevel.Critical,
+            CocoaSdk.SentryLevel.Debug => BreadcrumbLevel.Debug,
+            CocoaSdk.SentryLevel.Info => BreadcrumbLevel.Info,
+            CocoaSdk.SentryLevel.Warning => BreadcrumbLevel.Warning,
+            CocoaSdk.SentryLevel.Error => BreadcrumbLevel.Error,
+            CocoaSdk.SentryLevel.Fatal => BreadcrumbLevel.Critical,
             _ => throw new ArgumentOutOfRangeException(nameof(level), level, null)
         };
 
-    public static SentryCocoa.SentryLevel ToCocoaSentryLevel(this BreadcrumbLevel level) =>
+    public static CocoaSdk.SentryLevel ToCocoaSentryLevel(this BreadcrumbLevel level) =>
         level switch
         {
-            BreadcrumbLevel.Debug => SentryCocoa.SentryLevel.Debug,
-            BreadcrumbLevel.Info => SentryCocoa.SentryLevel.Info,
-            BreadcrumbLevel.Warning => SentryCocoa.SentryLevel.Warning,
-            BreadcrumbLevel.Error => SentryCocoa.SentryLevel.Error,
-            BreadcrumbLevel.Critical => SentryCocoa.SentryLevel.Fatal,
+            BreadcrumbLevel.Debug => CocoaSdk.SentryLevel.Debug,
+            BreadcrumbLevel.Info => CocoaSdk.SentryLevel.Info,
+            BreadcrumbLevel.Warning => CocoaSdk.SentryLevel.Warning,
+            BreadcrumbLevel.Error => CocoaSdk.SentryLevel.Error,
+            BreadcrumbLevel.Critical => CocoaSdk.SentryLevel.Fatal,
             _ => throw new ArgumentOutOfRangeException(nameof(level), level, message: default)
         };
 
-    public static bool? ToNullableBoolean(this SentryCocoa.SentrySampleDecision decision) =>
+    public static bool? ToNullableBoolean(this CocoaSdk.SentrySampleDecision decision) =>
         decision switch
         {
-            SentryCocoa.SentrySampleDecision.Yes => true,
-            SentryCocoa.SentrySampleDecision.No => false,
-            SentryCocoa.SentrySampleDecision.Undecided => null,
+            CocoaSdk.SentrySampleDecision.Yes => true,
+            CocoaSdk.SentrySampleDecision.No => false,
+            CocoaSdk.SentrySampleDecision.Undecided => null,
             _ => throw new ArgumentOutOfRangeException(nameof(decision), decision, null)
         };
 
-    public static SentryCocoa.SentrySampleDecision ToCocoaSampleDecision(this bool? decision) =>
+    public static CocoaSdk.SentrySampleDecision ToCocoaSampleDecision(this bool? decision) =>
         decision switch
         {
-            true => SentryCocoa.SentrySampleDecision.Yes,
-            false => SentryCocoa.SentrySampleDecision.No,
-            null => SentryCocoa.SentrySampleDecision.Undecided
+            true => CocoaSdk.SentrySampleDecision.Yes,
+            false => CocoaSdk.SentrySampleDecision.No,
+            null => CocoaSdk.SentrySampleDecision.Undecided
         };
 
-    public static SpanStatus? ToSpanStatus(this SentryCocoa.SentrySpanStatus status) =>
+    public static SpanStatus? ToSpanStatus(this CocoaSdk.SentrySpanStatus status) =>
         status switch
         {
-            SentryCocoa.SentrySpanStatus.Undefined => null,
-            SentryCocoa.SentrySpanStatus.Ok => SpanStatus.Ok,
-            SentryCocoa.SentrySpanStatus.Cancelled => SpanStatus.Cancelled,
-            SentryCocoa.SentrySpanStatus.InternalError => SpanStatus.InternalError,
-            SentryCocoa.SentrySpanStatus.UnknownError => SpanStatus.UnknownError,
-            SentryCocoa.SentrySpanStatus.InvalidArgument => SpanStatus.InvalidArgument,
-            SentryCocoa.SentrySpanStatus.DeadlineExceeded => SpanStatus.DeadlineExceeded,
-            SentryCocoa.SentrySpanStatus.NotFound => SpanStatus.NotFound,
-            SentryCocoa.SentrySpanStatus.AlreadyExists => SpanStatus.AlreadyExists,
-            SentryCocoa.SentrySpanStatus.PermissionDenied => SpanStatus.PermissionDenied,
-            SentryCocoa.SentrySpanStatus.ResourceExhausted => SpanStatus.ResourceExhausted,
-            SentryCocoa.SentrySpanStatus.FailedPrecondition => SpanStatus.FailedPrecondition,
-            SentryCocoa.SentrySpanStatus.Aborted => SpanStatus.Aborted,
-            SentryCocoa.SentrySpanStatus.OutOfRange => SpanStatus.OutOfRange,
-            SentryCocoa.SentrySpanStatus.Unimplemented => SpanStatus.Unimplemented,
-            SentryCocoa.SentrySpanStatus.Unavailable => SpanStatus.Unavailable,
-            SentryCocoa.SentrySpanStatus.DataLoss => SpanStatus.DataLoss,
-            SentryCocoa.SentrySpanStatus.Unauthenticated => SpanStatus.Unauthenticated,
+            CocoaSdk.SentrySpanStatus.Undefined => null,
+            CocoaSdk.SentrySpanStatus.Ok => SpanStatus.Ok,
+            CocoaSdk.SentrySpanStatus.Cancelled => SpanStatus.Cancelled,
+            CocoaSdk.SentrySpanStatus.InternalError => SpanStatus.InternalError,
+            CocoaSdk.SentrySpanStatus.UnknownError => SpanStatus.UnknownError,
+            CocoaSdk.SentrySpanStatus.InvalidArgument => SpanStatus.InvalidArgument,
+            CocoaSdk.SentrySpanStatus.DeadlineExceeded => SpanStatus.DeadlineExceeded,
+            CocoaSdk.SentrySpanStatus.NotFound => SpanStatus.NotFound,
+            CocoaSdk.SentrySpanStatus.AlreadyExists => SpanStatus.AlreadyExists,
+            CocoaSdk.SentrySpanStatus.PermissionDenied => SpanStatus.PermissionDenied,
+            CocoaSdk.SentrySpanStatus.ResourceExhausted => SpanStatus.ResourceExhausted,
+            CocoaSdk.SentrySpanStatus.FailedPrecondition => SpanStatus.FailedPrecondition,
+            CocoaSdk.SentrySpanStatus.Aborted => SpanStatus.Aborted,
+            CocoaSdk.SentrySpanStatus.OutOfRange => SpanStatus.OutOfRange,
+            CocoaSdk.SentrySpanStatus.Unimplemented => SpanStatus.Unimplemented,
+            CocoaSdk.SentrySpanStatus.Unavailable => SpanStatus.Unavailable,
+            CocoaSdk.SentrySpanStatus.DataLoss => SpanStatus.DataLoss,
+            CocoaSdk.SentrySpanStatus.Unauthenticated => SpanStatus.Unauthenticated,
             _ => throw new ArgumentOutOfRangeException(nameof(status), status, message: default)
         };
 
-    public static SentryCocoa.SentrySpanStatus ToCocoaSpanStatus(this SpanStatus? status) =>
+    public static CocoaSdk.SentrySpanStatus ToCocoaSpanStatus(this SpanStatus? status) =>
         status switch
         {
-            null => SentryCocoa.SentrySpanStatus.Undefined,
-            SpanStatus.Ok => SentryCocoa.SentrySpanStatus.Ok,
-            SpanStatus.Cancelled => SentryCocoa.SentrySpanStatus.Cancelled,
-            SpanStatus.InternalError => SentryCocoa.SentrySpanStatus.InternalError,
-            SpanStatus.UnknownError => SentryCocoa.SentrySpanStatus.UnknownError,
-            SpanStatus.InvalidArgument => SentryCocoa.SentrySpanStatus.InvalidArgument,
-            SpanStatus.DeadlineExceeded => SentryCocoa.SentrySpanStatus.DeadlineExceeded,
-            SpanStatus.NotFound => SentryCocoa.SentrySpanStatus.NotFound,
-            SpanStatus.AlreadyExists => SentryCocoa.SentrySpanStatus.AlreadyExists,
-            SpanStatus.PermissionDenied => SentryCocoa.SentrySpanStatus.PermissionDenied,
-            SpanStatus.ResourceExhausted => SentryCocoa.SentrySpanStatus.ResourceExhausted,
-            SpanStatus.FailedPrecondition => SentryCocoa.SentrySpanStatus.FailedPrecondition,
-            SpanStatus.Aborted => SentryCocoa.SentrySpanStatus.Aborted,
-            SpanStatus.OutOfRange => SentryCocoa.SentrySpanStatus.OutOfRange,
-            SpanStatus.Unimplemented => SentryCocoa.SentrySpanStatus.Unimplemented,
-            SpanStatus.Unavailable => SentryCocoa.SentrySpanStatus.Unavailable,
-            SpanStatus.DataLoss => SentryCocoa.SentrySpanStatus.DataLoss,
-            SpanStatus.Unauthenticated => SentryCocoa.SentrySpanStatus.Unauthenticated,
+            null => CocoaSdk.SentrySpanStatus.Undefined,
+            SpanStatus.Ok => CocoaSdk.SentrySpanStatus.Ok,
+            SpanStatus.Cancelled => CocoaSdk.SentrySpanStatus.Cancelled,
+            SpanStatus.InternalError => CocoaSdk.SentrySpanStatus.InternalError,
+            SpanStatus.UnknownError => CocoaSdk.SentrySpanStatus.UnknownError,
+            SpanStatus.InvalidArgument => CocoaSdk.SentrySpanStatus.InvalidArgument,
+            SpanStatus.DeadlineExceeded => CocoaSdk.SentrySpanStatus.DeadlineExceeded,
+            SpanStatus.NotFound => CocoaSdk.SentrySpanStatus.NotFound,
+            SpanStatus.AlreadyExists => CocoaSdk.SentrySpanStatus.AlreadyExists,
+            SpanStatus.PermissionDenied => CocoaSdk.SentrySpanStatus.PermissionDenied,
+            SpanStatus.ResourceExhausted => CocoaSdk.SentrySpanStatus.ResourceExhausted,
+            SpanStatus.FailedPrecondition => CocoaSdk.SentrySpanStatus.FailedPrecondition,
+            SpanStatus.Aborted => CocoaSdk.SentrySpanStatus.Aborted,
+            SpanStatus.OutOfRange => CocoaSdk.SentrySpanStatus.OutOfRange,
+            SpanStatus.Unimplemented => CocoaSdk.SentrySpanStatus.Unimplemented,
+            SpanStatus.Unavailable => CocoaSdk.SentrySpanStatus.Unavailable,
+            SpanStatus.DataLoss => CocoaSdk.SentrySpanStatus.DataLoss,
+            SpanStatus.Unauthenticated => CocoaSdk.SentrySpanStatus.Unauthenticated,
             _ => throw new ArgumentOutOfRangeException(nameof(status), status, message: default)
         };
 
     // These align, so we can just cast
-    public static TransactionNameSource ToTransactionNameSource(this SentryCocoa.SentryTransactionNameSource source) =>
+    public static TransactionNameSource ToTransactionNameSource(this CocoaSdk.SentryTransactionNameSource source) =>
         (TransactionNameSource)source;
-    public static SentryCocoa.SentryTransactionNameSource ToCocoaTransactionNameSource(this TransactionNameSource source) =>
-        (SentryCocoa.SentryTransactionNameSource)source;
+    public static CocoaSdk.SentryTransactionNameSource ToCocoaTransactionNameSource(this TransactionNameSource source) =>
+        (CocoaSdk.SentryTransactionNameSource)source;
 }

--- a/src/Sentry/Platforms/iOS/Extensions/MiscExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/MiscExtensions.cs
@@ -2,11 +2,11 @@ namespace Sentry.iOS.Extensions;
 
 internal static class MiscExtensions
 {
-    public static SentryId ToSentryId(this SentryCocoa.SentryId sentryId) => new(Guid.Parse(sentryId.SentryIdString));
+    public static SentryId ToSentryId(this CocoaSdk.SentryId sentryId) => new(Guid.Parse(sentryId.SentryIdString));
 
-    public static SentryCocoa.SentryId ToCocoaSentryId(this SentryId sentryId) => new(sentryId.ToString());
+    public static CocoaSdk.SentryId ToCocoaSentryId(this SentryId sentryId) => new(sentryId.ToString());
 
-    public static SpanId ToSpanId(this SentryCocoa.SentrySpanId spanId) => new(spanId.SentrySpanIdString);
+    public static SpanId ToSpanId(this CocoaSdk.SentrySpanId spanId) => new(spanId.SentrySpanIdString);
 
-    public static SentryCocoa.SentrySpanId ToCocoaSpanId(this SpanId spanId) => new(spanId.ToString());
+    public static CocoaSdk.SentrySpanId ToCocoaSpanId(this SpanId spanId) => new(spanId.ToString());
 }

--- a/src/Sentry/Platforms/iOS/Extensions/SamplingContextExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/SamplingContextExtensions.cs
@@ -4,7 +4,7 @@ namespace Sentry.iOS.Extensions;
 
 internal static class SamplingContextExtensions
 {
-    public static TransactionSamplingContext ToTransactionSamplingContext(this SentryCocoa.SentrySamplingContext context)
+    public static TransactionSamplingContext ToTransactionSamplingContext(this CocoaSdk.SentrySamplingContext context)
     {
         var transactionContext = new TransactionContextFacade(context.TransactionContext);
         var customSamplingContext = context.CustomSamplingContext.ToObjectDictionary();

--- a/src/Sentry/Platforms/iOS/Extensions/SentryEventExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/SentryEventExtensions.cs
@@ -18,7 +18,7 @@
 //      * updating the objects on either side.
 //      */
 //
-//     public static SentryEvent ToSentryEvent(this SentryCocoa.SentryEvent sentryEvent, SentryCocoaOptions cocoaOptions)
+//     public static SentryEvent ToSentryEvent(this CocoaSdk.SentryEvent sentryEvent, SentryCocoaOptions cocoaOptions)
 //     {
 //         using var stream = sentryEvent.ToJsonStream()!;
 //         //stream.Seek(0, SeekOrigin.Begin); ??
@@ -28,7 +28,7 @@
 //         return SentryEvent.FromJson(json.RootElement, exception);
 //     }
 //
-//     public static SentryCocoa.SentryEvent ToCocoaSentryEvent(this SentryEvent sentryEvent, SentryOptions options, SentryCocoaOptions cocoaOptions)
+//     public static CocoaSdk.SentryEvent ToCocoaSentryEvent(this SentryEvent sentryEvent, SentryOptions options, SentryCocoaOptions cocoaOptions)
 //     {
 //         var envelope = Envelope.FromEvent(sentryEvent);
 //
@@ -37,9 +37,9 @@
 //         stream.Seek(0, SeekOrigin.Begin);
 //
 //         using var data = NSData.FromStream(stream)!;
-//         var cocoaEnvelope = SentryCocoa.PrivateSentrySDKOnly.EnvelopeWithData(data);
+//         var cocoaEnvelope = CocoaSdk.PrivateSentrySDKOnly.EnvelopeWithData(data);
 //
-//         var cocoaEvent = (SentryCocoa.SentryEvent) cocoaEnvelope.Items[0];
+//         var cocoaEvent = (CocoaSdk.SentryEvent) cocoaEnvelope.Items[0];
 //         return cocoaEvent;
 //     }
 // }

--- a/src/Sentry/Platforms/iOS/Extensions/UserExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/UserExtensions.cs
@@ -4,7 +4,7 @@ namespace Sentry.iOS.Extensions;
 
 internal static class UserExtensions
 {
-    public static User ToUser(this SentryCocoa.SentryUser user, IDiagnosticLogger? logger = null) =>
+    public static User ToUser(this CocoaSdk.SentryUser user, IDiagnosticLogger? logger = null) =>
         new()
         {
             Email = user.Email,
@@ -15,9 +15,9 @@ internal static class UserExtensions
             Other = user.Data.ToStringDictionary(logger)
         };
 
-    public static SentryCocoa.SentryUser ToCocoaUser(this User user)
+    public static CocoaSdk.SentryUser ToCocoaUser(this User user)
     {
-        var cocoaUser = new SentryCocoa.SentryUser
+        var cocoaUser = new CocoaSdk.SentryUser
         {
             Email = user.Email,
             UserId = user.Id,

--- a/src/Sentry/Platforms/iOS/Extensions/UserExtensions.cs
+++ b/src/Sentry/Platforms/iOS/Extensions/UserExtensions.cs
@@ -11,6 +11,7 @@ internal static class UserExtensions
             Id = user.UserId,
             IpAddress = user.IpAddress,
             Username = user.Username,
+            Segment = user.Segment,
             Other = user.Data.ToStringDictionary(logger)
         };
 
@@ -22,6 +23,7 @@ internal static class UserExtensions
             UserId = user.Id,
             IpAddress = user.IpAddress,
             Username = user.Username,
+            Segment = user.Segment,
             Data = user.Other.ToNullableNSDictionary()
         };
 

--- a/src/Sentry/Platforms/iOS/Facades/TransactionContextFacade.cs
+++ b/src/Sentry/Platforms/iOS/Facades/TransactionContextFacade.cs
@@ -25,7 +25,7 @@ internal class TransactionContextFacade : ITransactionContext
 
     public string Operation => _context.Operation;
 
-    public string? Description => _context.Description;
+    public string Description => _context.Description;
 
     public SpanStatus? Status => _context.Status.ToSpanStatus();
 

--- a/src/Sentry/Platforms/iOS/Facades/TransactionContextFacade.cs
+++ b/src/Sentry/Platforms/iOS/Facades/TransactionContextFacade.cs
@@ -4,9 +4,9 @@ namespace Sentry.iOS.Facades;
 
 internal class TransactionContextFacade : ITransactionContext
 {
-    private readonly SentryCocoa.SentryTransactionContext _context;
+    private readonly CocoaSdk.SentryTransactionContext _context;
 
-    internal TransactionContextFacade(SentryCocoa.SentryTransactionContext context)
+    internal TransactionContextFacade(CocoaSdk.SentryTransactionContext context)
     {
         _context = context;
     }

--- a/src/Sentry/Platforms/iOS/IosEventProcessor.cs
+++ b/src/Sentry/Platforms/iOS/IosEventProcessor.cs
@@ -30,11 +30,11 @@ internal class IosEventProcessor : ISentryEventProcessor, IDisposable
         return @event;
     }
 
-    private static SentryCocoa.SentryEvent GetTempEvent()
+    private static CocoaSdk.SentryEvent GetTempEvent()
     {
         // This will populate an event with all of the information we need, without actually capturing that event.
-        var @event = new SentryCocoa.SentryEvent();
-        SentryCocoa.SentrySdk.ConfigureScope(scope =>
+        var @event = new CocoaSdk.SentryEvent();
+        CocoaSdk.SentrySdk.ConfigureScope(scope =>
         {
             scope.ApplyToEvent(@event, 0);
         });

--- a/src/Sentry/Platforms/iOS/IosEventProcessor.cs
+++ b/src/Sentry/Platforms/iOS/IosEventProcessor.cs
@@ -34,7 +34,7 @@ internal class IosEventProcessor : ISentryEventProcessor, IDisposable
     {
         // This will populate an event with all of the information we need, without actually capturing that event.
         var @event = new CocoaSdk.SentryEvent();
-        CocoaSdk.SentrySdk.ConfigureScope(scope =>
+        SentryCocoaSdk.ConfigureScope(scope =>
         {
             scope.ApplyToEvent(@event, 0);
         });

--- a/src/Sentry/Platforms/iOS/IosScopeObserver.cs
+++ b/src/Sentry/Platforms/iOS/IosScopeObserver.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Sentry.iOS.Extensions;
 using Sentry.Extensibility;
 

--- a/src/Sentry/Platforms/iOS/Sentry.iOS.props
+++ b/src/Sentry/Platforms/iOS/Sentry.iOS.props
@@ -19,8 +19,8 @@
     <Using Include="System.Globalization" />
     <Using Include="System.Text.Json" />
     <Using Include="Foundation" />
-    <Using Include="SentryCocoa.SentryOptions" Alias="SentryCocoaOptions" />
-    <Using Include="SentryCocoa.SentrySdk" Alias="SentryCocoaSdk" />
+    <Using Include="Sentry.CocoaSdk.SentryOptions" Alias="SentryCocoaOptions" />
+    <Using Include="Sentry.CocoaSdk.SentrySdk" Alias="SentryCocoaSdk" />
   </ItemGroup>
 
 </Project>

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -164,7 +164,7 @@ public static partial class SentrySdk
         SentryCocoaSdk.StartWithOptionsObject(cocoaOptions);
 
         // Set options for the managed SDK that depend on the Cocoa SDK. (The user will not be able to modify these.)
-        options.AddEventProcessor(new IosEventProcessor(cocoaOptions!));
+        options.AddEventProcessor(new IosEventProcessor(cocoaOptions));
         options.CrashedLastRun = () => SentryCocoaSdk.CrashedLastRun;
         options.EnableScopeSync = true;
         options.ScopeObserver = new IosScopeObserver(options);


### PR DESCRIPTION
- Bumped the Cocoa SDK to 7.28.0.
- Changed the internal namespace to match recent changes on the Android side.
- Added `User.Segment` to the conversion methods.
- Some other minor fixes.