### PR TITLE
Build/Test on Ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Using ubuntu-20.04 because ubuntu-latest is 22.04, which is fails Sentry.DiagnosticSource.Tests due to a SQLite on Mono issue.
         # Using macos-12 because we need Xcode 13.3 or later to build Sentry.Samples.Maui. (macos-latest currently points at macos-11 which uses Xcode 13.2)
         # Using windows-2019 because windows-latest is much slower and we don't need anything in particular from it.
-        os: [ubuntu-latest, windows-2019, macos-12]
+        os: [ubuntu-20.04, windows-2019, macos-12]
 
     steps:
       - name: Cancel Previous Runs


### PR DESCRIPTION
The `ubuntu-latest` image recently [moved from 20.04 to 22.04](https://github.com/actions/runner-images/issues/6399).

Shortly after this went into effect, we started getting test failures like this:

https://github.com/getsentry/sentry-dotnet/actions/runs/3625074115/jobs/6112708867#step:9:477

```
Error: System.TypeInitializationException : The type initializer for 'Microsoft.Data.Sqlite.SqliteConnection' threw an exception.
---- System.Reflection.TargetInvocationException : Exception has been thrown by the target of an invocation.
-------- System.Exception : Library e_sqlite3 not found

  Failed Sentry.DiagnosticSource.Tests.Integration.SQLite.SentryDiagnosticListenerTests.EfCoreIntegration_RunSynchronousQueryWithIssue_TransactionWithSpans [1 ms]
  Error Message:
   System.TypeInitializationException : The type initializer for 'Microsoft.Data.Sqlite.SqliteConnection' threw an exception.
---- System.Reflection.TargetInvocationException : Exception has been thrown by the target of an invocation.
-------- System.Exception : Library e_sqlite3 not found
  Stack Trace:
    at (wrapper managed-to-native) System.Object.__icall_wrapper_mono_generic_class_init(intptr)
  at Sentry.DiagnosticSource.Tests.Integration.SQLite.Database.CreateInMemoryDatabase () [0x00000] in <c9a1e384f84041bca9797b258b3a9c7d>:0 
  at Sentry.DiagnosticSource.Tests.Integration.SQLite.Database..ctor () [0x0000c] in <c9a1e384f84041bca9797b258b3a9c7d>:0 
  at Sentry.DiagnosticSource.Tests.Integration.SQLite.SentryDiagnosticListenerTests+Fixture..ctor () [0x000ec] in <c9a1e384f84041bca9797b258b3a9c7d>:0 
  at Sentry.DiagnosticSource.Tests.Integration.SQLite.SentryDiagnosticListenerTests..ctor () [0x00000] in <c9a1e384f84041bca9797b258b3a9c7d>:0 
  at (wrapper managed-to-native) System.Reflection.RuntimeConstructorInfo.InternalInvoke(System.Reflection.RuntimeConstructorInfo,object,object[],System.Exception&)
  at System.Reflection.RuntimeConstructorInfo.InternalInvoke (System.Object obj, System.Object[] parameters, System.Boolean wrapExceptions) [0x00005] in <de882a77e7c14f8ba5d298093dde82b2>:0 
----- Inner Stack Trace -----
  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00083] in <de882a77e7c14f8ba5d298093dde82b2>:0 
  at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in <de882a77e7c14f8ba5d298093dde82b2>:0 
  at Microsoft.Data.Sqlite.Utilities.BundleInitializer.Initialize () [0x0003a] in <79a9f3775da2436f8935b2e2f50b64dd>:0 
  at Microsoft.Data.Sqlite.SqliteConnection..cctor () [0x00000] in <79a9f3775da2436f8935b2e2f50b64dd>:0 
----- Inner Stack Trace -----
  at SQLitePCL.NativeLibrary.Load (System.String libraryName, System.Reflection.Assembly assy, System.Int32 flags) [0x00044] in <1f6960d44e444551b60c466982e1cd1f>:0 
  at SQLitePCL.Batteries_V2.MakeDynamic (System.String name, System.Int32 flags) [0x00010] in <d32ddf456ac641318381e555d9fed557>:0 
  at SQLitePCL.Batteries_V2.DoDynamic_cdecl (System.String name, System.Int32 flags) [0x00000] in <d32ddf456ac641318381e555d9fed557>:0 
  at SQLitePCL.Batteries_V2.Init () [0x00000] in <d32ddf456ac641318381e555d9fed557>:0 
  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <de882a77e7c14f8ba5d298093dde82b2>:0 
```

I believe this is the same as reported here: https://github.com/ericsink/SQLitePCL.raw/issues/524

Switching back to `ubuntu-20.04` for now to mitigate.