### PR TITLE
Add Custom Measurements API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Support DI for custom transaction processors ([#1993](https://github.com/getsentry/sentry-dotnet/pull/1993))
 - Mark Transaction as aborted when unhandled exception occurs ([#1996](https://github.com/getsentry/sentry-dotnet/pull/1996))
 - Build Windows and Tizen targets for `Sentry.Maui` ([#2005](https://github.com/getsentry/sentry-dotnet/pull/2005))
+- Add Custom Measurements API ([#2013](https://github.com/getsentry/sentry-dotnet/pull/2013))
 
 ### Fixes
 

--- a/src/Sentry/IHasMeasurements.cs
+++ b/src/Sentry/IHasMeasurements.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Sentry.Protocol;
+
+namespace Sentry
+{
+    /// <summary>
+    /// Interface for transactions that can keep track of measurements.
+    /// </summary>
+    /// <remarks>
+    /// Ideally, this would just be implemented as part of <see cref="ITransactionData"/>.
+    /// However, adding a property to a public interface is a breaking change.  We can do that in a future major version.
+    /// </remarks>
+    internal interface IHasMeasurements
+    {
+        /// <summary>
+        /// The measurements that have been set on the transaction.
+        /// </summary>
+        IReadOnlyDictionary<string, Measurement> Measurements { get; }
+
+        /// <summary>
+        /// Sets a measurement on the transaction.
+        /// </summary>
+        /// <param name="name">The name of the measurement.</param>
+        /// <param name="measurement">The measurement.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void SetMeasurement(string name, Measurement measurement);
+    }
+
+    /// <summary>
+    /// Extensions for <see cref="IHasMeasurements"/>
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class MeasurementExtensions
+    {
+        /// <summary>
+        /// Sets a measurement on the transaction.
+        /// </summary>
+        /// <param name="transaction">The transaction.</param>
+        /// <param name="name">The name of the measurement.</param>
+        /// <param name="value">The value of the measurement.</param>
+        /// <param name="unit">
+        /// The optional unit of the measurement.  Defaults to <see cref="MeasurementUnit.None" />.
+        /// </param>
+        public static void SetMeasurement(this ITransactionData transaction, string name, int value,
+            MeasurementUnit unit = default) =>
+            (transaction as IHasMeasurements)?.SetMeasurement(name, new Measurement(value, unit));
+
+        /// <inheritdoc cref="SetMeasurement(Sentry.ITransactionData,string,int,Sentry.MeasurementUnit)" />
+        public static void SetMeasurement(this ITransactionData transaction, string name, long value,
+            MeasurementUnit unit = default) =>
+            (transaction as IHasMeasurements)?.SetMeasurement(name, new Measurement(value, unit));
+
+        /// <inheritdoc cref="SetMeasurement(Sentry.ITransactionData,string,int,Sentry.MeasurementUnit)" />
+#if !__MOBILE__
+        // ulong parameter is not CLS compliant
+        [CLSCompliant(false)]
+#endif
+        public static void SetMeasurement(this ITransactionData transaction, string name, ulong value,
+            MeasurementUnit unit = default) =>
+            (transaction as IHasMeasurements)?.SetMeasurement(name, new Measurement(value, unit));
+
+        /// <inheritdoc cref="SetMeasurement(Sentry.ITransactionData,string,int,Sentry.MeasurementUnit)" />
+        public static void SetMeasurement(this ITransactionData transaction, string name, double value,
+            MeasurementUnit unit = default) =>
+            (transaction as IHasMeasurements)?.SetMeasurement(name, new Measurement(value, unit));
+    }
+}

--- a/src/Sentry/Internal/Polyfills.cs
+++ b/src/Sentry/Internal/Polyfills.cs
@@ -65,6 +65,34 @@ namespace System.Collections.Generic
             source.Reverse().Skip(count).Reverse();
     }
 }
+
+namespace System
+{
+    internal static class HashCode
+    {
+        public static int Combine<T1, T2>(T1 value1, T2 value2)
+        {
+            unchecked
+            {
+                var hashCode = value1 != null ? value1.GetHashCode() : 0;
+                hashCode = (hashCode * 397) ^ (value2 != null ? value2.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+
+        public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3)
+        {
+            unchecked
+            {
+                var hashCode = value1 != null ? value1.GetHashCode() : 0;
+                hashCode = (hashCode * 397) ^ (value2 != null ? value2.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (value3 != null ? value3.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+    }
+}
+
 #endif
 
 #if NET461

--- a/src/Sentry/MeasurementUnit.Duration.cs
+++ b/src/Sentry/MeasurementUnit.Duration.cs
@@ -1,0 +1,57 @@
+namespace Sentry
+{
+    public readonly partial struct MeasurementUnit
+    {
+        /// <summary>
+        /// A time duration unit
+        /// </summary>
+        /// <seealso href="https://getsentry.github.io/relay/relay_metrics/enum.DurationUnit.html"/>
+        public enum Duration
+        {
+            /// <summary>
+            /// Nanosecond unit (10^-9 seconds)
+            /// </summary>
+            Nanosecond,
+
+            /// <summary>
+            /// Microsecond unit (10^-6 seconds)
+            /// </summary>
+            Microsecond,
+
+            /// <summary>
+            /// Millisecond unit (10^-3 seconds)
+            /// </summary>
+            Millisecond,
+
+            /// <summary>
+            /// Second unit
+            /// </summary>
+            Second,
+
+            /// <summary>
+            /// Minute unit (60 seconds)
+            /// </summary>
+            Minute,
+
+            /// <summary>
+            /// Hour unit (3,600 seconds)
+            /// </summary>
+            Hour,
+
+            /// <summary>
+            /// Day unit (86,400 seconds)
+            /// </summary>
+            Day,
+
+            /// <summary>
+            /// Week unit (604,800 seconds)
+            /// </summary>
+            Week
+        }
+
+        /// <summary>
+        /// Implicitly casts a <see cref="MeasurementUnit.Duration"/> to a <see cref="MeasurementUnit"/>.
+        /// </summary>
+        public static implicit operator MeasurementUnit(Duration unit) => new(unit);
+    }
+}

--- a/src/Sentry/MeasurementUnit.Fraction.cs
+++ b/src/Sentry/MeasurementUnit.Fraction.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel;
+
+namespace Sentry
+{
+    public readonly partial struct MeasurementUnit
+    {
+        /// <summary>
+        /// A fraction unit
+        /// </summary>
+        /// <seealso href="https://getsentry.github.io/relay/relay_metrics/enum.FractionUnit.html"/>
+        public enum Fraction
+        {
+            /// <summary>
+            /// Floating point fraction of 1.
+            /// A ratio of 1.0 equals 100%.
+            /// </summary>
+            Ratio,
+
+            /// <summary>
+            /// Ratio expressed as a fraction of 100.
+            /// 100% equals a ratio of 1.0.
+            /// </summary>
+            Percent
+        }
+
+        /// <summary>
+        /// Implicitly casts a <see cref="MeasurementUnit.Fraction"/> to a <see cref="MeasurementUnit"/>.
+        /// </summary>
+        public static implicit operator MeasurementUnit(Fraction unit) => new(unit);
+    }
+}

--- a/src/Sentry/MeasurementUnit.Information.cs
+++ b/src/Sentry/MeasurementUnit.Information.cs
@@ -1,0 +1,90 @@
+namespace Sentry
+{
+    public readonly partial struct MeasurementUnit
+    {
+        /// <summary>
+        /// An information size unit
+        /// </summary>
+        /// <seealso href="https://getsentry.github.io/relay/relay_metrics/enum.InformationUnit.html"/>
+        public enum Information
+        {
+            /// <summary>
+            /// Bit unit (1/8 of byte)
+            /// </summary>
+            /// <remarks>
+            /// Some computer systems may have a different number of bits per byte.
+            /// </remarks>
+            Bit,
+
+            /// <summary>
+            /// Byte unit
+            /// </summary>
+            Byte,
+
+            /// <summary>
+            /// Kilobyte unit (10^3 bytes)
+            /// </summary>
+            Kilobyte,
+
+            /// <summary>
+            /// Kibibyte unit (2^10 bytes)
+            /// </summary>
+            Kibibyte,
+
+            /// <summary>
+            /// Megabyte unit (10^6 bytes)
+            /// </summary>
+            Megabyte,
+
+            /// <summary>
+            /// Mebibyte unit (2^20 bytes)
+            /// </summary>
+            Mebibyte,
+
+            /// <summary>
+            /// Gigabyte unit (10^9 bytes)
+            /// </summary>
+            Gigabyte,
+
+            /// <summary>
+            /// Gibibyte unit (2^30 bytes)
+            /// </summary>
+            Gibibyte,
+
+            /// <summary>
+            /// Terabyte unit (10^12 bytes)
+            /// </summary>
+            Terabyte,
+
+            /// <summary>
+            /// Tebibyte unit (2^40 bytes)
+            /// </summary>
+            Tebibyte,
+
+            /// <summary>
+            /// Petabyte unit (10^15 bytes)
+            /// </summary>
+            Petabyte,
+
+            /// <summary>
+            /// Pebibyte unit (2^50 bytes)
+            /// </summary>
+            Pebibyte,
+
+            /// <summary>
+            /// Exabyte unit (10^18 bytes)
+            /// </summary>
+            Exabyte,
+
+            /// <summary>
+            /// Exbibyte unit (2^60 bytes)
+            /// </summary>
+            Exbibyte
+        }
+
+        /// <summary>
+        /// Implicitly casts a <see cref="MeasurementUnit.Information"/> to a <see cref="MeasurementUnit"/>.
+        /// </summary>
+        public static implicit operator MeasurementUnit(Information unit) => new(unit);
+    }
+}

--- a/src/Sentry/MeasurementUnit.cs
+++ b/src/Sentry/MeasurementUnit.cs
@@ -1,0 +1,94 @@
+using System;
+
+namespace Sentry
+{
+    /// <summary>
+    /// The unit of measurement of a metric value.
+    /// </summary>
+    /// <seealso href="https://getsentry.github.io/relay/relay_metrics/enum.MetricUnit.html"/>
+    public readonly partial struct MeasurementUnit : IEquatable<MeasurementUnit>
+    {
+        private readonly Enum? _unit;
+        private readonly string? _name;
+
+        private MeasurementUnit(Enum unit)
+        {
+            _unit = unit;
+            _name = null;
+        }
+
+        private MeasurementUnit(string name)
+        {
+            _unit = null;
+            _name = name;
+        }
+
+        /// <summary>
+        /// Represents an untyped measurement unit, used for measurements that have no natural unit.
+        /// </summary>
+        public static MeasurementUnit None = new();
+
+        /// <summary>
+        /// Creates a custom measurement unit.
+        /// </summary>
+        /// <param name="name">The name of the custom measurement unit. It will be converted to lower case.</param>
+        /// <returns>The custom measurement unit.</returns>
+        public static MeasurementUnit Custom(string name) => new(name.ToLowerInvariant());
+
+        internal static MeasurementUnit Parse(string? name)
+        {
+            if (name == null)
+            {
+                return None;
+            }
+
+            name = name.Trim();
+
+            if (name.Length == 0)
+            {
+                return None;
+            }
+
+            if (Enum.TryParse<Duration>(name, ignoreCase: true, out var duration))
+            {
+                return duration;
+            }
+
+            if (Enum.TryParse<Information>(name, ignoreCase: true, out var information))
+            {
+                return information;
+            }
+
+            if (Enum.TryParse<Fraction>(name, ignoreCase: true, out var fraction))
+            {
+                return fraction;
+            }
+
+            return Custom(name);
+        }
+
+        /// <summary>
+        /// Returns the string representation of the measurement unit, as it will be sent to Sentry.
+        /// </summary>
+        public override string ToString() => _unit?.ToString().ToLowerInvariant() ?? _name ?? "";
+
+        /// <inheritdoc />
+        public bool Equals(MeasurementUnit other) => Equals(_unit, other._unit) && _name == other._name;
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj) => obj is MeasurementUnit other && Equals(other);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(_unit, _name, _unit?.GetType());
+
+        /// <summary>
+        /// Returns true if the operands are equal.
+        /// </summary>
+        public static bool operator ==(MeasurementUnit left, MeasurementUnit right) => left.Equals(right);
+
+        /// <summary>
+        /// Returns true if the operands are not equal.
+        /// </summary>
+        public static bool operator !=(MeasurementUnit left, MeasurementUnit right) => !left.Equals(right);
+    }
+}

--- a/src/Sentry/Protocol/Measurement.cs
+++ b/src/Sentry/Protocol/Measurement.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using Sentry.Extensibility;
+using Sentry.Internal.Extensions;
+
+namespace Sentry.Protocol
+{
+    /// <summary>
+    /// A measurement, containing a numeric value and a unit.
+    /// </summary>
+    public sealed class Measurement : IJsonSerializable
+    {
+        /// <summary>
+        /// The numeric value of the measurement.
+        /// </summary>
+        public object Value { get; }
+
+        /// <summary>
+        /// The unit of measurement.
+        /// </summary>
+        public MeasurementUnit Unit { get; }
+
+        private Measurement(object value, MeasurementUnit unit)
+        {
+            Value = value;
+            Unit = unit;
+        }
+
+        internal Measurement(int value, MeasurementUnit unit = default)
+        {
+            Value = value;
+            Unit = unit;
+        }
+
+        internal Measurement(long value, MeasurementUnit unit = default)
+        {
+            Value = value;
+            Unit = unit;
+        }
+
+        internal Measurement(ulong value, MeasurementUnit unit = default)
+        {
+            Value = value;
+            Unit = unit;
+        }
+
+        internal Measurement(double value, MeasurementUnit unit = default)
+        {
+            Value = value;
+            Unit = unit;
+        }
+
+        /// <inheritdoc />
+        public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? logger)
+        {
+            writer.WriteStartObject();
+
+            switch (Value)
+            {
+                case int number:
+                    writer.WriteNumber("value", number);
+                    break;
+                case long number:
+                    writer.WriteNumber("value", number);
+                    break;
+                case ulong number:
+                    writer.WriteNumber("value", number);
+                    break;
+                case double number:
+                    writer.WriteNumber("value", number);
+                    break;
+            }
+
+            writer.WriteStringIfNotWhiteSpace("unit", Unit.ToString());
+
+            writer.WriteEndObject();
+        }
+
+        /// <summary>
+        /// Parses from JSON.
+        /// </summary>
+        public static Measurement FromJson(JsonElement json)
+        {
+            var value = json.GetProperty("value").GetDynamicOrNull()!;
+            var unit = json.GetPropertyOrNull("unit")?.GetString();
+            return new Measurement(value, MeasurementUnit.Parse(unit));
+        }
+    }
+}

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -1,15 +1,17 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Sentry.Internal;
+using Sentry.Protocol;
 
 namespace Sentry
 {
     /// <summary>
     /// Transaction tracer.
     /// </summary>
-    public class TransactionTracer : ITransaction, IHasDistribution, IHasTransactionNameSource
+    public class TransactionTracer : ITransaction, IHasDistribution, IHasTransactionNameSource, IHasMeasurements
     {
         private readonly IHub _hub;
         private readonly SentryStopwatch _stopwatch = SentryStopwatch.StartNew();
@@ -165,6 +167,11 @@ namespace Sentry
         /// <inheritdoc />
         public IReadOnlyCollection<ISpan> Spans => _spans;
 
+        private readonly ConcurrentDictionary<string, Measurement> _measurements = new();
+
+        /// <inheritdoc />
+        public IReadOnlyDictionary<string, Measurement> Measurements => _measurements;
+
         /// <inheritdoc />
         public bool IsFinished => EndTimestamp is not null;
 
@@ -223,6 +230,11 @@ namespace Sentry
         /// <inheritdoc />
         public void UnsetTag(string key) =>
             _tags.TryRemove(key, out _);
+
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetMeasurement(string name, Measurement measurement) =>
+            _measurements[name] = measurement;
 
         internal ISpan StartChild(SpanId parentSpanId, string operation)
         {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -276,6 +276,61 @@ namespace Sentry
         string Name { get; }
     }
     public interface ITransactionData : Sentry.IEventLike, Sentry.IHasBreadcrumbs, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISpanContext, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.Protocol.ITraceContext { }
+    public static class MeasurementExtensions
+    {
+        public static void SetMeasurement(this Sentry.ITransactionData transaction, string name, double value, Sentry.MeasurementUnit unit = default) { }
+        public static void SetMeasurement(this Sentry.ITransactionData transaction, string name, int value, Sentry.MeasurementUnit unit = default) { }
+        public static void SetMeasurement(this Sentry.ITransactionData transaction, string name, long value, Sentry.MeasurementUnit unit = default) { }
+        [System.CLSCompliant(false)]
+        public static void SetMeasurement(this Sentry.ITransactionData transaction, string name, ulong value, Sentry.MeasurementUnit unit = default) { }
+    }
+    public readonly struct MeasurementUnit : System.IEquatable<Sentry.MeasurementUnit>
+    {
+        public static Sentry.MeasurementUnit None;
+        public bool Equals(Sentry.MeasurementUnit other) { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public override string ToString() { }
+        public static Sentry.MeasurementUnit Custom(string name) { }
+        public static Sentry.MeasurementUnit op_Implicit(Sentry.MeasurementUnit.Duration unit) { }
+        public static Sentry.MeasurementUnit op_Implicit(Sentry.MeasurementUnit.Fraction unit) { }
+        public static Sentry.MeasurementUnit op_Implicit(Sentry.MeasurementUnit.Information unit) { }
+        public static bool operator !=(Sentry.MeasurementUnit left, Sentry.MeasurementUnit right) { }
+        public static bool operator ==(Sentry.MeasurementUnit left, Sentry.MeasurementUnit right) { }
+        public enum Duration
+        {
+            Nanosecond = 0,
+            Microsecond = 1,
+            Millisecond = 2,
+            Second = 3,
+            Minute = 4,
+            Hour = 5,
+            Day = 6,
+            Week = 7,
+        }
+        public enum Fraction
+        {
+            Ratio = 0,
+            Percent = 1,
+        }
+        public enum Information
+        {
+            Bit = 0,
+            Byte = 1,
+            Kilobyte = 2,
+            Kibibyte = 3,
+            Megabyte = 4,
+            Mebibyte = 5,
+            Gigabyte = 6,
+            Gibibyte = 7,
+            Terabyte = 8,
+            Tebibyte = 9,
+            Petabyte = 10,
+            Pebibyte = 11,
+            Exabyte = 12,
+            Exbibyte = 13,
+        }
+    }
     public sealed class Package : Sentry.IJsonSerializable
     {
         public Package(string name, string version) { }
@@ -841,6 +896,7 @@ namespace Sentry
         public bool? IsParentSampled { get; set; }
         public bool? IsSampled { get; }
         public Sentry.SentryLevel? Level { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, Sentry.Protocol.Measurement> Measurements { get; }
         public string Name { get; }
         public Sentry.TransactionNameSource NameSource { get; }
         public string Operation { get; }
@@ -860,6 +916,7 @@ namespace Sentry
         public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb) { }
         public Sentry.SentryTraceHeader GetTraceHeader() { }
         public void SetExtra(string key, object? value) { }
+        public void SetMeasurement(string name, Sentry.Protocol.Measurement measurement) { }
         public void SetTag(string key, string value) { }
         public void UnsetTag(string key) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
@@ -911,6 +968,7 @@ namespace Sentry
         public bool? IsParentSampled { get; set; }
         public bool? IsSampled { get; }
         public Sentry.SentryLevel? Level { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, Sentry.Protocol.Measurement> Measurements { get; }
         public string Name { get; set; }
         public Sentry.TransactionNameSource NameSource { get; set; }
         public string Operation { get; set; }
@@ -935,6 +993,7 @@ namespace Sentry
         public Sentry.ISpan? GetLastActiveSpan() { }
         public Sentry.SentryTraceHeader GetTraceHeader() { }
         public void SetExtra(string key, object? value) { }
+        public void SetMeasurement(string name, Sentry.Protocol.Measurement measurement) { }
         public void SetTag(string key, string value) { }
         public Sentry.ISpan StartChild(string operation) { }
         public void UnsetTag(string key) { }
@@ -1354,6 +1413,13 @@ namespace Sentry.Protocol
         Sentry.SpanId SpanId { get; }
         Sentry.SpanStatus? Status { get; }
         Sentry.SentryId TraceId { get; }
+    }
+    public sealed class Measurement : Sentry.IJsonSerializable
+    {
+        public Sentry.MeasurementUnit Unit { get; }
+        public object Value { get; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Protocol.Measurement FromJson(System.Text.Json.JsonElement json) { }
     }
     public sealed class Mechanism : Sentry.IJsonSerializable
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_8.verified.txt
@@ -275,6 +275,61 @@ namespace Sentry
         string Name { get; }
     }
     public interface ITransactionData : Sentry.IEventLike, Sentry.IHasBreadcrumbs, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISpanContext, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.Protocol.ITraceContext { }
+    public static class MeasurementExtensions
+    {
+        public static void SetMeasurement(this Sentry.ITransactionData transaction, string name, double value, Sentry.MeasurementUnit unit = default) { }
+        public static void SetMeasurement(this Sentry.ITransactionData transaction, string name, int value, Sentry.MeasurementUnit unit = default) { }
+        public static void SetMeasurement(this Sentry.ITransactionData transaction, string name, long value, Sentry.MeasurementUnit unit = default) { }
+        [System.CLSCompliant(false)]
+        public static void SetMeasurement(this Sentry.ITransactionData transaction, string name, ulong value, Sentry.MeasurementUnit unit = default) { }
+    }
+    public readonly struct MeasurementUnit : System.IEquatable<Sentry.MeasurementUnit>
+    {
+        public static Sentry.MeasurementUnit None;
+        public bool Equals(Sentry.MeasurementUnit other) { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public override string ToString() { }
+        public static Sentry.MeasurementUnit Custom(string name) { }
+        public static Sentry.MeasurementUnit op_Implicit(Sentry.MeasurementUnit.Duration unit) { }
+        public static Sentry.MeasurementUnit op_Implicit(Sentry.MeasurementUnit.Fraction unit) { }
+        public static Sentry.MeasurementUnit op_Implicit(Sentry.MeasurementUnit.Information unit) { }
+        public static bool operator !=(Sentry.MeasurementUnit left, Sentry.MeasurementUnit right) { }
+        public static bool operator ==(Sentry.MeasurementUnit left, Sentry.MeasurementUnit right) { }
+        public enum Duration
+        {
+            Nanosecond = 0,
+            Microsecond = 1,
+            Millisecond = 2,
+            Second = 3,
+            Minute = 4,
+            Hour = 5,
+            Day = 6,
+            Week = 7,
+        }
+        public enum Fraction
+        {
+            Ratio = 0,
+            Percent = 1,
+        }
+        public enum Information
+        {
+            Bit = 0,
+            Byte = 1,
+            Kilobyte = 2,
+            Kibibyte = 3,
+            Megabyte = 4,
+            Mebibyte = 5,
+            Gigabyte = 6,
+            Gibibyte = 7,
+            Terabyte = 8,
+            Tebibyte = 9,
+            Petabyte = 10,
+            Pebibyte = 11,
+            Exabyte = 12,
+            Exbibyte = 13,
+        }
+    }
     public sealed class Package : Sentry.IJsonSerializable
     {
         public Package(string name, string version) { }
@@ -840,6 +895,7 @@ namespace Sentry
         public bool? IsParentSampled { get; set; }
         public bool? IsSampled { get; }
         public Sentry.SentryLevel? Level { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, Sentry.Protocol.Measurement> Measurements { get; }
         public string Name { get; }
         public Sentry.TransactionNameSource NameSource { get; }
         public string Operation { get; }
@@ -859,6 +915,7 @@ namespace Sentry
         public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb) { }
         public Sentry.SentryTraceHeader GetTraceHeader() { }
         public void SetExtra(string key, object? value) { }
+        public void SetMeasurement(string name, Sentry.Protocol.Measurement measurement) { }
         public void SetTag(string key, string value) { }
         public void UnsetTag(string key) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
@@ -910,6 +967,7 @@ namespace Sentry
         public bool? IsParentSampled { get; set; }
         public bool? IsSampled { get; }
         public Sentry.SentryLevel? Level { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, Sentry.Protocol.Measurement> Measurements { get; }
         public string Name { get; set; }
         public Sentry.TransactionNameSource NameSource { get; set; }
         public string Operation { get; set; }
@@ -934,6 +992,7 @@ namespace Sentry
         public Sentry.ISpan? GetLastActiveSpan() { }
         public Sentry.SentryTraceHeader GetTraceHeader() { }
         public void SetExtra(string key, object? value) { }
+        public void SetMeasurement(string name, Sentry.Protocol.Measurement measurement) { }
         public void SetTag(string key, string value) { }
         public Sentry.ISpan StartChild(string operation) { }
         public void UnsetTag(string key) { }
@@ -1354,6 +1413,13 @@ namespace Sentry.Protocol
         Sentry.SpanId SpanId { get; }
         Sentry.SpanStatus? Status { get; }
         Sentry.SentryId TraceId { get; }
+    }
+    public sealed class Measurement : Sentry.IJsonSerializable
+    {
+        public Sentry.MeasurementUnit Unit { get; }
+        public object Value { get; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Protocol.Measurement FromJson(System.Text.Json.JsonElement json) { }
     }
     public sealed class Mechanism : Sentry.IJsonSerializable
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -276,6 +276,61 @@ namespace Sentry
         string Name { get; }
     }
     public interface ITransactionData : Sentry.IEventLike, Sentry.IHasBreadcrumbs, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISpanContext, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.Protocol.ITraceContext { }
+    public static class MeasurementExtensions
+    {
+        public static void SetMeasurement(this Sentry.ITransactionData transaction, string name, double value, Sentry.MeasurementUnit unit = default) { }
+        public static void SetMeasurement(this Sentry.ITransactionData transaction, string name, int value, Sentry.MeasurementUnit unit = default) { }
+        public static void SetMeasurement(this Sentry.ITransactionData transaction, string name, long value, Sentry.MeasurementUnit unit = default) { }
+        [System.CLSCompliant(false)]
+        public static void SetMeasurement(this Sentry.ITransactionData transaction, string name, ulong value, Sentry.MeasurementUnit unit = default) { }
+    }
+    public readonly struct MeasurementUnit : System.IEquatable<Sentry.MeasurementUnit>
+    {
+        public static Sentry.MeasurementUnit None;
+        public bool Equals(Sentry.MeasurementUnit other) { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public override string ToString() { }
+        public static Sentry.MeasurementUnit Custom(string name) { }
+        public static Sentry.MeasurementUnit op_Implicit(Sentry.MeasurementUnit.Duration unit) { }
+        public static Sentry.MeasurementUnit op_Implicit(Sentry.MeasurementUnit.Fraction unit) { }
+        public static Sentry.MeasurementUnit op_Implicit(Sentry.MeasurementUnit.Information unit) { }
+        public static bool operator !=(Sentry.MeasurementUnit left, Sentry.MeasurementUnit right) { }
+        public static bool operator ==(Sentry.MeasurementUnit left, Sentry.MeasurementUnit right) { }
+        public enum Duration
+        {
+            Nanosecond = 0,
+            Microsecond = 1,
+            Millisecond = 2,
+            Second = 3,
+            Minute = 4,
+            Hour = 5,
+            Day = 6,
+            Week = 7,
+        }
+        public enum Fraction
+        {
+            Ratio = 0,
+            Percent = 1,
+        }
+        public enum Information
+        {
+            Bit = 0,
+            Byte = 1,
+            Kilobyte = 2,
+            Kibibyte = 3,
+            Megabyte = 4,
+            Mebibyte = 5,
+            Gigabyte = 6,
+            Gibibyte = 7,
+            Terabyte = 8,
+            Tebibyte = 9,
+            Petabyte = 10,
+            Pebibyte = 11,
+            Exabyte = 12,
+            Exbibyte = 13,
+        }
+    }
     public sealed class Package : Sentry.IJsonSerializable
     {
         public Package(string name, string version) { }
@@ -841,6 +896,7 @@ namespace Sentry
         public bool? IsParentSampled { get; set; }
         public bool? IsSampled { get; }
         public Sentry.SentryLevel? Level { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, Sentry.Protocol.Measurement> Measurements { get; }
         public string Name { get; }
         public Sentry.TransactionNameSource NameSource { get; }
         public string Operation { get; }
@@ -860,6 +916,7 @@ namespace Sentry
         public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb) { }
         public Sentry.SentryTraceHeader GetTraceHeader() { }
         public void SetExtra(string key, object? value) { }
+        public void SetMeasurement(string name, Sentry.Protocol.Measurement measurement) { }
         public void SetTag(string key, string value) { }
         public void UnsetTag(string key) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
@@ -911,6 +968,7 @@ namespace Sentry
         public bool? IsParentSampled { get; set; }
         public bool? IsSampled { get; }
         public Sentry.SentryLevel? Level { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, Sentry.Protocol.Measurement> Measurements { get; }
         public string Name { get; set; }
         public Sentry.TransactionNameSource NameSource { get; set; }
         public string Operation { get; set; }
@@ -935,6 +993,7 @@ namespace Sentry
         public Sentry.ISpan? GetLastActiveSpan() { }
         public Sentry.SentryTraceHeader GetTraceHeader() { }
         public void SetExtra(string key, object? value) { }
+        public void SetMeasurement(string name, Sentry.Protocol.Measurement measurement) { }
         public void SetTag(string key, string value) { }
         public Sentry.ISpan StartChild(string operation) { }
         public void UnsetTag(string key) { }
@@ -1354,6 +1413,13 @@ namespace Sentry.Protocol
         Sentry.SpanId SpanId { get; }
         Sentry.SpanStatus? Status { get; }
         Sentry.SentryId TraceId { get; }
+    }
+    public sealed class Measurement : Sentry.IJsonSerializable
+    {
+        public Sentry.MeasurementUnit Unit { get; }
+        public object Value { get; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Protocol.Measurement FromJson(System.Text.Json.JsonElement json) { }
     }
     public sealed class Mechanism : Sentry.IJsonSerializable
     {

--- a/test/Sentry.Tests/Helpers/JsonSerializableExtensions.cs
+++ b/test/Sentry.Tests/Helpers/JsonSerializableExtensions.cs
@@ -3,10 +3,10 @@ using System.Text.Json;
 
 internal static class JsonSerializableExtensions
 {
-    public static string ToJsonString(this IJsonSerializable serializable, IDiagnosticLogger logger) =>
+    public static string ToJsonString(this IJsonSerializable serializable, IDiagnosticLogger logger = null) =>
         WriteToJsonString(writer => writer.WriteSerializableValue(serializable, logger));
 
-    public static string ToJsonString(this object @object, IDiagnosticLogger logger) =>
+    public static string ToJsonString(this object @object, IDiagnosticLogger logger = null) =>
         WriteToJsonString(writer => writer.WriteDynamicValue(@object, logger));
 
     private static string WriteToJsonString(Action<Utf8JsonWriter> writeAction)

--- a/test/Sentry.Tests/MeasurementUnitTests.cs
+++ b/test/Sentry.Tests/MeasurementUnitTests.cs
@@ -1,0 +1,110 @@
+namespace Sentry.Tests;
+
+public class MeasurementUnitTests
+{
+    [Fact]
+    public void DefaultNone()
+    {
+        MeasurementUnit m = new();
+        Assert.Equal(MeasurementUnit.None, m);
+        Assert.Equal("", m.ToString());
+    }
+
+    [Fact]
+    public void CanUseDurationUnits()
+    {
+        MeasurementUnit m = MeasurementUnit.Duration.Second;
+        Assert.Equal("second", m.ToString());
+    }
+
+    [Fact]
+    public void CanUseInformationUnits()
+    {
+        MeasurementUnit m = MeasurementUnit.Information.Byte;
+        Assert.Equal("byte", m.ToString());
+    }
+
+    [Fact]
+    public void CanUseFractionUnits()
+    {
+        MeasurementUnit m = MeasurementUnit.Fraction.Percent;
+        Assert.Equal("percent", m.ToString());
+    }
+
+    [Fact]
+    public void CanUseCustomUnits()
+    {
+        var m = MeasurementUnit.Custom("foo");
+        Assert.Equal("foo", m.ToString());
+    }
+
+    [Fact]
+    public void ZeroInequality()
+    {
+        MeasurementUnit m1 = (MeasurementUnit.Duration)0;
+        MeasurementUnit m2 = (MeasurementUnit.Information)0;
+        Assert.NotEqual(m1, m2);
+    }
+
+    [Fact]
+    public void ZeroDifferentHashCodes()
+    {
+        MeasurementUnit m1 = (MeasurementUnit.Duration)0;
+        MeasurementUnit m2 = (MeasurementUnit.Information)0;
+        Assert.NotEqual(m1.GetHashCode(), m2.GetHashCode());
+    }
+
+    [Fact]
+    public void SimpleEquality()
+    {
+        MeasurementUnit m1 = MeasurementUnit.Duration.Second;
+        MeasurementUnit m2 = MeasurementUnit.Duration.Second;
+        Assert.Equal(m1, m2);
+
+        // we overload the == operator, so check that as well
+        Assert.True(m1 == m2);
+    }
+
+    [Fact]
+    public void SimpleInequality()
+    {
+        MeasurementUnit m1 = MeasurementUnit.Duration.Second;
+        MeasurementUnit m2 = MeasurementUnit.Duration.Millisecond;
+        Assert.NotEqual(m1, m2);
+
+        // we overload the != operator, so check that as well
+        Assert.True(m1 != m2);
+    }
+
+    [Fact]
+    public void MixedInequality()
+    {
+        MeasurementUnit m1 = MeasurementUnit.Duration.Nanosecond;
+        MeasurementUnit m2 = MeasurementUnit.Information.Bit;
+        Assert.NotEqual(m1, m2);
+    }
+
+    [Fact]
+    public void CustomEquality()
+    {
+        var m1 = MeasurementUnit.Custom("foo");
+        var m2 = MeasurementUnit.Custom("foo");
+        Assert.Equal(m1, m2);
+    }
+
+    [Fact]
+    public void CustomInequality()
+    {
+        var m1 = MeasurementUnit.Custom("foo");
+        var m2 = MeasurementUnit.Custom("bar");
+        Assert.NotEqual(m1, m2);
+    }
+
+    [Fact]
+    public void MixedInequalityWithCustom()
+    {
+        var m1 = MeasurementUnit.Custom("second");
+        var m2 = MeasurementUnit.Duration.Second;
+        Assert.NotEqual(m1, m2);
+    }
+}

--- a/test/Sentry.Tests/Protocol/MeasurementTests.Transaction_Serializes_Measurements.verified.txt
+++ b/test/Sentry.Tests/Protocol/MeasurementTests.Transaction_Serializes_Measurements.verified.txt
@@ -1,0 +1,56 @@
+﻿{
+  contexts: {
+    trace: {
+      op: operation,
+      trace_id: Guid_1,
+      type: trace
+    }
+  },
+  event_id: Guid_2,
+  measurements: {
+    a: {
+      value: 2147483647
+    },
+    b: {
+      unit: second,
+      value: 2147483647
+    },
+    c: {
+      value: 9223372036854775807
+    },
+    d: {
+      unit: kilobyte,
+      value: 9223372036854775807
+    },
+    e: {
+      value: 18446744073709551615
+    },
+    f: {
+      unit: exbibyte,
+      value: 18446744073709551615
+    },
+    g: {
+      value: 1.7976931348623157E+308
+    },
+    h: {
+      unit: foo,
+      value: 1.7976931348623157E+308
+    },
+    i: {
+      unit: ratio,
+      value: 0.5
+    },
+    j: {
+      unit: percent,
+      value: 88.25
+    }
+  },
+  platform: csharp,
+  sdk: {},
+  start_timestamp: DateTime_1,
+  transaction: name,
+  transaction_info: {
+    source: custom
+  },
+  type: transaction
+}

--- a/test/Sentry.Tests/Protocol/MeasurementTests.cs
+++ b/test/Sentry.Tests/Protocol/MeasurementTests.cs
@@ -1,0 +1,347 @@
+namespace Sentry.Tests.Protocol;
+
+[UsesVerify]
+public class MeasurementTests
+{
+    [Fact]
+    public void Constructor_IntValue()
+    {
+        var m = new Measurement(int.MaxValue);
+        Assert.Equal(int.MaxValue, m.Value);
+        Assert.Equal(MeasurementUnit.None, m.Unit);
+    }
+
+    [Fact]
+    public void Constructor_LongValue()
+    {
+        var m = new Measurement(long.MaxValue);
+        Assert.Equal(long.MaxValue, m.Value);
+        Assert.Equal(MeasurementUnit.None, m.Unit);
+    }
+
+    [Fact]
+    public void Constructor_ULongValue()
+    {
+        var m = new Measurement(ulong.MaxValue);
+        Assert.Equal(ulong.MaxValue, m.Value);
+        Assert.Equal(MeasurementUnit.None, m.Unit);
+    }
+
+    [Fact]
+    public void Constructor_DoubleValue()
+    {
+        var m = new Measurement(double.MaxValue);
+        Assert.Equal(double.MaxValue, m.Value);
+        Assert.Equal(MeasurementUnit.None, m.Unit);
+    }
+
+    [Fact]
+    public void Constructor_IntValue_WithUnit()
+    {
+        var m = new Measurement(int.MaxValue, MeasurementUnit.Duration.Second);
+        Assert.Equal(int.MaxValue, m.Value);
+        Assert.Equal(MeasurementUnit.Duration.Second, m.Unit);
+    }
+
+    [Fact]
+    public void Constructor_LongValue_WithUnit()
+    {
+        var m = new Measurement(long.MaxValue, MeasurementUnit.Duration.Second);
+        Assert.Equal(long.MaxValue, m.Value);
+        Assert.Equal(MeasurementUnit.Duration.Second, m.Unit);
+    }
+
+    [Fact]
+    public void Constructor_ULongValue_WithUnit()
+    {
+        var m = new Measurement(ulong.MaxValue, MeasurementUnit.Duration.Second);
+        Assert.Equal(ulong.MaxValue, m.Value);
+        Assert.Equal(MeasurementUnit.Duration.Second, m.Unit);
+    }
+
+    [Fact]
+    public void Constructor_DoubleValue_WithUnit()
+    {
+        var m = new Measurement(double.MaxValue, MeasurementUnit.Duration.Second);
+        Assert.Equal(double.MaxValue, m.Value);
+        Assert.Equal(MeasurementUnit.Duration.Second, m.Unit);
+    }
+
+    [Fact]
+    public void Json_IntValue()
+    {
+        var m = new Measurement(int.MaxValue);
+        var json = m.ToJsonString();
+        Assert.Equal("{\"value\":2147483647}", json);
+    }
+
+    [Fact]
+    public void Json_LongValue()
+    {
+        var m = new Measurement(long.MaxValue);
+        var json = m.ToJsonString();
+        Assert.Equal("{\"value\":9223372036854775807}", json);
+    }
+
+    [Fact]
+    public void Json_ULongValue()
+    {
+        var m = new Measurement(ulong.MaxValue);
+        var json = m.ToJsonString();
+        Assert.Equal("{\"value\":18446744073709551615}", json);
+    }
+
+    [Fact]
+    public void Json_DoubleValue()
+    {
+        var m = new Measurement(double.MaxValue);
+        var json = m.ToJsonString();
+        Assert.Equal("{\"value\":1.7976931348623157E+308}", json);
+    }
+
+    [Fact]
+    public void Json_IntValue_WithUnit()
+    {
+        var m = new Measurement(int.MaxValue, MeasurementUnit.Duration.Second);
+        var json = m.ToJsonString();
+        Assert.Equal("{\"value\":2147483647,\"unit\":\"second\"}", json);
+    }
+
+    [Fact]
+    public void Json_LongValue_WithUnit()
+    {
+        var m = new Measurement(long.MaxValue, MeasurementUnit.Duration.Second);
+        var json = m.ToJsonString();
+        Assert.Equal("{\"value\":9223372036854775807,\"unit\":\"second\"}", json);
+    }
+
+    [Fact]
+    public void Json_ULongValue_WithUnit()
+    {
+        var m = new Measurement(ulong.MaxValue, MeasurementUnit.Duration.Second);
+        var json = m.ToJsonString();
+        Assert.Equal("{\"value\":18446744073709551615,\"unit\":\"second\"}", json);
+    }
+
+    [Fact]
+    public void Json_DoubleValue_WithUnit()
+    {
+        var m = new Measurement(double.MaxValue, MeasurementUnit.Duration.Second);
+        var json = m.ToJsonString();
+        Assert.Equal("{\"value\":1.7976931348623157E+308,\"unit\":\"second\"}", json);
+    }
+
+    [Fact]
+    public void Transaction_SetMeasurement_IntValue()
+    {
+        // Arrange
+        var client = Substitute.For<ISentryClient>();
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            TracesSampleRate = 1.0
+        };
+        var hub = new Hub(options, client);
+        var transaction = hub.StartTransaction("name", "operation");
+
+        // Act
+        transaction.SetMeasurement("foo", int.MaxValue);
+        transaction.Finish();
+
+        // Assert
+        client.Received(1).CaptureTransaction(Arg.Is<Transaction>(t =>
+            t.Measurements.Count == 1 &&
+            t.Measurements["foo"].Value.Equals(int.MaxValue) &&
+            t.Measurements["foo"].Unit.Equals(MeasurementUnit.None)));
+    }
+
+    [Fact]
+    public void Transaction_SetMeasurement_LongValue()
+    {
+        // Arrange
+        var client = Substitute.For<ISentryClient>();
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            TracesSampleRate = 1.0
+        };
+        var hub = new Hub(options, client);
+        var transaction = hub.StartTransaction("name", "operation");
+
+        // Act
+        transaction.SetMeasurement("foo", long.MaxValue);
+        transaction.Finish();
+
+        // Assert
+        client.Received(1).CaptureTransaction(Arg.Is<Transaction>(t =>
+            t.Measurements.Count == 1 &&
+            t.Measurements["foo"].Value.Equals(long.MaxValue) &&
+            t.Measurements["foo"].Unit.Equals(MeasurementUnit.None)));
+    }
+
+    [Fact]
+    public void Transaction_SetMeasurement_ULongValue()
+    {
+        // Arrange
+        var client = Substitute.For<ISentryClient>();
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            TracesSampleRate = 1.0
+        };
+        var hub = new Hub(options, client);
+        var transaction = hub.StartTransaction("name", "operation");
+
+        // Act
+        transaction.SetMeasurement("foo", ulong.MaxValue);
+        transaction.Finish();
+
+        // Assert
+        client.Received(1).CaptureTransaction(Arg.Is<Transaction>(t =>
+            t.Measurements.Count == 1 &&
+            t.Measurements["foo"].Value.Equals(ulong.MaxValue) &&
+            t.Measurements["foo"].Unit.Equals(MeasurementUnit.None)));
+    }
+
+    [Fact]
+    public void Transaction_SetMeasurement_DoubleValue()
+    {
+        // Arrange
+        var client = Substitute.For<ISentryClient>();
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            TracesSampleRate = 1.0
+        };
+        var hub = new Hub(options, client);
+        var transaction = hub.StartTransaction("name", "operation");
+
+        // Act
+        transaction.SetMeasurement("foo", double.MaxValue);
+        transaction.Finish();
+
+        // Assert
+        client.Received(1).CaptureTransaction(Arg.Is<Transaction>(t =>
+            t.Measurements.Count == 1 &&
+            t.Measurements["foo"].Value.Equals(double.MaxValue) &&
+            t.Measurements["foo"].Unit.Equals(MeasurementUnit.None)));
+    }
+
+    [Fact]
+    public void Transaction_SetMeasurement_IntValue_WithUnit()
+    {
+        // Arrange
+        var client = Substitute.For<ISentryClient>();
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            TracesSampleRate = 1.0
+        };
+        var hub = new Hub(options, client);
+        var transaction = hub.StartTransaction("name", "operation");
+
+        // Act
+        transaction.SetMeasurement("foo", int.MaxValue, MeasurementUnit.Duration.Nanosecond);
+        transaction.Finish();
+
+        // Assert
+        client.Received(1).CaptureTransaction(Arg.Is<Transaction>(t =>
+            t.Measurements.Count == 1 &&
+            t.Measurements["foo"].Value.Equals(int.MaxValue) &&
+            t.Measurements["foo"].Unit.Equals(MeasurementUnit.Duration.Nanosecond)));
+    }
+
+    [Fact]
+    public void Transaction_SetMeasurement_LongValue_WithUnit()
+    {
+        // Arrange
+        var client = Substitute.For<ISentryClient>();
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            TracesSampleRate = 1.0
+        };
+        var hub = new Hub(options, client);
+        var transaction = hub.StartTransaction("name", "operation");
+
+        // Act
+        transaction.SetMeasurement("foo", long.MaxValue, MeasurementUnit.Duration.Nanosecond);
+        transaction.Finish();
+
+        // Assert
+        client.Received(1).CaptureTransaction(Arg.Is<Transaction>(t =>
+            t.Measurements.Count == 1 &&
+            t.Measurements["foo"].Value.Equals(long.MaxValue) &&
+            t.Measurements["foo"].Unit.Equals(MeasurementUnit.Duration.Nanosecond)));
+    }
+
+    [Fact]
+    public void Transaction_SetMeasurement_ULongValue_WithUnit()
+    {
+        // Arrange
+        var client = Substitute.For<ISentryClient>();
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            TracesSampleRate = 1.0
+        };
+        var hub = new Hub(options, client);
+        var transaction = hub.StartTransaction("name", "operation");
+
+        // Act
+        transaction.SetMeasurement("foo", ulong.MaxValue, MeasurementUnit.Duration.Nanosecond);
+        transaction.Finish();
+
+        // Assert
+        client.Received(1).CaptureTransaction(Arg.Is<Transaction>(t =>
+            t.Measurements.Count == 1 &&
+            t.Measurements["foo"].Value.Equals(ulong.MaxValue) &&
+            t.Measurements["foo"].Unit.Equals(MeasurementUnit.Duration.Nanosecond)));
+    }
+
+    [Fact]
+    public void Transaction_SetMeasurement_DoubleValue_WithUnit()
+    {
+        // Arrange
+        var client = Substitute.For<ISentryClient>();
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            TracesSampleRate = 1.0
+        };
+        var hub = new Hub(options, client);
+        var transaction = hub.StartTransaction("name", "operation");
+
+        // Act
+        transaction.SetMeasurement("foo", double.MaxValue, MeasurementUnit.Duration.Nanosecond);
+        transaction.Finish();
+
+        // Assert
+        client.Received(1).CaptureTransaction(Arg.Is<Transaction>(t =>
+            t.Measurements.Count == 1 &&
+            t.Measurements["foo"].Value.Equals(double.MaxValue) &&
+            t.Measurements["foo"].Unit.Equals(MeasurementUnit.Duration.Nanosecond)));
+    }
+
+    [Fact]
+    [Trait("Category", "Verify")]
+    public Task Transaction_Serializes_Measurements()
+    {
+        var transaction = new Transaction("name", "operation");
+        transaction.Contexts.Trace.SpanId = SpanId.Empty;
+
+        transaction.SetMeasurement("a", int.MaxValue);
+        transaction.SetMeasurement("b", int.MaxValue, MeasurementUnit.Duration.Second);
+        transaction.SetMeasurement("c", long.MaxValue);
+        transaction.SetMeasurement("d", long.MaxValue, MeasurementUnit.Information.Kilobyte);
+        transaction.SetMeasurement("e", ulong.MaxValue);
+        transaction.SetMeasurement("f", ulong.MaxValue, MeasurementUnit.Information.Exbibyte);
+        transaction.SetMeasurement("g", double.MaxValue);
+        transaction.SetMeasurement("h", double.MaxValue, MeasurementUnit.Custom("foo"));
+        transaction.SetMeasurement("i", 0.5, MeasurementUnit.Fraction.Ratio);
+        transaction.SetMeasurement("j", 88.25, MeasurementUnit.Fraction.Percent);
+
+        var json = transaction.ToJsonString();
+        return VerifyJson(json);
+    }
+}

--- a/test/Sentry.Tests/Protocol/TransactionTests.cs
+++ b/test/Sentry.Tests/Protocol/TransactionTests.cs
@@ -66,6 +66,9 @@ public class TransactionTests
         transaction.SetExtra("extra_key", "extra_value");
         transaction.Fingerprint = new[] { "fingerprint" };
         transaction.SetTag("tag_key", "tag_value");
+        transaction.SetMeasurement("measurement_1", 111);
+        transaction.SetMeasurement("measurement_2", 2.34, MeasurementUnit.Custom("things"));
+        transaction.SetMeasurement("measurement_3", 333, MeasurementUnit.Information.Terabyte);
 
         var child1 = transaction.StartChild("child_op123", "child_desc123");
         child1.Status = SpanStatus.Unimplemented;


### PR DESCRIPTION
Adds support for Custom Performance Metrics
https://docs.sentry.io/product/performance/metrics/#custom-performance-metrics

Usage:

```csharp
// integer values can be int, long, or ulong
transaction.SetMeasurement("some_time", 50, MeasurementUnit.Duration.Millisecond);

// floating point values are passed as double
transaction.SetMeasurement("file_size", 1.21, MeasurementUnit.Information.Gigabyte);

// set measurement without unit is the same as passing MeasurementUnit.None
transaction.SetMeasurement("num_widgets", 10);

// custom units can be used as well
transaction.SetMeasurement("foo", 5000, MeasurementUnit.Custom("bar"));
```

Resolves #1951