### PR TITLE
fix: Logging `Info` instead of `Warning` when skipping debug images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Logging info instead of warning when skipping debug images ([#2067](https://github.com/getsentry/sentry-dotnet/pull/2067))
+- Logging info instead of warning when skipping debug images ([#2101](https://github.com/getsentry/sentry-dotnet/pull/2101))
 
 ## 3.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Logging info instead of warning when skipping debug images ([#2067](https://github.com/getsentry/sentry-dotnet/pull/2067))
+
 ## 3.25.0
 
 ### Features

--- a/src/Sentry/Internal/DebugStackTrace.cs
+++ b/src/Sentry/Internal/DebugStackTrace.cs
@@ -471,7 +471,7 @@ internal class DebugStackTrace : SentryStackTrace
         // well, we are out of luck :-(
         if (debugId == null)
         {
-            _options.LogWarning("Skipping DebugImage for module '{0}' because DebugId couldn't be determined", module.Name);
+            _options.LogInfo("Skipping DebugImage for module '{0}' because DebugId couldn't be determined", module.Name);
             _debugImageIndexByModule.Add(id, DebugImageMissing); // don't try to resolve again
             return null;
         }


### PR DESCRIPTION
In Unity: The SDK is eternally logging `Warnings` in case of the stacktrace containing `mscorlib`, without the user having any influence over it or a way to fix it.