### PR TITLE
fix: SolutionDir pointed to wrong path when included from another solution, e.g. sentry-unity

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,6 @@
     <Deterministic>true</Deterministic>
     <Features>strict</Features>
     <ImplicitUsings>true</ImplicitUsings>
-    <SolutionDir>$(MSBuildThisFileDirectory)</SolutionDir>
 
     <!-- Allow references to unsigned assemblies (like MAUI) from signed projects -->
     <NoWarn>$(NoWarn);CS8002</NoWarn>
@@ -54,7 +53,7 @@
 
   <!-- Import the root global usings, except for samples. -->
   <ItemGroup Condition="!$(MSBuildProjectName.Contains('Samples'))">
-    <Compile Include="$(SolutionDir)GlobalUsings.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GlobalUsings.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -4,7 +4,7 @@
     <IsBindingProject>true</IsBindingProject>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
     <Description>.NET Bindings for the Sentry Cocoa SDK</Description>
-    <SentryCocoaSdkDirectory>$(SolutionDir)\modules\sentry-cocoa\</SentryCocoaSdkDirectory>
+    <SentryCocoaSdkDirectory>$(MSBuildThisFileDirectory)..\..\modules\sentry-cocoa\</SentryCocoaSdkDirectory>
     <SentryCocoaFramework>$(SentryCocoaSdkDirectory)Carthage\Build\Sentry.xcframework</SentryCocoaFramework>
   </PropertyGroup>
 

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -16,7 +16,7 @@
     <NativeReference Include="$(SentryCocoaFramework)" Kind="Framework" />
 
     <!-- Use a separate readme file in the nuget. -->
-    <None Remove="$(SolutionDir)README.md" />
+    <None Remove="$(MSBuildThisFileDirectory)..\..\README.md" />
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="" />
 
     <!-- Don't add the changelog to the nuget. -->
@@ -31,7 +31,7 @@
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="_InnerBuildSentryCocoaSDK" Properties="TargetFramework=once" />
   </Target>
   <Target Name="_InnerBuildSentryCocoaSDK">
-    <Exec Command="$(SolutionDir)scripts/build-sentry-cocoa.sh" />
+    <Exec Command="$(MSBuildThisFileDirectory)../../scripts/build-sentry-cocoa.sh" />
   </Target>
 
 </Project>


### PR DESCRIPTION
#skip-changelog