### PR TITLE
Allow SentryUploadSources to work even when not uploading symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Allow SentryUploadSources to work even when not uploading symbols ([#2197](https://github.com/getsentry/sentry-dotnet/pull/2197))
+- Allow `SentryUploadSources` to work even when not uploading symbols ([#2197](https://github.com/getsentry/sentry-dotnet/pull/2197))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Allow SentryUploadSources to work even when not uploading symbols ([#2197](https://github.com/getsentry/sentry-dotnet/pull/2197))
+
 ### Fixes
 
 - Fix assembly not found on Android in Debug configuration ([#2175](https://github.com/getsentry/sentry-dotnet/pull/2175))

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -30,11 +30,12 @@
 
   <Target Name="CheckSentryCLI" AfterTargets="Build" Condition="'$(InnerTargets)' == ''">
     <PropertyGroup>
-      <!-- This property controls whether symbols are to be sent to Sentry. -->
+      <!-- Set defaults for the Sentry properties. -->
       <SentryUploadSymbols Condition="'$(SentryUploadSymbols)' == '' And '$(Configuration)' == 'Release'">true</SentryUploadSymbols>
+      <SentryUploadSources Condition="'$(SentryUploadSources)' == ''">false</SentryUploadSources>
 
       <!-- This property controls if the Sentry CLI is to be used at all.  Setting false will disable all Sentry CLI usage. -->
-      <UseSentryCLI Condition="'$(UseSentryCLI)' == '' And ('$(SentryUploadSymbols)' == 'true')">true</UseSentryCLI>
+      <UseSentryCLI Condition="'$(UseSentryCLI)' == '' And ('$(SentryUploadSymbols)' == 'true' Or '$(SentryUploadSources)' == 'true')">true</UseSentryCLI>
     </PropertyGroup>
   </Target>
 
@@ -95,8 +96,9 @@
     </PropertyGroup>
   </Target>
 
-  <!-- Upload debug information files to Sentry after the build. -->
-  <Target Name="UploadSymbolsToSentry" AfterTargets="Build;Publish" DependsOnTargets="PrepareSentryCLI" Condition="'$(SentryUploadSymbols)' == 'true' And '$(SentryCLI)' != ''">
+  <!-- Upload symbols (and possibly sources) to Sentry after the build. -->
+  <Target Name="UploadSymbolsToSentry" AfterTargets="Build;Publish" DependsOnTargets="PrepareSentryCLI"
+    Condition="'$(SentryUploadSymbols)' == 'true' And '$(SentryCLI)' != ''">
 
     <Warning Condition="'$(SentryUploadSources)' == 'true' And '$(EmbedAllSources)' == 'true'"
       Text="Both SentryUploadSources and EmbedAllSources are enabled.  Disabling SentryUploadSources." />
@@ -110,7 +112,7 @@
       Text="Preparing to upload debug symbols and sources to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
 
     <PropertyGroup>
-      <_SentryCLICommand>&quot;$(SentryCLI)&quot; upload-dif</_SentryCLICommand>
+      <_SentryCLICommand>&quot;$(SentryCLI)&quot; dif upload</_SentryCLICommand>
       <_SentryCLICommand Condition="'$(SentryCLIOptions.Trim())' != ''">$(_SentryCLICommand) $(SentryCLIOptions.Trim())</_SentryCLICommand>
       <_SentryCLICommand Condition="'$(SentryUploadSources)' == 'true'">$(_SentryCLICommand) --include-sources</_SentryCLICommand>
       <_SentryCLICommand>$(_SentryCLICommand) $(IntermediateOutputPath)</_SentryCLICommand>
@@ -127,6 +129,37 @@
     <MSBuild Condition="'$(_SentryCLIExitCode)' != '0' And '$(SentryUploadSources)' == 'true'"
       Projects="$(MSBuildProjectFile)" Targets="UploadSymbolsToSentry"
       Properties="SentryUploadSymbols=true;SentryUploadSources=false;SentryCLI=$(SentryCLI);SentryCLIOptions=$(SentryCLIOptions)" />
+
+  </Target>
+
+  <!-- Upload sources to Sentry after the build, if we didn't upload them with the symbols. -->
+  <Target Name="UploadSourcesToSentry" AfterTargets="Build;UploadSymbolsToSentry" DependsOnTargets="PrepareSentryCLI"
+    Condition="'$(SentryUploadSources)' == 'true' And '$(SentryUploadSymbols)' != 'true' And '$(SentryCLI)' != ''">
+
+    <Message Importance="High" Condition="'$(SentryUploadSources)' == 'true'"
+      Text="Preparing to upload sources to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
+
+    <PropertyGroup>
+      <_SentryDebugInfoFile>@(IntermediateAssembly->'$(IntermediateOutputPath)%(FileName).pdb')</_SentryDebugInfoFile>
+      <_SentryDebugInfoFile Condition="!Exists('$(_SentryDebugInfoFile)')">@(IntermediateAssembly->'$(IntermediateOutputPath)%(FileName)%(Extension)')</_SentryDebugInfoFile>
+      <_SentrySourceBundle>@(IntermediateAssembly->'$(IntermediateOutputPath)%(FileName).src.zip')</_SentrySourceBundle>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <_SentryCLICommand>&quot;$(SentryCLI)&quot; dif bundle-sources $(_SentryDebugInfoFile)</_SentryCLICommand>
+    </PropertyGroup>
+    <Exec Command="$(_SentryCLICommand)" IgnoreExitCode="true" ContinueOnError="WarnAndContinue" />
+
+    <PropertyGroup>
+      <_SentryCLICommand>&quot;$(SentryCLI)&quot; dif upload</_SentryCLICommand>
+      <_SentryCLICommand Condition="'$(SentryCLIOptions.Trim())' != ''">$(_SentryCLICommand) $(SentryCLIOptions.Trim())</_SentryCLICommand>
+      <_SentryCLICommand>$(_SentryCLICommand) $(_SentrySourceBundle)</_SentryCLICommand>
+    </PropertyGroup>
+    <Exec Command="$(_SentryCLICommand)" IgnoreExitCode="true" ContinueOnError="WarnAndContinue" Condition="Exists('$(_SentrySourceBundle)')">
+      <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
+    </Exec>
+
+    <Warning Condition="'$(_SentryCLIExitCode)' != '0'" Text="Sentry CLI could not upload sources." />
 
   </Target>
 


### PR DESCRIPTION
Resolves #2196 

Caveat: Symbols still need to be *created*, even if they're not uploaded.  If symbols are not created, we can't resolve the files needed to generate the source bundle.

Additionally, if symbols are *embedded* (using `<DebugType>embedded</DebugType`), sources won't be uploaded due to https://github.com/getsentry/sentry-cli/issues/1491.  Once that is fixed, the subsequent version of Sentry CLI will remove this limitation.