### PR TITLE
Set Sentry.Scope.User to be nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Mark `Sentry.Scope.User` as nullable, as per its implementation and the documentation
+
 ### Features
 
 - Publish `Sentry.Android.AssemblyReader` as a separate nuget package (for reuse by `Sentry.Xamarin`) ([#2127](https://github.com/getsentry/sentry-dotnet/pull/2127))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Mark `Sentry.Scope.User` as nullable, as per its implementation and the documentation
+- Mark `Sentry.Scope.User` as nullable, as per its implementation and the documentation ([#2133](https://github.com/getsentry/sentry-dotnet/pull/2133))
 
 ### Features
 

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -117,7 +117,7 @@ public class Scope : IEventLike, IHasDistribution
     private User? _user;
 
     /// <inheritdoc />
-    public User User
+    public User? User
     {
         get => _user ??= new User { PropertyChanged = UserChanged };
         set


### PR DESCRIPTION
Sentry.Scope.User was written to take a `null` value correctly (and even the documentation suggests to do so) but the actual annotation marked it as non-nullable until now.