### PR TITLE
WIP: Remove floating versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,9 +51,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="UnoptimizedAssemblyDetector" Version="0.1.*" PrivateAssets="All" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.*" PrivateAssets="All" />
-    <PackageReference Include="Nullable" Version="1.*" PrivateAssets="All" />
+    <PackageReference Include="UnoptimizedAssemblyDetector" Version="0.1.1" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.2.0" PrivateAssets="All" />
+    <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Import the root global usings, except for samples. -->

--- a/benchmarks/Sentry.Benchmarks/Sentry.Benchmarks.csproj
+++ b/benchmarks/Sentry.Benchmarks/Sentry.Benchmarks.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.*" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Sentry.Samples.AspNetCore.Blazor.Wasm.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Sentry.Samples.AspNetCore.Blazor.Wasm.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.*" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="[6.0.14,7)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="[6.0.14,7)" PrivateAssets="all" />
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
   </ItemGroup>

--- a/samples/Sentry.Samples.AspNetCore.Grpc/Sentry.Samples.AspNetCore.Grpc.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Grpc/Sentry.Samples.AspNetCore.Grpc.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.*" />
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.*" />
-    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.*" />
-    <PackageReference Include="Grpc.Tools" Version="2.*" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.22.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.51.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.51.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.51.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.AspNetCore.Serilog/Sentry.Samples.AspNetCore.Serilog.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Serilog/Sentry.Samples.AspNetCore.Serilog.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.*" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.*" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.*" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.Aws.Lambda.AspNetCoreServer/Sentry.Samples.Aws.Lambda.AspNetCoreServer.csproj
+++ b/samples/Sentry.Samples.Aws.Lambda.AspNetCoreServer/Sentry.Samples.Aws.Lambda.AspNetCoreServer.csproj
@@ -5,8 +5,8 @@
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.*" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.*" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="8.0.0" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.4" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Controllers" />

--- a/samples/Sentry.Samples.Aws.Lambda.AspNetCoreServer/aws-lambda-tools-defaults.json
+++ b/samples/Sentry.Samples.Aws.Lambda.AspNetCoreServer/aws-lambda-tools-defaults.json
@@ -4,7 +4,7 @@
   "profile": "",
   "region": "",
   "configuration": "Release",
-  "framework": "netcoreapp3.1",
+  "framework": "net6.0",
   "s3-prefix": "aws-aspnet/",
   "template": "serverless.template",
   "template-parameters": "ShouldCreateBucket=true;BucketName="

--- a/samples/Sentry.Samples.Console.Customized/README.md
+++ b/samples/Sentry.Samples.Console.Customized/README.md
@@ -4,8 +4,8 @@ Get your `DSN` at [sentry.io](sentry.io).
 
 ### Running with .NET Core:
 
-dotnet run -c Release -f netcoreapp2.1
+dotnet run -c Release -f net6.0
 
 ### Running with .NET Framework or Mono
 
-dotnet run -c Release -f net472
+dotnet run -c Release -f net8

--- a/samples/Sentry.Samples.EntityFramework/Sentry.Samples.EntityFramework.csproj
+++ b/samples/Sentry.Samples.EntityFramework/Sentry.Samples.EntityFramework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.EntityFramework/Sentry.Samples.EntityFramework.csproj
+++ b/samples/Sentry.Samples.EntityFramework/Sentry.Samples.EntityFramework.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Effort.EF6" Version="2.2.16" />
 
     <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
-    <PackageReference Include="System.Drawing.Common" Version="[6.0.0,7)" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.EntityFramework/Sentry.Samples.EntityFramework.csproj
+++ b/samples/Sentry.Samples.EntityFramework/Sentry.Samples.EntityFramework.csproj
@@ -8,11 +8,11 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.EntityFramework\Sentry.EntityFramework.csproj" />
 
-    <PackageReference Include="EntityFramework" Version="6.*" />
-    <PackageReference Include="Effort.EF6" Version="2.*" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
+    <PackageReference Include="Effort.EF6" Version="2.2.16" />
 
     <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
