### PR TITLE
Build Windows and Tizen targets for `Sentry.Maui`

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -53,4 +53,4 @@ runs:
     - name: Install Tizen Workload
       if: runner.os == 'macOS'
       shell: bash
-        run: "curl -sSL https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.sh | sudo bash"
+      run: "curl -sSL https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.sh | sudo bash"

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -43,6 +43,14 @@ runs:
       run: >
         dotnet workload install \
           maui-android \
-          ${{ runner.os == 'macOS' && 'maui-ios maui-maccatalyst' || '' }} \
+          ${{ runner.os == 'macOS' && 'maui-ios maui-maccatalyst maui-windows maui-tizen' || '' }} \
           ${{ runner.os == 'Windows' && 'maui-windows' || '' }} \
           --temp-dir "${{ runner.temp }}"
+
+    # We build Sentry.Maui for every supported MAUI target so we can access platform-specific features.
+    # That includes Tizen. We don't need the entire Tizen SDK, but we do need the base Tizen workload.
+    # Though we could install it on all runners, we really only need it when building and packing for NuGet, which we do on macOS only.
+    - name: Install Tizen Workload
+      if: runner.os == 'macOS'
+      shell: bash
+        run: curl -sSL https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.sh | sudo bash

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -53,4 +53,4 @@ runs:
     - name: Install Tizen Workload
       if: runner.os == 'macOS'
       shell: bash
-        run: curl -sSL https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.sh | sudo bash
+        run: "curl -sSL https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.sh | sudo bash"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Allow custom processors to be added as a scoped dependency ([#1979](https://github.com/getsentry/sentry-dotnet/pull/1979))
 - Support DI for custom transaction processors ([#1993](https://github.com/getsentry/sentry-dotnet/pull/1993))
 - Mark Transaction as aborted when unhandled exception occurs ([#1996](https://github.com/getsentry/sentry-dotnet/pull/1996))
+- Build Windows and Tizen targets for `Sentry.Maui` ([#2005](https://github.com/getsentry/sentry-dotnet/pull/2005))
 
 ### Fixes
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,6 +20,7 @@
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'ios'">10.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'tizen'">6.5</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -9,6 +9,7 @@
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'ios'">10.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'tizen'">6.5</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>
@@ -26,6 +27,11 @@
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'windows'">
     <Compile Remove="**\*.Windows.cs" />
     <Compile Remove="**\Windows\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'tizen'">
+    <Compile Remove="**\*.Tizen.cs" />
+    <Compile Remove="**\Tizen\**\*.cs" />
   </ItemGroup>
 
   <!-- Workaround the fact that http doesnt exist in earlier frameworks -->

--- a/src/Sentry.Maui/Sentry.Maui.csproj
+++ b/src/Sentry.Maui/Sentry.Maui.csproj
@@ -3,11 +3,21 @@
   <PropertyGroup>
     <Description>Official MAUI integration for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
     <!--
-      Build for net6.0 to cover all managed platforms,
-      but also target platforms where we intend to bundle native SDKs.
+      Target net6.0 so we can run unit tests on platform-neutral code.
+      Target other platforms so we can include platform-specific code, and bundle native SDKs.
     -->
     <TargetFrameworks>net6.0;net6.0-android</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows')) Or $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
+
+    <!-- Target Tizen only if the Tizen SDK workload pack is installed. -->
+    <TargetFrameworks Condition="Exists('$(MSBuildBinPath)\..\..\packs\Samsung.Tizen.Sdk')">$(TargetFrameworks);net6.0-tizen</TargetFrameworks>
+
+    <!--
+      This flag allows us to target Windows-specific code when building on OSX, so we can build and pack all platforms on a single machine.
+      See https://learn.microsoft.com/dotnet/core/tools/sdk-errors/netsdk1100
+    -->
+    <EnableWindowsTargeting Condition="$([MSBuild]::IsOSPlatform('OSX'))">true</EnableWindowsTargeting>
 
     <!-- We'll need to package this only on OSX, so we get the iOS native support. -->
     <IsPackable Condition="!$([MSBuild]::IsOSPlatform('OSX'))">false</IsPackable>


### PR DESCRIPTION
In order to access certain MAUI APIs, we need to always be able to conditionally target all supported MAUI platforms.  Currently we ship the NuGet package with separate targets for Android, iOS, and MacCatalyst only.  We need to add Windows and Tizen to that list.

With this PR, the Windows target will also now build on macOS where we package the NuGet.  We can do this for class libraries only, as we don't have the actual WinUI3 runtime available.

We also add the Tizen target, but conditionally include it only if the Tizen workloads are present, as to not create yet another required developer dependency.  We also now install the minimum Tizen workloads in the CI build.