### PR TITLE
Fix tests on Mono and consolidate to theory

### DIFF
--- a/src/Sentry/Protocol/Envelopes/Envelope.cs
+++ b/src/Sentry/Protocol/Envelopes/Envelope.cs
@@ -63,7 +63,10 @@ namespace Sentry.Protocol.Envelopes
         {
             void Error(string message)
             {
+// On mobile platforms, Debug.Fail will crash the app
+#if !__MOBILE__
                 Debug.Fail(message);
+#endif
                 logger?.LogError(message);
             }
 


### PR DESCRIPTION
In #1959, we didn't take into account that `Debug.Fail` doesn't throw an exception on Mono.  Thus, when running tests locally on a Mac, these fail:

<img width="662" alt="image" src="https://user-images.githubusercontent.com/1396388/196010148-0fb988e5-7add-4868-a9b7-66ef135e05ae.png">

Additionally, `Debug.Fail` crashes the Android device test runner in a way that makes it difficult to see the test failure.  We didn't see this in CI, because we run in Release configuration there.

This resolves both issues.

Also consolidated these tests into a theory.

#skip-changelog