-    <PackageReference Include="System.Drawing.Common" Version="6.*" />
+    <PackageReference Include="System.Drawing.Common" Version="[6.0.0,7)" />
   </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.GenericHost/Sentry.Samples.GenericHost.csproj
+++ b/samples/Sentry.Samples.GenericHost/Sentry.Samples.GenericHost.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="[6.0.1,7)" />
   </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.Google.Cloud.Functions/Sentry.Samples.Google.Cloud.Functions.csproj
+++ b/samples/Sentry.Samples.Google.Cloud.Functions/Sentry.Samples.Google.Cloud.Functions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.*" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
     <ProjectReference Include="..\..\src\Sentry.Google.Cloud.Functions\Sentry.Google.Cloud.Functions.csproj" />
   </ItemGroup>
 

--- a/samples/Sentry.Samples.ME.Logging/Sentry.Samples.ME.Logging.csproj
+++ b/samples/Sentry.Samples.ME.Logging/Sentry.Samples.ME.Logging.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="[6.0.0,)" />
   </ItemGroup>
 </Project>

--- a/samples/Sentry.Samples.NLog/Sentry.Samples.NLog.csproj
+++ b/samples/Sentry.Samples.NLog/Sentry.Samples.NLog.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.*" />
+    <PackageReference Include="NLog" Version="5.1.2" />
     <ProjectReference Include="..\..\src\Sentry.NLog\Sentry.NLog.csproj">
       <Private>true</Private>
     </ProjectReference>

--- a/samples/Sentry.Samples.Serilog/Sentry.Samples.Serilog.csproj
+++ b/samples/Sentry.Samples.Serilog/Sentry.Samples.Serilog.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.*" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.*" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -59,9 +59,6 @@
   </ItemGroup>
 
   <!-- these are needed because the versions that are brought in transitively have vulnerability warnings -->
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2"/>
-  </ItemGroup>
   <ItemGroup Condition="$(TargetFramework) != 'net48'">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -41,30 +41,30 @@
     <Using Include="Xunit" />
     <Using Include="Xunit.Abstractions" />
 
-    <PackageReference Include="NSubstitute" Version="4.*" />
-    <PackageReference Include="FluentAssertions" Version="6.*" />
-    <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.*" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.*" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.*" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.1.18" />
   </ItemGroup>
 
   <!-- only non-platform-specific projects should include these packages -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)'==''">
-    <PackageReference Include="Verify.Xunit" Version="19.*" />
-    <PackageReference Include="Verify.DiffPlex" Version="2.*" />
-    <PackageReference Include="PublicApiGenerator" Version="10.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" PrivateAssets="All" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" PrivateAssets="All" />
+    <PackageReference Include="Verify.Xunit" Version="19.10.0" />
+    <PackageReference Include="Verify.DiffPlex" Version="2.2.0" />
+    <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- these are needed because the versions that are brought in transitively have vulnerability warnings -->
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.*"/>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2"/>
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework) != 'net48'">
-    <PackageReference Include="System.Net.Http" Version="4.*" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.*" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/test/MauiTestUtils/DeviceTests.Runners.SourceGen/TestUtils.DeviceTests.Runners.SourceGen.csproj
+++ b/test/MauiTestUtils/DeviceTests.Runners.SourceGen/TestUtils.DeviceTests.Runners.SourceGen.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MauiTestUtils/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/test/MauiTestUtils/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="xunit.runner.utility" Version="2.*" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.utility" Version="2.4.2" />
     <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.*-*" />
   </ItemGroup>
 

--- a/test/MauiTestUtils/DeviceTests/TestUtils.DeviceTests.csproj
+++ b/test/MauiTestUtils/DeviceTests/TestUtils.DeviceTests.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="xunit.runner.utility" Version="2.*" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.utility" Version="2.4.2" />
     <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.*-*" />
   </ItemGroup>
 

--- a/test/MauiTestUtils/Directory.Build.props
+++ b/test/MauiTestUtils/Directory.Build.props
@@ -6,8 +6,8 @@
 
   <!-- these are needed because the versions that are brought in transitively have vulnerability warnings -->
   <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="4.*" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.*" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/test/Sentry.AspNetCore.Grpc.Tests/Sentry.AspNetCore.Grpc.Tests.csproj
