### PR TITLE
Stop embedding PDBs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,3 +72,4 @@ jobs:
           if-no-files-found: error
           path: |
             ${{ github.workspace }}/src/**/Release/*.nupkg
+            ${{ github.workspace }}/src/**/Release/*.snupkg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Workaround Visual Studio "Pair to Mac" issue (on Windows), and Update bundled Cocoa SDK to version 7.31.5 ([#2164](https://github.com/getsentry/sentry-dotnet/pull/2164))
+- Sentry SDK assemblies no longer have PDBs embedded ([#2166](https://github.com/getsentry/sentry-dotnet/pull/2166))
 
 ## 3.27.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Workaround Visual Studio "Pair to Mac" issue (on Windows), and Update bundled Cocoa SDK to version 7.31.5 ([#2164](https://github.com/getsentry/sentry-dotnet/pull/2164))
-- Sentry SDK assemblies no longer have PDBs embedded ([#2166](https://github.com/getsentry/sentry-dotnet/pull/2166))
+- Sentry SDK assemblies no longer have PDBs embedded. Debug symbols are uploaded to `nuget.org` as `snupkg` packages  ([#2166](https://github.com/getsentry/sentry-dotnet/pull/2166))
 
 ## 3.27.1
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,15 +23,18 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
-    <!-- Prop required by Microsoft.SourceLink.GitHub -->
-    <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <!--
+      SourceLink configuration
+      See https://github.com/dotnet/sourcelink/blob/main/README.md
+      And https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props
+    -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!-- Embed source files that are not tracked by the source control manager in the PDB -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 
     <Nullable>annotations</Nullable>
-
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,8 +28,6 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Embed source files that are not tracked by the source control manager in the PDB -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <!-- Embed PDB inside the assembly -->
-    <DebugType>embedded</DebugType>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 
     <Nullable>annotations</Nullable>


### PR DESCRIPTION
We now have support for NuGet symbol servers in Sentry, configurable on the `Debug Files` tab, from the project settings in the Sentry UI.

<img width="978" alt="image" src="https://user-images.githubusercontent.com/1396388/217404783-27057125-0d0b-4b03-9016-f35c68ddddff.png">

Thus, there's no longer any need to embed symbols in the PDBs themselves.  Instead, we'll publish NuGet Symbols package (`.snupkg`) files.

Note: For now, we will also still upload them to Sentry directly via Sentry CLI so that we get sources in the Sentry UI.  Eventually we'll be able to just rely on SourceLink (see https://github.com/getsentry/symbolic/issues/735).

Fixes #2159.