### PR TITLE
Update transitive dependencies to resolve security warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Update unobserved task exception integration ([#2034](https://github.com/getsentry/sentry-dotnet/pull/2034))
 - Fix trace propagation targets setter ([#2035](https://github.com/getsentry/sentry-dotnet/pull/2035))
 - Fix DiagnosticSource integration disabled incorrectly with TracesSampler ([#2039](https://github.com/getsentry/sentry-dotnet/pull/2039))
+- Update transitive dependencies to resolve security warnings ([#2045](https://github.com/getsentry/sentry-dotnet/pull/2045))
 
 ## 3.23.1
 

--- a/src/Sentry.AspNetCore/Sentry.AspNetCore.csproj
+++ b/src/Sentry.AspNetCore/Sentry.AspNetCore.csproj
@@ -19,6 +19,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
+
+    <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">

--- a/src/Sentry.EntityFramework/Sentry.EntityFramework.csproj
+++ b/src/Sentry.EntityFramework/Sentry.EntityFramework.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Sentry\Sentry.csproj" />
-    
+
     <Using Include="System.ComponentModel" />
     <Using Include="System.Data" />
     <Using Include="System.Data.Common" />
@@ -27,6 +27,9 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="EntityFramework" Version="6.3.0" />
+
+    <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
As reported by `dotnet list package --vulnerable --include-transitive`

```
Project `Sentry.AspNetCore` has the following vulnerable packages
   [netstandard2.0]: 
   Transitive Package               Resolved   Severity   Advisory URL                                     
   > Microsoft.AspNetCore.Http      2.1.0      High       https://github.com/advisories/GHSA-hxrm-9w7p-39cc

Project `Sentry.EntityFramework` has the following vulnerable packages
   [netstandard2.1]: 
   Transitive Package           Resolved   Severity   Advisory URL                                     
   > System.Data.SqlClient      4.7.0      Moderate   https://github.com/advisories/GHSA-8g2p-5pqh-5jmc

Project `Sentry.Samples.EntityFramework` has the following vulnerable packages
   [netcoreapp3.1]: 
   Transitive Package           Resolved   Severity   Advisory URL                                     
   > System.Data.SqlClient      4.8.1      Moderate   https://github.com/advisories/GHSA-8g2p-5pqh-5jmc
```

Resolved by:

- In `Sentry.AspNetCore` for `netstandard2.0` target only, added `Microsoft.AspNetCore.Http` 2.1.22 per https://github.com/advisories/GHSA-hxrm-9w7p-39cc.

- In `Sentry.EntityFramework` for `netstandard2.1` target only, added `System.Data.SqlClient` 4.8.5 per https://github.com/advisories/GHSA-8g2p-5pqh-5jmc.  This also resolves the same warning for the samples project.