+++ b/test/Sentry.AspNetCore.Grpc.Tests/Sentry.AspNetCore.Grpc.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.*" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.*" />
-    <PackageReference Include="Grpc.Tools" Version="2.*" PrivateAssets="All" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.51.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.51.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.51.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.AspNetCore.TestUtils/Sentry.AspNetCore.TestUtils.csproj
+++ b/test/Sentry.AspNetCore.TestUtils/Sentry.AspNetCore.TestUtils.csproj
@@ -32,6 +32,7 @@
 
     <!-- This is needed because the version that is brought in transitively also has a vulnerability warning -->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="[2.1.25,2.2)" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2"/>
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">

--- a/test/Sentry.AspNetCore.TestUtils/Sentry.AspNetCore.TestUtils.csproj
+++ b/test/Sentry.AspNetCore.TestUtils/Sentry.AspNetCore.TestUtils.csproj
@@ -26,30 +26,30 @@
     See https://github.com/dotnet/aspnetcore/issues/15423
   -->
   <ItemGroup Condition="$(TargetFramework) == 'net48'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="[2.1.7,2.2)" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.1.1,2.2)" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="[2.1.1,2.2)" />
 
     <!-- This is needed because the version that is brought in transitively also has a vulnerability warning -->
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="[2.1.25,2.2)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.*" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="[3.1.32,4)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.*" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.*" />
-    <PackageReference Include="Verify.AspNetCore" Version="2.*" />
-    <PackageReference Include="Verify.Http" Version="4.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="[6.0.14,7)" />
+    <PackageReference Include="Verify.AspNetCore" Version="[2.0.0,3)" />
+    <PackageReference Include="Verify.Http" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.*" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.*" />
-    <PackageReference Include="Verify.AspNetCore" Version="3.*" />
-    <PackageReference Include="Verify.Http" Version="4.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="[7.0.3,8)" />
+    <PackageReference Include="Verify.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="Verify.Http" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
@@ -11,29 +11,29 @@
 
   <!-- Test EF Core 7 on .NET 7 -->
   <!-- <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Verify.EntityFramework" Version="8.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.*" />
+    <PackageReference Include="Verify.EntityFramework" Version="9.4.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[7.0.3,8)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[7.0.3,8)" />
   </ItemGroup> -->
 
   <!-- Test EF Core 6 on .NET 6 and 7 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Verify.EntityFramework" Version="7.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.*" />
+    <PackageReference Include="Verify.EntityFramework" Version="[7.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6.0.14,7)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[6.0.14,7)" />
   </ItemGroup>
 
   <!-- Test EF Core 5 on .NET Core 3.1 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5.0.17,6)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[5.0.17,6)" />
   </ItemGroup>
 
   <!-- Test EF Core 3.1 on .NET Framework -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48' ">
     <ProjectReference Include="..\..\src\Sentry.DiagnosticSource\Sentry.DiagnosticSource.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1.32,4)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[3.1.32,4)" />
   </ItemGroup>
 
   <!--
@@ -41,15 +41,15 @@
     See https://github.com/getsentry/sentry-dotnet/issues/2189
   -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="LocalDb" Version="14.2.1" />
+    <PackageReference Include="LocalDb" Version="[14.2.1]" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <PackageReference Include="LocalDb" Version="14.*" />
+    <PackageReference Include="LocalDb" Version="14.3.2" />
   </ItemGroup>
 
   <ItemGroup>
     <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
-    <PackageReference Include="System.Drawing.Common" Version="6.*" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
 
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />

--- a/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
@@ -27,6 +27,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5.0.17,6)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[5.0.17,6)" />
+
+    <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
   </ItemGroup>
 
   <!-- Test EF Core 3.1 on .NET Framework -->
@@ -48,9 +51,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
-    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
-
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />

--- a/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
@@ -18,7 +18,7 @@
 
   <!-- Test EF Core 6 on .NET 6 and 7 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Verify.EntityFramework" Version="[7.0.0)" />
+    <PackageReference Include="Verify.EntityFramework" Version="[7.0.0,8)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6.0.14,7)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[6.0.14,7)" />
   </ItemGroup>

