### PR TITLE
Add support for BeforeSendTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Allow `SentryUploadSources` to work even when not uploading symbols ([#2197](https://github.com/getsentry/sentry-dotnet/pull/2197))
+- Add support for `BeforeSendTransaction` ([#2188](https://github.com/getsentry/sentry-dotnet/pull/2188))
 
 ### Fixes
 

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -135,8 +135,7 @@ public class SentryClient : ISentryClient, IDisposable
         var processedTransaction = BeforeSendTransaction(transaction);
         if (processedTransaction is null) // Rejected transaction
         {
-            // TODO: should the dropped transaction be recorded?
-            //_options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.BeforeSendTransaction, DataCategory.Error);
+            _options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Transaction);
             _options.LogInfo("Transaction dropped by BeforeSendTransaction callback.");
             return;
         }

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -122,7 +122,7 @@ public class SentryClient : ISentryClient, IDisposable
         }
 
         // Sampling decision MUST have been made at this point
-        Debug.Assert(transaction.IsSampled is null,
+        Debug.Assert(transaction.IsSampled is not null,
             "Attempt to capture transaction without sampling decision.");
 
         if (transaction.IsSampled is false)

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -315,6 +315,16 @@ public class SentryOptions
     public Func<SentryEvent, SentryEvent?>? BeforeSend { get; set; }
 
     /// <summary>
+    /// A callback to invoke before sending a transaction to Sentry
+    /// </summary>
+    /// <remarks>
+    /// The return of this transaction will be sent to Sentry. This allows the application
+    /// a chance to inspect and/or modify the transaction before it's sent. If the transaction
+    /// should not be sent at all, return null from the callback.
+    /// </remarks>
+    public Func<Transaction, Transaction?>? BeforeSendTransaction { get; set; }
+
+    /// <summary>
     /// A callback invoked when a breadcrumb is about to be stored.
     /// </summary>
     /// <remarks>

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -546,6 +546,7 @@ namespace Sentry
         public Sentry.Extensibility.IBackgroundWorker? BackgroundWorker { get; set; }
         public System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?>? BeforeBreadcrumb { get; set; }
         public System.Func<Sentry.SentryEvent, Sentry.SentryEvent?>? BeforeSend { get; set; }
+        public System.Func<Sentry.Transaction, Sentry.Transaction?>? BeforeSendTransaction { get; set; }
         public string? CacheDirectoryPath { get; set; }
         public System.Action<System.Net.Http.HttpClient>? ConfigureClient { get; set; }
         public System.Func<bool>? CrashedLastRun { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -546,6 +546,7 @@ namespace Sentry
         public Sentry.Extensibility.IBackgroundWorker? BackgroundWorker { get; set; }
         public System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?>? BeforeBreadcrumb { get; set; }
         public System.Func<Sentry.SentryEvent, Sentry.SentryEvent?>? BeforeSend { get; set; }
+        public System.Func<Sentry.Transaction, Sentry.Transaction?>? BeforeSendTransaction { get; set; }
         public string? CacheDirectoryPath { get; set; }
         public System.Action<System.Net.Http.HttpClient>? ConfigureClient { get; set; }
         public System.Func<bool>? CrashedLastRun { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -546,6 +546,7 @@ namespace Sentry
         public Sentry.Extensibility.IBackgroundWorker? BackgroundWorker { get; set; }
         public System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?>? BeforeBreadcrumb { get; set; }
         public System.Func<Sentry.SentryEvent, Sentry.SentryEvent?>? BeforeSend { get; set; }
+        public System.Func<Sentry.Transaction, Sentry.Transaction?>? BeforeSendTransaction { get; set; }
         public string? CacheDirectoryPath { get; set; }
         public System.Action<System.Net.Http.HttpClient>? ConfigureClient { get; set; }
         public System.Func<bool>? CrashedLastRun { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -545,6 +545,7 @@ namespace Sentry
         public Sentry.Extensibility.IBackgroundWorker? BackgroundWorker { get; set; }
         public System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?>? BeforeBreadcrumb { get; set; }
         public System.Func<Sentry.SentryEvent, Sentry.SentryEvent?>? BeforeSend { get; set; }
+        public System.Func<Sentry.Transaction, Sentry.Transaction?>? BeforeSendTransaction { get; set; }
         public string? CacheDirectoryPath { get; set; }
         public System.Action<System.Net.Http.HttpClient>? ConfigureClient { get; set; }
         public System.Func<bool>? CrashedLastRun { get; set; }

--- a/test/Sentry.Tests/SentryClientTests.CaptureTransaction_BeforeSendTransactionThrows_ErrorToEventBreadcrumb.verified.txt
+++ b/test/Sentry.Tests/SentryClientTests.CaptureTransaction_BeforeSendTransactionThrows_ErrorToEventBreadcrumb.verified.txt
@@ -1,0 +1,14 @@
+﻿[
+  {
+    Timestamp: DateTimeOffset_1,
+    Message: BeforeSendTransaction callback failed.,
+    Data: {
+      message: Exception message!,
+      stackTrace:
+at Task Sentry.Tests.SentryClientTests.CaptureTransaction_BeforeSendTransactionThrows_ErrorToEventBreadcrumb()
+at Transaction Sentry.SentryClient.BeforeSendTransaction(...)
+    },
+    Category: SentryClient,
+    Level: error
+  }
+]

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -665,6 +665,24 @@ public partial class SentryClientTests
     }
 
     [Fact]
+    public void CaptureTransaction_BeforeSendTransaction_SetToNull_Dropped()
+    {
+        _fixture.SentryOptions.BeforeSendTransaction = _ => null;
+
+        var sut = _fixture.GetSut();
+        sut.CaptureTransaction(
+            new Transaction(
+                "test name",
+                "test operation")
+            {
+                IsSampled = true,
+                EndTimestamp = DateTimeOffset.Now // finished
+            });
+
+        _ = _fixture.BackgroundWorker.DidNotReceive().EnqueueEnvelope(Arg.Any<Envelope>());
+    }
+
+    [Fact]
     public void Dispose_Worker_FlushCalled()
     {
         var client = _fixture.GetSut();

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -722,7 +722,7 @@ public partial class SentryClientTests
     [Fact(Skip = "TBD")]
     public void CaptureTransaction_BeforeSendTransaction_RejectEvent_RecordsDiscard()
     {
-        _fixture.SentryOptions.BeforeSend = _ => null;
+        _fixture.SentryOptions.BeforeSendTransaction = _ => null;
 
         var sut = _fixture.GetSut();
         sut.CaptureTransaction( new Transaction("test name", "test operation")
@@ -732,7 +732,7 @@ public partial class SentryClientTests
         });
 
         _fixture.ClientReportRecorder.Received(1)
-            .RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Error);
+            .RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Transaction);
     }
 
     [Fact]

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -719,7 +719,7 @@ public partial class SentryClientTests
         Assert.Same(transaction, received);
     }
 
-    [Fact(Skip = "TBD")]
+    [Fact]
     public void CaptureTransaction_BeforeSendTransaction_RejectEvent_RecordsDiscard()
     {
         _fixture.SentryOptions.BeforeSendTransaction = _ => null;

--- a/test/Sentry.Tests/SentryClientTests.verify.cs
+++ b/test/Sentry.Tests/SentryClientTests.verify.cs
@@ -16,4 +16,18 @@ public partial class SentryClientTests
 
         return Verify(@event.Breadcrumbs);
     }
+
+    [Fact]
+    public Task CaptureTransaction_BeforeSendTransactionThrows_ErrorToEventBreadcrumb()
+    {
+        var error = new Exception("Exception message!");
+        _fixture.SentryOptions.BeforeSendTransaction = _ => throw error;
+
+        var @event = new SentryEvent();
+
+        var sut = _fixture.GetSut();
+        _ = sut.CaptureEvent(@event);
+
+        return Verify(@event.Breadcrumbs);
+    }
 }

--- a/test/Sentry.Tests/SentryClientTests.verify.cs
+++ b/test/Sentry.Tests/SentryClientTests.verify.cs
@@ -23,11 +23,14 @@ public partial class SentryClientTests
         var error = new Exception("Exception message!");
         _fixture.SentryOptions.BeforeSendTransaction = _ => throw error;
 
-        var @event = new SentryEvent();
+        var transaction = new Transaction("name", "operation")
+        {
+            IsSampled = true
+        };
 
         var sut = _fixture.GetSut();
-        _ = sut.CaptureEvent(@event);
+        sut.CaptureTransaction(transaction);
 
-        return Verify(@event.Breadcrumbs);
+        return Verify(transaction.Breadcrumbs);
     }
 }


### PR DESCRIPTION
Add `BeforeSendTransaction` to work similarly to `BeforeSend` but for transactions instead of events.

Fixes #2077 