### PR TITLE
Fix warning caused by db connection span closed prematurely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix warning caused by db connection span closed prematurely ([#2068](https://github.com/getsentry/sentry-dotnet/pull/2068))
+
 ## 3.24.0
 
 ### Features

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.Logging.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.Logging.DotNet6_0.verified.txt
@@ -25,20 +25,6 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();
             eventId: Microsoft.EntityFrameworkCore.Infrastructure.ContextInitialized
           },
           Category: Microsoft.EntityFrameworkCore.Infrastructure
-        },
-        {
-          Message:
-Executed DbCommand
-SET NOCOUNT ON;
-INSERT INTO [TestEntities] ([Property])
-VALUES (@p0);
-SELECT [Id]
-FROM [TestEntities]
-WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();,
-          Data: {
-            eventId: Microsoft.EntityFrameworkCore.Database.Command.CommandExecuted
-          },
-          Category: Microsoft.EntityFrameworkCore.Database.Command
         }
       ],
       Tags: {
@@ -80,6 +66,19 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();,
       Spans: [
         {
           IsFinished: true,
+          Operation: db.connection,
+          Status: Ok,
+          IsSampled: true,
+          Extra: {
+            bytes_received: 677,
+            bytes_sent : 510,
+            db.connection_id: Guid_1,
+            db.operation_id: Guid_2,
+            rows_sent: 0
+          }
+        },
+        {
+          IsFinished: true,
           Operation: db.query,
           Description:
 SET NOCOUNT ON;
@@ -94,7 +93,7 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();
           IsSampled: true,
           Extra: {
             db.connection_id: Guid_1,
-            db.operation_id: Guid_2
+            db.operation_id: Guid_3
           }
         }
       ],

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.Logging.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.Logging.DotNet6_0.verified.txt
@@ -70,7 +70,6 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();,
           Status: Ok,
           IsSampled: true,
           Extra: {
-            bytes_received: 677,
             bytes_sent : 510,
             db.connection_id: Guid_1,
             db.operation_id: Guid_2,

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.Logging.DotNet7_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.Logging.DotNet7_0.verified.txt
@@ -25,20 +25,6 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();
             eventId: Microsoft.EntityFrameworkCore.Infrastructure.ContextInitialized
           },
           Category: Microsoft.EntityFrameworkCore.Infrastructure
-        },
-        {
-          Message:
-Executed DbCommand
-SET NOCOUNT ON;
-INSERT INTO [TestEntities] ([Property])
-VALUES (@p0);
-SELECT [Id]
-FROM [TestEntities]
-WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();,
-          Data: {
-            eventId: Microsoft.EntityFrameworkCore.Database.Command.CommandExecuted
-          },
-          Category: Microsoft.EntityFrameworkCore.Database.Command
         }
       ],
       Tags: {
@@ -80,6 +66,19 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();,
       Spans: [
         {
           IsFinished: true,
+          Operation: db.connection,
+          Status: Ok,
+          IsSampled: true,
+          Extra: {
+            bytes_received: 677,
+            bytes_sent : 510,
+            db.connection_id: Guid_1,
+            db.operation_id: Guid_2,
+            rows_sent: 0
+          }
+        },
+        {
+          IsFinished: true,
           Operation: db.query,
           Description:
 SET NOCOUNT ON;
@@ -94,7 +93,7 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();
           IsSampled: true,
           Extra: {
             db.connection_id: Guid_1,
-            db.operation_id: Guid_2
+            db.operation_id: Guid_3
           }
         }
       ],

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.Logging.DotNet7_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.Logging.DotNet7_0.verified.txt
@@ -70,7 +70,6 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();,
           Status: Ok,
           IsSampled: true,
           Extra: {
-            bytes_received: 677,
             bytes_sent : 510,
             db.connection_id: Guid_1,
             db.operation_id: Guid_2,

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.Core3_1.verified.txt
@@ -51,8 +51,11 @@
           Status: Ok,
           IsSampled: true,
           Extra: {
+            bytes_received: 304,
+            bytes_sent : 704,
             db.connection_id: Guid_1,
-            db.operation_id: Guid_2
+            db.operation_id: Guid_2,
+            rows_sent: 1
           }
         },
         {

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.Core3_1.verified.txt
@@ -47,6 +47,16 @@
       Spans: [
         {
           IsFinished: true,
+          Operation: db.connection,
+          Status: Ok,
+          IsSampled: true,
+          Extra: {
+            db.connection_id: Guid_1,
+            db.operation_id: Guid_2
+          }
+        },
+        {
+          IsFinished: true,
           Operation: db.query,
           Description:
 SET NOCOUNT ON;
@@ -61,7 +71,7 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();
           IsSampled: true,
           Extra: {
             db.connection_id: Guid_1,
-            db.operation_id: Guid_2
+            db.operation_id: Guid_3
           }
         },
         {
@@ -81,7 +91,7 @@ FROM [TestEntities] AS [t],
           IsSampled: true,
           Extra: {
             db.connection_id: Guid_1,
-            db.operation_id: Guid_3
+            db.operation_id: Guid_4
           }
         }
       ],

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.DotNet6_0.verified.txt
@@ -51,8 +51,11 @@
           Status: Ok,
           IsSampled: true,
           Extra: {
+            bytes_received: 304,
+            bytes_sent : 704,
             db.connection_id: Guid_1,
-            db.operation_id: Guid_2
+            db.operation_id: Guid_2,
+            rows_sent: 1
           }
         },
         {

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.DotNet6_0.verified.txt
@@ -47,6 +47,16 @@
       Spans: [
         {
           IsFinished: true,
+          Operation: db.connection,
+          Status: Ok,
+          IsSampled: true,
+          Extra: {
+            db.connection_id: Guid_1,
+            db.operation_id: Guid_2
+          }
+        },
+        {
+          IsFinished: true,
           Operation: db.query,
           Description:
 SET NOCOUNT ON;
@@ -61,7 +71,7 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();
           IsSampled: true,
           Extra: {
             db.connection_id: Guid_1,
-            db.operation_id: Guid_2
+            db.operation_id: Guid_3
           }
         },
         {
@@ -81,7 +91,7 @@ FROM [TestEntities] AS [t],
           IsSampled: true,
           Extra: {
             db.connection_id: Guid_1,
-            db.operation_id: Guid_3
+            db.operation_id: Guid_4
           }
         }
       ],

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.DotNet7_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.DotNet7_0.verified.txt
@@ -51,8 +51,11 @@
           Status: Ok,
           IsSampled: true,
           Extra: {
+            bytes_received: 304,
+            bytes_sent : 704,
             db.connection_id: Guid_1,
-            db.operation_id: Guid_2
+            db.operation_id: Guid_2,
+            rows_sent: 1
           }
         },
         {

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.DotNet7_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.DotNet7_0.verified.txt
@@ -47,6 +47,16 @@
       Spans: [
         {
           IsFinished: true,
+          Operation: db.connection,
+          Status: Ok,
+          IsSampled: true,
+          Extra: {
+            db.connection_id: Guid_1,
+            db.operation_id: Guid_2
+          }
+        },
+        {
+          IsFinished: true,
           Operation: db.query,
           Description:
 SET NOCOUNT ON;
@@ -61,7 +71,7 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();
           IsSampled: true,
           Extra: {
             db.connection_id: Guid_1,
-            db.operation_id: Guid_2
+            db.operation_id: Guid_3
           }
         },
         {
@@ -81,7 +91,7 @@ FROM [TestEntities] AS [t],
           IsSampled: true,
           Extra: {
             db.connection_id: Guid_1,
-            db.operation_id: Guid_3
+            db.operation_id: Guid_4
           }
         }
       ],

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsSql.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsSql.verified.txt
@@ -47,6 +47,19 @@
       Spans: [
         {
           IsFinished: true,
+          Operation: db.connection,
+          Status: Ok,
+          IsSampled: true,
+          Extra: {
+            bytes_received: 167,
+            bytes_sent : 542,
+            db.connection_id: Guid_1,
+            db.operation_id: Guid_2,
+            rows_sent: 1
+          }
+        },
+        {
+          IsFinished: true,
           Operation: db.query,
           Description:
 insert into MyTable (Value)
@@ -55,7 +68,7 @@ values (@value);,
           IsSampled: true,
           Extra: {
             db.connection_id: Guid_1,
-            db.operation_id: Guid_2
+            db.operation_id: Guid_3
           }
         },
         {
@@ -66,7 +79,7 @@ values (@value);,
           IsSampled: true,
           Extra: {
             db.connection_id: Guid_1,
-            db.operation_id: Guid_3
+            db.operation_id: Guid_4
           }
         }
       ],

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.verify.cs
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.verify.cs
@@ -117,6 +117,11 @@ public class SqlListenerTests : IClassFixture<LocalDbFixture>
             .ScrubInlineGuids()
             .IgnoreMember<SentryEvent>(_ => _.SentryThreads)
             .IgnoreMember<IEventLike>(_ => _.Environment)
+
+            // Really not sure why, but bytes received for this test varies randomly when run in CI
+            // TODO: remove this and investigate
+            .IgnoreMember("bytes_received")
+
             .ScrubLinesWithReplace(line =>
             {
                 if (line.StartsWith("Executed DbCommand ("))
@@ -128,15 +133,6 @@ public class SqlListenerTests : IClassFixture<LocalDbFixture>
                 {
                     return "Failed executing DbCommand";
                 }
-
-#if CI_BUILD
-                // Really not sure why, but bytes received for this test only are different in CI
-                // TODO: remove this and investigate
-                if (line.Contains("bytes_received"))
-                {
-                    return line.Replace("677", "665");
-                }
-#endif
 
                 var efVersion = typeof(DbContext).Assembly.GetName().Version!.ToString(3);
                 return line.Replace(efVersion, "");

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.verify.cs
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.verify.cs
@@ -129,6 +129,15 @@ public class SqlListenerTests : IClassFixture<LocalDbFixture>
                     return "Failed executing DbCommand";
                 }
 
+#if CI_BUILD
+                // Really not sure why, but bytes received for this test only are different in CI
+                // TODO: remove this and investigate
+                if (line.Contains("bytes_received"))
+                {
+                    return line.Replace("677", "665");
+                }
+#endif
+
                 var efVersion = typeof(DbContext).Assembly.GetName().Version!.ToString(3);
                 return line.Replace(efVersion, "");
             })

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.verify.cs
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.verify.cs
@@ -37,8 +37,13 @@ public class SqlListenerTests : IClassFixture<LocalDbFixture>
             var transaction = hub.StartTransaction("my transaction", "my operation");
             hub.ConfigureScope(scope => scope.Transaction = transaction);
             hub.CaptureException(new("my exception"));
-            await TestDbBuilder.AddDataAsync(database);
-            await TestDbBuilder.GetDataAsync(database);
+
+            await using (var connection = await database.OpenNewConnection())
+            {
+                await TestDbBuilder.AddDataAsync(connection);
+                await TestDbBuilder.GetDataAsync(connection);
+            }
+
             transaction.Finish();
         }
 
