### PR TITLE
Increase iOS launch timeout in CI

### DIFF
--- a/.github/workflows/device-tests-ios.yml
+++ b/.github/workflows/device-tests-ios.yml
@@ -39,6 +39,7 @@ jobs:
           xharness apple test \
             --app=test/Sentry.Maui.Device.TestApp/bin/Release/net7.0-ios/iossimulator-x64/Sentry.Maui.Device.TestApp.app \
             --target=ios-simulator-64 \
+            --launch-timeout=00:10:00 \
             --output-directory=./test_output
 
       - name: Create Test Report


### PR DESCRIPTION
We've been getting a lot of these for the iOS device tests in CI.

https://github.com/getsentry/sentry-dotnet/actions/runs/4058524866/jobs/6985551215#step:9:28

<img width="1262" alt="image" src="https://user-images.githubusercontent.com/1396388/215922743-6ebd0c63-e4e7-483e-8b09-4306c3d48a99.png">

The default launch timeout is *supposed* to be 5 minutes, but from the timestamps shown here, I think it's being measured from the start of installing the app, rather than the start of launching it.

Increasing to 10 minutes to hopefully avoid these.

#skip-changelog