### PR TITLE
Attach db connections to child spans correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix missing stack trace on UnobservedTaskException ([#2067](https://github.com/getsentry/sentry-dotnet/pull/2067))
 - Fix warning caused by db connection span closed prematurely ([#2068](https://github.com/getsentry/sentry-dotnet/pull/2068))
+- Attach db connections to child spans correctly ([#2071](https://github.com/getsentry/sentry-dotnet/pull/2071))
 
 ## 3.24.0
 

--- a/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentryEFCoreListener.cs
+++ b/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentryEFCoreListener.cs
@@ -66,7 +66,7 @@ internal class SentryEFCoreListener : IObserver<KeyValuePair<string, object?>>
     {
         _hub.ConfigureScope(scope =>
         {
-            if (scope.Transaction?.IsSampled != true)
+            if (scope.Transaction is not {IsSampled: true} transaction)
             {
                 return;
             }

--- a/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentrySqlListener.cs
+++ b/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentrySqlListener.cs
@@ -78,12 +78,12 @@ internal class SentrySqlListener : IObserver<KeyValuePair<string, object?>>
 
             switch (type)
             {
-                case SentrySqlSpanType.Connection when transaction.StartChild(operation) is { } connectionSpan:
+                case SentrySqlSpanType.Connection when transaction.GetDbParentSpan().StartChild(operation) is { } connectionSpan:
                     SetOperationId(connectionSpan, operationId);
                     break;
 
                 case SentrySqlSpanType.Execution when value?.GetGuidProperty("ConnectionId") is { } connectionId:
-                    var parent = TryGetConnectionSpan(scope, connectionId) ?? transaction;
+                    var parent = TryGetConnectionSpan(scope, connectionId) ?? transaction.GetDbParentSpan();
                     var span = TryStartChild(parent, operation, null);
                     if (span != null)
                     {

--- a/test/Sentry.DiagnosticSource.Tests/DiagnosticsSentryOptionsExtensionsTests.cs
+++ b/test/Sentry.DiagnosticSource.Tests/DiagnosticsSentryOptionsExtensionsTests.cs
@@ -16,7 +16,7 @@ public class DiagnosticsSentryOptionsExtensionsTests
         TracesSampler = null
     };
 
-    public DiagnosticsSentryOptionsExtensionsTests(ITestOutputHelper output)
+    public DiagnosticsSentryOptionsExtensionsTests()
     {
 #if NETFRAMEWORK
         _options.AddDiagnosticSourceIntegration();

--- a/test/Sentry.DiagnosticSource.Tests/SentrySqlListenerTests.cs
+++ b/test/Sentry.DiagnosticSource.Tests/SentrySqlListenerTests.cs
@@ -16,6 +16,7 @@ public class SentrySqlListenerTests
                 SqlDataWriteConnectionCloseAfterCommand =>
                 span => span.Description is null &&
                         span.Operation == "db.connection",
+
             SqlDataBeforeExecuteCommand or
                 SqlMicrosoftBeforeExecuteCommand or
                 SqlDataAfterExecuteCommand or
@@ -28,13 +29,11 @@ public class SentrySqlListenerTests
 
     private class ThrowToOperationClass
     {
-        private string _operationId;
-        public string OperationId
-        {
-            get => throw new Exception();
-            set => _operationId = value;
-        }
+        // ReSharper disable UnusedMember.Local
+        public string OperationId => throw new Exception();
+
         public string ConnectionId { get; set; }
+        // ReSharper restore UnusedMember.Local
     }
 
     private class Fixture
@@ -46,7 +45,8 @@ public class SentrySqlListenerTests
         public SentryOptions Options { get; }
 
         public IReadOnlyCollection<ISpan> Spans => Tracer?.Spans;
-        public IHub Hub { get; set; }
+        public IHub Hub { get; }
+
         public Fixture()
         {
             Logger = new InMemoryDiagnosticLogger();
@@ -56,17 +56,20 @@ public class SentrySqlListenerTests
                 Debug = true,
                 DiagnosticLogger = Logger,
                 DiagnosticLevel = SentryLevel.Debug,
-                TracesSampleRate = 1,
+                TracesSampleRate = 1
             };
+
+            Hub = Substitute.For<IHub>();
             Tracer = new TransactionTracer(Hub, "foo", "bar")
             {
                 IsSampled = true
             };
+
             var scope = new Scope
             {
                 Transaction = Tracer
             };
-            Hub = Substitute.For<IHub>();
+
             Hub.When(hub => hub.ConfigureScope(Arg.Any<Action<Scope>>()))
                 .Do(callback => callback.Arg<Action<Scope>>().Invoke(scope));
         }
@@ -106,7 +109,15 @@ public class SentrySqlListenerTests
         // Act
         interceptor.OnNext(
             new(key,
-                new { OperationId = Guid.NewGuid(), ConnectionId = Guid.NewGuid(), Command = new { CommandText = "" } }));
+                new
+                {
+                    OperationId = Guid.NewGuid(),
+                    ConnectionId = Guid.NewGuid(),
+                    Command = new
+                    {
+                        CommandText = ""
+                    }
+                }));
 
         // Assert
         var spans = _fixture.Spans.Where(s => s.Operation != "abc");
@@ -128,15 +139,27 @@ public class SentrySqlListenerTests
         // Act
         interceptor.OnNext(
             new(key,
-                new { OperationId = Guid.NewGuid(), ConnectionId = Guid.NewGuid(), Command = new { CommandText = "" } }));
+                new
+                {
+                    OperationId = Guid.NewGuid(),
+                    ConnectionId = Guid.NewGuid(),
+                    Command = new
+                    {
+                        CommandText = ""
+                    }
+                }));
 
         Assert.Empty(_fixture.Tracer.Spans);
     }
 
     [Theory]
-    [InlineData(SqlMicrosoftWriteConnectionOpenBeforeCommand, SqlMicrosoftWriteConnectionOpenAfterCommand, SqlMicrosoftWriteConnectionCloseAfterCommand, SqlMicrosoftBeforeExecuteCommand, SqlMicrosoftAfterExecuteCommand)]
-    [InlineData(SqlDataWriteConnectionOpenBeforeCommand, SqlDataWriteConnectionOpenAfterCommand, SqlDataWriteConnectionCloseAfterCommand, SqlDataBeforeExecuteCommand, SqlDataAfterExecuteCommand)]
-    public void OnNext_HappyPaths_IsValid(string connectionOpenKey, string connectionUpdateKey, string connectionCloseKey, string queryStartKey, string queryEndKey)
+    [InlineData(SqlMicrosoftWriteConnectionOpenBeforeCommand, SqlMicrosoftWriteConnectionOpenAfterCommand,
+        SqlMicrosoftWriteConnectionCloseAfterCommand, SqlMicrosoftBeforeExecuteCommand,
+        SqlMicrosoftAfterExecuteCommand)]
+    [InlineData(SqlDataWriteConnectionOpenBeforeCommand, SqlDataWriteConnectionOpenAfterCommand,
+        SqlDataWriteConnectionCloseAfterCommand, SqlDataBeforeExecuteCommand, SqlDataAfterExecuteCommand)]
+    public void OnNext_HappyPaths_IsValid(string connectionOpenKey, string connectionUpdateKey,
+        string connectionCloseKey, string queryStartKey, string queryEndKey)
     {
         // Arrange
         var hub = _fixture.Hub;
@@ -150,31 +173,56 @@ public class SentrySqlListenerTests
         // Act
         interceptor.OnNext(
             new(connectionOpenKey,
-                new { OperationId = connectionOperationId }));
+                new
+                {
+                    OperationId = connectionOperationId
+                }));
         interceptor.OnNext(
             new(connectionUpdateKey,
-                new { OperationId = connectionOperationId, ConnectionId = connectionId }));
+                new
+                {
+                    OperationId = connectionOperationId,
+                    ConnectionId = connectionId
+                }));
         interceptor.OnNext(
             new(queryStartKey,
-                new { OperationId = queryOperationId, ConnectionId = connectionId }));
+                new
+                {
+                    OperationId = queryOperationId,
+                    ConnectionId = connectionId
+                }));
         interceptor.OnNext(
             new(queryEndKey,
-                new { OperationId = queryOperationId, ConnectionId = connectionId, Command = new { CommandText = query } }));
+                new
+                {
+                    OperationId = queryOperationId,
+                    ConnectionId = connectionId,
+                    Command = new
+                    {
+                        CommandText = query
+                    }
+                }));
         interceptor.OnNext(
             new(connectionCloseKey,
-                new { OperationId = connectionOperationIdClosed, ConnectionId = connectionId }));
-        //Connection", "ClientConnectionId
+                new
+                {
+                    OperationId = connectionOperationIdClosed,
+                    ConnectionId = connectionId
+                }));
+
         // Assert
         _fixture.Spans.Should().HaveCount(2);
         var connectionSpan = _fixture.Spans.First(s => GetValidator(connectionOpenKey)(s));
         var commandSpan = _fixture.Spans.First(s => GetValidator(queryStartKey)(s));
 
         // Validate if all spans were finished.
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         Assert.All(_fixture.Spans, span =>
         {
             Assert.True(span.IsFinished);
             Assert.Equal(SpanStatus.Ok, span.Status);
         });
