### PR TITLE
Fix trace propagation targets setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Simplify API for flushing events ([#2030](https://github.com/getsentry/sentry-dotnet/pull/2030))
 
+### Fixes
+
+- Fix trace propagation targets setter ([#2035](https://github.com/getsentry/sentry-dotnet/pull/2035))
+
 ## 3.23.1
 
 ### Fixes

--- a/src/Sentry/Internal/AutoClearingList.cs
+++ b/src/Sentry/Internal/AutoClearingList.cs
@@ -6,9 +6,15 @@ namespace Sentry.Internal;
 
 internal class AutoClearingList<T> : IList<T>
 {
-    private readonly IList<T> _list = new List<T>();
+    private readonly IList<T> _list;
 
     private bool _clearOnNextAdd;
+
+    public AutoClearingList(IEnumerable<T> initialItems, bool clearOnNextAdd)
+    {
+        _list = initialItems.ToList();
+        _clearOnNextAdd = clearOnNextAdd;
+    }
 
     public void Add(T item)
     {
@@ -19,12 +25,6 @@ internal class AutoClearingList<T> : IList<T>
         }
 
         _list.Add(item);
-    }
-
-    public AutoClearingList<T> ClearOnNextAdd()
-    {
-        _clearOnNextAdd = true;
-        return this;
     }
 
     public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
@@ -45,7 +45,16 @@ internal class AutoClearingList<T> : IList<T>
 
     public int IndexOf(T item) => _list.IndexOf(item);
 
-    public void Insert(int index, T item) => _list.Insert(index, item);
+    public void Insert(int index, T item)
+    {
+        if (_clearOnNextAdd)
+        {
+            Clear();
+            _clearOnNextAdd = false;
+        }
+
+        _list.Insert(index, item);
+    }
 
     public void RemoveAt(int index) => _list.RemoveAt(index);
 

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -603,27 +603,24 @@ namespace Sentry
             get => _tracePropagationTargets;
             set
             {
-                if (value.Count == 1 && value[0].ToString() == ".*")
+                switch (value.Count)
                 {
-                    // There's only one item in the list, and it's the wildcard, so reset to the initial state.
-                    _tracePropagationTargets = new AutoClearingList<TracePropagationTarget>(value, clearOnNextAdd: true);
-                    return;
-                }
+                    case 1 when value[0].ToString() == ".*":
+                        // There's only one item in the list, and it's the wildcard, so reset to the initial state.
+                        _tracePropagationTargets = new AutoClearingList<TracePropagationTarget>(value, clearOnNextAdd: true);
+                        break;
 
-                if (value.Count > 1)
-                {
-                    // There's more than one item in the list.  Remove the wildcard.
-                    for (var i = 0; i < value.Count; i++)
-                    {
-                        if (value[i].ToString() == ".*")
-                        {
-                            value.RemoveAt(i);
-                            break;
-                        }
-                    }
-                }
+                    case > 1:
+                        // There's more than one item in the list.  Remove the wildcard.
+                        var targets = value.ToList();
+                        targets.RemoveAll(t => t.ToString() == ".*");
+                        _tracePropagationTargets = targets;
+                        break;
 
-                _tracePropagationTargets = value;
+                    default:
+                        _tracePropagationTargets = value;
+                        break;
+                }
             }
         }
 

--- a/test/Sentry.Tests/TracePropagationTargetTests.cs
+++ b/test/Sentry.Tests/TracePropagationTargetTests.cs
@@ -115,6 +115,24 @@ public class TracePropagationTargetTests
     }
 
     [Fact]
+    public void SentryOptions_TracePropagationTargets_SetRemovesDefault()
+    {
+        var options = new SentryOptions();
+        var targets = new []
+        {
+            new TracePropagationTarget(".*"),
+            new TracePropagationTarget("foo"),
+            new TracePropagationTarget("bar")
+        };
+
+        options.TracePropagationTargets = targets;
+
+        Assert.Equal(2, options.TracePropagationTargets.Count);
+        Assert.Equal("foo", options.TracePropagationTargets[0].ToString());
+        Assert.Equal("bar", options.TracePropagationTargets[1].ToString());
+    }
+
+    [Fact]
     public void SentryOptions_TracePropagationTargets_DefaultPropagatesAll()
     {
         var options = new SentryOptions();


### PR DESCRIPTION
While testing with .NET 7 (in #1952), I found that configuration bindings for lists have changed.  It used to be that an existing list would have its `Add` method called to incorporate items during binding.  Now it appears the whole list is replaced.

With `SentryOptions.TracePropagationTargets`, we use `[".*"]` by default.  If the user provides a different list via config, or adds to the existing list in code, we have to clear the wildcard automatically.

With these changes, we now do this correctly for both adding to this _or replacing_ the list - so it works correctly on all targets and we don't have to make any assumptions about configuration binding behavior per version.