### PR TITLE
Fix session ending as crashed for unobserved task exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Logging info instead of warning when skipping debug images ([#2101](https://github.com/getsentry/sentry-dotnet/pull/2101))
 - Fix unhandled exception not captured when hub disabled ([#2103](https://github.com/getsentry/sentry-dotnet/pull/2103))
 - Fix Android support for Portable PDB format when app uses split APKs ([#2108](https://github.com/getsentry/sentry-dotnet/pull/2108))
+- Fix session ending as crashed for unobserved task exceptions ([#2112](https://github.com/getsentry/sentry-dotnet/pull/2112))
 
 ## 3.25.0
 

--- a/src/Sentry/Integrations/UnobservedTaskExceptionIntegration.cs
+++ b/src/Sentry/Integrations/UnobservedTaskExceptionIntegration.cs
@@ -5,6 +5,8 @@ namespace Sentry.Integrations;
 
 internal class UnobservedTaskExceptionIntegration : ISdkIntegration
 {
+    internal const string MechanismKey = "UnobservedTaskException";
+
     private readonly IAppDomain _appDomain;
     private IHub _hub = null!;
 
@@ -33,7 +35,7 @@ internal class UnobservedTaskExceptionIntegration : ISdkIntegration
         var ex = e.Exception!;
 #endif
         ex.Data[Mechanism.HandledKey] = false;
-        ex.Data[Mechanism.MechanismKey] = "UnobservedTaskException";
+        ex.Data[Mechanism.MechanismKey] = MechanismKey;
 
         // Call the internal implementation, so that we still capture even if the hub has been disabled.
         _hub.CaptureExceptionInternal(ex);

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -318,8 +318,8 @@ internal class Hub : IHubEx, IDisposable
                 evt.Contexts.Trace.ParentSpanId = linkedSpan.ParentSpanId;
             }
 
-            var hasUnhandledException = evt.HasUnhandledException();
-            if (hasUnhandledException)
+            var hasTerminalException = evt.HasTerminalException();
+            if (hasTerminalException)
             {
                 // Event contains a terminal exception -> end session as crashed
                 _options.LogDebug("Ending session as Crashed, due to unhandled exception.");
@@ -336,7 +336,7 @@ internal class Hub : IHubEx, IDisposable
             actualScope.LastEventId = id;
             actualScope.SessionUpdate = null;
 
-            if (hasUnhandledException)
+            if (hasTerminalException)
             {
                 // Event contains a terminal exception -> finish any current transaction as aborted
                 // Do this *after* the event was captured, so that the event is still linked to the transaction.


### PR DESCRIPTION
An exception on an unobserved task should be marked as *unhandled*, but that doesn't mean it is *terminal*.  The session should only end as crashed if the exception is terminal.

Fixes #2104 