### PR TITLE
Add `ISpan.GetTransaction` convenience method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Support DI for custom transaction processors ([#1993](https://github.com/getsentry/sentry-dotnet/pull/1993))
 - Mark Transaction as aborted when unhandled exception occurs ([#1996](https://github.com/getsentry/sentry-dotnet/pull/1996))
 - Build Windows and Tizen targets for `Sentry.Maui` ([#2005](https://github.com/getsentry/sentry-dotnet/pull/2005))
+- Add `ISpan.GetTransaction` convenience method ([#2014](https://github.com/getsentry/sentry-dotnet/pull/2014))
 
 ### Fixes
 

--- a/src/Sentry/ISpan.cs
+++ b/src/Sentry/ISpan.cs
@@ -68,5 +68,16 @@ namespace Sentry
 
             return child;
         }
+
+        /// <summary>
+        /// Gets the transaction that this span belongs to.
+        /// </summary>
+        public static ITransaction GetTransaction(this ISpan span) =>
+            span switch
+            {
+                ITransaction transaction => transaction,
+                SpanTracer tracer => tracer.Transaction,
+                _ => throw new ArgumentOutOfRangeException(nameof(span), span, null)
+            };
     }
 }

--- a/src/Sentry/SpanTracer.cs
+++ b/src/Sentry/SpanTracer.cs
@@ -58,14 +58,13 @@ namespace Sentry
         public void UnsetTag(string key) =>
             (_tags ??= new ConcurrentDictionary<string, string>()).TryRemove(key, out _);
 
-        private ConcurrentDictionary<string, object?> _data = new();
+        private readonly ConcurrentDictionary<string, object?> _data = new();
 
         /// <inheritdoc />
         public IReadOnlyDictionary<string, object?> Extra => _data;
 
         /// <inheritdoc />
-        public void SetExtra(string key, object? value) =>
-            _data[key] = value;
+        public void SetExtra(string key, object? value) => _data[key] = value;
 
         /// <summary>
         /// Initializes an instance of <see cref="SpanTracer"/>.
@@ -86,8 +85,7 @@ namespace Sentry
         }
 
         /// <inheritdoc />
-        public ISpan StartChild(string operation) =>
-            Transaction.StartChild(SpanId, operation);
+        public ISpan StartChild(string operation) => Transaction.StartChild(SpanId, operation);
 
         /// <inheritdoc />
         public void Finish()
@@ -111,13 +109,9 @@ namespace Sentry
         }
 
         /// <inheritdoc />
-        public void Finish(Exception exception) =>
-            Finish(exception, SpanStatusConverter.FromException(exception));
+        public void Finish(Exception exception) => Finish(exception, SpanStatusConverter.FromException(exception));
 
         /// <inheritdoc />
-        public SentryTraceHeader GetTraceHeader() => new(
-            TraceId,
-            SpanId,
-            IsSampled);
+        public SentryTraceHeader GetTraceHeader() => new(TraceId, SpanId, IsSampled);
     }
 }

--- a/src/Sentry/SpanTracer.cs
+++ b/src/Sentry/SpanTracer.cs
@@ -11,8 +11,9 @@ namespace Sentry
     public class SpanTracer : ISpan
     {
         private readonly IHub _hub;
-        private readonly TransactionTracer _transaction;
         private readonly SentryStopwatch _stopwatch = SentryStopwatch.StartNew();
+
+        internal TransactionTracer Transaction { get; }
 
         /// <inheritdoc />
         public SpanId SpanId { get; }
@@ -77,8 +78,7 @@ namespace Sentry
             string operation)
         {
             _hub = hub;
-            _transaction = transaction;
-
+            Transaction = transaction;
             SpanId = SpanId.Create();
             ParentSpanId = parentSpanId;
             TraceId = traceId;
@@ -87,7 +87,7 @@ namespace Sentry
 
         /// <inheritdoc />
         public ISpan StartChild(string operation) =>
-            _transaction.StartChild(SpanId, operation);
+            Transaction.StartChild(SpanId, operation);
 
         /// <inheritdoc />
         public void Finish()

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -737,6 +737,7 @@ namespace Sentry
     }
     public static class SpanExtensions
     {
+        public static Sentry.ITransaction GetTransaction(this Sentry.ISpan span) { }
         public static Sentry.ISpan StartChild(this Sentry.ISpan span, string operation, string? description) { }
     }
     public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet4_8.verified.txt
@@ -736,6 +736,7 @@ namespace Sentry
     }
     public static class SpanExtensions
     {
+        public static Sentry.ITransaction GetTransaction(this Sentry.ISpan span) { }
         public static Sentry.ISpan StartChild(this Sentry.ISpan span, string operation, string? description) { }
     }
     public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -737,6 +737,7 @@ namespace Sentry
     }
     public static class SpanExtensions
     {
+        public static Sentry.ITransaction GetTransaction(this Sentry.ISpan span) { }
         public static Sentry.ISpan StartChild(this Sentry.ISpan span, string operation, string? description) { }
     }
     public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>

--- a/test/Sentry.Tests/Protocol/TransactionTests.cs
+++ b/test/Sentry.Tests/Protocol/TransactionTests.cs
@@ -362,4 +362,33 @@ public class TransactionTests
         // Assert
         span.Status.Should().Be(SpanStatus.DataLoss);
     }
+
+    [Fact]
+    public void ISpan_GetTransaction_FromTransaction()
+    {
+        // Arrange
+        var hub = Substitute.For<IHub>();
+        ISpan transaction = new TransactionTracer(hub, "my name", "my op");
+
+        // Act
+        var result = transaction.GetTransaction();
+
+        // Assert
+        Assert.Same(transaction, result);
+    }
+
+    [Fact]
+    public void ISpan_GetTransaction_FromSpan()
+    {
+        // Arrange
+        var hub = Substitute.For<IHub>();
+        var transaction = new TransactionTracer(hub, "my name", "my op");
+        var span = transaction.StartChild("child op");
+
+        // Act
+        var result = span.GetTransaction();
+
+        // Assert
+        Assert.Same(transaction, result);
+    }
 }


### PR DESCRIPTION
This adds a convenience method for when you have an `ISpan` and need to get the `ITransaction` it belongs to.

For example:

```csharp
void DoSomething(ISpan span)
{
    var transaction = span.GetTransaction();
}
```

This also works well anywhere we have a `GetSpan` method, such as `IHub` and `SentrySdk`

```csharp
var hub = serviceProvider.GetRequiredService<IHub>();
var transaction = hub.GetSpan()?.GetTransaction();
```

or

```csharp
var transaction = SentrySdk.GetSpan()?.GetTransaction();
```


### Motivation

With custom measurements added in #2013, we have this:

```csharp
transaction.SetMeasurement("some_time", 50, MeasurementUnit.Duration.Millisecond);
```

Since sometimes we only have a span, we need to do this:

```csharp
span.GetTransaction().SetMeasurement("some_time", 50, MeasurementUnit.Duration.Millisecond);
```

The alternative would have been to attach `SetMeasurement` extension methods on `ISpan` as well, but that would imply that measurement data is set on individual spans - which it is not.

This seems cleaner and has other usages as well.