### PR TITLE
Sort context during serialization

### DIFF
--- a/src/Sentry/Contexts.cs
+++ b/src/Sentry/Contexts.cs
@@ -111,8 +111,11 @@ public sealed class Contexts : ConcurrentDictionary<string, object>, IJsonSerial
     }
 
     /// <inheritdoc />
-    public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? logger) =>
-        writer.WriteDictionaryValue(this!, logger, includeNullValues: false);
+    public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? logger)
+    {
+        var contexts = this.OrderBy(x => x.Key, StringComparer.Ordinal);
+        writer.WriteDictionaryValue(contexts!, logger, includeNullValues: false);
+    }
 
     /// <summary>
     /// Parses from JSON.

--- a/test/Sentry.Tests/Protocol/Context/ContextsTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/ContextsTests.cs
@@ -143,6 +143,20 @@ public class ContextsTests
     }
 
     [Fact]
+    public void SerializeObject_SortsContextKeys()
+    {
+        var sut = new Contexts
+        {
+            ["c"] = "3",
+            ["a"] = "1",
+            ["b"] = "2",
+        };
+
+        var actualString = sut.ToJsonString(_testOutputLogger);
+        Assert.Equal("{\"a\":\"1\",\"b\":\"2\",\"c\":\"3\"}", actualString);
+    }
+
+    [Fact]
     public void SerializeObject_Null_Should_Be_Ignored()
     {
         // Arrange

--- a/test/Sentry.Tests/Protocol/SentryEventTests.SerializeObject_AllPropertiesSetToNonDefault_SerializesValidObject.verified.txt
+++ b/test/Sentry.Tests/Protocol/SentryEventTests.SerializeObject_AllPropertiesSetToNonDefault_SerializesValidObject.verified.txt
@@ -37,7 +37,8 @@
       .NET Framework: "v2.0.50727", "v3.0", "v3.5",
       .NET Framework Client: "v4.8", "v4.0.0.0",
       .NET Framework Full: "v4.8"
-    }
+    },
+    context_key: context_value
   },
   user: {
     id: user-id

--- a/test/Sentry.Tests/Protocol/SentryEventTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryEventTests.cs
@@ -25,6 +25,7 @@ public class SentryEventTests
             Request = new Request { Method = "POST" },
             Contexts = new Contexts
             {
+                ["context_key"] = "context_value",
                 [".NET Framework"] = new Dictionary<string, string>
                 {
                     [".NET Framework"] = "\"v2.0.50727\", \"v3.0\", \"v3.5\"",


### PR DESCRIPTION
In #1998 I updated Verify, and it highlighted an inconsistent sort order when serializing our `Contexts` object.  I speculate that's because it inherits from `ConcurrentDictionary`.

This PR fixes the problem, adds a test, and restores the part of the verify test I previously removed.

This only matters for snapshot testing - Sentry doesn't care what order contexts are sent in.

#skip-changelog