### PR TITLE
Use Sentry CLI after build to upload symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ docs/docfx.zip
 mono_crash.*.json
 test_output/
 test/**/*.apk
+/tools/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Use Sentry CLI after build to upload symbols ([#2107](https://github.com/getsentry/sentry-dotnet/pull/2107))
+
 ### Fixes
 
 - Logging info instead of warning when skipping debug images ([#2101](https://github.com/getsentry/sentry-dotnet/pull/2101))

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,4 +56,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)GlobalUsings.cs" />
   </ItemGroup>
 
+  <!-- Set the version and local path for Sentry CLI (downloaded in the restore phase of Sentry.csproj) -->
+  <PropertyGroup Condition="'$(SolutionName)' != 'Sentry.Unity'">
+    <SentryCLIVersion>2.11.0</SentryCLIVersion>
+    <SentryCLIDirectory>$(MSBuildThisFileDirectory)tools\sentry-cli\$(SentryCLIVersion)\</SentryCLIDirectory>
+  </PropertyGroup>
+
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -47,10 +47,11 @@
   </Target>
 
   <!--
-  This is needed because we use project references in this solution.
-  In an app that uses our nuget packages, it will come through the nuget package automatically.
+  These are needed because we use project references in this solution.
+  In an app that uses our nuget packages, they will come through the nuget packages automatically.
   -->
+  <Import Project="$(MSBuildThisFileDirectory)src\Sentry\buildTransitive\Sentry.props" />
   <Import Project="$(MSBuildThisFileDirectory)src\Sentry.Bindings.Cocoa\buildTransitive\Sentry.Bindings.Cocoa.targets"
-      Condition="'$(OutputType)' == 'Exe' And ('$(TargetPlatformIdentifier)' == 'ios' Or '$(TargetPlatformIdentifier)' == 'maccatalyst')" />
+    Condition="'$(OutputType)' == 'Exe' And ('$(TargetPlatformIdentifier)' == 'ios' Or '$(TargetPlatformIdentifier)' == 'maccatalyst')" />
 
 </Project>

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -67,4 +67,25 @@
     <None Include="buildTransitive\Sentry.props" Pack="true" PackagePath="build\Sentry.props" />
   </ItemGroup>
 
+  <!-- Download and bundle Sentry CLI with the nuget package. -->
+  <Target Name="DownloadSentryCLI" BeforeTargets="CollectPackageReferences" Condition="'$(SentryCLIDirectory)' != ''">
+    <ItemGroup>
+      <SentryCLIDownload Include="sentry-cli-Darwin-arm64" DestinationFolder="osx-arm64\" DestinationFileName="sentry-cli" />
+      <SentryCLIDownload Include="sentry-cli-Darwin-x86_64" DestinationFolder="osx-x64\" DestinationFileName="sentry-cli" />
+      <SentryCLIDownload Include="sentry-cli-Linux-aarch64" DestinationFolder="linux-arm64\" DestinationFileName="sentry-cli" />
+      <SentryCLIDownload Include="sentry-cli-Linux-x86_64" DestinationFolder="linux-x64\" DestinationFileName="sentry-cli" />
+      <SentryCLIDownload Include="sentry-cli-Windows-x86_64.exe" DestinationFolder="windows-x64\" DestinationFileName="sentry-cli.exe" />
+    </ItemGroup>
+    <DownloadFile
+      SourceUrl="https://github.com/getsentry/sentry-cli/releases/download/$(SentryCLIVersion)/%(SentryCLIDownload.Identity)"
+      DestinationFolder="$(SentryCLIDirectory)%(SentryCLIDownload.DestinationFolder)"
+      DestinationFileName="%(SentryCLIDownload.DestinationFileName)"
+      Condition="!Exists('$(SentryCLIDirectory)%(SentryCLIDownload.DestinationFolder)%(SentryCLIDownload.DestinationFileName)')"
+      Retries="3" />
+    <Exec Command="chmod +x $(SentryCLIDirectory)*/*" Condition="!$([MSBuild]::IsOSPlatform('Windows'))" />
+  </Target>
+  <ItemGroup Condition="'$(SentryCLIDirectory)' != ''">
+    <None Include="$(SentryCLIDirectory)**" Pack="true" PackagePath="tools\" />
+  </ItemGroup>
+
 </Project>

--- a/src/Sentry/buildTransitive/Sentry.props
+++ b/src/Sentry/buildTransitive/Sentry.props
@@ -32,4 +32,27 @@
               ItemName="FileWrites" />
     </WriteCodeFragment>
   </Target>
+
+  <Target Name="UploadSymbolsToSentry" AfterTargets="AfterBuild" Condition="'$(PkgSentry)' != '' Or '$(SentryCLIDirectory)' != ''">
+    <PropertyGroup>
+      <!-- Sentry CLI comes from the Sentry Nuget package when installed. -->
+      <SentryCLIDirectory Condition="'$(PkgSentry)' != ''">$(PkgSentry)\tools\</SentryCLIDirectory>
+
+      <!-- We bundle Sentry CLI for these architectures (in Sentry.csproj) -->
+      <_OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</_OSArchitecture>
+      <SentryCLI Condition="$([MSBuild]::IsOSPlatform('OSX')) And $(_OSArchitecture) == 'Arm64'">$(SentryCLIDirectory)osx-arm64\sentry-cli</SentryCLI>
+      <SentryCLI Condition="$([MSBuild]::IsOSPlatform('OSX')) And $(_OSArchitecture) == 'X64'">$(SentryCLIDirectory)osx-x64\sentry-cli</SentryCLI>
+      <SentryCLI Condition="$([MSBuild]::IsOSPlatform('Linux')) And $(_OSArchitecture) == 'Arm64'">$(SentryCLIDirectory)linux-arm64\sentry-cli</SentryCLI>
+      <SentryCLI Condition="$([MSBuild]::IsOSPlatform('Linux')) And $(_OSArchitecture) == 'X64'">$(SentryCLIDirectory)linux-x64\sentry-cli</SentryCLI>
+      <SentryCLI Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(SentryCLIDirectory)windows-x64\sentry-cli.exe</SentryCLI>
+    </PropertyGroup>
+
+    <Message Importance="High" Text="Preparing to upload debug symbols to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
+
+    <Exec
+      Condition="'$(SENTRY_AUTH_TOKEN)' != '' And '$(SENTRY_ORG)' != '' And '$(SENTRY_PROJECT)' != '' And '$(SentryCLI)' != '' And Exists('$(SentryCLI)')"
+      Command="'$(SentryCLI)' upload-dif '$(IntermediateOutputPath)'" />
+
+  </Target>
+
 </Project>

--- a/test/Sentry.Tests/Sentry.Tests.csproj
+++ b/test/Sentry.Tests/Sentry.Tests.csproj
@@ -14,6 +14,4 @@
     <ProjectReference Include="..\Sentry.Testing.CrashableApp\Sentry.Testing.CrashableApp.csproj" />
   </ItemGroup>
 
-  <Import Project="..\..\src\Sentry\buildTransitive\Sentry.props" />
-
 </Project>


### PR DESCRIPTION
As part of #2074, this PR adds the following:
- Download and bundle the Sentry CLI with the `Sentry` nuget package
- Call the Sentry CLI to upload debug information files (symbols, etc.) after a successful build.

Currently requires setting the following environment variables manually before running the build.
- `SENTRY_AUTH_TOKEN`
- `SENTRY_ORG`
- `SENTRY_PROJECT`
- `SENTRY_URL` (if self-hosted)

See https://docs.sentry.io/product/cli/configuration/