+
         // Check connections between spans.
         Assert.Equal(_fixture.Tracer.SpanId, connectionSpan.ParentSpanId);
         Assert.Equal(connectionSpan.SpanId, commandSpan.ParentSpanId);
@@ -183,47 +231,70 @@ public class SentrySqlListenerTests
     }
 
     [Theory]
-    [InlineData(SqlMicrosoftWriteConnectionOpenBeforeCommand, SqlMicrosoftWriteConnectionOpenAfterCommand, SqlMicrosoftWriteConnectionCloseAfterCommand)]
-    [InlineData(SqlDataWriteConnectionOpenBeforeCommand, SqlDataWriteConnectionOpenAfterCommand, SqlDataWriteConnectionCloseAfterCommand)]
-    public void OnNext_TwoConnectionSpansWithSameId_FinishBothWithOk(string connectionBeforeKey, string connectionUpdate, string connectionClose)
+    [InlineData(SqlMicrosoftWriteConnectionOpenBeforeCommand, SqlMicrosoftWriteConnectionOpenAfterCommand,
+        SqlMicrosoftWriteConnectionCloseAfterCommand)]
+    [InlineData(SqlDataWriteConnectionOpenBeforeCommand, SqlDataWriteConnectionOpenAfterCommand,
+        SqlDataWriteConnectionCloseAfterCommand)]
+    public void OnNext_TwoConnectionSpansWithSameId_FinishBothWithOk(string connectionBeforeKey,
+        string connectionUpdate, string connectionClose)
     {
         // Arrange
         var hub = _fixture.Hub;
         var interceptor = new SentrySqlListener(hub, new SentryOptions());
         var connectionId = Guid.NewGuid();
-        var connectionOperationIds = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var connectionOperationIds = new List<Guid>
+        {
+            Guid.NewGuid(),
+            Guid.NewGuid()
+        };
 
         // Act
         for (var i = 0; i < 2; i++)
         {
             interceptor.OnNext(
                 new(connectionBeforeKey,
-                    new { OperationId = connectionOperationIds[i] }));
+                    new
+                    {
+                        OperationId = connectionOperationIds[i]
+                    }));
             // Connection Id is set.
             interceptor.OnNext(
                 new(connectionUpdate,
-                    new { OperationId = connectionOperationIds[i], ConnectionId = connectionId }));
+                    new
+                    {
+                        OperationId = connectionOperationIds[i],
+                        ConnectionId = connectionId
+                    }));
             interceptor.OnNext(
                 new(connectionClose,
-                    new { OperationId = connectionOperationIds[i], ConnectionId = connectionId }));
+                    new
+                    {
+                        OperationId = connectionOperationIds[i],
+                        ConnectionId = connectionId
+                    }));
         }
 
         // Assert
         _fixture.Spans.Should().HaveCount(2);
 
         // Validate if all spans were finished.
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         Assert.All(_fixture.Spans, span =>
         {
             Assert.True(span.IsFinished);
             Assert.Equal(SpanStatus.Ok, span.Status);
-            Assert.Equal(connectionId, (Guid)span.Extra[ConnectionExtraKey]);
+            Assert.Equal(connectionId, (Guid)span.Extra[ConnectionExtraKey]!);
         });
     }
 
     [Theory]
