### PR TITLE
Remove separate version for Android AssemblyReader

### DIFF
--- a/src/Sentry.Android.AssemblyReader/Sentry.Android.AssemblyReader.csproj
+++ b/src/Sentry.Android.AssemblyReader/Sentry.Android.AssemblyReader.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-
-    <!-- This package revs independently.  Bump this version manually when making changes. -->
-    <Version>1.0.0</Version>
     <Description>.NET assembly reader for Android</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
I recently learned that Craft will fail to publish to nuget if a package with the same version already exists.

See https://github.com/getsentry/craft/pull/456

Removing the independent versioning from `Sentry.Android.AssemblyReader` so we'll be able to pass the next release.

#skip-changelog