### PR TITLE
Remove debug.fail from envelope tests

### DIFF
--- a/src/Sentry/Protocol/Envelopes/Envelope.cs
+++ b/src/Sentry/Protocol/Envelopes/Envelope.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text.Json;
 using Sentry.Extensibility;
 using Sentry.Infrastructure;
@@ -55,15 +54,6 @@ public sealed class Envelope : ISerializable, IDisposable
     /// </summary>
     internal SentryId? TryGetEventId(IDiagnosticLogger? logger)
     {
-        void Error(string message)
-        {
-// On mobile platforms, Debug.Fail will crash the app
-#if !__MOBILE__
-                Debug.Fail(message);
-#endif
-            logger?.LogError(message);
-        }
-
         if (_eventId != null)
         {
             // use the cached value
@@ -77,25 +67,25 @@ public sealed class Envelope : ISerializable, IDisposable
 
         if (value == null)
         {
-            Error("Header event_id is null");
+            logger?.LogError("Header event_id is null");
             return null;
         }
 
         if (value is not string valueString)
         {
-            Error($"Header event_id has incorrect type: {value.GetType()}");
+            logger?.LogError($"Header event_id has incorrect type: {value.GetType()}");
             return null;
         }
 
         if (!Guid.TryParse(valueString, out var guid))
         {
-            Error($"Header event_id is not a GUID: {value}");
+            logger?.LogError($"Header event_id is not a GUID: {value}");
             return null;
         }
 
         if (guid == Guid.Empty)
         {
-            Error("Envelope contains an empty event_id header");
+            logger?.LogError("Envelope contains an empty event_id header");
             _eventId = SentryId.Empty;
             return _eventId;
         }

--- a/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
@@ -26,7 +26,7 @@ public class EnvelopeTests
 
         var id = envelope.TryGetEventId(logger);
 
-        Assert.Equal("12c2d058d58442709aa2eca08bf20986", id.Value!.ToString());
+        Assert.Equal("12c2d058d58442709aa2eca08bf20986", id?.ToString());
         Assert.Empty(logger.Entries);
     }
 

--- a/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
@@ -1,10 +1,5 @@
 using Sentry.Testing;
 
-#if DEBUG && !__MOBILE__
-using Sentry.PlatformAbstractions;
-using Runtime = Sentry.PlatformAbstractions.Runtime;
-#endif
-
 namespace Sentry.Tests.Protocol.Envelopes;
 
 public class EnvelopeTests
@@ -62,16 +57,6 @@ public class EnvelopeTests
             Array.Empty<EnvelopeItem>());
 
         var logger = new InMemoryDiagnosticLogger();
-
-#if DEBUG && !__MOBILE__
-        if (!Runtime.Current.IsMono())
-        {
-            // Test for the exception thrown by Debug.Fail (doesn't throw on Mono)
-            var exception = Assert.ThrowsAny<Exception>(() => envelope.TryGetEventId(logger));
-            Assert.Contains(message, exception.Message);
-            return;
-        }
-#endif
 
         var id = envelope.TryGetEventId(logger);
         Assert.Equal(message, logger.Entries.Single().Message);


### PR DESCRIPTION
This was added in #1959, but it creates some problems.  In particular, running `dotnet test` on Windows (not in CI) always gets interrupted with modal dialog popups cause by the test itself - even when everything is fine.

I think it's just not good to rely on this magic anyway.  Let's have the test determine failure the same way for all targets and runtimes.

Also fixed an unrelated nullability warning.

#skip-changelog