### PR TITLE
Update bundled Cocoa SDK to version 7.31.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add support for Portable PDB format ([#2050](https://github.com/getsentry/sentry-dotnet/pull/2050))
+- Update bundled Cocoa SDK to version 7.31.4 ([#2096](https://github.com/getsentry/sentry-dotnet/pull/2096))
 
 ## 3.24.1
 

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -26,6 +26,17 @@
     <None Include="buildTransitive\Sentry.Bindings.Cocoa.targets" Pack="true" PackagePath="buildTransitive\Sentry.Bindings.Cocoa.targets" />
   </ItemGroup>
 
+  <!-- Workaround for https://github.com/xamarin/xamarin-macios/issues/15299 -->
+  <Target Name="_SetGeneratedSupportDelegatesInternal" BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <GeneratedSupportDelegatesFile>$(MSBuildThisFileDirectory)$(GeneratedSourcesDir)SupportDelegates.g.cs</GeneratedSupportDelegatesFile>
+    </PropertyGroup>
+    <WriteLinesToFile
+      File="$(GeneratedSupportDelegatesFile)"
+      Lines="$([System.IO.File]::ReadAllText($(GeneratedSupportDelegatesFile)).Replace('public delegate','internal delegate'))"
+      Overwrite="true" />
+  </Target>
+
   <!-- Build the Sentry Cocoa SDK -->
   <Target Name="_BuildSentryCocoaSDK" BeforeTargets="DispatchToInnerBuilds;BeforeBuild" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="_InnerBuildSentryCocoaSDK" Properties="TargetFramework=once" />


### PR DESCRIPTION
Update bundled Cocoa SDK to version 7.31.4.

Also updates bindings to use named delegates, taking advantage of workaround described in https://github.com/xamarin/xamarin-macios/issues/15299#issuecomment-1360457783

Note: Return type nullability is still not correct for `SentryBeforeBreadcrumbCallback`, `SentryBeforeSendEventCallback`, and `SentryTracesSamplerCallback`.  Waiting on https://github.com/xamarin/xamarin-macios/issues/17109 to fix that.

Also adds missing binding for `PrivateSentrySdkOnly.CaptureScreenshots` added in 7.31.1.  We might use that when we get to #1935.