### PR TITLE
Improvements for Sentry CLI integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Publish `Sentry.Android.AssemblyReader` as a separate nuget package (for reuse by `Sentry.Xamarin`) ([#2127](https://github.com/getsentry/sentry-dotnet/pull/2127))
+- Improvements for Sentry CLI integration ([#2145](https://github.com/getsentry/sentry-dotnet/pull/2145))
 
 ## 3.26.2
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
     <!-- Configure Sentry CLI -->
     <SentryOrg>sentry-sdks</SentryOrg>
     <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSources>true</SentryUploadSources>
 
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -66,7 +66,7 @@
 
   <!-- Set the version and local path for Sentry CLI (downloaded in the restore phase of Sentry.csproj) -->
   <PropertyGroup Condition="'$(SolutionName)' != 'Sentry.Unity'">
-    <SentryCLIVersion>2.11.0</SentryCLIVersion>
+    <SentryCLIVersion>2.12.0</SentryCLIVersion>
     <SentryCLIDirectory>$(MSBuildThisFileDirectory)tools\sentry-cli\$(SentryCLIVersion)\</SentryCLIDirectory>
   </PropertyGroup>
 

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -75,13 +75,13 @@
       Update with each new version.
     -->
     <ItemGroup>
-      <SentryCLIDownload Include="sentry-cli-Darwin-arm64" FileHash="fbefb40a8e5ce29f82e0f7195e84f569dbeaaae07cdc1f983f5f3418fd9a376d" />
-      <SentryCLIDownload Include="sentry-cli-Darwin-x86_64" FileHash="d55ee5636d12bd193a4f526ab426e6af6273bec5bc2dc22e81dc8357d6e039eb" />
-      <SentryCLIDownload Include="sentry-cli-Linux-aarch64" FileHash="c62c5c1259307611e78af4f24a4c30162cff8adb0f021d363b307c42cded5c70" />
-      <SentryCLIDownload Include="sentry-cli-Linux-i686" FileHash="25c5e7e6d978d1e66bc26c9e4282633135a318ed0ac36cb73b4fa58f59fcb089" />
-      <SentryCLIDownload Include="sentry-cli-Linux-x86_64" FileHash="bc8f5f223fa688b3ad963c60a729f02aa8f5b17525de66fb3abf86800977ff6e" />
-      <SentryCLIDownload Include="sentry-cli-Windows-i686.exe" FileHash="2bb96fc94ea749e24cd607f48750b121572a3fb4b3f9499f63a996f83c56ef2b" />
-      <SentryCLIDownload Include="sentry-cli-Windows-x86_64.exe" FileHash="7b70536177419dcd2fdb2c823422290abfe25180ffa3beae000fb3c9b1473c1f"/>
+      <SentryCLIDownload Include="sentry-cli-Darwin-arm64" FileHash="49f2d51c169ee46b4dcdad4913cac5a72fd7c25a1e55423ef62035ce7d1dec22" />
+      <SentryCLIDownload Include="sentry-cli-Darwin-x86_64" FileHash="47ae7f2145dc9a50156b815f2db241c44282fcc8173bf7b43897492d1eb3f3d5" />
+      <SentryCLIDownload Include="sentry-cli-Linux-aarch64" FileHash="4b9e88a1925dd09c706c2263d2d671682bc4b2f146f2ee12670ec7fe6cd51f1d" />
+      <SentryCLIDownload Include="sentry-cli-Linux-i686" FileHash="624aa49b839d052d95eba156ae465a459f4fb0d9509c7497909eec0bab2171db" />
+      <SentryCLIDownload Include="sentry-cli-Linux-x86_64" FileHash="ab6723a84675bc7d11bbf4f723511150af0c58e10c1c1dafb8210837d2a97673" />
+      <SentryCLIDownload Include="sentry-cli-Windows-i686.exe" FileHash="bf90b9a411f9cef7cfce72cfe4a24595b4fbc125e40fb67eaaa702cfc4d347d0" />
+      <SentryCLIDownload Include="sentry-cli-Windows-x86_64.exe" FileHash="138d3cd500d69a07b0548f15d297139c5f0d6604c4c806b54596abe14895bdf2"/>
     </ItemGroup>
 
     <!-- Download the files -->

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -113,7 +113,8 @@
       <_SentryCLICommand>&quot;$(SentryCLI)&quot; upload-dif</_SentryCLICommand>
       <_SentryCLICommand Condition="'$(SentryCLIOptions.Trim())' != ''">$(_SentryCLICommand) $(SentryCLIOptions.Trim())</_SentryCLICommand>
       <_SentryCLICommand Condition="'$(SentryUploadSources)' == 'true'">$(_SentryCLICommand) --include-sources</_SentryCLICommand>
-      <_SentryCLICommand>$(_SentryCLICommand) $(IntermediateOutputPath)</_SentryCLICommand>
+      <_SentryCLICommand>$(_SentryCLICommand) $(OutputPath)</_SentryCLICommand>
+      <_SentryCLICommand Condition="'$(SentryIncludeIntermediateOutputPath)' == 'true'">$(_SentryCLICommand) $(IntermediateOutputPath)</_SentryCLICommand>
     </PropertyGroup>
     <Exec Command="$(_SentryCLICommand)" IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -78,19 +78,19 @@
       <_SentryCLICommand Condition="'$(SentryOrg)' != '' And '$(SentryProject)' != ''">$(_SentryCLICommand) --no-defaults</_SentryCLICommand>
     </PropertyGroup>
     <Exec Condition="'$(SentryCLI)' != ''" Command="$(_SentryCLICommand)" IgnoreExitCode="true" ConsoleToMsBuild="true" StandardOutputImportance="Low">
-      <Output TaskParameter="ExitCode" PropertyName="SentryCLIExitCode" />
-      <Output TaskParameter="ConsoleOutput" PropertyName="SentryCLIOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
+      <Output TaskParameter="ConsoleOutput" PropertyName="_SentryCLIOutput" />
     </Exec>
 
-    <PropertyGroup Condition="'$(SentryCLIExitCode)' != '0'">
-      <_SentryCLIRequestFailed Condition="$(SentryCLIOutput.Contains('API request failed'))">true</_SentryCLIRequestFailed>
+    <PropertyGroup Condition="'$(_SentryCLIExitCode)' != '0'">
+      <_SentryCLIRequestFailed Condition="$(_SentryCLIOutput.Contains('API request failed'))">true</_SentryCLIRequestFailed>
     </PropertyGroup>
     <Warning Condition="'$(_SentryCLIRequestFailed)' != ''"
       Text="Sentry API request failed.  Either the authentication info is invalid, or the Sentry server could not be reached." />
 
-    <Message Importance="High" Condition="'$(SentryCLIExitCode)' != '0' And '$(_SentryCLIRequestFailed)' == ''"
+    <Message Importance="High" Condition="'$(_SentryCLIExitCode)' != '0' And '$(_SentryCLIRequestFailed)' == ''"
       Text="The Sentry CLI is not fully configured with authentication, organization, and project." />
-    <PropertyGroup Condition="'$(SentryCLIExitCode)' != '0'">
+    <PropertyGroup Condition="'$(_SentryCLIExitCode)' != '0'">
       <SentryCLI />
     </PropertyGroup>
   </Target>

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -97,9 +97,14 @@
   <!-- Upload debug information files to Sentry after the build. -->
   <Target Name="UploadSymbolsToSentry" AfterTargets="Build;Publish" DependsOnTargets="PrepareSentryCLI" Condition="'$(SentryUploadSymbols)' == 'true' And '$(SentryCLI)' != ''">
 
+    <Warning Condition="'$(SentryUploadSources)' == 'true' And '$(EmbedAllSources)' == 'true'"
+      Text="Both SentryUploadSources and EmbedAllSources are enabled.  Disabling SentryUploadSources." />
+    <PropertyGroup Condition="'$(SentryUploadSources)' == 'true' And '$(EmbedAllSources)' == 'true'">
+      <SentryUploadSources>false</SentryUploadSources>
+    </PropertyGroup>
+
     <Message Importance="High" Condition="'$(SentryUploadSources)' != 'true'"
       Text="Preparing to upload debug symbols to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
-
     <Message Importance="High" Condition="'$(SentryUploadSources)' == 'true'"
       Text="Preparing to upload debug symbols and sources to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
 

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -115,7 +115,18 @@
       <_SentryCLICommand Condition="'$(SentryUploadSources)' == 'true'">$(_SentryCLICommand) --include-sources</_SentryCLICommand>
       <_SentryCLICommand>$(_SentryCLICommand) $(IntermediateOutputPath)</_SentryCLICommand>
     </PropertyGroup>
-    <Exec Command="$(_SentryCLICommand)" />
+    <Exec Command="$(_SentryCLICommand)" IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
+      <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
+    </Exec>
+
+    <Warning Condition="'$(_SentryCLIExitCode)' != '0' And '$(SentryUploadSources)' != 'true'"
+      Text="Sentry CLI could not upload debug files." />
+    <Warning Condition="'$(_SentryCLIExitCode)' != '0' And '$(SentryUploadSources)' == 'true'"
+      Text="Sentry CLI could not upload debug files with sources.  Will retry without sources." />
+
+    <MSBuild Condition="'$(_SentryCLIExitCode)' != '0' And '$(SentryUploadSources)' == 'true'"
+      Projects="$(MSBuildProjectFile)" Targets="UploadSymbolsToSentry"
+      Properties="SentryUploadSymbols=true;SentryUploadSources=false;SentryCLI=$(SentryCLI);SentryCLIOptions=$(SentryCLIOptions)" />
 
   </Target>
 

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -73,10 +73,11 @@
       <SentryCLI Condition="!Exists('$(SentryCLI)')"/>
     </PropertyGroup>
 
-    <PropertyGroup>
-      <_SentryCLIInfoOptions Condition="'$(SentryOrg)' != '' And '$(SentryProject)' != ''">--no-defaults</_SentryCLIInfoOptions>
+    <PropertyGroup Condition="'$(SentryCLI)' != ''">
+      <_SentryCLICommand>&quot;$(SentryCLI)&quot; info</_SentryCLICommand>
+      <_SentryCLICommand Condition="'$(SentryOrg)' != '' And '$(SentryProject)' != ''">$(_SentryCLICommand) --no-defaults</_SentryCLICommand>
     </PropertyGroup>
-    <Exec Command="&quot;$(SentryCLI)&quot; info $(_SentryCLIInfoOptions)" Condition="'$(SentryCLI)' != ''" IgnoreExitCode="true" ConsoleToMsBuild="true" StandardOutputImportance="Low">
+    <Exec Condition="'$(SentryCLI)' != ''" Command="$(_SentryCLICommand)" IgnoreExitCode="true" ConsoleToMsBuild="true" StandardOutputImportance="Low">
       <Output TaskParameter="ExitCode" PropertyName="SentryCLIExitCode" />
       <Output TaskParameter="ConsoleOutput" PropertyName="SentryCLIOutput" />
     </Exec>
@@ -108,11 +109,14 @@
     <Message Importance="High" Condition="'$(SentryUploadSources)' == 'true'"
       Text="Preparing to upload debug symbols and sources to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
 
-    <PropertyGroup Condition="'$(SentryUploadSources)' == 'true'">
-      <_SentryUploadOptions>--include-sources</_SentryUploadOptions>
+    <PropertyGroup>
+      <_SentryCLICommand>&quot;$(SentryCLI)&quot; upload-dif</_SentryCLICommand>
+      <_SentryCLICommand Condition="'$(SentryCLIOptions.Trim())' != ''">$(_SentryCLICommand) $(SentryCLIOptions.Trim())</_SentryCLICommand>
+      <_SentryCLICommand Condition="'$(SentryUploadSources)' == 'true'">$(_SentryCLICommand) --include-sources</_SentryCLICommand>
+      <_SentryCLICommand>$(_SentryCLICommand) $(IntermediateOutputPath)</_SentryCLICommand>
     </PropertyGroup>
+    <Exec Command="$(_SentryCLICommand)" />
 
-    <Exec Command="&quot;$(SentryCLI)&quot; upload-dif $(_SentryUploadOptions) $(SentryCLIOptions) $(IntermediateOutputPath)" />
   </Target>
 
 </Project>

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -28,7 +28,7 @@
     </WriteCodeFragment>
   </Target>
 
-  <Target Name="CheckSentryCLI" AfterTargets="DispatchToInnerBuilds;AfterBuild">
+  <Target Name="CheckSentryCLI" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
     <PropertyGroup>
       <!-- This property controls whether symbols are to be sent to Sentry. -->
       <SentryUploadSymbols Condition="'$(SentryUploadSymbols)' == '' And '$(Configuration)' == 'Release'">true</SentryUploadSymbols>
@@ -95,7 +95,7 @@
   </Target>
 
   <!-- Upload debug information files to Sentry after the build. -->
-  <Target Name="UploadSymbolsToSentry" AfterTargets="AfterBuild" DependsOnTargets="PrepareSentryCLI" Condition="'$(SentryUploadSymbols)' == 'true' And '$(SentryCLI)' != ''">
+  <Target Name="UploadSymbolsToSentry" AfterTargets="Build;Publish" DependsOnTargets="PrepareSentryCLI" Condition="'$(SentryUploadSymbols)' == 'true' And '$(SentryCLI)' != ''">
 
     <Message Importance="High" Condition="'$(SentryUploadSources)' != 'true'"
       Text="Preparing to upload debug symbols to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -31,7 +31,7 @@
   <Target Name="CheckSentryCLI" AfterTargets="DispatchToInnerBuilds;AfterBuild">
     <PropertyGroup>
       <!-- This property controls whether symbols are to be sent to Sentry. -->
-      <SentryUploadSymbols Condition="'$(SentryUploadSymbols)' == '' And '$(Configuration)' == 'Release' And '$(DebugType)' != 'embedded'">true</SentryUploadSymbols>
+      <SentryUploadSymbols Condition="'$(SentryUploadSymbols)' == '' And '$(Configuration)' == 'Release'">true</SentryUploadSymbols>
 
       <!-- This property controls if the Sentry CLI is to be used at all.  Setting false will disable all Sentry CLI usage. -->
       <UseSentryCLI Condition="'$(UseSentryCLI)' == '' And ('$(SentryUploadSymbols)' == 'true')">true</UseSentryCLI>
@@ -94,10 +94,20 @@
     </PropertyGroup>
   </Target>
 
-  <!-- Upload symbols (and any other debug information files) to Sentry after the build. -->
+  <!-- Upload debug information files to Sentry after the build. -->
   <Target Name="UploadSymbolsToSentry" AfterTargets="AfterBuild" DependsOnTargets="PrepareSentryCLI" Condition="'$(SentryUploadSymbols)' == 'true' And '$(SentryCLI)' != ''">
-    <Message Importance="High" Text="Preparing to upload debug symbols to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
-    <Exec Command="&quot;$(SentryCLI)&quot; upload-dif $(SentryCLIOptions) $(IntermediateOutputPath)" />
+
+    <Message Importance="High" Condition="'$(SentryUploadSources)' != 'true'"
+      Text="Preparing to upload debug symbols to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
+
+    <Message Importance="High" Condition="'$(SentryUploadSources)' == 'true'"
+      Text="Preparing to upload debug symbols and sources to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
+
+    <PropertyGroup Condition="'$(SentryUploadSources)' == 'true'">
+      <_SentryUploadOptions>--include-sources</_SentryUploadOptions>
+    </PropertyGroup>
+
+    <Exec Command="&quot;$(SentryCLI)&quot; upload-dif $(_SentryUploadOptions) $(SentryCLIOptions) $(IntermediateOutputPath)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
- Updates Sentry CLI to 2.12.0
- Updates the msbuild target order to resolve #2137 
- Adds `SentryUploadSources` msbuild property.  Set `true` to opt-in to uploading sources while uploading symbols. See https://github.com/getsentry/sentry-dotnet/issues/646#issuecomment-1408960693 
- Now uploads from the project's `bin` folder by default, and adds a `SentryIncludeIntermediateOutputPath` property which can be set `true` to also include the `obj` folder.
- Warns instead of erroring if upload fails.
- If upload fails when `SentryUploadSources` is enabled, it will retry with symbols only (no sources).