### PR TITLE
Install Android 33 to fix build failure

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -23,11 +23,15 @@ runs:
         sudo xcode-select -s "/Applications/Xcode_14.1.app"
         echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_14.1.app" >> $GITHUB_ENV
 
+    # Android SDK is pre-installed, but this makes sure it is current and on the path.
+    - name: Setup Android Environment
+      uses: android-actions/setup-android@7c5672355aaa8fde5f97a91aa9a99616d1ace6bc # pin @v2
+
     # Android 33 is required for .NET Android targets, but is missing on windows-2019 images.
     - name: Install Android 33
       if: runner.os == 'Windows'
       shell: cmd
-      run: '%ANDROID_SDK_ROOT%\tools\bin\sdkmanager "platforms;android-33"'
+      run: sdkmanager "platforms;android-33"
 
     # Note, the following is needed on the windows-2019 image only.
     # All other versions of .NET we need are pre-installed on the GitHub Actions virtual images.

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -23,11 +23,11 @@ runs:
         sudo xcode-select -s "/Applications/Xcode_14.1.app"
         echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_14.1.app" >> $GITHUB_ENV
 
-    # Android 33 is required for .NET MAUI, but is missing on windows-2019 images.
+    # Android 33 is required for .NET Android targets, but is missing on windows-2019 images.
     - name: Install Android 33
       if: runner.os == 'Windows'
-      shell: bash
-      run: sdkmanager "platforms;android-33"
+      shell: cmd
+      run: '%ANDROID_SDK_ROOT%\tools\bin\sdkmanager "platforms;android-33"'
 
     # Note, the following is needed on the windows-2019 image only.
     # All other versions of .NET we need are pre-installed on the GitHub Actions virtual images.

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -23,6 +23,12 @@ runs:
         sudo xcode-select -s "/Applications/Xcode_14.1.app"
         echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_14.1.app" >> $GITHUB_ENV
 
+    # Android 33 is required for .NET MAUI, but is missing on windows-2019 images.
+    - name: Install Android 33
+      if: runner.os == 'Windows'
+      shell: bash
+      run: sdkmanager "platforms;android-33"
+
     # Note, the following is needed on the windows-2019 image only.
     # All other versions of .NET we need are pre-installed on the GitHub Actions virtual images.
     - name: Install .NET 6 SDK


### PR DESCRIPTION
The latest .NET Android workloads now require Android 33, which is not pre-installed on the `windows-2019` Github Actions image.

Example failure: https://github.com/getsentry/sentry-dotnet/actions/runs/3984439134/jobs/6830656184#step:8:669

> Error: C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\33.0.26\tools\Xamarin.Android.Tooling.targets(100,5): error XA5207: Could not find android.jar for API level 33. This means the Android SDK platform for API level 33 is not installed. Either install it in the Android SDK Manager (Tools > Android > Android SDK Manager...), or change the Xamarin.Android project to target an API version that is installed. (C:\Program Files (x86)\Android\android-sdk\platforms\android-33\android.jar missing.) [D:\a\sentry-dotnet\sentry-dotnet\test\Sentry.Tests\Sentry.Tests.csproj::TargetFramework=net7.0-android]

See also https://github.com/actions/runner-images/issues/6955

#skip-changelog