### PR TITLE
Fix CacheDirectoryPath option on MAUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix DiagnosticSource integration disabled incorrectly with TracesSampler ([#2039](https://github.com/getsentry/sentry-dotnet/pull/2039))
 - Update transitive dependencies to resolve security warnings ([#2045](https://github.com/getsentry/sentry-dotnet/pull/2045))
 - Fix issue with Hot Restart for iOS ([#2047](https://github.com/getsentry/sentry-dotnet/pull/2047))
+- Fix `CacheDirectoryPath` option on MAUI ([#2055](https://github.com/getsentry/sentry-dotnet/pull/2055))
 
 ## 3.23.1
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,6 +30,11 @@
     <TargetPlatformMinVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>
 
+  <!-- This is helpful in code to distinguish neutral targets. -->
+  <PropertyGroup>
+    <DefineConstants Condition="'$(TargetPlatformIdentifier)' == ''">$(DefineConstants);PLATFORM_NEUTRAL</DefineConstants>
+  </PropertyGroup>
+
   <!-- We're aware it's out of support but this is a library and it doesn't require nca3.1.  -->
   <!-- there's no reason to cause friction to a consumer that for some reason is stuck on an unsupported version. -->
   <PropertyGroup>

--- a/src/Sentry.Maui/Internal/SentryMauiOptionsSetup.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiOptionsSetup.cs
@@ -25,18 +25,9 @@ internal class SentryMauiOptionsSetup : ConfigureFromConfigurationOptions<Sentry
         // We'll use an event processor to set things like SDK name
         options.AddEventProcessor(new SentryMauiEventProcessor(options));
 
-        // Everything in this block is only valid on real devices, not in unit tests.
-        // We have to check this at runtime, as we don't compile for every possible platform.
-        if (DeviceInfo.Current.Platform != DevicePlatform.Unknown)
-        {
-            // Set a default cache path on the device.
-            // NOTE: We move the Android SDK's cache path one level below this, in src/Sentry/Android/SentrySdk.cs
-            //       We'll want to do something similar when we add iOS support,
-            //       but that's blocked by https://github.com/getsentry/sentry-cocoa/issues/1051
-            options.CacheDirectoryPath = Path.Combine(FileSystem.CacheDirectory, "sentry");
-
-            // We can use MAUI's network connectivity information to inform the CachingTransport when we're offline.
-            options.NetworkStatusListener = new MauiNetworkStatusListener(Connectivity.Current, options);
-        }
+#if !PLATFORM_NEUTRAL
+        // We can use MAUI's network connectivity information to inform the CachingTransport when we're offline.
+        options.NetworkStatusListener = new MauiNetworkStatusListener(Connectivity.Current, options);
+#endif
     }
 }

--- a/src/Sentry.Maui/SentryMauiOptions.cs
+++ b/src/Sentry.Maui/SentryMauiOptions.cs
@@ -19,6 +19,9 @@ public class SentryMauiOptions : SentryLoggingOptions
 
         AutoSessionTracking = true;
         DetectStartupTime = StartupTimeDetectionMode.Fast;
+#if !PLATFORM_NEUTRAL
+        CacheDirectoryPath = Microsoft.Maui.Storage.FileSystem.CacheDirectory;
+#endif
     }
 
     /// <summary>


### PR DESCRIPTION
We were overwriting the user's setting with the default.

Fixes #2052

Also:
- Removed the extra `/sentry` in the default cache path, because we already add one when the caching transport is invoked anyway.
- Improved some internals