### PR TITLE
Update nuget dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,9 +36,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="UnoptimizedAssemblyDetector" Version="0.1.1" PrivateAssets="All" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.1.1" PrivateAssets="All" />
-    <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
+    <PackageReference Include="UnoptimizedAssemblyDetector" Version="0.1.*" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.*" PrivateAssets="All" />
+    <PackageReference Include="Nullable" Version="1.*" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/benchmarks/Sentry.Benchmarks/Sentry.Benchmarks.csproj
+++ b/benchmarks/Sentry.Benchmarks/Sentry.Benchmarks.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Sentry.Samples.AspNetCore.Blazor.Wasm.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Sentry.Samples.AspNetCore.Blazor.Wasm.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.10" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.*" PrivateAssets="all" />
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
   </ItemGroup>

--- a/samples/Sentry.Samples.AspNetCore.Grpc/Sentry.Samples.AspNetCore.Grpc.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Grpc/Sentry.Samples.AspNetCore.Grpc.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.21.7" />
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.49.0" />
-    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.49.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.48.1" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.*" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.*" />
+    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.*" />
+    <PackageReference Include="Grpc.Tools" Version="2.*" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.AspNetCore.Serilog/Sentry.Samples.AspNetCore.Serilog.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Serilog/Sentry.Samples.AspNetCore.Serilog.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
+    <PackageReference Include="Serilog" Version="2.*" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.*" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.Aws.Lambda.AspNetCoreServer/Sentry.Samples.Aws.Lambda.AspNetCoreServer.csproj
+++ b/samples/Sentry.Samples.Aws.Lambda.AspNetCoreServer/Sentry.Samples.Aws.Lambda.AspNetCoreServer.csproj
@@ -5,8 +5,8 @@
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.*" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.*" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Controllers" />

--- a/samples/Sentry.Samples.EntityFramework/Sentry.Samples.EntityFramework.csproj
+++ b/samples/Sentry.Samples.EntityFramework/Sentry.Samples.EntityFramework.csproj
@@ -6,9 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Sentry.EntityFramework\Sentry.EntityFramework.csproj" />
+
     <PackageReference Include="EntityFramework" Version="6.*" />
     <PackageReference Include="Effort.EF6" Version="2.*" />
-    <ProjectReference Include="..\..\src\Sentry.EntityFramework\Sentry.EntityFramework.csproj" />
+
+    <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
+    <PackageReference Include="System.Drawing.Common" Version="6.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.EntityFramework/Sentry.Samples.EntityFramework.csproj
+++ b/samples/Sentry.Samples.EntityFramework/Sentry.Samples.EntityFramework.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Effort.EF6" Version="2.2.16" />
+    <PackageReference Include="EntityFramework" Version="6.*" />
+    <PackageReference Include="Effort.EF6" Version="2.*" />
     <ProjectReference Include="..\..\src\Sentry.EntityFramework\Sentry.EntityFramework.csproj" />
   </ItemGroup>
 

--- a/samples/Sentry.Samples.GenericHost/Sentry.Samples.GenericHost.csproj
+++ b/samples/Sentry.Samples.GenericHost/Sentry.Samples.GenericHost.csproj
@@ -13,11 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.Google.Cloud.Functions/Sentry.Samples.Google.Cloud.Functions.csproj
+++ b/samples/Sentry.Samples.Google.Cloud.Functions/Sentry.Samples.Google.Cloud.Functions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.*" />
     <ProjectReference Include="..\..\src\Sentry.Google.Cloud.Functions\Sentry.Google.Cloud.Functions.csproj" />
   </ItemGroup>
 

--- a/samples/Sentry.Samples.ME.Logging/Sentry.Samples.ME.Logging.csproj
+++ b/samples/Sentry.Samples.ME.Logging/Sentry.Samples.ME.Logging.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.*" />
   </ItemGroup>
 </Project>

--- a/samples/Sentry.Samples.NLog/Sentry.Samples.NLog.csproj
+++ b/samples/Sentry.Samples.NLog/Sentry.Samples.NLog.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.0.4" />
+    <PackageReference Include="NLog" Version="5.*" />
     <ProjectReference Include="..\..\src\Sentry.NLog\Sentry.NLog.csproj">
       <Private>true</Private>
     </ProjectReference>

