### PR TITLE
Fix unhandled exception not captured when hub disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Logging info instead of warning when skipping debug images ([#2101](https://github.com/getsentry/sentry-dotnet/pull/2101))
+- Fix unhandled exception not captured when hub disabled ([#2103](https://github.com/getsentry/sentry-dotnet/pull/2103))
 
 ## 3.25.0
 

--- a/samples/Sentry.Samples.Console.Basic/Program.cs
+++ b/samples/Sentry.Samples.Console.Basic/Program.cs
@@ -1,7 +1,13 @@
 using Sentry;
 
-using (SentrySdk.Init("https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537"))
+using var _ = SentrySdk.Init(o =>
 {
-    // The following exception is captured and sent to Sentry
-    throw null;
-}
+    // The DSN is required.
+    o.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+
+    // When debug is enabled, the Sentry client will emit detailed debugging information to the console.
+    o.Debug = true;
+});
+
+// The following unhandled exception will be captured and sent to Sentry.
+throw new Exception("test");

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -155,6 +155,12 @@ public static class HubExtensions
         public void Dispose() => _scope.Dispose();
     }
 
+    internal static SentryId CaptureExceptionInternal(this IHub hub, Exception ex) =>
+        hub.CaptureEventInternal(new SentryEvent(ex));
+
+    internal static SentryId CaptureEventInternal(this IHub hub, SentryEvent evt) =>
+        hub is IHubEx hubEx ? hubEx.CaptureEventInternal(evt) : hub.CaptureEvent(evt);
+
     /// <summary>
     /// Captures the exception with a configurable scope callback.
     /// </summary>

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -162,10 +162,8 @@ public static class HubExtensions
     /// <param name="ex">The exception.</param>
     /// <param name="configureScope">The callback to configure the scope.</param>
     /// <returns>The Id of the event</returns>
-    public static SentryId CaptureException(this IHub hub, Exception ex, Action<Scope> configureScope)
-        => !hub.IsEnabled
-            ? new SentryId()
-            : hub.CaptureEvent(new SentryEvent(ex), configureScope);
+    public static SentryId CaptureException(this IHub hub, Exception ex, Action<Scope> configureScope) =>
+        hub.CaptureEvent(new SentryEvent(ex), configureScope);
 
     /// <summary>
     /// Captures a message with a configurable scope callback.
@@ -175,20 +173,22 @@ public static class HubExtensions
     /// <param name="configureScope">The callback to configure the scope.</param>
     /// <param name="level">The message level.</param>
     /// <returns>The Id of the event</returns>
-    public static SentryId CaptureMessage(
-        this IHub hub,
-        string message,
-        Action<Scope> configureScope,
+    public static SentryId CaptureMessage(this IHub hub, string message, Action<Scope> configureScope,
         SentryLevel level = SentryLevel.Info)
-        => !hub.IsEnabled || string.IsNullOrWhiteSpace(message)
-            ? new SentryId()
-            : hub.CaptureEvent(
-                new SentryEvent
-                {
-                    Message = message,
-                    Level = level
-                },
-                configureScope);
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return new SentryId();
+        }
+
+        var sentryEvent = new SentryEvent
+        {
+            Message = message,
+            Level = level
+        };
+
+        return hub.CaptureEvent(sentryEvent, configureScope);
+    }
 
     internal static ITransaction StartTransaction(
         this IHub hub,

--- a/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
@@ -1,3 +1,4 @@
+using Sentry.Extensibility;
 using Sentry.Internal;
 using Sentry.Protocol;
 
@@ -26,11 +27,15 @@ internal class AppDomainUnhandledExceptionIntegration : ISdkIntegration
     [SecurityCritical]
     internal void Handle(object sender, UnhandledExceptionEventArgs e)
     {
+        _options?.LogDebug("AppDomain Unhandled Exception");
+
         if (e.ExceptionObject is Exception ex)
         {
             ex.Data[Mechanism.HandledKey] = false;
             ex.Data[Mechanism.MechanismKey] = "AppDomain.UnhandledException";
-            _ = _hub?.CaptureException(ex);
+
+            // Call the internal implementation, so that we still capture even if the hub has been disabled.
+            _hub?.CaptureExceptionInternal(ex);
         }
 
         if (e.IsTerminating)

--- a/src/Sentry/Integrations/UnobservedTaskExceptionIntegration.cs
+++ b/src/Sentry/Integrations/UnobservedTaskExceptionIntegration.cs
@@ -34,6 +34,8 @@ internal class UnobservedTaskExceptionIntegration : ISdkIntegration
 #endif
         ex.Data[Mechanism.HandledKey] = false;
         ex.Data[Mechanism.MechanismKey] = "UnobservedTaskException";
-        _hub.CaptureException(ex);
+
+        // Call the internal implementation, so that we still capture even if the hub has been disabled.
+        _hub.CaptureExceptionInternal(ex);
     }
 }

--- a/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
@@ -118,7 +118,9 @@ internal class WinUIUnhandledExceptionIntegration : ISdkIntegration
         // Set some useful data and capture the exception
         exception.Data[Protocol.Mechanism.HandledKey] = handled;
         exception.Data[Protocol.Mechanism.MechanismKey] = "Microsoft.UI.Xaml.UnhandledException";
-        _hub.CaptureException(exception);
+
+        // Call the internal implementation, so that we still capture even if the hub has been disabled.
+        _hub.CaptureExceptionInternal(exception);
 
         if (!handled)
         {

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -281,6 +281,11 @@ internal class Hub : IHub, IDisposable
 
     public SentryId CaptureEvent(SentryEvent evt, Action<Scope> configureScope)
     {
+        if (!IsEnabled)
+        {
+            return SentryId.Empty;
+        }
+
         try
         {
             var clonedScope = ScopeManager.GetCurrent().Key.Clone();
@@ -297,6 +302,11 @@ internal class Hub : IHub, IDisposable
 
     public SentryId CaptureEvent(SentryEvent evt, Scope? scope = null)
     {
+        if (!IsEnabled)
+        {
+            return SentryId.Empty;
+        }
+
         try
         {
             var currentScope = ScopeManager.GetCurrent();
@@ -347,6 +357,11 @@ internal class Hub : IHub, IDisposable
 
     public void CaptureUserFeedback(UserFeedback userFeedback)
     {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
         try
         {
             _ownedClient.CaptureUserFeedback(userFeedback);
@@ -359,6 +374,11 @@ internal class Hub : IHub, IDisposable
 
     public void CaptureTransaction(Transaction transaction)
     {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
         try
         {
             // Apply scope data
@@ -395,6 +415,11 @@ internal class Hub : IHub, IDisposable
 
     public void CaptureSession(SessionUpdate sessionUpdate)
     {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
         try
         {
             _ownedClient.CaptureSession(sessionUpdate);

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -3,7 +3,7 @@ using Sentry.Infrastructure;
 
 namespace Sentry.Internal;
 
-internal class Hub : IHub, IDisposable
+internal class Hub : IHubEx, IDisposable
 {
     private readonly object _sessionPauseLock = new();
 
@@ -300,13 +300,11 @@ internal class Hub : IHub, IDisposable
         }
     }
 
-    public SentryId CaptureEvent(SentryEvent evt, Scope? scope = null)
-    {
-        if (!IsEnabled)
-        {
-            return SentryId.Empty;
-        }
+    public SentryId CaptureEvent(SentryEvent evt, Scope? scope = null) =>
+        IsEnabled ? ((IHubEx)this).CaptureEventInternal(evt, scope) : SentryId.Empty;
 
+    SentryId IHubEx.CaptureEventInternal(SentryEvent evt, Scope? scope)
+    {
         try
         {
             var currentScope = ScopeManager.GetCurrent();

--- a/src/Sentry/Internal/IHubEx.cs
+++ b/src/Sentry/Internal/IHubEx.cs
@@ -1,0 +1,6 @@
+namespace Sentry.Internal;
+
+internal interface IHubEx : IHub
+{
+    SentryId CaptureEventInternal(SentryEvent evt, Scope? scope = null);
+}

--- a/src/Sentry/SentryClientExtensions.cs
+++ b/src/Sentry/SentryClientExtensions.cs
@@ -15,12 +15,8 @@ public static class SentryClientExtensions
     /// <param name="client">The Sentry client.</param>
     /// <param name="ex">The exception.</param>
     /// <returns>The Id of the event</returns>
-    public static SentryId CaptureException(this ISentryClient client, Exception ex)
-    {
-        return !client.IsEnabled
-            ? new SentryId()
-            : client.CaptureEvent(new SentryEvent(ex));
-    }
+    public static SentryId CaptureException(this ISentryClient client, Exception ex) =>
+        client.CaptureEvent(new SentryEvent(ex));
 
     /// <summary>
     /// Captures a message.
@@ -29,19 +25,21 @@ public static class SentryClientExtensions
     /// <param name="message">The message to send.</param>
     /// <param name="level">The message level.</param>
     /// <returns>The Id of the event</returns>
-    public static SentryId CaptureMessage(
-        this ISentryClient client,
-        string message,
+    public static SentryId CaptureMessage(this ISentryClient client, string message,
         SentryLevel level = SentryLevel.Info)
     {
-        return !client.IsEnabled || string.IsNullOrWhiteSpace(message)
-            ? new SentryId()
-            : client.CaptureEvent(
-                new SentryEvent
-                {
-                    Message = message,
-                    Level = level
-                });
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return new SentryId();
+        }
+
+        var sentryEvent = new SentryEvent
+        {
+            Message = message,
+            Level = level
+        };
+
+        return client.CaptureEvent(sentryEvent);
     }
 
     /// <summary>
@@ -52,13 +50,9 @@ public static class SentryClientExtensions
     /// <param name="email">The user email.</param>
     /// <param name="comments">The user comments.</param>
     /// <param name="name">The optional username.</param>
-    public static void CaptureUserFeedback(this ISentryClient client, SentryId eventId, string email, string comments, string? name = null)
-    {
-        if (client.IsEnabled)
-        {
-            client.CaptureUserFeedback(new UserFeedback(eventId, name, email, comments));
-        }
-    }
+    public static void CaptureUserFeedback(this ISentryClient client, SentryId eventId, string email, string comments,
+        string? name = null) =>
+        client.CaptureUserFeedback(new UserFeedback(eventId, name, email, comments));
 
     /// <summary>
     /// Flushes the queue of captured events until the timeout set in <see cref="SentryOptions.FlushTimeout"/>

--- a/src/Sentry/SentryId.cs
+++ b/src/Sentry/SentryId.cs
@@ -12,7 +12,7 @@ public readonly struct SentryId : IEquatable<SentryId>, IJsonSerializable
     /// <summary>
     /// An empty sentry id.
     /// </summary>
-    public static readonly SentryId Empty = Guid.Empty;
+    public static readonly SentryId Empty = default;
 
     /// <summary>
     /// Creates a new instance of a Sentry Id.

--- a/test/Sentry.Tests/Extensibility/HubAdapterTests.cs
+++ b/test/Sentry.Tests/Extensibility/HubAdapterTests.cs
@@ -33,7 +33,7 @@ public class HubAdapterTests : IDisposable
     {
         var expected = new Exception();
         _ = HubAdapter.Instance.CaptureException(expected);
-        _ = Hub.Received(1).CaptureException(expected);
+        _ = Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(s => s.Exception == expected));
     }
 
     [Fact]

--- a/test/Sentry.Tests/Extensibility/HubAdapterTests.cs
+++ b/test/Sentry.Tests/Extensibility/HubAdapterTests.cs
@@ -3,20 +3,20 @@ namespace Sentry.Tests.Extensibility;
 [Collection(nameof(SentrySdkCollection))]
 public class HubAdapterTests : IDisposable
 {
-    public IHub Hub { get; set; }
+    private IHub Hub { get; }
 
     public HubAdapterTests()
     {
         Hub = Substitute.For<IHub>();
-        _ = SentrySdk.UseHub(Hub);
+        SentrySdk.UseHub(Hub);
     }
 
     [Fact]
     public void CaptureEvent_MockInvoked()
     {
         var expected = new SentryEvent();
-        _ = HubAdapter.Instance.CaptureEvent(expected);
-        _ = Hub.Received(1).CaptureEvent(expected);
+        HubAdapter.Instance.CaptureEvent(expected);
+        Hub.Received(1).CaptureEvent(expected);
     }
 
     [Fact]
@@ -24,16 +24,17 @@ public class HubAdapterTests : IDisposable
     {
         var expectedEvent = new SentryEvent();
         var expectedScope = new Scope();
-        _ = HubAdapter.Instance.CaptureEvent(expectedEvent, expectedScope);
-        _ = Hub.Received(1).CaptureEvent(expectedEvent, expectedScope);
+        HubAdapter.Instance.CaptureEvent(expectedEvent, expectedScope);
+        Hub.Received(1).CaptureEvent(expectedEvent, expectedScope);
     }
 
     [Fact]
     public void CaptureException_MockInvoked()
     {
         var expected = new Exception();
-        _ = HubAdapter.Instance.CaptureException(expected);
-        _ = Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(s => s.Exception == expected));
+        Hub.IsEnabled.Returns(true);
+        HubAdapter.Instance.CaptureException(expected);
+        Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(s => s.Exception == expected));
     }
 
     [Fact]
@@ -65,15 +66,14 @@ public class HubAdapterTests : IDisposable
     {
         static Task Expected(Scope _) => Task.CompletedTask;
 
-        _ = HubAdapter.Instance.ConfigureScopeAsync(Expected);
-        _ = Hub.Received(1).ConfigureScopeAsync(Expected);
+        HubAdapter.Instance.ConfigureScopeAsync(Expected);
+        Hub.Received(1).ConfigureScopeAsync(Expected);
     }
 
     [Fact]
     public void ConfigureScope_MockInvoked()
     {
-        void Expected(Scope _)
-        { }
+        void Expected(Scope _) { }
         HubAdapter.Instance.ConfigureScope(Expected);
         Hub.Received(1).ConfigureScope(Expected);
     }
@@ -82,8 +82,7 @@ public class HubAdapterTests : IDisposable
     [Fact]
     public void WithScope_MockInvoked()
     {
-        void Expected(Scope _)
-        { }
+        void Expected(Scope _) { }
         HubAdapter.Instance.WithScope(Expected);
         Hub.Received(1).WithScope(Expected);
     }
@@ -91,16 +90,16 @@ public class HubAdapterTests : IDisposable
     [Fact]
     public void PushScope_MockInvoked()
     {
-        _ = HubAdapter.Instance.PushScope();
-        _ = Hub.Received(1).PushScope();
+        HubAdapter.Instance.PushScope();
+        Hub.Received(1).PushScope();
     }
 
     [Fact]
     public void PushScope_State_MockInvoked()
     {
         var expected = new object();
-        _ = HubAdapter.Instance.PushScope(expected);
-        _ = Hub.Received(1).PushScope(expected);
+        HubAdapter.Instance.PushScope(expected);
+        Hub.Received(1).PushScope(expected);
     }
 
     [Fact]
@@ -121,7 +120,7 @@ public class HubAdapterTests : IDisposable
     public void AddBreadcrumb_WithClock_BreadcrumbInstanceCreated()
     {
         var clock = Substitute.For<ISystemClock>();
-        _ = clock.GetUtcNow().Returns(DateTimeOffset.MaxValue);
+        clock.GetUtcNow().Returns(DateTimeOffset.MaxValue);
 
         TestAddBreadcrumbExtension((message, category, type, data, level)
             => HubAdapter.Instance.AddBreadcrumb(
@@ -132,7 +131,7 @@ public class HubAdapterTests : IDisposable
                 data,
                 level));
 
-        _ = clock.Received(1).GetUtcNow();
+        clock.Received(1).GetUtcNow();
     }
 
     private void TestAddBreadcrumbExtension(
@@ -164,7 +163,7 @@ public class HubAdapterTests : IDisposable
         Assert.Equal(type, crumb.Type);
         Assert.Equal(category, crumb.Category);
         Assert.Equal(level, crumb.Level);
-        Assert.Equal(data.Count, crumb.Data.Count);
+        Assert.Equal(data.Count, crumb.Data?.Count);
         Assert.Equal(data.ToImmutableDictionary(), crumb.Data);
     }
 

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -965,6 +965,87 @@ public partial class HubTests
     }
 
     [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CaptureEvent_HubEnabled(bool enabled)
+    {
+        // Arrange
+        var hub = _fixture.GetSut();
+        if (!enabled)
+        {
+            hub.Dispose();
+        }
+
+        var evt = new SentryEvent();
+
+        // Act
+        hub.CaptureEvent(evt);
+
+        // Assert
+        _fixture.Client.Received(enabled ? 1 : 0).CaptureEvent(Arg.Any<SentryEvent>(), Arg.Any<Scope>());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CaptureUserFeedback_HubEnabled(bool enabled)
+    {
+        // Arrange
+        var hub = _fixture.GetSut();
+        if (!enabled)
+        {
+            hub.Dispose();
+        }
+
+        var feedback = new UserFeedback(SentryId.Create(), "foo", "bar", "baz");
+
+        // Act
+        hub.CaptureUserFeedback(feedback);
+
+        // Assert
+        _fixture.Client.Received(enabled ? 1 : 0).CaptureUserFeedback(Arg.Any<UserFeedback>());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CaptureSession_HubEnabled(bool enabled)
+    {
+        // Arrange
+        var hub = _fixture.GetSut();
+        if (!enabled)
+        {
+            hub.Dispose();
+        }
+
+        // Act
+        hub.StartSession();
+
+        // Assert
+        _fixture.Client.Received(enabled ? 1 : 0).CaptureSession(Arg.Any<SessionUpdate>());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CaptureTransaction_HubEnabled(bool enabled)
+    {
+        // Arrange
+        var hub = _fixture.GetSut();
+        if (!enabled)
+        {
+            hub.Dispose();
+        }
+
+        // Act
+        var t = hub.StartTransaction("test", "test");
+        t.Finish();
+
+        // Assert
+        _fixture.Client.Received(enabled ? 1 : 0).CaptureTransaction(Arg.Any<Transaction>());
+    }
+
+    [Theory]
     [InlineData(false)]
     [InlineData(true)]
     public async Task FlushOnDispose_SendsEnvelope(bool cachingEnabled)

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1012,6 +1012,7 @@ public partial class HubTests
     public void CaptureSession_HubEnabled(bool enabled)
     {
         // Arrange
+        _fixture.Options.Release = "release";
         var hub = _fixture.GetSut();
         if (!enabled)
         {

--- a/test/Sentry.Tests/SentryClientExtensionsTests.cs
+++ b/test/Sentry.Tests/SentryClientExtensionsTests.cs
@@ -5,37 +5,15 @@ public class SentryClientExtensionsTests
     private readonly ISentryClient _sut = Substitute.For<ISentryClient>();
 
     [Fact]
-    public void CaptureException_DisabledClient_DoesNotCaptureEvent()
+    public void CaptureException_CapturesEvent()
     {
-        _ = _sut.IsEnabled.Returns(false);
-        var id = _sut.CaptureException(new Exception());
-
-        _ = _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
-        Assert.Equal(default, id);
-    }
-
-    [Fact]
-    public void CaptureException_EnabledClient_CapturesEvent()
-    {
-        _ = _sut.IsEnabled.Returns(true);
         _ = _sut.CaptureException(new Exception());
         _ = _sut.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
     }
 
     [Fact]
-    public void CaptureMessage_DisabledClient_DoesNotCaptureEvent()
+    public void CaptureMessage_CapturesEvent()
     {
-        _ = _sut.IsEnabled.Returns(false);
-        var id = _sut.CaptureMessage("Message");
-
-        _ = _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
-        Assert.Equal(default, id);
-    }
-
-    [Fact]
-    public void CaptureMessage_EnabledClient_CapturesEvent()
-    {
-        _ = _sut.IsEnabled.Returns(true);
         _ = _sut.CaptureMessage("Message");
         _ = _sut.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
     }
@@ -44,7 +22,6 @@ public class SentryClientExtensionsTests
     public void CaptureMessage_Level_CapturesEventWithLevel()
     {
         const SentryLevel expectedLevel = SentryLevel.Fatal;
-        _ = _sut.IsEnabled.Returns(true);
         _ = _sut.CaptureMessage("Message", expectedLevel);
         _ = _sut.Received(1).CaptureEvent(Arg.Is<SentryEvent>(e => e.Level == expectedLevel));
     }
@@ -53,7 +30,6 @@ public class SentryClientExtensionsTests
     public void CaptureMessage_Message_CapturesEventWithMessage()
     {
         const string expectedMessage = "message";
-        _ = _sut.IsEnabled.Returns(true);
         _ = _sut.CaptureMessage(expectedMessage);
         _ = _sut.Received(1).CaptureEvent(Arg.Is<SentryEvent>(e => e.Message.Message == expectedMessage));
     }
@@ -61,7 +37,6 @@ public class SentryClientExtensionsTests
     [Fact]
     public void CaptureMessage_WhitespaceMessage_DoesNotCapturesEventWithMessage()
     {
-        _ = _sut.IsEnabled.Returns(true);
         var id = _sut.CaptureMessage("   ");
 
         _ = _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
@@ -71,28 +46,17 @@ public class SentryClientExtensionsTests
     [Fact]
     public void CaptureMessage_NullMessage_DoesNotCapturesEventWithMessage()
     {
-        _ = _sut.IsEnabled.Returns(true);
-        var id = _sut.CaptureMessage(null);
+        var id = _sut.CaptureMessage(null!);
 
         _ = _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
         Assert.Equal(default, id);
     }
 
     [Fact]
-    public void CaptureUserFeedback_EnabledClient_CapturesUserFeedback()
+    public void CaptureUserFeedback_CapturesUserFeedback()
     {
-        _ = _sut.IsEnabled.Returns(true);
         _sut.CaptureUserFeedback(Guid.Parse("1ec19311a7c048818de80b18dcc43eaa"), "email@email.com", "comments");
         _sut.Received(1).CaptureUserFeedback(Arg.Any<UserFeedback>());
-    }
-
-    [Fact]
-    public void CaptureUserFeedback_DisabledClient_DoesNotCaptureUserFeedback()
-    {
-        _ = _sut.IsEnabled.Returns(false);
-        _sut.CaptureUserFeedback(Guid.Parse("1ec19311a7c048818de80b18dcc43eea"), "email@email.com", "comments");
-
-        _sut.DidNotReceive().CaptureUserFeedback(Arg.Any<UserFeedback>());
     }
 
     [Fact]

--- a/test/Sentry.Tests/SentryClientExtensionsTests.cs
+++ b/test/Sentry.Tests/SentryClientExtensionsTests.cs
@@ -5,15 +5,37 @@ public class SentryClientExtensionsTests
     private readonly ISentryClient _sut = Substitute.For<ISentryClient>();
 
     [Fact]
-    public void CaptureException_CapturesEvent()
+    public void CaptureException_DisabledClient_DoesNotCaptureEvent()
     {
+        _ = _sut.IsEnabled.Returns(false);
+        var id = _sut.CaptureException(new Exception());
+
+        _ = _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+        Assert.Equal(default, id);
+    }
+
+    [Fact]
+    public void CaptureException_EnabledClient_CapturesEvent()
+    {
+        _ = _sut.IsEnabled.Returns(true);
         _ = _sut.CaptureException(new Exception());
         _ = _sut.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
     }
 
     [Fact]
-    public void CaptureMessage_CapturesEvent()
+    public void CaptureMessage_DisabledClient_DoesNotCaptureEvent()
     {
+        _ = _sut.IsEnabled.Returns(false);
+        var id = _sut.CaptureMessage("Message");
+
+        _ = _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+        Assert.Equal(default, id);
+    }
+
+    [Fact]
+    public void CaptureMessage_EnabledClient_CapturesEvent()
+    {
+        _ = _sut.IsEnabled.Returns(true);
         _ = _sut.CaptureMessage("Message");
         _ = _sut.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
     }
@@ -22,6 +44,7 @@ public class SentryClientExtensionsTests
     public void CaptureMessage_Level_CapturesEventWithLevel()
     {
         const SentryLevel expectedLevel = SentryLevel.Fatal;
+        _ = _sut.IsEnabled.Returns(true);
         _ = _sut.CaptureMessage("Message", expectedLevel);
         _ = _sut.Received(1).CaptureEvent(Arg.Is<SentryEvent>(e => e.Level == expectedLevel));
     }
@@ -30,6 +53,7 @@ public class SentryClientExtensionsTests
     public void CaptureMessage_Message_CapturesEventWithMessage()
     {
         const string expectedMessage = "message";
+        _ = _sut.IsEnabled.Returns(true);
         _ = _sut.CaptureMessage(expectedMessage);
         _ = _sut.Received(1).CaptureEvent(Arg.Is<SentryEvent>(e => e.Message.Message == expectedMessage));
     }
@@ -37,6 +61,7 @@ public class SentryClientExtensionsTests
     [Fact]
     public void CaptureMessage_WhitespaceMessage_DoesNotCapturesEventWithMessage()
     {
+        _ = _sut.IsEnabled.Returns(true);
         var id = _sut.CaptureMessage("   ");
 
         _ = _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
@@ -46,6 +71,7 @@ public class SentryClientExtensionsTests
     [Fact]
     public void CaptureMessage_NullMessage_DoesNotCapturesEventWithMessage()
     {
+        _ = _sut.IsEnabled.Returns(true);
         var id = _sut.CaptureMessage(null!);
 
         _ = _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
@@ -53,10 +79,20 @@ public class SentryClientExtensionsTests
     }
 
     [Fact]
-    public void CaptureUserFeedback_CapturesUserFeedback()
+    public void CaptureUserFeedback_EnabledClient_CapturesUserFeedback()
     {
+        _ = _sut.IsEnabled.Returns(true);
         _sut.CaptureUserFeedback(Guid.Parse("1ec19311a7c048818de80b18dcc43eaa"), "email@email.com", "comments");
         _sut.Received(1).CaptureUserFeedback(Arg.Any<UserFeedback>());
+    }
+
+    [Fact]
+    public void CaptureUserFeedback_DisabledClient_DoesNotCaptureUserFeedback()
+    {
+        _ = _sut.IsEnabled.Returns(false);
+        _sut.CaptureUserFeedback(Guid.Parse("1ec19311a7c048818de80b18dcc43eea"), "email@email.com", "comments");
+
+        _sut.DidNotReceive().CaptureUserFeedback(Arg.Any<UserFeedback>());
     }
 
     [Fact]

--- a/test/Sentry.Tests/UnobservedTaskExceptionIntegrationTests.cs
+++ b/test/Sentry.Tests/UnobservedTaskExceptionIntegrationTests.cs
@@ -4,7 +4,7 @@ public class UnobservedTaskExceptionIntegrationTests
 {
     private class Fixture
     {
-        public IHub Hub { get; set; } = Substitute.For<IHub, IDisposable>();
+        public IHubEx Hub { get; set; } = Substitute.For<IHubEx, IDisposable>();
         public IAppDomain AppDomain { get; set; } = Substitute.For<IAppDomain>();
 
         public Fixture() => Hub.IsEnabled.Returns(true);
@@ -24,7 +24,7 @@ public class UnobservedTaskExceptionIntegrationTests
 
         sut.Handle(this, new UnobservedTaskExceptionEventArgs(new AggregateException()));
 
-        _ = _fixture.Hub.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
+        _ = _fixture.Hub.Received(1).CaptureEventInternal(Arg.Any<SentryEvent>());
     }
 
     // Test is flaky on mobile in CI.
@@ -35,7 +35,7 @@ public class UnobservedTaskExceptionIntegrationTests
         _fixture.AppDomain = AppDomainAdapter.Instance;
         var captureCalledEvent = new ManualResetEvent(false);
         SentryEvent capturedEvent = null;
-        _fixture.Hub.When(x => x.CaptureEvent(Arg.Any<SentryEvent>()))
+        _fixture.Hub.When(x => x.CaptureEventInternal(Arg.Any<SentryEvent>()))
             .Do(callInfo =>
             {
                 capturedEvent = callInfo.Arg<SentryEvent>();


### PR DESCRIPTION
I noticed that the `Sentry.Samples.Console.Basic` example wasn't working when run on my Mac with the `net48` target, but was working fine with the `net6.0` target, or on Windows with either target.

After some investigation, it turns out that the Mono desktop runtime will call any `Dispose` from a `using` statement (or any `finally` block) *before* it invokes `AppDomain.UnhandledException` or similar events.  That's probably a bug in Mono, as  the behavior on .NET or .NET Framework is to fire those events immediately and *not* dispose.  This doesn't look like it will be fixed in Mono any time soon, so we should accept the current behavior.

The problem is that if `Hub.Dispose` is called before the unhandled exception integration captures the exception, the hub will have been disabled and the exception won't be captured.  The solution thus is to allow the unhandled exception integration (and similar) to capture even if the hub has been disabled.

While resolving this, I also noticed that we were checking `IsEnabled` only on extension methods like `CaptureException`, `CaptureMessage`, etc.   So it was always possible to still send events post-dispose by calling `CaptureEvent` directly.  That is a separate bug, but also resolved in this PR.  The hub now checks if it is disabled before capturing anything, rather than the extension methods.  An internal `CaptureEventInternal` and some related code will allow the integrations to bypass those checks and still capture on disabled hubs.

This change means that *no* events will not be captured post-dispose unless they come from an internal integration.  That was always the intention, but only behaved that way with extension methods like `CaptureException`, and not with the basic `CaptureEvent` method.