### PR TITLE
Fix Android support for Portable PDB format when app uses split APKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Logging info instead of warning when skipping debug images ([#2101](https://github.com/getsentry/sentry-dotnet/pull/2101))
 - Fix unhandled exception not captured when hub disabled ([#2103](https://github.com/getsentry/sentry-dotnet/pull/2103))
+- Fix Android support for Portable PDB format when app uses split APKs ([#2108](https://github.com/getsentry/sentry-dotnet/pull/2108))
 
 ## 3.25.0
 

--- a/src/Sentry/Internal/DebugStackTrace.cs
+++ b/src/Sentry/Internal/DebugStackTrace.cs
@@ -384,7 +384,17 @@ internal class DebugStackTrace : SentryStackTrace
 #if ANDROID
     private static IAndroidAssemblyReader? GetAndroidAssemblyReader(SentryOptions options)
     {
-        var apkPath = Environment.CommandLine;
+        // NOTE: Environment.CommandLine contains the APK that the app was launched from.
+        // In a release build, that may be a "split" APK rather than the base.
+        // .NET Assemblies are placed into the base APK, so we shouldn't use Environment.CommandLine.
+        // Instead, we can get the base APK from the info in the Android app context.
+
+        var apkPath = Application.Context.ApplicationInfo!.SourceDir;
+
+        // Also, we are assuming that .NET assemblies are never placed into one of the split APKs.
+        // If that turns out to be incorrect, we can use the SplitSourceDirs property to get the split APK info,
+        // but then we'll have to rework our assembly reader to support searching multiple APKs.
+
         try
         {
             if (File.Exists(apkPath))


### PR DESCRIPTION
When an Android app is built in release configuration, it may be configured to be deployed to the device using multiple "split" APKs.  For example, building `Sentry.Samples.Android` in release mode, after deploying to a device and browsing the device file system, looks like this:

<img width="521" alt="image" src="https://user-images.githubusercontent.com/1396388/211104092-686ea178-cd81-43f6-b828-0ba61b866466.png">

Previously, we were getting the APK at runtime using `Environment.CommandLine` - but in the case of multiple APKs, that will resolve to one of the splits, not to the base APK where the assemblies are located.  Thus, we weren't getting the debug info sent to Sentry in the stack trace.

Resolved by getting the base APK path from the Android application context info.

I don't think assemblies will ever be in one of the splits, but I left a comment about it in the code just in case that comes up in the future.