### PR TITLE
Fix default host issue for the Sentry Tunnel middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix DI issue by binding to MAUI using lifecycle events ([#2006](https://github.com/getsentry/sentry-dotnet/pull/2006))
 - Unhide `SentryEvent.Exception` ([#2011](https://github.com/getsentry/sentry-dotnet/pull/2011))
 - Bump `Google.Cloud.Functions.Hosting` to version 1.1.0 ([#2015](https://github.com/getsentry/sentry-dotnet/pull/2015))
+- Fix default host issue for the Sentry Tunnel middleware ([#2019](https://github.com/getsentry/sentry-dotnet/pull/2019))
 
 ## 3.22.0
 

--- a/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
@@ -110,8 +110,12 @@ public static class SentryWebHostBuilderExtensions
     /// <summary>
     /// Adds and configures the Sentry tunneling middleware.
     /// </summary>
-    /// <param name="services"></param>
-    /// <param name="hostnames">The extra hostnames to be allowed for the tunneling. sentry.io is allowed by default; add your own Sentry domain if you use a self-hosted Sentry or Relay.</param>
+    /// <param name="services">The service collection</param>
+    /// <param name="hostnames">
+    /// The extra hostnames to be allowed for the tunneling.
+    /// Hosts ending in <c>.sentry.io</c> are always allowed, and do not need to be included in this list.
+    /// Add your own domain if you use a self-hosted Sentry or Relay.
+    /// </param>
     public static void AddSentryTunneling(this IServiceCollection services, params string[] hostnames) =>
         services.AddScoped(_ => new SentryTunnelMiddleware(hostnames));
 

--- a/test/Sentry.AspNetCore.Tests/Tunnel/IntegrationsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/Tunnel/IntegrationsTests.cs
@@ -28,13 +28,16 @@ public class IntegrationsTests : IDisposable
         _server = new TestServer(builder);
     }
 
-    [Fact]
-    public async Task TunnelMiddleware_CanForwardValidEnvelope()
+    [Theory]
+    [InlineData("sentry.io")]
+    [InlineData("ingest.sentry.io")]
+    [InlineData("o12345.ingest.sentry.io")]
+    public async Task TunnelMiddleware_CanForwardValidEnvelope(string host)
     {
         var requestMessage = new HttpRequestMessage(new HttpMethod("POST"), "/tunnel")
         {
             Content = new StringContent(
-            @"{""sent_at"":""2021-01-01T00:00:00.000Z"",""sdk"":{""name"":""sentry.javascript.browser"",""version"":""6.8.0""},""dsn"":""https://dns@sentry.io/1""}
+            @"{""sent_at"":""2021-01-01T00:00:00.000Z"",""sdk"":{""name"":""sentry.javascript.browser"",""version"":""6.8.0""},""dsn"":""https://dns@" + host + @"/1""}
 {""type"":""session""}
 {""sid"":""fda00e933162466c849962eaea0cfaff""}")
         };


### PR DESCRIPTION
The default allowed host for the `SentryTunnelMiddleware` was `"sentry.io"`. 
After this change, any hosting ending in `".sentry.io"` is also allowed by default.

Fixes #2017