### PR TITLE
Update FakeFileSystem.cs

### DIFF
--- a/test/Sentry.Testing/FakeFileSystem.cs
+++ b/test/Sentry.Testing/FakeFileSystem.cs
@@ -44,7 +44,7 @@ public class FakeFileSystem : IFileSystem
     public void DeleteFile(string path) => _mockFileSystem.File.Delete(path);
 
     public DateTimeOffset GetFileCreationTime(string path) =>
-        _mockFileSystem.FileInfo.FromFileName(path).CreationTimeUtc;
+        _mockFileSystem.FileInfo.New(path).CreationTimeUtc;
 
     public string ReadAllTextFromFile(string file) => _mockFileSystem.File.ReadAllText(file);
 


### PR DESCRIPTION
Resolve obsoletion warning

```csharp
test/Sentry.Testing/FakeFileSystem.cs(47,9): error CS0618: 'IFileInfoFactory.FromFileName(string)' is obsolete: 'Use `IFileInfoFactory.New(string)` instead'
```


#skip-changelog