### PR TITLE
Workaround issue with Verify on Windows in Rider on .NET 7

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -9,6 +9,17 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <!--
+    Workaround for Verify issue with scrubbing when running in Rider on Windows.
+    Ensures that the volume label is upper cased ("C:" instead of "c:"), which is read
+    from ProjectDir and SolutionDir properties during compilation and written to the
+    assembly metadata attributes.
+  -->
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <ProjectDir Condition="'$(ProjectDir)' != ''">$(ProjectDir.Substring(0, 1).ToUpper())$(ProjectDir.Substring(1))</ProjectDir>
+    <SolutionDir Condition="'$(SolutionDir)' != ''">$(SolutionDir.Substring(0, 1).ToUpper())$(SolutionDir.Substring(1))</SolutionDir>
+  </PropertyGroup>
+
   <ItemGroup>
     <Using Include="Sentry" />
     <Using Include="Sentry.DsnSamples" Static="True" />


### PR DESCRIPTION
Two Verify tests are failing, only on Windows, only on Rider, and only for .NET 7.

![image](https://user-images.githubusercontent.com/1396388/218224951-53fc8eb7-e522-4fd3-bbd5-916eeea183a3.png)

```
Received: SentryStackTraceFactoryTests.MethodGeneric_mode=Enhanced.DotNet7_0.received.txt
Verified: SentryStackTraceFactoryTests.MethodGeneric_mode=Enhanced.verified.txt
Compare Result:
  {
    FileName: Internals/SentryStackTraceFactoryTests.cs,
    Function: void SentryStackTraceFactoryTests.GenericMethodThatThrows<T>(T value),
-   AbsolutePath: {ProjectDirectory}Internals/SentryStackTraceFactoryTests.cs,
+   AbsolutePath: {UserProfile}/Code/getsentry/sentry-dotnet/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs,
    InApp: true,
    AddressMode: rel:0
  }
```

On closer inspection, it appears that the `ProjectDir` and `SolutionDir` MSBuild properties are being passed with a lower-case drive letter `c:\` instead of `C:\`.  These get written to assembly metadata attributes, and then fails the replacement that Verify does when scrubbing.

Will add an issue to Verify for @SimonCropp to investigate, but for now I'm working around it by forcing the drive letter to be upper-cased.

@SeanFeldman - This will fix the test fail you had while onboarding.

#skip-changelog