### PR TITLE
Fix build error on Windows

### DIFF
--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <!-- Workaround for https://github.com/xamarin/xamarin-macios/issues/15299 -->
-  <Target Name="_SetGeneratedSupportDelegatesInternal" BeforeTargets="CoreCompile">
+  <Target Name="_SetGeneratedSupportDelegatesInternal" BeforeTargets="CoreCompile" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
     <PropertyGroup>
       <GeneratedSupportDelegatesFile>$(MSBuildThisFileDirectory)$(GeneratedSourcesDir)SupportDelegates.g.cs</GeneratedSupportDelegatesFile>
     </PropertyGroup>


### PR DESCRIPTION
Building the entire `Sentry.sln` fails on Windows, because one of the custom tasks in `Sentry.Bindings.Cocoa` still executes.  This resolves the issue.  (`Sentry.Bindings.Cocoa.dll` will be an empty assembly, but the build will pass.)

#skip-changelog