### PR TITLE
Drop preview tag for MAUI

### DIFF
--- a/src/Sentry.Maui/Sentry.Maui.csproj
+++ b/src/Sentry.Maui/Sentry.Maui.csproj
@@ -22,9 +22,6 @@
     <!-- We'll need to package this only on OSX, so we get the iOS native support. -->
     <IsPackable Condition="!$([MSBuild]::IsOSPlatform('OSX'))">false</IsPackable>
 
-    <!-- Add a pre-release identifier for this package  -->
-    <Version>$(Version)-preview.3</Version>
-
     <!--
       Imports MAUI dependencies.
       Requires the MAUI .NET workload to be installed with:


### PR DESCRIPTION
I think we can finally drop the preview tag for the next release of `Sentry.Maui`. 🎉 

Resolves #1850

#skip-changelog