### PR TITLE
Ensure logs with lower levels are captured by `Sentry.Extensions.Logging`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - NuGet package `Sentry` now depends on `Sentry.Bindings.Android` for `net6.0-android` targets.
   - NuGet package `Sentry` now depends on `Sentry.Bindings.Cocoa` for `net6.0-ios` and `net6.0-maccatalyst` targets.
 - Exclude EF error message from logging ([#1980](https://github.com/getsentry/sentry-dotnet/pull/1980))
+- Ensure logs with lower levels are captured by `Sentry.Extensions.Logging` ([#1992](https://github.com/getsentry/sentry-dotnet/pull/1992))
 
 ## 3.22.0
 

--- a/src/Sentry.Extensions.Logging/LoggingBuilderExtensions.cs
+++ b/src/Sentry.Extensions.Logging/LoggingBuilderExtensions.cs
@@ -43,14 +43,20 @@ public static class LoggingBuilderExtensions
 
         if (optionsConfiguration != null)
         {
-            _ = builder.Services.Configure(optionsConfiguration);
+            builder.Services.Configure(optionsConfiguration);
         }
 
-        _ = builder.Services.AddSingleton<IConfigureOptions<SentryLoggingOptions>, SentryLoggingOptionsSetup>();
+        builder.Services.AddSingleton<IConfigureOptions<SentryLoggingOptions>, SentryLoggingOptionsSetup>();
 
-        _ = builder.Services.AddSingleton<ILoggerProvider, SentryLoggerProvider>();
+        builder.Services.AddSingleton<ILoggerProvider, SentryLoggerProvider>();
 
-        _ = builder.Services.AddSentry<SentryLoggingOptions>();
+        builder.Services.AddSentry<SentryLoggingOptions>();
+
+        // All logs should flow to the SentryLogger, regardless of level.
+        // Filtering of events is handled in SentryLogger, using SentryOptions.MinimumEventLevel
+        // Filtering of breadcrumbs is handled in SentryLogger, using SentryOptions.MinimumBreadcrumbLevel
+        builder.AddFilter<SentryLoggerProvider>(_ => true);
+
         return builder;
     }
 }

--- a/test/Sentry.Extensions.Logging.Tests/LoggingTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/LoggingTests.cs
@@ -1,0 +1,92 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Sentry.Extensions.Logging.Tests;
+
+public class LoggingTests
+{
+    [Theory]
+    [InlineData(LogLevel.Critical)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Trace)]
+    public void Log_CapturesEvent(LogLevel logLevel)
+    {
+        // Arrange
+        var worker = Substitute.For<IBackgroundWorker>();
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging(builder => builder.AddSentry(o =>
+        {
+            o.Dsn = ValidDsn;
+            o.MinimumEventLevel = logLevel;
+            o.MinimumBreadcrumbLevel = LogLevel.None;
+            o.BackgroundWorker = worker;
+        }));
+        using var serviceProvider = serviceCollection.BuildServiceProvider();
+        using var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+
+        // Act
+        const string message = "test message";
+        var logger = loggerFactory.CreateLogger("test");
+        logger.Log(logLevel, message);
+
+        // Assert
+        worker.Received(1).EnqueueEnvelope(
+            Arg.Is<Envelope>(e =>
+                e.Items
+                    .Select(i => i.Payload).OfType<JsonSerializable>()
+                    .Select(i => i.Source).OfType<SentryEvent>()
+                    .SingleOrDefault(evt =>
+                        evt.Level == logLevel.ToSentryLevel() &&
+                        evt.Message.Message == message)
+                != null));
+    }
+
+    [Theory]
+    [InlineData(LogLevel.Critical)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Trace)]
+    public void Log_AddsBreadcrumb(LogLevel logLevel)
+    {
+        // Arrange
+        var worker = Substitute.For<IBackgroundWorker>();
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging(builder => builder.AddSentry(o =>
+        {
+            o.Dsn = ValidDsn;
+            o.MinimumBreadcrumbLevel = logLevel;
+            o.MinimumEventLevel = LogLevel.None;
+            o.BackgroundWorker = worker;
+        }));
+        using var serviceProvider = serviceCollection.BuildServiceProvider();
+        using var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+
+        // Act
+        const string message = "test message";
+        var logger = loggerFactory.CreateLogger("test");
+        logger.Log(logLevel, message);
+
+        var hub = serviceProvider.GetRequiredService<IHub>();
+        hub.CaptureEvent(new SentryEvent());
+
+        // Assert
+        worker.Received(1).EnqueueEnvelope(
+            Arg.Is<Envelope>(e =>
+                e.Items
+                    .Select(i => i.Payload).OfType<JsonSerializable>()
+                    .Select(i => i.Source).OfType<SentryEvent>()
+                    .Single()
+                    .Breadcrumbs
+                    .SingleOrDefault(b =>
+                        b.Level == logLevel.ToBreadcrumbLevel() &&
+                        b.Message == message)
+                != null));
+    }
+}


### PR DESCRIPTION
Fixes #1986 