### PR TITLE
Bump `Google.Cloud.Functions.Hosting` to version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix bug with pre-formatted strings passed to diagnostic loggers ([#2004](https://github.com/getsentry/sentry-dotnet/pull/2004))
 - Fix DI issue by binding to MAUI using lifecycle events ([#2006](https://github.com/getsentry/sentry-dotnet/pull/2006))
 - Unhide `SentryEvent.Exception` ([#2011](https://github.com/getsentry/sentry-dotnet/pull/2011))
+- Bump `Google.Cloud.Functions.Hosting` to version 1.1.0 ([#2015](https://github.com/getsentry/sentry-dotnet/pull/2015))
 
 ## 3.22.0
 

--- a/samples/Sentry.Samples.Google.Cloud.Functions/Sentry.Samples.Google.Cloud.Functions.csproj
+++ b/samples/Sentry.Samples.Google.Cloud.Functions/Sentry.Samples.Google.Cloud.Functions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
     <ProjectReference Include="..\..\src\Sentry.Google.Cloud.Functions\Sentry.Google.Cloud.Functions.csproj" />
   </ItemGroup>
 

--- a/src/Sentry.Google.Cloud.Functions/Sentry.Google.Cloud.Functions.csproj
+++ b/src/Sentry.Google.Cloud.Functions/Sentry.Google.Cloud.Functions.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Sentry.AspNetCore\Sentry.AspNetCore.csproj" />
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes a potential security vulnerability in transitive dependencies of `Sentry.Google.Cloud.Functions`.

See https://github.com/GoogleCloudPlatform/functions-framework-dotnet/issues/260 for details.