-    [InlineData(SqlMicrosoftWriteConnectionOpenBeforeCommand, SqlMicrosoftWriteConnectionOpenAfterCommand, SqlMicrosoftWriteConnectionCloseAfterCommand, SqlMicrosoftBeforeExecuteCommand, SqlMicrosoftAfterExecuteCommand)]
-    [InlineData(SqlDataWriteConnectionOpenBeforeCommand, SqlDataWriteConnectionOpenAfterCommand, SqlDataWriteConnectionCloseAfterCommand, SqlDataBeforeExecuteCommand, SqlDataAfterExecuteCommand)]
-    public void OnNext_ExecuteQueryCalledBeforeConnectionId_ExecuteParentIsConnectionSpan(string connectionBeforeKey, string connectionUpdate, string connectionClose, string executeBeforeKey, string executeAfterKey)
+    [InlineData(SqlMicrosoftWriteConnectionOpenBeforeCommand, SqlMicrosoftWriteConnectionOpenAfterCommand,
+        SqlMicrosoftWriteConnectionCloseAfterCommand, SqlMicrosoftBeforeExecuteCommand,
+        SqlMicrosoftAfterExecuteCommand)]
+    [InlineData(SqlDataWriteConnectionOpenBeforeCommand, SqlDataWriteConnectionOpenAfterCommand,
+        SqlDataWriteConnectionCloseAfterCommand, SqlDataBeforeExecuteCommand, SqlDataAfterExecuteCommand)]
+    public void OnNext_ExecuteQueryCalledBeforeConnectionId_ExecuteParentIsConnectionSpan(string connectionBeforeKey,
+        string connectionUpdate, string connectionClose, string executeBeforeKey, string executeAfterKey)
     {
         // Arrange
         var hub = _fixture.Hub;
@@ -236,22 +307,45 @@ public class SentrySqlListenerTests
         // Act
         interceptor.OnNext(
             new(connectionBeforeKey,
-                new { OperationId = connectionOperationId }));
+                new
+                {
+                    OperationId = connectionOperationId
+                }));
         // Connection span has no connection ID and query will temporarily have Transaction as parent.
         interceptor.OnNext(
             new(executeBeforeKey,
-                new { OperationId = queryOperationId, ConnectionId = connectionId }));
+                new
+                {
+                    OperationId = queryOperationId,
+                    ConnectionId = connectionId
+                }));
         // Connection Id is set.
         interceptor.OnNext(
             new(connectionUpdate,
-                new { OperationId = connectionOperationId, ConnectionId = connectionId }));
+                new
+                {
+                    OperationId = connectionOperationId,
+                    ConnectionId = connectionId
+                }));
         // Query sets ParentId to ConnectionId.
         interceptor.OnNext(
             new(executeAfterKey,
-                new { OperationId = queryOperationId, ConnectionId = connectionId, Command = new { CommandText = query } }));
+                new
+                {
+                    OperationId = queryOperationId,
+                    ConnectionId = connectionId,
+                    Command = new
+                    {
+                        CommandText = query
+                    }
+                }));
         interceptor.OnNext(
             new(connectionClose,
-                new { OperationId = connectionOperationId, ConnectionId = connectionId }));
+                new
+                {
+                    OperationId = connectionOperationId,
+                    ConnectionId = connectionId
+                }));
 
         // Assert
         _fixture.Spans.Should().HaveCount(2);
