### PR TITLE
Remove Windows target for device test app

### DIFF
--- a/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
+++ b/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
 
     <TargetFrameworks>net7.0-android</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
 
     <!-- Use arm runtime on arm Macs  -->


### PR DESCRIPTION
Building the `Sentry.Maui.Device.TestApp` project on a Windows machine is failing:

```
C:\Users\mattj\.nuget\packages\microsoft.windowsappsdk\1.1.5\buildTransitive\Microsoft.Build.Msix.Packaging.targets(1479,5)
: error APPX1101: Payload contains two or more files with the same destination path 'xunit.runner.utility.netcoreapp10.dll' 
. Source files:  [C:\Users\mattj\Code\getsentry\sentry-dotnet\test\Sentry.Maui.Device.TestApp\Sentry.Maui.Device.TestApp.cs 
proj::TargetFramework=net7.0-windows10.0.19041.0]
C:\Users\mattj\.nuget\packages\microsoft.windowsappsdk\1.1.5\buildTransitive\Microsoft.Build.Msix.Packaging.targets(1479,5) 
: error APPX1101: C:\Users\mattj\.nuget\packages\xunit.runner.visualstudio\2.4.5\build\netcoreapp3.1\xunit.runner.utility.n 
etcoreapp10.dll [C:\Users\mattj\Code\getsentry\sentry-dotnet\test\Sentry.Maui.Device.TestApp\Sentry.Maui.Device.TestApp.csp 
roj::TargetFramework=net7.0-windows10.0.19041.0]
C:\Users\mattj\.nuget\packages\microsoft.windowsappsdk\1.1.5\buildTransitive\Microsoft.Build.Msix.Packaging.targets(1479,5) 
: error APPX1101: C:\Users\mattj\.nuget\packages\xunit.runner.utility\2.4.2\lib\netcoreapp1.0\xunit.runner.utility.netcorea 
pp10.dll [C:\Users\mattj\Code\getsentry\sentry-dotnet\test\Sentry.Maui.Device.TestApp\Sentry.Maui.Device.TestApp.csproj::Ta 
rgetFramework=net7.0-windows10.0.19041.0]
```

Since we don't do Windows-specific device tests yet, we can mitigate by just removing this target.  If we ever want platform-specific tests for UWP, or MAUI for WinUI3, we can put it back and try to fix it at that time.

#skip-changelog