### PR TITLE
Fix assembly not found on Android in Debug configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix assembly not found on Android in Debug configuration ([#2175](https://github.com/getsentry/sentry-dotnet/pull/2175))
+
 ## 3.28.1
 
 ### Fixes

--- a/src/Sentry.Android.AssemblyReader/AndroidAssemblyDirectoryReader.cs
+++ b/src/Sentry.Android.AssemblyReader/AndroidAssemblyDirectoryReader.cs
@@ -8,6 +8,13 @@ internal sealed class AndroidAssemblyDirectoryReader : AndroidAssemblyReader, IA
 
     public PEReader? TryReadAssembly(string name)
     {
+        if (File.Exists(name))
+        {
+            // The assembly is already extracted to the file system.  Just read it.
+            var stream = File.OpenRead(name);
+            return new PEReader(stream);
+        }
+
         var zipEntry = FindAssembly(name);
         if (zipEntry is null)
         {


### PR DESCRIPTION
Noticed that when building an Android app in *debug* configuration, with Sentry debugging on, I was seeing failures reading the assembly to create debug info:

```
Debug: Creating SentryStackTrace. isCurrentStackTrace: False.
Debug: Couldn't find assembly /data/data/com.companyname.mymauiapp/files/.__override__/MyMauiApp.dll in the APK
Debug: Skipping DebugImage for module 'MyMauiApp.dll' because assembly wasn't found: '/data/data/com.companyname.mymauiapp/files/.__override__/MyMauiApp.dll'
Debug: Couldn't find assembly /data/data/com.companyname.mymauiapp/files/.__override__/Microsoft.Maui.Controls.dll in the APK
Debug: Skipping DebugImage for module 'Microsoft.Maui.Controls.dll' because assembly wasn't found: '/data/data/com.companyname.mymauiapp/files/.__override__/Microsoft.Maui.Controls.dll'
Debug: Couldn't find assembly /data/data/com.companyname.mymauiapp/files/.__override__/Microsoft.Maui.dll in the APK
Debug: Skipping DebugImage for module 'Microsoft.Maui.dll' because assembly wasn't found: '/data/data/com.companyname.mymauiapp/files/.__override__/Microsoft.Maui.dll'
Debug: Couldn't find assembly /data/data/com.companyname.mymauiapp/files/.__override__/Mono.Android.dll in the APK
Debug: Skipping DebugImage for module 'Mono.Android.dll' because assembly wasn't found: '/data/data/com.companyname.mymauiapp/files/.__override__/Mono.Android.dll'
Debug: Created DebugStackTrace with 10 frames.
```

On closer inspection, it looks like assemblies are only embedded in the APK in *release* mode.  In debug mode, they're put on disk as normal files.

Updating the Android assembly reader to use the file on disk if it exists.