### PR TITLE
Fix Sentry CLI MSBuild for Xamarin and NetFX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix Sentry CLI MSBuild for Xamarin and NetFX ([#2153](https://github.com/getsentry/sentry-dotnet/pull/2153))
+
 ## 3.27.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix Sentry CLI MSBuild for Xamarin and NetFX ([#2153](https://github.com/getsentry/sentry-dotnet/pull/2153))
+- Fix Sentry CLI MSBuild for Xamarin and NetFX ([#2154](https://github.com/getsentry/sentry-dotnet/pull/2154))
 
 ## 3.27.0
 

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -113,8 +113,7 @@
       <_SentryCLICommand>&quot;$(SentryCLI)&quot; upload-dif</_SentryCLICommand>
       <_SentryCLICommand Condition="'$(SentryCLIOptions.Trim())' != ''">$(_SentryCLICommand) $(SentryCLIOptions.Trim())</_SentryCLICommand>
       <_SentryCLICommand Condition="'$(SentryUploadSources)' == 'true'">$(_SentryCLICommand) --include-sources</_SentryCLICommand>
-      <_SentryCLICommand>$(_SentryCLICommand) $(OutputPath)</_SentryCLICommand>
-      <_SentryCLICommand Condition="'$(SentryIncludeIntermediateOutputPath)' == 'true'">$(_SentryCLICommand) $(IntermediateOutputPath)</_SentryCLICommand>
+      <_SentryCLICommand>$(_SentryCLICommand) $(IntermediateOutputPath)</_SentryCLICommand>
     </PropertyGroup>
     <Exec Command="$(_SentryCLICommand)" IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -28,7 +28,7 @@
     </WriteCodeFragment>
   </Target>
 
-  <Target Name="CheckSentryCLI" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
+  <Target Name="CheckSentryCLI" AfterTargets="Build" Condition="'$(InnerTargets)' == ''">
     <PropertyGroup>
       <!-- This property controls whether symbols are to be sent to Sentry. -->
       <SentryUploadSymbols Condition="'$(SentryUploadSymbols)' == '' And '$(Configuration)' == 'Release'">true</SentryUploadSymbols>


### PR DESCRIPTION
Some further testing on Xamarin and .NET Framework projects after the 3.27.0 release, found symbol uploads not working as expected.

- We can't rely on checking for a non-empty `TargetFramework` property, because that only exists in the newer SDK-style .NET projects.  Since the intention here is to run for anything *other* than the outer build when multi-targeting, we can check for an *empty* `InnerTargets` property (which is only set in the case we need to exclude).

- On Xamarin Android projects, we always will need the `obj` folder contents rather than `bin` to get the correct debug files uploaded.  Since the `obj` folder is guaranteed to always have the files we need, we should make it the default and remove the `SentryIncludeIntermediateOutputPath` option.  (We don't need to use the `bin` folder at all.)