@@ -70,44 +75,41 @@ public class SqlListenerTests : IClassFixture<LocalDbFixture>
         var options = new SentryLoggingOptions();
         ApplyOptions(options);
 
-        var loggerFactory = LoggerFactory.Create(_ => _.AddSentry(ApplyOptions));
-
-#if NET6_0_OR_GREATER
         await using var database = await _fixture.SqlInstance.Build();
-#else
-        using var database = await _fixture.SqlInstance.Build();
-#endif
-        var builder = new DbContextOptionsBuilder<TestDbContext>();
-        builder.UseSqlServer(database);
-        builder.UseLoggerFactory(loggerFactory);
-        builder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
 
-        await using var dbContext = new TestDbContext(builder.Options);
-        dbContext.Add(new TestEntity
+        await using (var dbContext = TestDbBuilder.GetDbContext(database.Connection))
         {
-            Property = "Value"
-        });
-
-        await dbContext.SaveChangesAsync();
-
-        using (var hub = new Hub(options))
-        {
-            var transaction = hub.StartTransaction("my transaction", "my operation");
-            hub.ConfigureScope(scope => scope.Transaction = transaction);
-
             dbContext.Add(new TestEntity
             {
                 Property = "Value"
             });
 
-            try
+            await dbContext.SaveChangesAsync();
+        }
+
+        var loggerFactory = LoggerFactory.Create(_ => _.AddSentry(ApplyOptions));
+        using (var hub = new Hub(options))
+        {
+            var transaction = hub.StartTransaction("my transaction", "my operation");
+            hub.ConfigureScope(scope => scope.Transaction = transaction);
+
+            await using (var connection = await database.OpenNewConnection())
+            await using (var dbContext = TestDbBuilder.GetDbContext(connection, loggerFactory))
             {
-                await dbContext.SaveChangesAsync();
-            }
-            catch
-            {
-                // Suppress the exception so we can test that we received the error through logging.
-                // Note, this uses the Sentry.Extensions.Logging integration.
+                dbContext.Add(new TestEntity
+                {
+                    Property = "Value"
+                });
+
+                try
+                {
+                    await dbContext.SaveChangesAsync();
+                }
+                catch
+                {
+                    // Suppress the exception so we can test that we received the error through logging.
+                    // Note, this uses the Sentry.Extensions.Logging integration.
+                }
             }
 
             transaction.Finish();
@@ -191,8 +193,17 @@ public class SqlListenerTests : IClassFixture<LocalDbFixture>
             var transaction = hub.StartTransaction("my transaction", "my operation");
             hub.ConfigureScope(scope => scope.Transaction = transaction);
             hub.CaptureException(new("my exception"));
-            await TestDbBuilder.AddEfDataAsync(database);
-            await TestDbBuilder.GetEfDataAsync(database);
+
+#if NETCOREAPP
+            await using (var connection = await database.OpenNewConnection())
+#else
+            using (var connection = await database.OpenNewConnection())
+#endif
+            {
+                await TestDbBuilder.AddEfDataAsync(connection);
+                await TestDbBuilder.GetEfDataAsync(connection);
+            }
+
             transaction.Finish();
         }
 

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.verify.cs
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.verify.cs
@@ -58,8 +58,6 @@ public class SqlListenerTests : IClassFixture<LocalDbFixture>
     [SkippableFact]
     public async Task Logging()
     {
-        _logger.LogDebug(RelationalEventId.CommandError.Name!);
-
         Skip.If(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
         var transport = new RecordingTransport();
 

--- a/test/Sentry.DiagnosticSource.IntegrationTests/TestDbBuilder.cs
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/TestDbBuilder.cs
@@ -17,11 +17,16 @@ public static class TestDbBuilder
         await command.ExecuteNonQueryAsync();
     }
 
-    private static TestDbContext GetDbContext(SqlConnection connection)
+    public static TestDbContext GetDbContext(SqlConnection connection, ILoggerFactory loggerFactory = null)
     {
         var builder = new DbContextOptionsBuilder<TestDbContext>();
         builder.UseSqlServer(connection);
         builder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
+        if (loggerFactory != null)
+        {
+            builder.UseLoggerFactory(loggerFactory);
+        }
+
         return new TestDbContext(builder.Options);
     }
 

--- a/test/Sentry.DiagnosticSource.Tests/SentrySqlListenerTests.cs
+++ b/test/Sentry.DiagnosticSource.Tests/SentrySqlListenerTests.cs
@@ -13,9 +13,7 @@ public class SentrySqlListenerTests
                 SqlMicrosoftWriteConnectionOpenAfterCommand or
                 SqlDataWriteConnectionOpenAfterCommand or
                 SqlMicrosoftWriteConnectionCloseAfterCommand or
-                SqlDataWriteConnectionCloseAfterCommand or
-                SqlDataWriteTransactionCommitAfter or
-                SqlMicrosoftWriteTransactionCommitAfter =>
+                SqlDataWriteConnectionCloseAfterCommand =>
                 span => span.Description is null &&
                         span.Operation == "db.connection",
             SqlDataBeforeExecuteCommand or
@@ -138,7 +136,7 @@ public class SentrySqlListenerTests
     [Theory]
     [InlineData(SqlMicrosoftWriteConnectionOpenBeforeCommand, SqlMicrosoftWriteConnectionOpenAfterCommand, SqlMicrosoftWriteConnectionCloseAfterCommand, SqlMicrosoftBeforeExecuteCommand, SqlMicrosoftAfterExecuteCommand)]
     [InlineData(SqlDataWriteConnectionOpenBeforeCommand, SqlDataWriteConnectionOpenAfterCommand, SqlDataWriteConnectionCloseAfterCommand, SqlDataBeforeExecuteCommand, SqlDataAfterExecuteCommand)]
-    public void OnNext_HappyPathsWithoutTransaction_IsValid(string connectionOpenKey, string connectionUpdateKey, string connectionCloseKey, string queryStartKey, string queryEndKey)
+    public void OnNext_HappyPaths_IsValid(string connectionOpenKey, string connectionUpdateKey, string connectionCloseKey, string queryStartKey, string queryEndKey)
     {
         // Arrange
         var hub = _fixture.Hub;
@@ -166,55 +164,6 @@ public class SentrySqlListenerTests
             new(connectionCloseKey,
                 new { OperationId = connectionOperationIdClosed, ConnectionId = connectionId }));
         //Connection", "ClientConnectionId
-        // Assert
-        _fixture.Spans.Should().HaveCount(2);
-        var connectionSpan = _fixture.Spans.First(s => GetValidator(connectionOpenKey)(s));
-        var commandSpan = _fixture.Spans.First(s => GetValidator(queryStartKey)(s));
-
-        // Validate if all spans were finished.
-        Assert.All(_fixture.Spans, span =>
-        {
-            Assert.True(span.IsFinished);
-            Assert.Equal(SpanStatus.Ok, span.Status);
-        });
-        // Check connections between spans.
-        Assert.Equal(_fixture.Tracer.SpanId, connectionSpan.ParentSpanId);
-        Assert.Equal(connectionSpan.SpanId, commandSpan.ParentSpanId);
-
-        Assert.Equal(query, commandSpan.Description);
-    }
-
-    [Theory]
-    [InlineData(SqlMicrosoftWriteConnectionOpenBeforeCommand, SqlMicrosoftWriteConnectionOpenAfterCommand, SqlMicrosoftWriteTransactionCommitAfter, SqlMicrosoftBeforeExecuteCommand, SqlMicrosoftAfterExecuteCommand)]
-    [InlineData(SqlDataWriteConnectionOpenBeforeCommand, SqlDataWriteConnectionOpenAfterCommand, SqlDataWriteTransactionCommitAfter, SqlDataBeforeExecuteCommand, SqlDataAfterExecuteCommand)]
-    public void OnNext_HappyPathsWithTransaction_IsValid(string connectionOpenKey, string connectionUpdateKey, string connectionCloseKey, string queryStartKey, string queryEndKey)
-    {
-        // Arrange
-        var hub = _fixture.Hub;
-        var interceptor = new SentrySqlListener(hub, new SentryOptions());
-        var query = "SELECT * FROM ...";
-        var connectionId = Guid.NewGuid();
-        var connectionOperationId = Guid.NewGuid();
-        var connectionOperationIdClosed = Guid.NewGuid();
-        var queryOperationId = Guid.NewGuid();
-
-        // Act
-        interceptor.OnNext(
-            new(connectionOpenKey,
-                new { OperationId = connectionOperationId }));
-        interceptor.OnNext(
-            new(connectionUpdateKey,
-                new { OperationId = connectionOperationId, ConnectionId = connectionId }));
-        interceptor.OnNext(
-            new(queryStartKey,
-                new { OperationId = queryOperationId, ConnectionId = connectionId }));
-        interceptor.OnNext(
-            new(queryEndKey,
-                new { OperationId = queryOperationId, ConnectionId = connectionId, Command = new { CommandText = query } }));
-        interceptor.OnNext(
-            new(connectionCloseKey,
-                new { OperationId = connectionOperationIdClosed, Connection = new { ClientConnectionId = connectionId } }));
-
         // Assert
         _fixture.Spans.Should().HaveCount(2);
         var connectionSpan = _fixture.Spans.First(s => GetValidator(connectionOpenKey)(s));


### PR DESCRIPTION
In #1179, some logic was added to close connection spans when `WriteTransactionCommitAfter`.  The comments from the state that `WriteConnectionCloseAfter` was not called in certain cases.  However, after investigating, I believe this was an incorrect assumption.  The actual reason `WriteConnectionCloseAfter` may not fire is when the connection is actually held open.  Committing a transaction isn't a good place to close the connection span, because more than one command (and more than one transaction) can execute on a given connection.

Indeed, our own [`RecordsEf`](https://github.com/getsentry/sentry-dotnet/blob/ee7920b94d53e07bb640ce1773ee7ccd0254f46f/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.verify.cs#L167) integration test (added later) was showing the connection span warning, because _both_ the `WriteTransactionCommitAfter` and `WriteConnectionCloseAfter` events were firing.  Since the first one closed the connection span, the second one failed to find an unfinished span.

Therefore, the fix is to remove that logic and close the connection span only with `WriteConnectionCloseAfter`.

Also, some of our integration tests were not capturing the connection span correctly in the first place - because they were re-using a connection that was opened automatically by creating the LocalDB instance, which was done *before* the hub was initialized.  I fixed these tests such that they open, use, and close a new db connection within the Sentry transaction being captured.

As a sanity check, I ran the new tests with the versions of EF Core and SQL Client that were used at the time #1179 was authored, and I was not able to get any scenario where `WriteConnectionCloseAfter` was not called.  Thus, it wasn't related to some other older EF/SQL bug.

Also, a nice side-effect of this change is that connection statistics are now captured in more cases.

I'll drop some more comments inline.

Should fix #2060 (at least in part)