### PR TITLE
Configure Sentry CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Build
         run: dotnet build Sentry-CI-Build-${{ runner.os }}.slnf -c Release --no-restore --nologo /p:CopyLocalLockFileAssemblies=true
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Test
         run: dotnet test Sentry-CI-Test.slnf -c Release --no-build --nologo -l GitHubActions -l "trx;LogFilePrefix=testresults_${{ runner.os }}"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,10 @@
     <!-- Allow references to unsigned assemblies (like MAUI) from signed projects -->
     <NoWarn>$(NoWarn);CS8002</NoWarn>
 
+    <!-- Configure Sentry CLI -->
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
This configures the build to use the Sentry CLI integration (in Release configuration).

Using the MSBuild properties for org and project, so that it also works locally - as long as you have authenticated (for example, `sentry-cli login`).

In GH Actions, we'll set the auth token from a secret on the repo.

#skip-changelog