### PR TITLE
Bump Craft to 1.1.1

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-minVersion: 1.1.0
+minVersion: 1.1.1
 changelogPolicy: auto
 targets:
   - name: nuget


### PR DESCRIPTION
Needed for correct `.snupkg` publishing

#skip-changelog