### PR TITLE
Fix CI build detection for mobile tests

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,7 @@
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <DefineConstants>$(DefineConstants);CI_BUILD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1,6 +1,5 @@
 using System.IO.Compression;
 using System.Net.Http;
-using DiffEngine;
 using Sentry.Internal.Http;
 using Sentry.Testing;
 
@@ -1154,8 +1153,8 @@ public class HubTests
     [InlineData(true)]
     public async Task FlushOnDispose_SendsEnvelope(bool cachingEnabled)
     {
-#if __MOBILE__
-        Skip.If(cachingEnabled && BuildServerDetector.Detected, "Test is flaky on mobile in CI.");
+#if __MOBILE__ && CI_BUILD
+        Skip.If(cachingEnabled, "Test is flaky on mobile in CI.");
 #endif
 
         // Arrange

--- a/test/Sentry.Tests/UnobservedTaskExceptionIntegrationTests.cs
+++ b/test/Sentry.Tests/UnobservedTaskExceptionIntegrationTests.cs
@@ -33,7 +33,7 @@ public class UnobservedTaskExceptionIntegrationTests
     public void Handle_UnobservedTaskException_CaptureEvent()
     {
 #if __MOBILE__ && CI_BUILD
-        Skip.If(true, "Test is flaky on mobile in CI.");
+        throw new Xunit.SkipException("Test is flaky on mobile in CI.");
 #endif
 
         _fixture.AppDomain = AppDomainAdapter.Instance;

--- a/test/Sentry.Tests/UnobservedTaskExceptionIntegrationTests.cs
+++ b/test/Sentry.Tests/UnobservedTaskExceptionIntegrationTests.cs
@@ -1,7 +1,3 @@
-#if RELEASE
-using DiffEngine;
-#endif
-
 namespace Sentry.Tests;
 
 public class UnobservedTaskExceptionIntegrationTests
@@ -36,8 +32,8 @@ public class UnobservedTaskExceptionIntegrationTests
     [SkippableFact]
     public void Handle_UnobservedTaskException_CaptureEvent()
     {
-#if __MOBILE__
-        Skip.If(BuildServerDetector.Detected, "Test is flaky on mobile in CI.");
+#if __MOBILE__ && CI_BUILD
+        Skip.If(true, "Test is flaky on mobile in CI.");
 #endif
 
         _fixture.AppDomain = AppDomainAdapter.Instance;

--- a/test/Sentry.Tests/UnobservedTaskExceptionIntegrationTests.cs
+++ b/test/Sentry.Tests/UnobservedTaskExceptionIntegrationTests.cs
@@ -34,7 +34,7 @@ public class UnobservedTaskExceptionIntegrationTests
     {
 #if __MOBILE__ && CI_BUILD
         throw new Xunit.SkipException("Test is flaky on mobile in CI.");
-#endif
+#else
 
         _fixture.AppDomain = AppDomainAdapter.Instance;
         var captureCalledEvent = new ManualResetEvent(false);
@@ -57,6 +57,7 @@ public class UnobservedTaskExceptionIntegrationTests
             GC.Collect();
             GC.WaitForPendingFinalizers();
         } while (!captureCalledEvent.WaitOne(TimeSpan.FromMilliseconds(100)));
+#endif
     }
 #endif
 

--- a/test/Sentry.Tests/UnobservedTaskExceptionIntegrationTests.cs
+++ b/test/Sentry.Tests/UnobservedTaskExceptionIntegrationTests.cs
@@ -27,15 +27,14 @@ public class UnobservedTaskExceptionIntegrationTests
         _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
     }
 
-    // Only triggers in release mode.
-#if RELEASE
     [SkippableFact]
     public void Handle_UnobservedTaskException_CaptureEvent()
     {
-#if __MOBILE__ && CI_BUILD
-        throw new Xunit.SkipException("Test is flaky on mobile in CI.");
+#if DEBUG
+        throw new SkipException("UnobservedTaskException does not fire in DEBUG configuration.");
+#elif __MOBILE__ && CI_BUILD
+        throw new SkipException("Test is flaky on mobile in CI.");
 #else
-
         _fixture.AppDomain = AppDomainAdapter.Instance;
         var captureCalledEvent = new ManualResetEvent(false);
         _fixture.Hub.When(x => x.CaptureEvent(Arg.Any<SentryEvent>()))
@@ -59,7 +58,6 @@ public class UnobservedTaskExceptionIntegrationTests
         } while (!captureCalledEvent.WaitOne(TimeSpan.FromMilliseconds(100)));
 #endif
     }
-#endif
 
     [Fact]
     public void Register_UnhandledException_Subscribes()


### PR DESCRIPTION
Detecting CI for mobile tests needs to be done at build time.  At runtime, we're executing in an emulator, so the environment variables used by `BuildServerDetector` are not available.

#skip-changelog