### PR TITLE
Unhide `SentryEvent.Exception`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Ensure logs with lower levels are captured by `Sentry.Extensions.Logging` ([#1992](https://github.com/getsentry/sentry-dotnet/pull/1992))
 - Fix bug with pre-formatted strings passed to diagnostic loggers ([#2004](https://github.com/getsentry/sentry-dotnet/pull/2004))
 - Fix DI issue by binding to MAUI using lifecycle events ([#2006](https://github.com/getsentry/sentry-dotnet/pull/2006))
+- Unhide `SentryEvent.Exception` ([#2011](https://github.com/getsentry/sentry-dotnet/pull/2011))
 
 ## 3.22.0
 

--- a/src/Sentry/SentryEvent.cs
+++ b/src/Sentry/SentryEvent.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Text.Json;
@@ -27,7 +26,6 @@ namespace Sentry
         /// The information from this exception is used by the Sentry SDK
         /// to add the relevant data to the event prior to sending to Sentry.
         /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public Exception? Exception { get; }
 
         /// <summary>


### PR DESCRIPTION
`SentryEvent.Exception` is public, but it is hidden with `[EditorBrowsable(EditorBrowsableState.Never)]`.

We demonstrate using it in a `BeforeSend` hook [in the docs](https://docs.sentry.io/platforms/dotnet/configuration/filtering/#using-platformidentifier-namebefore-send-), so it should not be hidden.