--- a/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
+++ b/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[5.0.17,6)" />
 
     <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
-    <PackageReference Include="System.Text.Encodings.Web" Version="[6.0.0,7)" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="[5.0.1,6)" />
   </ItemGroup>
 
   <!-- Test EF Core 3.1 on .NET Framework -->
@@ -34,6 +34,9 @@
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1.32,4)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[3.1.31,4)" />
+
+    <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
+++ b/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
@@ -7,33 +7,33 @@
   <!-- Test EF Core 7 on .NET 7 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[7.0.3,8)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[7.0.3,8)" />
   </ItemGroup>
 
   <!-- Test EF Core 6 on .NET 6 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6.0.14,7)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[6.0.14,7)" />
   </ItemGroup>
 
   <!-- Test EF Core 5 on .NET Core 3.1 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5.0.17,6)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[5.0.17,6)" />
 
     <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
-    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="[6.0.0,7)" />
   </ItemGroup>
 
   <!-- Test EF Core 3.1 on .NET Framework -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <ProjectReference Include="..\..\src\Sentry.DiagnosticSource\Sentry.DiagnosticSource.csproj" />
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1.32,4)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[3.1.31,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.EntityFramework.Tests/Sentry.EntityFramework.Tests.csproj
+++ b/test/Sentry.EntityFramework.Tests/Sentry.EntityFramework.Tests.csproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.*" />
-    <PackageReference Include="Effort.EF6" Version="2.*" />
-    <PackageReference Include="EfClassicLocalDb" Version="14.*" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
+    <PackageReference Include="Effort.EF6" Version="2.2.16" />
+    <PackageReference Include="EfClassicLocalDb" Version="14.3.2" />
 
     <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
-    <PackageReference Include="System.Drawing.Common" Version="6.*" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
 
     <ProjectReference Include="..\..\src\Sentry.EntityFramework\Sentry.EntityFramework.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />

--- a/test/Sentry.EntityFramework.Tests/Sentry.EntityFramework.Tests.csproj
+++ b/test/Sentry.EntityFramework.Tests/Sentry.EntityFramework.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="EfClassicLocalDb" Version="14.3.2" />
 
     <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
-    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
 
     <ProjectReference Include="..\..\src\Sentry.EntityFramework\Sentry.EntityFramework.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />

--- a/test/Sentry.Extensions.Logging.Tests/Sentry.Extensions.Logging.Tests.csproj
+++ b/test/Sentry.Extensions.Logging.Tests/Sentry.Extensions.Logging.Tests.csproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == ''">

--- a/test/Sentry.Log4Net.Tests/Sentry.Log4Net.Tests.csproj
+++ b/test/Sentry.Log4Net.Tests/Sentry.Log4Net.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.*" />
+    <PackageReference Include="log4net" Version="2.0.15" />
     <ProjectReference Include="..\..\src\Sentry.Log4Net\Sentry.Log4Net.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
 

--- a/test/Sentry.NLog.Tests/Sentry.NLog.Tests.csproj
+++ b/test/Sentry.NLog.Tests/Sentry.NLog.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.*" />
+    <PackageReference Include="NLog" Version="5.1.2" />
     <ProjectReference Include="..\..\src\Sentry.NLog\Sentry.NLog.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
 

--- a/test/Sentry.Serilog.Tests/Sentry.Serilog.Tests.csproj
+++ b/test/Sentry.Serilog.Tests/Sentry.Serilog.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.*" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.*" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
 
     <ProjectReference Include="..\..\src\Sentry.Serilog\Sentry.Serilog.csproj" />
     <ProjectReference Include="..\Sentry.AspNetCore.TestUtils\Sentry.AspNetCore.TestUtils.csproj" />


### PR DESCRIPTION
Floating versions in tests and samples have reduced frequency of deps-only PRs, but they have occasionally broken the CI build at inconvenient times.  We should go back to using regular version numbers.  In cases where we need to not take latest, we should use semver ranges (such as `[1.2.3,2)`).  We will need to update the dependency updating scripts and/or dependabot to support these.

#skip-changelog