### PR TITLE
Workaround VS Pair to Mac issue

### DIFF
--- a/.github/actions/buildcocoasdk/action.yml
+++ b/.github/actions/buildcocoasdk/action.yml
@@ -36,7 +36,7 @@ runs:
       id: cache-sentry-cocoa
       uses: actions/cache@v3
       with:
-        path: modules/sentry-cocoa/Carthage/Build
+        path: modules/sentry-cocoa/Carthage
         key: sentry-cocoa-${{ env.SENTRY_COCOA_SHA }}
 
     - name: Build Sentry Cocoa SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Workaround VS Pair to Mac issue, and Update bundled Cocoa SDK to version 7.31.5 ([#2164](https://github.com/getsentry/sentry-dotnet/pull/2164))
+- Workaround Visual Studio "Pair to Mac" issue (on Windows), and Update bundled Cocoa SDK to version 7.31.5 ([#2164](https://github.com/getsentry/sentry-dotnet/pull/2164))
 
 ## 3.27.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Workaround VS Pair to Mac issue, and Update bundled Cocoa SDK to version 7.31.5 ([#2164](https://github.com/getsentry/sentry-dotnet/pull/2164))
+
 ## 3.27.1
 
 ### Fixes

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -24,7 +24,7 @@ then
 
     # Keep track of the submodule's SHA so we only build when we need to
     SHA=$(git rev-parse HEAD)
-    SHAFILE=Carthage/Build/.built-from-sha
+    SHAFILE=Carthage/.built-from-sha
     [ -f $SHAFILE ] && SHAFROMFILE=$(<$SHAFILE)
     VERSION="$(git describe --tags) ($(git rev-parse --short HEAD))"
 
@@ -33,7 +33,20 @@ then
     else
         echo "---------- Building Sentry Cocoa SDK $VERSION ---------- "
         rm -rf Carthage
-        ../$CARTHAGE build --use-xcframeworks --no-skip-current --platform ios,macCatalyst
+
+        # Note - We keep the build output in separate directories so that .NET
+        # bundles iOS with net6.0-ios and Mac Catalyst with net6.0-maccatalyst.
+        # The lack of symlinks in the ios builds, means we should also be able
+        # to use the package on Windows with "Pair to Mac".
+
+        # Build for iOS.  We'll get both ios and ios-simulator from this.
+        ../$CARTHAGE build --use-xcframeworks --no-skip-current --platform ios
+        mv Carthage/Build Carthage/Build-ios
+
+        # Separately, build for Mac Catalyst in its own directory.
+        ../$CARTHAGE build --use-xcframeworks --no-skip-current --platform macCatalyst
+        mv Carthage/Build Carthage/Build-maccatalyst
+
         echo $SHA > $SHAFILE
         echo ""
     fi

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -51,7 +51,9 @@ then
         echo ""
     fi
 
-    cd ..
+    # Remove anything we don't want to bundle in the nuget package.
+    cd Carthage
+    find . \( -name Headers -o -name PrivateHeaders -o -name Modules \) -exec rm -rf {} +
 fi
 
 popd > /dev/null

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -5,7 +5,7 @@
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
     <Description>.NET Bindings for the Sentry Cocoa SDK</Description>
     <SentryCocoaSdkDirectory>$(MSBuildThisFileDirectory)..\..\modules\sentry-cocoa\</SentryCocoaSdkDirectory>
-    <SentryCocoaFramework>$(SentryCocoaSdkDirectory)Carthage\Build\Sentry.xcframework</SentryCocoaFramework>
+    <SentryCocoaFramework>$(SentryCocoaSdkDirectory)Carthage\Build-$(TargetPlatformIdentifier)\Sentry.xcframework</SentryCocoaFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Workaround https://github.com/xamarin/xamarin-macios/issues/16001 by ensuring that the `net6.0-ios` target of `Sentry.Bindings.Cocoa` does not contain a zipped resources file.

We can do this by building the Sentry Cocoa SDK *separately* for iOS than for MacCatalyst.  Only the MacCatalyst build contains symlinks, so the iOS resources will be copied into the package directly instead of being zipped.  Nice side effect of this is the `Sentry.Bindings.Cocoa` nuget package reduces in size from 20MB to 10.5MB, because each target only has the native files it needs, rather than the whole xcframework.

Now that the resources aren't being zipped, we also need to strip out the Cocoa header files.  Otherwise, the build gives an error when packaging due to long file paths.  (We don't need the header files in the nuget package anyway.)

Fixes #2037 - Tested with VS on Windows with a pre-release package.

Also bumped the Cocoa SDK from 7.31.4 to 7.31.5.  (We'll do 8.x with #2148)