### PR TITLE
Update bundled Android SDK to version 6.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Simplify API for flushing events ([#2030](https://github.com/getsentry/sentry-dotnet/pull/2030))
 - Update bundled Cocoa SDK to version 7.31.1 ([#2053](https://github.com/getsentry/sentry-dotnet/pull/2053))
+- Update bundled Android SDK to version 6.7.1 ([#2058](https://github.com/getsentry/sentry-dotnet/pull/2058))
 
 ### Fixes
 

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0-android</TargetFramework>
     <!-- BG8605 and BG8606 happen because there's a missing androidx.lifecycle dependency, but we don't need it here.  (The native Android Sentry SDK will use it if it exists.) -->
     <NoWarn>$(NoWarn);BG8605;BG8606</NoWarn>
-    <SentryAndroidSdkVersion>6.5.0</SentryAndroidSdkVersion>
+    <SentryAndroidSdkVersion>6.7.1</SentryAndroidSdkVersion>
     <SentryAndroidSdkDirectory>$(BaseIntermediateOutputPath)sdks\Sentry\Android\$(SentryAndroidSdkVersion)\</SentryAndroidSdkDirectory>
     <Description>.NET Bindings for the Sentry Android SDK</Description>
   </PropertyGroup>

--- a/src/Sentry.Bindings.Android/Transforms/Metadata.xml
+++ b/src/Sentry.Bindings.Android/Transforms/Metadata.xml
@@ -61,6 +61,7 @@
   <remove-node path="/api/package[@name='io.sentry']/class[@name='EnvelopeSender']" />
   <remove-node path="/api/package[@name='io.sentry']/class[@name='OutboxSender']" />
   <remove-node path="/api/package[@name='io.sentry.cache']/class[@name='EnvelopeCache']" />
+  <remove-node path="/api/package[@name='io.sentry.android.core.cache']/class[@name='AndroidEnvelopeCache']" />
   <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='TempSensorBreadcrumbsIntegration']" />
   <remove-node path="/api/package[@name='io.sentry.android.core.internal.gestures']" />
 
@@ -71,5 +72,6 @@
   <remove-node path="/api/package[@name='io.sentry.exception']/class[@name='ExceptionMechanismException']" />
   <remove-node path="/api/package[@name='io.sentry.exception']/class[@name='InvalidSentryTraceHeaderException']" />
   <remove-node path="/api/package[@name='io.sentry.exception']/class[@name='SentryEnvelopeException']" />
+  <remove-node path="/api/package[@name='io.sentry.exception']/class[@name='SentryHttpClientException']" />
   <remove-node path="/api/package[@name='io.sentry.vendor.gson.stream']/class[@name='MalformedJsonException']" />
 </metadata>


### PR DESCRIPTION
Updates the Sentry Android SDK from 6.5.0 to 6.7.1 [[diff]](https://github.com/getsentry/sentry-java/compare/6.5.0...6.7.1) [[changelog]](https://github.com/getsentry/sentry-java/blob/master/CHANGELOG.md).