@@ -259,11 +353,13 @@ public class SentrySqlListenerTests
         var commandSpan = _fixture.Spans.First(s => GetValidator(executeBeforeKey)(s));
 
         // Validate if all spans were finished.
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         Assert.All(_fixture.Spans, span =>
         {
             Assert.True(span.IsFinished);
             Assert.Equal(SpanStatus.Ok, span.Status);
         });
+
         // Check connections between spans.
         Assert.Equal(_fixture.Tracer.SpanId, connectionSpan.ParentSpanId);
         Assert.Equal(connectionSpan.SpanId, commandSpan.ParentSpanId);
@@ -317,9 +413,10 @@ public class SentrySqlListenerTests
             {
                 ready.Set();
             }
+
             evt.WaitOne();
 
-            // 1 repeated connection  with 1 query where the first query will start before connection span gets the connectionId.
+            // 1 repeated connection with 1 query where the first query will start before connection span gets the connectionId.
             void SimulateDbRequest(List<Guid> connectionOperationIds, List<Guid> queryOperationIds)
             {
                 interceptor.OpenConnectionStart(connectionOperationIds[threadId]);
@@ -328,9 +425,12 @@ public class SentrySqlListenerTests
                 interceptor.ExecuteQueryFinish(queryOperationIds[threadId], connectionsIds[threadId], query);
                 interceptor.OpenConnectionClose(connectionOperationIds[threadId], connectionsIds[threadId]);
             }
