### PR TITLE
Fix flaky test due to leading zeros on debug id

### DIFF
--- a/src/Sentry/Internal/DebugStackTrace.cs
+++ b/src/Sentry/Internal/DebugStackTrace.cs
@@ -474,7 +474,7 @@ internal class DebugStackTrace : SentryStackTrace
             // should be used to match the PE/COFF image with the associated PDB (instead of Guid and Age).
             // Matching PDB ID is stored in the #Pdb stream of the .pdb file.
             // See https://github.com/dotnet/runtime/blob/main/docs/design/specs/PE-COFF.md#codeview-debug-directory-entry-type-2
-            debugId = $"{codeView.Guid}-{entry.Stamp:x}";
+            debugId = $"{codeView.Guid}-{entry.Stamp:x8}";
             debugFile = codeView.Path;
         }
 

--- a/test/Sentry.Tests/HubTests.verify.cs
+++ b/test/Sentry.Tests/HubTests.verify.cs
@@ -46,6 +46,7 @@ public partial class HubTests
                 _.DebugFile != null && (
                     _.DebugFile.Contains("Xunit.SkippableFact") ||
                     _.DebugFile.Contains("xunit.runner") ||
+                    _.DebugFile.Contains("JetBrains.ReSharper.TestRunner") ||
                     _.DebugFile.Contains("Microsoft.TestPlatform")
                 )
             );


### PR DESCRIPTION
See https://github.com/getsentry/sentry-dotnet/actions/runs/3905323733/jobs/6674159827#step:9:100

The `debug_id` is masked correctly for the verify test, but the last segment is short by one character, causing the test to fail.  This is because the `TimeDateStamp` portion of the generated deterministic debug id is less than `0x10000000`.  For example, it could be `0x0fffffff`, which gets appended as `fffffff` instead of `0fffffff`.

Since it's interpreted as bytes anyway, it's only the string representation that is off.  See also:
https://github.com/getsentry/symbolic/pull/658#discussion_r1068728598

(Also added Jetbrains to the ignore list so I could debug this test locally.)

#skip-changelog