### PR TITLE
Fix MAUI missing breadcrumbs for lifecycle and UI events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix MAUI missing breadcrumbs for lifecycle and UI events ([#2170](https://github.com/getsentry/sentry-dotnet/pull/2170))
+
 ## 3.28.0
 
 ### Features

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -102,14 +102,20 @@ public static class SentryMauiAppBuilderExtensions
 
     private static void BindMauiEvents(this IPlatformApplication platformApplication)
     {
-        // Bind to the MAUI application events in a real application control,
-        // because the required events are not present on the interfaces.
-        if (platformApplication.Application is not Application application)
+        // We need to resolve the application manually, because it's not necessarily
+        // set on platformApplication.Application at this point in the lifecycle.
+        var services = platformApplication.Services;
+        var app = services.GetService<IApplication>();
+
+        // Use a real Application control, because the required events needed for binding
+        // are not present on IApplication and related interfaces.
+        if (app is not Application application)
         {
             return;
         }
 
-        var binder = platformApplication.Services.GetRequiredService<IMauiEventsBinder>();
+        // Bind the events
+        var binder = services.GetRequiredService<IMauiEventsBinder>();
         binder.BindApplicationEvents(application);
     }
 }

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Maui.LifecycleEvents;
+using Sentry.Extensibility;
 using Sentry.Extensions.Logging;
 using Sentry.Extensions.Logging.Extensions.DependencyInjection;
 using Sentry.Maui;
@@ -111,6 +112,8 @@ public static class SentryMauiAppBuilderExtensions
         // are not present on IApplication and related interfaces.
         if (app is not Application application)
         {
+            var options = services.GetService<IOptions<SentryMauiOptions>>()?.Value;
+            options?.LogWarning("Could not bind to MAUI events!");
             return;
         }
 

--- a/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.Android.cs
+++ b/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.Android.cs
@@ -10,14 +10,15 @@ public partial class SentryMauiAppBuilderExtensionsTests
     public void UseSentry_BindsToApplicationStartupEvent_Android()
     {
         // Arrange
+        var application = MockApplication.Create();
         var binder = Substitute.For<IMauiEventsBinder>();
 
         var builder = _fixture.Builder;
+        builder.Services.AddSingleton<IApplication>(application);
         builder.Services.AddSingleton(binder);
         builder.UseSentry(ValidDsn);
         using var app = builder.Build();
 
-        var application = MockApplication.Create();
         var androidApplication = new MockAndroidApplication(application, app.Services);
 
         // Act

--- a/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.iOS.cs
+++ b/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.iOS.cs
@@ -11,14 +11,15 @@ public partial class SentryMauiAppBuilderExtensionsTests
     public void UseSentry_BindsToApplicationStartupEvent_iOS()
     {
         // Arrange
+        var application = MockApplication.Create();
         var binder = Substitute.For<IMauiEventsBinder>();
 
         var builder = _fixture.Builder;
+        builder.Services.AddSingleton<IApplication>(application);
         builder.Services.AddSingleton(binder);
         builder.UseSentry(ValidDsn);
         using var app = builder.Build();
 
-        var application = MockApplication.Create();
         var iosApplication = new MockIosApplication(application, app.Services);
 
         // A bit of hackery here, because we can't mock UIKit.UIApplication.


### PR DESCRIPTION
I'm really not sure *when* this started happening, but I noticed that we are no longer getting any breadcrumbs for lifecycle and UI events in MAUI apps.

Running our MAUI sample shows only these:

<img width="880" alt="image" src="https://user-images.githubusercontent.com/1396388/217727076-b6fcf97f-2967-459f-a238-ab5ee6964220.png">

The two breadcrumbs before the exception are from *logging* that the MAUI sample does, and are picked up by `Sentry.Extensions.Logging`.  There's no indication of Application, Windows, or Button events as there used to be.

The last time I worked on this part of the MAUI code was with #2001 / #2006.  It's possible the issue was introduced then.  If so, I'm surprised we didn't notice until now.  It's also possible that something changed in MAUI between then and now.

On investigation, it seems that MAUI's `IPlatformApplication.Application` property is not set until *after* the event we use.  See [here](https://github.com/dotnet/maui/blob/8f5fc9719a83db1f6c7fb324acd23373308bcdde/src/Core/src/Platform/Android/MauiApplication.cs#L35-L37) in the MAUI source code.

Thus, there are two options:

1. Bind at a later event, after the `Application` property has been resolved
2. Resolve the `Application` property ourselves through the `Services` container.

This PR takes the second approach, which appears to work:

<img width="907" alt="image" src="https://user-images.githubusercontent.com/1396388/217728147-c9f37ea1-a69e-497b-be2b-d2899d1638a4.png">

I also went back and validated that this didn't regress #2001.