+
             SimulateDbRequest(connectionOperationsIds, queryOperationsIds);
             SimulateDbRequest(connectionOperations2Ids, queryOperations2Ids);
+
         })).ToList();
+
         ready.WaitOne();
         evt.Set();
         await Task.WhenAll(taskList);
@@ -354,6 +454,7 @@ public class SentrySqlListenerTests
         Assert.All(closedSpans, span => Assert.Equal(SpanStatus.Ok, span.Status));
 
         // Assert that all connectionIds is set and ParentId set to Trace.
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         Assert.All(closedConnectionSpans, connectionSpan =>
         {
             Assert.NotNull(connectionSpan.Extra[ConnectionExtraKey]);
@@ -365,11 +466,11 @@ public class SentrySqlListenerTests
         Assert.All(querySpans, querySpan =>
         {
             Assert.True(querySpan.IsFinished);
-            var connectionId = (Guid)querySpan.Extra[ConnectionExtraKey];
+            var connectionId = (Guid)querySpan.Extra[ConnectionExtraKey]!;
             var connectionSpan = connectionSpans.Single(span => span.SpanId == querySpan.ParentSpanId);
 
             Assert.NotEqual(_fixture.Tracer.SpanId, querySpan.ParentSpanId);
-            Assert.Equal((Guid)connectionSpan.Extra[ConnectionExtraKey], connectionId);
+            Assert.Equal((Guid)connectionSpan.Extra[ConnectionExtraKey]!, connectionId);
         });
 
         _fixture.Logger.Entries.Should().BeEmpty();
@@ -390,20 +491,43 @@ public class SentrySqlListenerTests
         // Act
         interceptor.OnNext(
             new(SqlMicrosoftWriteConnectionOpenBeforeCommand,
-                new { OperationId = connectionOperationId }));
+                new
+                {
+                    OperationId = connectionOperationId
+                }));
         interceptor.OnNext(
             new(SqlMicrosoftWriteConnectionOpenAfterCommand,
-                new { OperationId = connectionOperationId, ConnectionId = connectionId }));
+                new
+                {
+                    OperationId = connectionOperationId,
+                    ConnectionId = connectionId
+                }));
         interceptor.OnNext(
             new(SqlMicrosoftBeforeExecuteCommand,
-                new { OperationId = queryOperationId, ConnectionId = connectionId }));
+                new
+                {
+                    OperationId = queryOperationId,
+                    ConnectionId = connectionId
+                }));
         //Errored Query
         interceptor.OnNext(
             new(SqlMicrosoftWriteCommandError,
-                new { OperationId = queryOperationId, ConnectionId = connectionId, Command = new { CommandText = query } }));
+                new
+                {
+                    OperationId = queryOperationId,
+                    ConnectionId = connectionId,
+                    Command = new
+                    {
+                        CommandText = query
+                    }
+                }));
         interceptor.OnNext(
             new(SqlMicrosoftWriteConnectionCloseAfterCommand,
-                new { OperationId = connectionOperationIdClosed, ConnectionId = connectionId }));
+                new
+                {
+                    OperationId = connectionOperationIdClosed,
+                    ConnectionId = connectionId
+                }));
 
         // Assert
         _fixture.Spans.Should().HaveCount(2);


### PR DESCRIPTION
Ensures that db connection spans are placed on the last active non-db span, rather than the transaction root.

Fixes #2023 

Replaces #1671 

Some minor refactoring/cleanup included as well.
