### PR TITLE
Minor fix for device tests in CI

### DIFF
--- a/scripts/parse-xunit2-xml.ps1
+++ b/scripts/parse-xunit2-xml.ps1
@@ -2,6 +2,14 @@ param([string] $File)
 
 Set-StrictMode -Version Latest
 
+if (!Test-Path($File))
+{
+    Write-Warning "$File was not found."
+
+    # Return success exit code so that GitHub Actions highlights the failure in the test run, rather than in this script.
+    return
+}
+
 [xml]$xml = Get-Content $File
 
 function ElementText([System.Xml.XmlElement] $element)

--- a/scripts/parse-xunit2-xml.ps1
+++ b/scripts/parse-xunit2-xml.ps1
@@ -2,9 +2,9 @@ param([string] $File)
 
 Set-StrictMode -Version Latest
 
-if (!Test-Path($File))
+if ([string]::IsNullOrEmpty($File) -or !(Test-Path($File)))
 {
-    Write-Warning "$File was not found."
+    Write-Warning "Test output file was not found."
 
     # Return success exit code so that GitHub Actions highlights the failure in the test run, rather than in this script.
     return


### PR DESCRIPTION
Fix a minor annoyance with CI test output for iOS and Android device tests.

If the test runner fails, we should see the test runner failure as the primary issue, not the script failure.

<img width="890" alt="image" src="https://user-images.githubusercontent.com/1396388/221433765-c7832252-5212-40a3-b582-e3f75edb8b7e.png">

We'll just warn and return exit code `0` instead.  Then it won't hide the real issue:

<img width="1292" alt="image" src="https://user-images.githubusercontent.com/1396388/221433920-021e9c83-8bf7-4132-b4e2-413925aaef92.png">

#skip-changelog