### PR TITLE
Fix hybrid sdk names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix MAUI missing breadcrumbs for lifecycle and UI events ([#2170](https://github.com/getsentry/sentry-dotnet/pull/2170))
+- Fix hybrid sdk names ([#2171](https://github.com/getsentry/sentry-dotnet/pull/2171))
 
 ## 3.28.0
 

--- a/src/Sentry/Internal/Constants.cs
+++ b/src/Sentry/Internal/Constants.cs
@@ -33,11 +33,5 @@ internal static class Constants
     public const string DebugEnvironmentSetting = "debug";
 
     // See: https://github.com/getsentry/sentry-release-registry
-#if ANDROID
-        public const string SdkName = "sentry.dotnet.android";
-#elif __IOS__
-    public const string SdkName = "sentry.dotnet.cocoa";
-#else
-        public const string SdkName = "sentry.dotnet";
-#endif
+    public const string SdkName = "sentry.dotnet";
 }

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -160,6 +160,9 @@ public static partial class SentrySdk
             return evt;
         };
 
+        // Set hybrid SDK name
+        CocoaSdk.PrivateSentrySdkOnly.SetSdkName("sentry.cocoa.dotnet");
+
         // Now initialize the Cocoa SDK
         SentryCocoaSdk.StartWithOptionsObject(cocoaOptions);
 

--- a/src/Sentry/Properties/AssemblyInfo.cs
+++ b/src/Sentry/Properties/AssemblyInfo.cs
@@ -32,7 +32,10 @@
 // Don't let the Sentry Android SDK auto-init, as we do that manually in SentrySdk.Init
 // See https://docs.sentry.io/platforms/android/configuration/manual-init/
 // This attribute automatically adds the metadata to the final AndroidManifest.xml
-[assembly: Android.App.MetaData("io.sentry.auto-init", Value = "false")]
+[assembly: MetaData("io.sentry.auto-init", Value = "false")]
+
+// Set the hybrid SDK name
+[assembly: MetaData("io.sentry.sdk.name", Value = "sentry.java.android.dotnet")]
 
 #endif
 


### PR DESCRIPTION
- Use `sentry.java.android.dotnet` for the Android SDK
- Use `sentry.cocoa.dotnet` for the iOS SDK
- Use `sentry.dotnet` for the base .NET SDK (regardless of target)
- Use `sentry.dotnet.maui` for the MAUI .NET SDK (no change required)