--- a/samples/Sentry.Samples.Serilog/Sentry.Samples.Serilog.csproj
+++ b/samples/Sentry.Samples.Serilog/Sentry.Samples.Serilog.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="2.*" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -28,27 +28,27 @@
     <Using Include="NSubstitute.Core" />
     <Using Include="NSubstitute.ReturnsExtensions" />
     <Using Include="Sentry.DsnSamples" Static="True" />
-    <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="Verify.Xunit" Version="17.10.2" />
-    <PackageReference Include="Verify.DiffPlex" Version="1.3.0" />
-    <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
+    <PackageReference Include="NSubstitute" Version="4.*" />
+    <PackageReference Include="FluentAssertions" Version="6.*" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.*" />
+    <PackageReference Include="Verify.Xunit" Version="17.*" />
+    <PackageReference Include="Verify.DiffPlex" Version="1.*" />
+    <PackageReference Include="PublicApiGenerator" Version="10.*" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.*" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.*" />
   </ItemGroup>
 
   <!-- only non-platform-specific projects should include these packages -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)'==''">
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- these are needed because the versions that are brought in transitively have vulnerability warnings -->
   <ItemGroup Condition="$(TargetFramework) != 'net48'">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="System.Net.Http" Version="4.*" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.*" />
   </ItemGroup>
 
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -46,6 +46,9 @@
   </ItemGroup>
 
   <!-- these are needed because the versions that are brought in transitively have vulnerability warnings -->
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.*"/>
+  </ItemGroup>
   <ItemGroup Condition="$(TargetFramework) != 'net48'">
     <PackageReference Include="System.Net.Http" Version="4.*" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.*" />

--- a/test/MauiTestUtils/DeviceTests.Runners.SourceGen/TestUtils.DeviceTests.Runners.SourceGen.csproj
+++ b/test/MauiTestUtils/DeviceTests.Runners.SourceGen/TestUtils.DeviceTests.Runners.SourceGen.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.*" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MauiTestUtils/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/test/MauiTestUtils/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.utility" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.utility" Version="2.*" />
     <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.*-*" />
   </ItemGroup>
 

--- a/test/MauiTestUtils/DeviceTests/TestUtils.DeviceTests.csproj
+++ b/test/MauiTestUtils/DeviceTests/TestUtils.DeviceTests.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.utility" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.utility" Version="2.*" />
     <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.*-*" />
   </ItemGroup>
 

--- a/test/MauiTestUtils/Directory.Build.props
+++ b/test/MauiTestUtils/Directory.Build.props
@@ -7,8 +7,8 @@
 
   <!-- these are needed because the versions that are brought in transitively have vulnerability warnings -->
   <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="System.Net.Http" Version="4.*" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.*" />
   </ItemGroup>
 
 </Project>

--- a/test/Sentry.AspNetCore.Grpc.Tests/Sentry.AspNetCore.Grpc.Tests.csproj
+++ b/test/Sentry.AspNetCore.Grpc.Tests/Sentry.AspNetCore.Grpc.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.49.0" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.49.1" PrivateAssets="All" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.*" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.*" />
+    <PackageReference Include="Grpc.Tools" Version="2.*" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.AspNetCore.Tests/Sentry.AspNetCore.Tests.csproj
+++ b/test/Sentry.AspNetCore.Tests/Sentry.AspNetCore.Tests.csproj
@@ -10,23 +10,23 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net48'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.*" />
 
     <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
-    <PackageReference Include="Microsoft.AspNetCore.Server.IIS" Version="2.2.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IIS" Version="2.*" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.29" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.*" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.10" />
-    <PackageReference Include="Verify.AspNetCore" Version="1.5.0" />
-    <PackageReference Include="Verify.Http" Version="2.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.*" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.*" />
+    <PackageReference Include="Verify.AspNetCore" Version="1.*" />
+    <PackageReference Include="Verify.Http" Version="2.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
@@ -23,6 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="LocalDb" Version="13.*" />
+
+    <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
+    <PackageReference Include="System.Drawing.Common" Version="6.*" />
+
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />

