### PR TITLE
Fix concurrency bug in caching transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix concurrency bug in caching transport ([#2026](https://github.com/getsentry/sentry-dotnet/pull/2026))
+
 ## 3.23.0
 
 ### Features

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -25,6 +25,9 @@ internal class CachingTransport : ITransport, IAsyncDisposable, IDisposable
     // Pre-released because the directory might already have files from previous sessions.
     private readonly Signal _workerSignal = new(true);
 
+    // Signal that ensures only one thread can process items from the cache at a time
+    private readonly Signal _processingSignal = new(true);
+
     // Lock to synchronize file system operations inside the cache directory.
     // It's required because there are multiple threads that may attempt to both read
     // and write from/to the cache directory.
@@ -254,18 +257,29 @@ internal class CachingTransport : ITransport, IAsyncDisposable, IDisposable
 
     private async Task ProcessCacheAsync(CancellationToken cancellation)
     {
-        // Signal that we can start waiting for _options.InitCacheFlushTimeout
-        _preInitCacheResetEvent?.Set();
-
-        // Process the cache
-        _options.LogDebug("Flushing cached envelopes.");
-        while (await TryPrepareNextCacheFileAsync(cancellation).ConfigureAwait(false) is { } file)
+        try
         {
-            await InnerProcessCacheAsync(file, cancellation).ConfigureAwait(false);
-        }
+            // Make sure we're the only thread processing items
+            await _processingSignal.WaitAsync(cancellation).ConfigureAwait(false);
 
-        // Signal that we can continue with initialization, if we're using _options.InitCacheFlushTimeout
-        _initCacheResetEvent?.Set();
+            // Signal that we can start waiting for _options.InitCacheFlushTimeout
+            _preInitCacheResetEvent?.Set();
+
+            // Process the cache
+            _options.LogDebug("Flushing cached envelopes.");
+            while (await TryPrepareNextCacheFileAsync(cancellation).ConfigureAwait(false) is { } file)
+            {
+                await InnerProcessCacheAsync(file, cancellation).ConfigureAwait(false);
+            }
+
+            // Signal that we can continue with initialization, if we're using _options.InitCacheFlushTimeout
+            _initCacheResetEvent?.Set();
+        }
+        finally
+        {
+            // Release the signal so the next pass or another thread can enter
+            _processingSignal.Release();
+        }
     }
 
     private async Task InnerProcessCacheAsync(string file, CancellationToken cancellation)

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -137,7 +137,7 @@ internal class CachingTransport : ITransport, IAsyncDisposable, IDisposable
             try
             {
                 await _workerSignal.WaitAsync(_workerCts.Token).ConfigureAwait(false);
-                _options.LogDebug("Worker signal triggered: flushing cached envelopes.");
+                _options.LogDebug("CachingTransport worker signal triggered.");
                 await ProcessCacheAsync(_workerCts.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (_workerCts.IsCancellationRequested)
@@ -258,6 +258,7 @@ internal class CachingTransport : ITransport, IAsyncDisposable, IDisposable
         _preInitCacheResetEvent?.Set();
 
         // Process the cache
+        _options.LogDebug("Flushing cached envelopes.");
         while (await TryPrepareNextCacheFileAsync(cancellation).ConfigureAwait(false) is { } file)
         {
             await InnerProcessCacheAsync(file, cancellation).ConfigureAwait(false);
@@ -465,7 +466,7 @@ internal class CachingTransport : ITransport, IAsyncDisposable, IDisposable
 
     public Task FlushAsync(CancellationToken cancellationToken = default)
     {
-        _options.LogDebug("External FlushAsync invocation: flushing cached envelopes.");
+        _options.LogDebug("CachingTransport received request to flush the cache.");
         return ProcessCacheAsync(cancellationToken);
     }
 

--- a/test/Sentry.Tests/Internals/BackgroundWorkerTests.cs
+++ b/test/Sentry.Tests/Internals/BackgroundWorkerTests.cs
@@ -488,6 +488,6 @@ public class BackgroundWorkerTests
 
         // Assert
         _fixture.Logger.Received(1)
-            .Log(SentryLevel.Debug, "External FlushAsync invocation: flushing cached envelopes.");
+            .Log(SentryLevel.Debug, "CachingTransport received request to flush the cache.");
     }
 }


### PR DESCRIPTION
This is basic usage and should always work:

```csharp
using (SentrySdk.Init(options))
{
    SentrySdk.CaptureEvent(new SentryEvent());

    // possible other application logic, perhaps some that takes a bit of time
}
```

It *does* work, if caching is not enabled.

However when caching is enabled, it *sometimes* sends the envelope, and sometimes exits the program before the envelope can be sent.  It is intermittent, depending on how much time (if any) is allowed to pass for the background worker and cache worker to complete.  If there's no time at all between the capture and the dispose, then the envelope isn't sent.

This is happening because there's a race condition between the normal background cache worker that is processing items within the caching transport, and the flush that occurs when the transport is disposed.

- If the *flush* processes first, it dequeues the envelope, sends it to the inner transport, and exits after the transport completes.  The cache worker might start at any time, but it finds nothing in the queue.  All is good.
- If the *cache worker* processes first, it dequeues the envelope, but then the flush happens before the envelope is sent.  The flush finds no items and exits immediately.  If the app terminates before the worker can continue, the envelope is not sent. It's left in the processing folder until the next run of the app.

I fixed this by only allowing one thread at a time to be processing items in the cache.  If the flush occurs while the cache worker is processing, it will wait asynchronously until the worker completes processing.

Added a test to demonstrate this both with and without caching.  Without the fix applied, the test passes only when caching is disabled.   With the fix applied, the test passes both with and without caching.

Fixes #2025