### PR TITLE
Fix DI issue by binding to MAUI using lifecycle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Exclude EF error message from logging ([#1980](https://github.com/getsentry/sentry-dotnet/pull/1980))
 - Ensure logs with lower levels are captured by `Sentry.Extensions.Logging` ([#1992](https://github.com/getsentry/sentry-dotnet/pull/1992))
 - Fix bug with pre-formatted strings passed to diagnostic loggers ([#2004](https://github.com/getsentry/sentry-dotnet/pull/2004))
+- Fix DI issue by binding to MAUI using lifecycle events ([#2006](https://github.com/getsentry/sentry-dotnet/pull/2006))
 
 ## 3.22.0
 

--- a/src/Sentry.Maui/Internal/SentryMauiInitializer.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiInitializer.cs
@@ -4,20 +4,19 @@ namespace Sentry.Maui.Internal;
 
 internal class SentryMauiInitializer : IMauiInitializeService
 {
+    // This method is invoked automatically within MauiAppBuilder.Build, just after it registers all the services.
+    // That makes it an ideal place to initialize the Sentry SDK.
     public void Initialize(IServiceProvider services)
     {
+        // Get dependencies from the service provider.
         var options = services.GetRequiredService<IOptions<SentryMauiOptions>>().Value;
         var disposer = services.GetRequiredService<Disposer>();
 
+        // Initialize the Sentry SDK.
         var disposable = SentrySdk.Init(options);
 
         // Register the return value from initializing the SDK with the disposer.
         // This will ensure that it gets disposed when the service provider is disposed.
-        // TODO: re-evaluate this with respect to MAUI app lifecycle events
         disposer.Register(disposable);
-
-        // Bind MAUI events
-        var binder = services.GetRequiredService<MauiEventsBinder>();
-        binder.BindMauiEvents();
     }
 }

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Maui.LifecycleEvents;
 using Sentry.Extensions.Logging;
 using Sentry.Extensions.Logging.Extensions.DependencyInjection;
 using Sentry.Maui;
@@ -60,6 +61,43 @@ public static class SentryMauiAppBuilderExtensions
 
         services.AddSentry<SentryMauiOptions>();
 
+        builder.RegisterMauiEventsBinder();
+
         return builder;
+    }
+
+    private static void RegisterMauiEventsBinder(this MauiAppBuilder builder)
+    {
+        // Bind to MAUI events during the platform-specific application creating events.
+        // Note that we used to do this in SentryMauiInitializer, but that approach caused the
+        // IApplication instance to be constructed earlier than normal, having the side-effect
+        // of interfering with a common approach to static DI in App.xaml.cs or AppShell.xaml.cs.
+        // See https://github.com/getsentry/sentry-dotnet/issues/2001
+
+        builder.ConfigureLifecycleEvents(events =>
+        {
+#if __IOS__
+            events.AddiOS(lifecycle => lifecycle.WillFinishLaunching((application, _) =>
+            {
+                (application.Delegate as MauiUIApplicationDelegate)?.BindMauiEvents();
+                return true;
+            }));
+#elif ANDROID
+            events.AddAndroid(android => android.OnApplicationCreating(application =>
+                (application as MauiApplication)?.BindMauiEvents()));
+#elif WINDOWS
+            events.AddWindows(lifecycle => lifecycle.OnLaunching((application, _) =>
+                (application as MauiWinUIApplication)?.BindMauiEvents()));
+#elif TIZEN
+            events.AddTizen(lifecycle => lifecycle.OnCreate(application =>
+                (application as MauiApplication)?.BindMauiEvents()));
+#endif
+        });
+    }
+
+    private static void BindMauiEvents(this IPlatformApplication application)
+    {
+        var binder = application.Services.GetRequiredService<MauiEventsBinder>();
+        binder.BindMauiEvents();
     }
 }

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -83,7 +83,7 @@ public static class SentryMauiAppBuilderExtensions
                 return true;
             }));
 #elif ANDROID
-            events.AddAndroid(android => android.OnApplicationCreating(application =>
+            events.AddAndroid(lifecycle => lifecycle.OnApplicationCreating(application =>
                 (application as MauiApplication)?.BindMauiEvents()));
 #elif WINDOWS
             events.AddWindows(lifecycle => lifecycle.OnLaunching((application, _) =>


### PR DESCRIPTION
This PR fixes #2001 by binding to MAUI events during the [platform lifecycle events](https://learn.microsoft.com/dotnet/maui/fundamentals/app-lifecycle#platform-lifecycle-events) for application creation, rather than during the main initialization provided by `SentryMauiInitializer`.  This allows MAUI to materialize the `IApplication` singleton instance where it usually does - rather than forced earlier by our dependency.

We still will initialize the rest of Sentry in `SentryMauiInitializer`, as to catch unhandled exceptions as early as possible.

(Note, this PR requires #2005 to be merged also.)