### PR TITLE
Update targets for ios/maccat samples

### DIFF
--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -1,0 +1,17 @@
+<Project>
+
+  <Import Project="..\Directory.Build.targets" />
+
+  <!-- Workaround for https://github.com/xamarin/xamarin-macios/issues/15897 -->
+  <Target Name="_SetPublishFolderTypeNoneOnDocFileItems"
+          BeforeTargets="_ComputePublishLocation"
+          Condition="'$(TargetPlatformIdentifier)' == 'ios' Or '$(TargetPlatformIdentifier)' == 'maccatalyst'">
+    <ItemGroup>
+      <ResolvedFileToPublish
+        Update="@(ResolvedFileToPublish)"
+        Condition="'%(ResolvedFileToPublish.Extension)' == '.xml' And '%(ResolvedFileToPublish.PublishFolderType)' == ''"
+        PublishFolderType="None" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -14,4 +14,11 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    This is only needed because we use project references in this solution.
+    In a real app, it will come through the nuget package automatically.
+  -->
+  <Import Project="$(SolutionDir)src\Sentry.Bindings.Cocoa\buildTransitive\Sentry.Bindings.Cocoa.targets"
+          Condition="'$(TargetPlatformIdentifier)' == 'ios' Or '$(TargetPlatformIdentifier)' == 'maccatalyst'" />
+
 </Project>

--- a/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
+++ b/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
@@ -18,17 +18,4 @@
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>
 
-  <!--
-    Workaround for https://github.com/dotnet/maui/issues/7272 (also happens for iOS without MAUI)
-    This should not be needed in a real application.
-  -->
-  <Target Name="_SetPublishFolderTypeNoneOnDocFileItems" BeforeTargets="_ComputePublishLocation">
-    <ItemGroup>
-      <ResolvedFileToPublish
-        Update="@(ResolvedFileToPublish)"
-        Condition="'%(ResolvedFileToPublish.Extension)' == '.xml' And '%(ResolvedFileToPublish.PublishFolderType)' == ''"
-        PublishFolderType="None" />
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/samples/Sentry.Samples.MacCatalyst/Sentry.Samples.MacCatalyst.csproj
+++ b/samples/Sentry.Samples.MacCatalyst/Sentry.Samples.MacCatalyst.csproj
@@ -18,17 +18,4 @@
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>
 
-  <!--
-    Workaround for https://github.com/dotnet/maui/issues/7272 (also happens for iOS without MAUI)
-    This should not be needed in a real application.
-  -->
-  <Target Name="_SetPublishFolderTypeNoneOnDocFileItems" BeforeTargets="_ComputePublishLocation">
-    <ItemGroup>
-      <ResolvedFileToPublish
-        Update="@(ResolvedFileToPublish)"
-        Condition="'%(ResolvedFileToPublish.Extension)' == '.xml' And '%(ResolvedFileToPublish.PublishFolderType)' == ''"
-        PublishFolderType="None" />
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
+++ b/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
@@ -62,14 +62,4 @@
     <ProjectReference Include="..\..\src\Sentry.Maui\Sentry.Maui.csproj" />
   </ItemGroup>
 
-  <!-- Workaround for https://github.com/dotnet/maui/issues/7272 -->
-  <Target Name="_SetPublishFolderTypeNoneOnDocFileItems" BeforeTargets="_ComputePublishLocation">
-    <ItemGroup>
-      <ResolvedFileToPublish
-        Update="@(ResolvedFileToPublish)"
-        Condition="'%(ResolvedFileToPublish.Extension)' == '.xml' And '%(ResolvedFileToPublish.PublishFolderType)' == ''"
-        PublishFolderType="None" />
-    </ItemGroup>
-  </Target>
-
 </Project>


### PR DESCRIPTION
- Moves existing targets in samples to a common `Directory.Build.targets`
- Adds the transitive targets we include in our nuget package, so they also get included with our samples through the project reference.

#skip-changelog