### PR TITLE
Fix hash string case

### DIFF
--- a/src/Sentry/Internal/Extensions/HashExtensions.cs
+++ b/src/Sentry/Internal/Extensions/HashExtensions.cs
@@ -2,11 +2,11 @@ namespace Sentry.Internal.Extensions;
 
 internal static class HashExtensions
 {
-    public static string GetHashString(this string str)
+    public static string GetHashString(this string str, bool upperCase = true)
     {
         var bytes = Encoding.UTF8.GetBytes(str);
         using var sha = SHA1.Create();
         var hash = sha.ComputeHash(bytes);
-        return hash.ToHexString();
+        return hash.ToHexString(upperCase);
     }
 }

--- a/src/Sentry/Internal/Extensions/MiscExtensions.cs
+++ b/src/Sentry/Internal/Extensions/MiscExtensions.cs
@@ -9,22 +9,27 @@ internal static class MiscExtensions
             ? value
             : null;
 
-    public static string ToHexString(this long l) => "0x" + l.ToString("x", CultureInfo.InvariantCulture);
+    public static string ToHexString(this long l, bool upperCase = false) =>
+        "0x" + l.ToString("x", CultureInfo.InvariantCulture);
 
-    public static string ToHexString(this byte[] bytes) => new ReadOnlySpan<byte>(bytes).ToHexString();
+    public static string ToHexString(this byte[] bytes, bool upperCase = false) =>
+        new ReadOnlySpan<byte>(bytes).ToHexString(upperCase);
 
-    public static string ToHexString(this Span<byte> bytes) => ((ReadOnlySpan<byte>)bytes).ToHexString();
+    public static string ToHexString(this Span<byte> bytes, bool upperCase = false) =>
+        ((ReadOnlySpan<byte>)bytes).ToHexString(upperCase);
 
-    public static string ToHexString(this ReadOnlySpan<byte> bytes)
+    public static string ToHexString(this ReadOnlySpan<byte> bytes, bool upperCase = false)
     {
 #if NET5_0_OR_GREATER
-        return Convert.ToHexString(bytes).ToLowerInvariant();
+        var s = Convert.ToHexString(bytes);
+        return upperCase ? s : s.ToLowerInvariant();
 #else
         var buffer = new StringBuilder(bytes.Length * 2);
+        var format = upperCase ? "X2" : "x2";
 
         foreach (var t in bytes)
         {
-            buffer.Append(t.ToString("x2", CultureInfo.InvariantCulture));
+            buffer.Append(t.ToString(format, CultureInfo.InvariantCulture));
         }
 
         return buffer.ToString();


### PR DESCRIPTION
In #2050 I refactored some code to consolidate the `ToHexString` internal extension method, and made it return the string in lower-case.

However, the existing `GetHashString` method was using upper case previously.  Switching to lower case created a problem (observed on iOS) where the caching transport failed to create its directory because another directory cased differently already existed.

This PR adds an option for the casing.  The default is lower-case, except for `GetHashString` where the default is upper-case to preserve previous behavior.

#skip-changelog because #2050 where the bug was introduced has not yet been released.