--- a/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
@@ -5,24 +5,24 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Verify.EntityFramework" Version="6.6.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.10" />
+    <PackageReference Include="Verify.EntityFramework" Version="6.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.17" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48' ">
     <ProjectReference Include="..\..\src\Sentry.DiagnosticSource\Sentry.DiagnosticSource.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.29" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.29" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.*" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LocalDb" Version="13.9.4" />
+    <PackageReference Include="LocalDb" Version="13.*" />
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />

--- a/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
+++ b/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
@@ -6,14 +6,14 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.17" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.*" />
 
     <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
@@ -22,8 +22,8 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <ProjectReference Include="..\..\src\Sentry.DiagnosticSource\Sentry.DiagnosticSource.csproj" />
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.29" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.29" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.EntityFramework.Tests/Sentry.EntityFramework.Tests.csproj
+++ b/test/Sentry.EntityFramework.Tests/Sentry.EntityFramework.Tests.csproj
@@ -14,6 +14,9 @@
     <PackageReference Include="Effort.EF6" Version="2.*" />
     <PackageReference Include="EfClassicLocalDb" Version="13.*" />
 
+    <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
+    <PackageReference Include="System.Drawing.Common" Version="6.*" />
+
     <ProjectReference Include="..\..\src\Sentry.EntityFramework\Sentry.EntityFramework.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
 

--- a/test/Sentry.EntityFramework.Tests/Sentry.EntityFramework.Tests.csproj
+++ b/test/Sentry.EntityFramework.Tests/Sentry.EntityFramework.Tests.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Effort.EF6" Version="2.2.16" />
-    <PackageReference Include="EfClassicLocalDb" Version="13.9.4" />
+    <PackageReference Include="EntityFramework" Version="6.*" />
+    <PackageReference Include="Effort.EF6" Version="2.*" />
+    <PackageReference Include="EfClassicLocalDb" Version="13.*" />
 
     <ProjectReference Include="..\..\src\Sentry.EntityFramework\Sentry.EntityFramework.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />

--- a/test/Sentry.Extensions.Logging.Tests/Sentry.Extensions.Logging.Tests.csproj
+++ b/test/Sentry.Extensions.Logging.Tests/Sentry.Extensions.Logging.Tests.csproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.*" />
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.Log4Net.Tests/Sentry.Log4Net.Tests.csproj
+++ b/test/Sentry.Log4Net.Tests/Sentry.Log4Net.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.15" />
+    <PackageReference Include="log4net" Version="2.*" />
     <ProjectReference Include="..\..\src\Sentry.Log4Net\Sentry.Log4Net.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
 

--- a/test/Sentry.NLog.Tests/Sentry.NLog.Tests.csproj
+++ b/test/Sentry.NLog.Tests/Sentry.NLog.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.0.4" />
+    <PackageReference Include="NLog" Version="5.*" />
     <ProjectReference Include="..\..\src\Sentry.NLog\Sentry.NLog.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
 

--- a/test/Sentry.Serilog.Tests/Sentry.Serilog.Tests.csproj
+++ b/test/Sentry.Serilog.Tests/Sentry.Serilog.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog" Version="2.*" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.*" />
 
     <ProjectReference Include="..\..\src\Sentry.Serilog\Sentry.Serilog.csproj" />
     <ProjectReference Include="..\Sentry.AspNetCore.Tests\Sentry.AspNetCore.Tests.csproj" />


### PR DESCRIPTION
Update package references to use [floating versions](https://learn.microsoft.com/nuget/concepts/dependency-resolution#floating-versions) in tools, tests, and samples.  For example, `1.*` instead of `1.2.3` (or `0.1.*` instead of `0.1.2`).  This should reduce the amount of updates we need to do to keep healthy.

We will still use specific minimal versions for projects under `/src`, as those affect consumers of our nuget packages.

Also bumps a few more transitive dependencies to resolve all security warnings.

#skip-changelog