### PR TITLE
Set Xcode version

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -19,7 +19,9 @@ runs:
     - name: Set XCode Version
       if: runner.os == 'macOS'
       shell: bash
-      run: sudo xcode-select -s "/Applications/Xcode_14.1.app"
+      run: |
+        sudo xcode-select -s "/Applications/Xcode_14.1.app"
+        echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_14.1.app" >> $GITHUB_ENV
 
     # Note, the following is needed on the windows-2019 image only.
     # All other versions of .NET we need are pre-installed on the GitHub Actions virtual images.

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -16,6 +16,11 @@ runs:
         distribution: 'temurin'
         java-version: '11'
 
+    - name: Set XCode Version
+      if: runner.os == 'macOS'
+      shell: bash
+      run: sudo xcode-select -s "/Applications/Xcode_14.1.app"
+
     # Note, the following is needed on the windows-2019 image only.
     # All other versions of .NET we need are pre-installed on the GitHub Actions virtual images.
     - name: Install .NET 6 SDK


### PR DESCRIPTION
Fix macOS / iOS build failures due to default Xcode being 14.0.1 but MAUI needing 14.1

See https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode

Also: https://github.com/getsentry/sentry-dotnet/actions/runs/3709206020/jobs/6287586423#step:8:616

```
ILLINK : error MT2301: The linker step 'Setup' failed during processing: This version of Microsoft.iOS requires the iOS 16.1 SDK (shipped with Xcode 14.1). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options > Linker Behavior (to try to avoid the new APIs). [/Users/runner/work/sentry-dotnet/sentry-dotnet/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj]
```

#skip-changelog
