### PR TITLE
Fix api verifications

### DIFF
--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1,14 +1,30 @@
 ﻿namespace Microsoft.AspNetCore.Builder
 {
-    public static class SentryTracingMiddlewareExtensions { }
+    public static class SentryTracingMiddlewareExtensions
+    {
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseSentryTracing(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder) { }
+    }
 }
 namespace Microsoft.AspNetCore.Hosting
 {
-    public static class SentryWebHostBuilderExtensions { }
+    public static class SentryWebHostBuilderExtensions
+    {
+        public static void AddSentryTunneling(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, params string[] hostnames) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Sentry.AspNetCore.ISentryBuilder>? configureSentry) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Sentry.AspNetCore.SentryAspNetCoreOptions>? configureOptions) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Sentry.AspNetCore.ISentryBuilder>? configureSentry) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Sentry.AspNetCore.SentryAspNetCoreOptions>? configureOptions) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, string dsn) { }
+        public static void UseSentryTunneling(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder, string path = "/tunnel") { }
+    }
 }
 namespace Microsoft.Extensions.DependencyInjection
 {
-    public static class ServiceCollectionExtensions { }
+    public static class ServiceCollectionExtensions
+    {
+        public static Sentry.AspNetCore.ISentryBuilder AddSentry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+    }
 }
 namespace Sentry.AspNetCore
 {

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet4_8.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet4_8.verified.txt
@@ -1,14 +1,30 @@
 ﻿namespace Microsoft.AspNetCore.Builder
 {
-    public static class SentryTracingMiddlewareExtensions { }
+    public static class SentryTracingMiddlewareExtensions
+    {
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseSentryTracing(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder) { }
+    }
 }
 namespace Microsoft.AspNetCore.Hosting
 {
-    public static class SentryWebHostBuilderExtensions { }
+    public static class SentryWebHostBuilderExtensions
+    {
+        public static void AddSentryTunneling(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, params string[] hostnames) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Sentry.AspNetCore.ISentryBuilder>? configureSentry) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Sentry.AspNetCore.SentryAspNetCoreOptions>? configureOptions) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Sentry.AspNetCore.ISentryBuilder>? configureSentry) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Sentry.AspNetCore.SentryAspNetCoreOptions>? configureOptions) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, string dsn) { }
+        public static void UseSentryTunneling(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder, string path = "/tunnel") { }
+    }
 }
 namespace Microsoft.Extensions.DependencyInjection
 {
-    public static class ServiceCollectionExtensions { }
+    public static class ServiceCollectionExtensions
+    {
+        public static Sentry.AspNetCore.ISentryBuilder AddSentry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+    }
 }
 namespace Sentry.AspNetCore
 {

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,14 +1,30 @@
 ﻿namespace Microsoft.AspNetCore.Builder
 {
-    public static class SentryTracingMiddlewareExtensions { }
+    public static class SentryTracingMiddlewareExtensions
+    {
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseSentryTracing(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder) { }
+    }
 }
 namespace Microsoft.AspNetCore.Hosting
 {
-    public static class SentryWebHostBuilderExtensions { }
+    public static class SentryWebHostBuilderExtensions
+    {
+        public static void AddSentryTunneling(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, params string[] hostnames) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Sentry.AspNetCore.ISentryBuilder>? configureSentry) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Sentry.AspNetCore.SentryAspNetCoreOptions>? configureOptions) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Sentry.AspNetCore.ISentryBuilder>? configureSentry) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Sentry.AspNetCore.SentryAspNetCoreOptions>? configureOptions) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, string dsn) { }
+        public static void UseSentryTunneling(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder, string path = "/tunnel") { }
+    }
 }
 namespace Microsoft.Extensions.DependencyInjection
 {
-    public static class ServiceCollectionExtensions { }
+    public static class ServiceCollectionExtensions
+    {
+        public static Sentry.AspNetCore.ISentryBuilder AddSentry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+    }
 }
 namespace Sentry.AspNetCore
 {

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1,14 +1,30 @@
 ﻿namespace Microsoft.AspNetCore.Builder
 {
-    public static class SentryTracingMiddlewareExtensions { }
+    public static class SentryTracingMiddlewareExtensions
+    {
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseSentryTracing(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder) { }
+    }
 }
 namespace Microsoft.AspNetCore.Hosting
 {
-    public static class SentryWebHostBuilderExtensions { }
+    public static class SentryWebHostBuilderExtensions
+    {
+        public static void AddSentryTunneling(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, params string[] hostnames) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Sentry.AspNetCore.ISentryBuilder>? configureSentry) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Sentry.AspNetCore.SentryAspNetCoreOptions>? configureOptions) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Sentry.AspNetCore.ISentryBuilder>? configureSentry) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Sentry.AspNetCore.SentryAspNetCoreOptions>? configureOptions) { }
+        public static Microsoft.AspNetCore.Hosting.IWebHostBuilder UseSentry(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, string dsn) { }
+        public static void UseSentryTunneling(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder, string path = "/tunnel") { }
+    }
 }
 namespace Microsoft.Extensions.DependencyInjection
 {
-    public static class ServiceCollectionExtensions { }
+    public static class ServiceCollectionExtensions
+    {
+        public static Sentry.AspNetCore.ISentryBuilder AddSentry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+    }
 }
 namespace Sentry.AspNetCore
 {

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1,7 +1,15 @@
-namespace Microsoft.Extensions.Logging
+﻿namespace Microsoft.Extensions.Logging
 {
-    public static class LoggingBuilderExtensions { }
-    public static class SentryLoggerFactoryExtensions { }
+    public static class LoggingBuilderExtensions
+    {
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddSentry(this Microsoft.Extensions.Logging.ILoggingBuilder builder) { }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddSentry(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<Sentry.Extensions.Logging.SentryLoggingOptions>? optionsConfiguration) { }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddSentry(this Microsoft.Extensions.Logging.ILoggingBuilder builder, string dsn) { }
+    }
+    public static class SentryLoggerFactoryExtensions
+    {
+        public static Microsoft.Extensions.Logging.ILoggerFactory AddSentry(this Microsoft.Extensions.Logging.ILoggerFactory factory, System.Action<Sentry.Extensions.Logging.SentryLoggingOptions>? optionsConfiguration = null) { }
+    }
 }
 namespace Sentry.Extensions.Logging
 {

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet4_8.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet4_8.verified.txt
@@ -1,7 +1,15 @@
 ﻿namespace Microsoft.Extensions.Logging
 {
-    public static class LoggingBuilderExtensions { }
-    public static class SentryLoggerFactoryExtensions { }
+    public static class LoggingBuilderExtensions
+    {
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddSentry(this Microsoft.Extensions.Logging.ILoggingBuilder builder) { }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddSentry(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<Sentry.Extensions.Logging.SentryLoggingOptions>? optionsConfiguration) { }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddSentry(this Microsoft.Extensions.Logging.ILoggingBuilder builder, string dsn) { }
+    }
+    public static class SentryLoggerFactoryExtensions
+    {
+        public static Microsoft.Extensions.Logging.ILoggerFactory AddSentry(this Microsoft.Extensions.Logging.ILoggerFactory factory, System.Action<Sentry.Extensions.Logging.SentryLoggingOptions>? optionsConfiguration = null) { }
+    }
 }
 namespace Sentry.Extensions.Logging
 {

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,7 +1,15 @@
 ﻿namespace Microsoft.Extensions.Logging
 {
-    public static class LoggingBuilderExtensions { }
-    public static class SentryLoggerFactoryExtensions { }
+    public static class LoggingBuilderExtensions
+    {
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddSentry(this Microsoft.Extensions.Logging.ILoggingBuilder builder) { }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddSentry(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<Sentry.Extensions.Logging.SentryLoggingOptions>? optionsConfiguration) { }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddSentry(this Microsoft.Extensions.Logging.ILoggingBuilder builder, string dsn) { }
+    }
+    public static class SentryLoggerFactoryExtensions
+    {
+        public static Microsoft.Extensions.Logging.ILoggerFactory AddSentry(this Microsoft.Extensions.Logging.ILoggerFactory factory, System.Action<Sentry.Extensions.Logging.SentryLoggingOptions>? optionsConfiguration = null) { }
+    }
 }
 namespace Sentry.Extensions.Logging
 {

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1,7 +1,15 @@
 ﻿namespace Microsoft.Extensions.Logging
 {
-    public static class LoggingBuilderExtensions { }
-    public static class SentryLoggerFactoryExtensions { }
+    public static class LoggingBuilderExtensions
+    {
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddSentry(this Microsoft.Extensions.Logging.ILoggingBuilder builder) { }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddSentry(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<Sentry.Extensions.Logging.SentryLoggingOptions>? optionsConfiguration) { }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddSentry(this Microsoft.Extensions.Logging.ILoggingBuilder builder, string dsn) { }
+    }
+    public static class SentryLoggerFactoryExtensions
+    {
+        public static Microsoft.Extensions.Logging.ILoggerFactory AddSentry(this Microsoft.Extensions.Logging.ILoggerFactory factory, System.Action<Sentry.Extensions.Logging.SentryLoggingOptions>? optionsConfiguration = null) { }
+    }
 }
 namespace Sentry.Extensions.Logging
 {

--- a/test/Sentry.Maui.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Maui.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,6 +1,11 @@
 ﻿namespace Microsoft.Maui.Hosting
 {
-    public static class SentryMauiAppBuilderExtensions { }
+    public static class SentryMauiAppBuilderExtensions
+    {
+        public static Microsoft.Maui.Hosting.MauiAppBuilder UseSentry(this Microsoft.Maui.Hosting.MauiAppBuilder builder) { }
+        public static Microsoft.Maui.Hosting.MauiAppBuilder UseSentry(this Microsoft.Maui.Hosting.MauiAppBuilder builder, System.Action<Sentry.Maui.SentryMauiOptions>? configureOptions) { }
+        public static Microsoft.Maui.Hosting.MauiAppBuilder UseSentry(this Microsoft.Maui.Hosting.MauiAppBuilder builder, string dsn) { }
+    }
 }
 namespace Sentry.Maui
 {

--- a/test/Sentry.Maui.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Maui.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1,6 +1,11 @@
 ﻿namespace Microsoft.Maui.Hosting
 {
-    public static class SentryMauiAppBuilderExtensions { }
+    public static class SentryMauiAppBuilderExtensions
+    {
+        public static Microsoft.Maui.Hosting.MauiAppBuilder UseSentry(this Microsoft.Maui.Hosting.MauiAppBuilder builder) { }
+        public static Microsoft.Maui.Hosting.MauiAppBuilder UseSentry(this Microsoft.Maui.Hosting.MauiAppBuilder builder, System.Action<Sentry.Maui.SentryMauiOptions>? configureOptions) { }
+        public static Microsoft.Maui.Hosting.MauiAppBuilder UseSentry(this Microsoft.Maui.Hosting.MauiAppBuilder builder, string dsn) { }
+    }
 }
 namespace Sentry.Maui
 {

--- a/test/Sentry.Testing/ApiExtensions.cs
+++ b/test/Sentry.Testing/ApiExtensions.cs
@@ -8,7 +8,10 @@ public static class ApiExtensions
 {
     public static Task CheckApproval(this Assembly assembly, [CallerFilePath] string filePath = "")
     {
-        var generatorOptions = new ApiGeneratorOptions { WhitelistedNamespacePrefixes = new[] { "Sentry" } };
+        var generatorOptions = new ApiGeneratorOptions
+        {
+            WhitelistedNamespacePrefixes = new[] { "Sentry", "Microsoft" }
+        };
         var apiText = assembly.GeneratePublicApi(generatorOptions);
         return Verifier.Verify(apiText, null, filePath)
             .AutoVerify(includeBuildServer: false)


### PR DESCRIPTION
The API generator filters out Microsoft-prefixed namespaces by default.  We should include them, because our public API adds various extension methods in Microsoft namespaces.

#skip-changelog