### PR TITLE
Pin LocalDB for .NET Core 3.1 to fix failing test

### DIFF
--- a/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
@@ -36,9 +36,18 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.*" />
   </ItemGroup>
 
-  <ItemGroup>
+  <!--
+    Pin to LocalDb 14.2.1 on .NET Core 3.1 for the transitive dependency on Microsoft.Data.SqClient 5.0.1.
+    See https://github.com/getsentry/sentry-dotnet/issues/2189
+  -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="LocalDb" Version="14.2.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="LocalDb" Version="14.*" />
+  </ItemGroup>
 
+  <ItemGroup>
     <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
     <PackageReference Include="System.Drawing.Common" Version="6.*" />
 


### PR DESCRIPTION
Fixes #2189 

#skip-changelog