### PR TITLE
Update Cocoa SDK to 8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 - Bump CLI from v2.12.0 to v2.13.0 ([#2187](https://github.com/getsentry/sentry-dotnet/pull/2187))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2130)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.12.0...2.13.0)
+- Bump Cocoa SDK from v7.31.5 to v8.2.0 ([#2198](https://github.com/getsentry/sentry-dotnet/pull/2198))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#820)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.31.5...8.2.0)
 
 ## 3.28.1
 

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -47,13 +47,16 @@ then
         ../$CARTHAGE build --use-xcframeworks --no-skip-current --platform macCatalyst
         mv Carthage/Build Carthage/Build-maccatalyst
 
+        # Copy headers - used for generating bindings
+        mkdir Carthage/Headers
+        find Carthage/Build-ios/Sentry.xcframework/ios-arm64 -name '*.h' -exec cp {} Carthage/Headers \;
+
         echo $SHA > $SHAFILE
         echo ""
     fi
 
     # Remove anything we don't want to bundle in the nuget package.
-    cd Carthage
-    find . \( -name Headers -o -name PrivateHeaders -o -name Modules \) -exec rm -rf {} +
+    find Carthage/Build* \( -name Headers -o -name PrivateHeaders -o -name Modules \) -exec rm -rf {} +
 fi
 
 popd > /dev/null

--- a/scripts/generate-cocoa-bindings.ps1
+++ b/scripts/generate-cocoa-bindings.ps1
@@ -128,11 +128,16 @@ $Text = $Text -replace '\s*\[Verify \(StronglyTypedNSArray\)\]\n', ''
 # Fix broken line comment
 $Text = $Text -replace '(DEPRECATED_MSG_ATTRIBUTE\()\n\s*', '$1'
 
-# Remove APIs that use SentryTraceContext because it does not have a public header
-$Text = $Text -replace '(?ms)\n?^ *// [^\n]*SentryTraceContext.*?$.*?[;}]\n', ''
+# Remove APIs that use non-public objects
+$Text = $Text -replace '(?ms)\n?^ *// [^\n]*(?:SentryTraceContext|SentryEnvelope|SentrySession)\b.*?$.*?[;}]\n', ''
 
 # Remove default IsEqual implementation (already implemented by NSObject)
 $Text = $Text -replace '(?ms)\n?^ *// [^\n]*isEqual:.*?$.*?;\n', ''
+
+# Replace obsolete platform avaialbility attributes
+$Text = $Text -replace '([\[,] )MacCatalyst \(', '$1Introduced (PlatformName.MacCatalyst, '
+$Text = $Text -replace '([\[,] )Mac \(', '$1Introduced (PlatformName.MacOSX, '
+$Text = $Text -replace '([\[,] )iOS \(', '$1Introduced (PlatformName.iOS, '
 
 $Text | Out-File "$BindingsPath/$File"
 Write-Output 'Done!'

--- a/scripts/generate-cocoa-bindings.ps1
+++ b/scripts/generate-cocoa-bindings.ps1
@@ -1,0 +1,130 @@
+Set-StrictMode -Version Latest
+
+$RootPath = (Get-Item $PSScriptRoot).Parent.FullName
+$CocoaSdkPath = "$RootPath/modules/sentry-cocoa"
+$BindingsPath = "$RootPath/src/Sentry.Bindings.Cocoa"
+
+# Ensure running on macOS
+if (!$IsMacOS) {
+    Write-Error 'Bindings generation can only be performed on macOS.' `
+        -CategoryActivity Error -ErrorAction Stop
+}
+
+# Ensure Objective Sharpie is installed
+if (!(Get-Command sharpie -ErrorAction SilentlyContinue)) {
+    Write-Output 'Objective Sharpie not found.  Attempting to install via Homebrew.'
+    brew install --cask objectivesharpie
+}
+if (!(Get-Command sharpie -ErrorAction SilentlyContinue)) {
+    Write-Error 'Could not install Objective Sharpie automatically.  Try installing from https://aka.ms/objective-sharpie manually.' `
+        -CategoryActivity Error -ErrorAction Stop
+}
+
+# Generate bindings
+Write-Output 'Generating bindings with Objective Sharpie.'
+sharpie bind -sdk iphoneos -quiet `
+    -scope "$CocoaSdkPath/Carthage/Headers" `
+    "$CocoaSdkPath/Carthage/Headers/Sentry.h" `
+    "$CocoaSdkPath/Carthage/Headers/PrivateSentrySDKOnly.h" `
+    -o $BindingsPath
+
+################################################################################
+# Patch StructsAndEnums.cs
+################################################################################
+$File = 'StructsAndEnums.cs'
+Write-Output "Patching $File"
+$Text = Get-Content "$BindingsPath/$File" -Raw
+
+# Tabs to spaces
+$Text = $Text -replace '\t', '    '
+
+# Trim extra newline at EOF
+$Text = $Text -replace '\n$', ''
+
+# Insert namespace
+$Text = $Text -replace 'using .+;\n\n', "$&namespace Sentry.CocoaSdk;`n`n"
+
+# Public to internal
+$Text = $Text -replace '\bpublic\b', 'internal'
+
+# Remove static CFunctions class
+$Text = $Text -replace '(?ms)\nstatic class CFunctions.*?}\n', ''
+
+$Text | Out-File "$BindingsPath/$File"
+
+################################################################################
+# Patch ApiDefinitions.cs
+################################################################################
+$File = 'ApiDefinitions.cs'
+Write-Output "Patching $File"
+$Text = Get-Content "$BindingsPath/$File" -Raw
+
+# Tabs to spaces
+$Text = $Text -replace '\t', '    '
+
+# Trim extra newline at EOF
+$Text = $Text -replace '\n$', ''
+
+# Insert namespace
+$Text = $Text -replace 'using .+;\n\n', "$&namespace Sentry.CocoaSdk;`n`n"
+
+# Set Internal attributes on interfaces and delegates
+$Text = $Text -replace '(?m)^(partial interface|interface|delegate)\b', "[Internal]`n$&"
+
+# Fix ISentrySerializable usage
+$Text = $Text -replace '\bISentrySerializable\b', 'SentrySerializable'
+
+# Remove INSCopying due to https://github.com/xamarin/xamarin-macios/issues/17130
+$Text = $Text -replace ': INSCopying,', ':' -replace '[:,] INSCopying', ''
+
+# Fix delegate argument names
+$Text = $Text -replace '(NSError) arg\d', '$1 error'
+$Text = $Text -replace '(NSHttpUrlResponse) arg\d', '$1 response'
+$Text = $Text -replace '(SentryEvent) arg\d', '$1 @event'
+$Text = $Text -replace '(SentrySamplingContext) arg\d', '$1 samplingContext'
+$Text = $Text -replace '(SentryBreadcrumb) arg\d', '$1 breadcrumb'
+$Text = $Text -replace '(SentrySpan) arg\d', '$1 span'
+$Text = $Text -replace '(SentryAppStartMeasurement) arg\d', '$1 appStartMeasurement'
+
+# Adjust nullable return delegates (though broken until this is fixed: https://github.com/xamarin/xamarin-macios/issues/17109)
+$Text = $Text -replace 'delegate \w+ Sentry(BeforeBreadcrumb|BeforeSendEvent|TracesSampler)Callback', "[return: NullAllowed]`n$&"
+
+# Adjust protocols (some are models)
+$Text = $Text -replace '(?ms)(@protocol.+?)/\*.+?\*/', '$1'
+$Text = $Text -replace '(?ms)@protocol (SentrySerializable|SentrySpan).+?\[Protocol\]', "`$&`n[Model]"
+
+# Adjust SentrySpan base type
+$Text = $Text -replace 'interface SentrySpan\b', "[BaseType (typeof(NSObject))]`n`$&"
+
+# Fix string constants
+$Text = $Text -replace 'byte\[\] SentryVersionString', "[return: PlainString]`n    NSString SentryVersionString"
+$Text = $Text -replace '(?m)(.*\n){2}^\s{4}NSString k.+?\n\n?', ''
+$Text = $Text -replace '(?m)(.*\n){4}^partial interface Constants\n{\n}\n', ''
+$Text = $Text -replace '\[Verify \(ConstantsInterfaceAssociation\)\]\n', ''
+
+# Remove duplicate attributes
+$s = 'partial interface Constants'
+$t = $Text -split $s, 2
+$t[1] = $t[1] -replace "\[Static\]\n\[Internal\]\n$s", $s
+$Text = $t -join $s
+
+# Update MethodToProperty translations
+$Text = $Text -replace '(Export \("get\w+"\)\]\n)\s*\[Verify \(MethodToProperty\)\]\n(.+ \{ get; \})', '$1$2'
+$Text = $Text -replace '\[Verify \(MethodToProperty\)\]\n\s*(.+ (?:Hash|Value|DefaultIntegrations) \{ get; \})', '$1'
+$Text = $Text -replace '\[Verify \(MethodToProperty\)\]\n\s*(.+) \{ get; \}', '$1();'
+
+# Allow weakly typed NSArray
+# We have some that accept either NSString or NSRegularExpression, which have no common type so they use NSObject
+$Text = $Text -replace '\s*\[Verify \(StronglyTypedNSArray\)\]\n', ''
+
+# Fix broken line comment
+$Text = $Text -replace '(DEPRECATED_MSG_ATTRIBUTE\()\n\s*', '$1'
+
+# Remove APIs that use SentryTraceContext because it does not have a public header
+$Text = $Text -replace '(?ms)\n?^ *// [^\n]*SentryTraceContext.*?$.*?[;}]\n', ''
+
+# Remove default IsEqual implementation (already implemented by NSObject)
+$Text = $Text -replace '(?ms)\n?^ *// [^\n]*isEqual:.*?$.*?;\n', ''
+
+$Text | Out-File "$BindingsPath/$File"
+Write-Output 'Done!'

--- a/scripts/generate-cocoa-bindings.ps1
+++ b/scripts/generate-cocoa-bindings.ps1
@@ -139,5 +139,8 @@ $Text = $Text -replace '([\[,] )MacCatalyst \(', '$1Introduced (PlatformName.Mac
 $Text = $Text -replace '([\[,] )Mac \(', '$1Introduced (PlatformName.MacOSX, '
 $Text = $Text -replace '([\[,] )iOS \(', '$1Introduced (PlatformName.iOS, '
 
+# Make interface partial if we need to access private APIs.  Other parts will be defined in PrivateApiDefinitions.cs
+$Text = $Text -replace '(?m)^interface SentryScope', 'partial $&'
+
 $Text | Out-File "$BindingsPath/$File"
 Write-Output 'Done!'

--- a/scripts/generate-cocoa-bindings.ps1
+++ b/scripts/generate-cocoa-bindings.ps1
@@ -3,6 +3,7 @@ Set-StrictMode -Version Latest
 $RootPath = (Get-Item $PSScriptRoot).Parent.FullName
 $CocoaSdkPath = "$RootPath/modules/sentry-cocoa"
 $BindingsPath = "$RootPath/src/Sentry.Bindings.Cocoa"
+$BackupPath = "$BindingsPath/obj/_unpatched"
 
 # Ensure running on macOS
 if (!$IsMacOS) {
@@ -28,11 +29,17 @@ sharpie bind -sdk iphoneos -quiet `
     "$CocoaSdkPath/Carthage/Headers/PrivateSentrySDKOnly.h" `
     -o $BindingsPath
 
+# Ensure backup path exists
+if (!(Test-Path $BackupPath)) {
+    New-Item -ItemType Directory -Path $BackupPath
+}
+
 ################################################################################
 # Patch StructsAndEnums.cs
 ################################################################################
 $File = 'StructsAndEnums.cs'
 Write-Output "Patching $File"
+Copy-Item "$BindingsPath/$File" -Destination "$BackupPath/$File"
 $Text = Get-Content "$BindingsPath/$File" -Raw
 
 # Tabs to spaces
@@ -57,6 +64,7 @@ $Text | Out-File "$BindingsPath/$File"
 ################################################################################
 $File = 'ApiDefinitions.cs'
 Write-Output "Patching $File"
+Copy-Item "$BindingsPath/$File" -Destination "$BackupPath/$File"
 $Text = Get-Content "$BindingsPath/$File" -Raw
 
 # Tabs to spaces

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -6,7 +6,7 @@ namespace Sentry.CocoaSdk;
 
 [Static]
 [Internal]
-interface Constants
+partial interface Constants
 {
     // extern double SentryVersionNumber;
     [Field ("SentryVersionNumber", "__Internal")]
@@ -16,10 +16,6 @@ interface Constants
     [Field ("SentryVersionString", "__Internal")]
     [return: PlainString]
     NSString SentryVersionString { get; }
-
-    // extern NSString *const _Nonnull SentryErrorDomain __attribute__((visibility("default")));
-    [Field ("SentryErrorDomain", "__Internal")]
-    NSString SentryErrorDomain { get; }
 }
 
 // typedef void (^SentryRequestFinished)(NSError * _Nullable);
@@ -56,102 +52,6 @@ delegate NSNumber SentryTracesSamplerCallback (SentrySamplingContext samplingCon
 // typedef void (^SentrySpanCallback)(id<SentrySpan> _Nullable);
 [Internal]
 delegate void SentrySpanCallback ([NullAllowed] SentrySpan span);
-
-// typedef void (^SentryOnAppStartMeasurementAvailable)(SentryAppStartMeasurement * _Nullable);
-[Internal]
-delegate void SentryOnAppStartMeasurementAvailable ([NullAllowed] SentryAppStartMeasurement appStartMeasurement);
-
-// @interface PrivateSentrySDKOnly : NSObject
-[BaseType (typeof(NSObject), Name="PrivateSentrySDKOnly")]
-[Internal]
-interface PrivateSentrySdkOnly
-{
-    // +(void)storeEnvelope:(SentryEnvelope * _Nonnull)envelope;
-    [Static]
-    [Export ("storeEnvelope:")]
-    void StoreEnvelope (SentryEnvelope envelope);
-
-    // +(void)captureEnvelope:(SentryEnvelope * _Nonnull)envelope;
-    [Static]
-    [Export ("captureEnvelope:")]
-    void CaptureEnvelope (SentryEnvelope envelope);
-
-    // +(SentryEnvelope * _Nullable)envelopeWithData:(NSData * _Nonnull)data;
-    [Static]
-    [Export ("envelopeWithData:")]
-    [return: NullAllowed]
-    SentryEnvelope EnvelopeWithData (NSData data);
-
-    // +(NSArray<SentryDebugMeta *> * _Nonnull)getDebugImages;
-    [Static]
-    [Export ("getDebugImages")]
-    SentryDebugMeta[] DebugImages { get; }
-
-    // +(void)setSdkName:(NSString * _Nonnull)sdkName andVersionString:(NSString * _Nonnull)versionString;
-    [Static]
-    [Export ("setSdkName:andVersionString:")]
-    void SetSdkName (string sdkName, string versionString);
-
-    // +(void)setSdkName:(NSString * _Nonnull)sdkName;
-    [Static]
-    [Export ("setSdkName:")]
-    void SetSdkName (string sdkName);
-
-    // +(NSString * _Nonnull)getSdkName;
-    [Static]
-    [Export ("getSdkName")]
-    string SdkName { get; }
-
-    // +(NSString * _Nonnull)getSdkVersionString;
-    [Static]
-    [Export ("getSdkVersionString")]
-    string SdkVersionString { get; }
-
-    // @property (copy, nonatomic, class) SentryOnAppStartMeasurementAvailable _Nullable onAppStartMeasurementAvailable;
-    [Static]
-    [NullAllowed, Export ("onAppStartMeasurementAvailable", ArgumentSemantic.Copy)]
-    SentryOnAppStartMeasurementAvailable OnAppStartMeasurementAvailable { get; set; }
-
-    // @property (readonly, nonatomic, class) SentryAppStartMeasurement * _Nullable appStartMeasurement;
-    [Static]
-    [NullAllowed, Export ("appStartMeasurement")]
-    SentryAppStartMeasurement AppStartMeasurement { get; }
-
-    // @property (readonly, copy, nonatomic, class) NSString * _Nonnull installationID;
-    [Static]
-    [Export ("installationID")]
-    string InstallationID { get; }
-
-    // @property (readonly, copy, nonatomic, class) SentryOptions * _Nonnull options;
-    [Static]
-    [Export ("options", ArgumentSemantic.Copy)]
-    SentryOptions Options { get; }
-
-    // @property (assign, nonatomic, class) BOOL appStartMeasurementHybridSDKMode;
-    [Static]
-    [Export ("appStartMeasurementHybridSDKMode")]
-    bool AppStartMeasurementHybridSdkMode { get; set; }
-
-    // @property (assign, nonatomic, class) BOOL framesTrackingMeasurementHybridSDKMode;
-    [Static]
-    [Export ("framesTrackingMeasurementHybridSDKMode")]
-    bool FramesTrackingMeasurementHybridSdkMode { get; set; }
-
-    // @property (readonly, assign, nonatomic, class) BOOL isFramesTrackingRunning;
-    [Static]
-    [Export ("isFramesTrackingRunning")]
-    bool IsFramesTrackingRunning { get; }
-
-    // @property (readonly, assign, nonatomic, class) SentryScreenFrames * _Nonnull currentScreenFrames;
-    [Static]
-    [Export ("currentScreenFrames", ArgumentSemantic.Assign)]
-    SentryScreenFrames CurrentScreenFrames { get; }
-
-    // +(NSArray<NSData *> * _Nonnull)captureScreenshots;
-    [Static]
-    [Export ("captureScreenshots")]
-    NSData[] CaptureScreenshots();
-}
 
 // @interface SentryAppStartMeasurement : NSObject
 [BaseType (typeof(NSObject))]
@@ -197,7 +97,8 @@ interface SentryAppStartMeasurement
 }
 
 // @protocol SentrySerializable <NSObject>
-[Protocol] [Model]
+[Protocol]
+[Model]
 [BaseType (typeof(NSObject))]
 [DisableDefaultCtor]
 [Internal]
@@ -288,10 +189,6 @@ interface SentryBreadcrumb : SentrySerializable
     // -(NSDictionary<NSString *,id> * _Nonnull)serialize;
     [Export ("serialize")]
     NSDictionary<NSString, NSObject> Serialize();
-
-    // // -(BOOL)isEqual:(id _Nullable)other;
-    // [Export ("isEqual:")]
-    // bool IsEqual ([NullAllowed] NSObject other);
 
     // -(BOOL)isEqualToBreadcrumb:(SentryBreadcrumb * _Nonnull)breadcrumb;
     [Export ("isEqualToBreadcrumb:")]
@@ -452,15 +349,6 @@ interface SentryEnvelopeHeader
     [Export ("initWithId:")]
     NativeHandle Constructor ([NullAllowed] SentryId eventId);
 
-    // // -(instancetype _Nonnull)initWithId:(SentryId * _Nullable)eventId traceContext:(SentryTraceContext * _Nullable)traceContext;
-    // [Export ("initWithId:traceContext:")]
-    // NativeHandle Constructor ([NullAllowed] SentryId eventId, [NullAllowed] SentryTraceContext traceContext);
-
-    // // -(instancetype _Nonnull)initWithId:(SentryId * _Nullable)eventId sdkInfo:(SentrySdkInfo * _Nullable)sdkInfo traceContext:(SentryTraceContext * _Nullable)traceContext __attribute__((objc_designated_initializer));
-    // [Export ("initWithId:sdkInfo:traceContext:")]
-    // [DesignatedInitializer]
-    // NativeHandle Constructor ([NullAllowed] SentryId eventId, [NullAllowed] SentrySdkInfo sdkInfo, [NullAllowed] SentryTraceContext traceContext);
-
     // @property (readonly, copy, nonatomic) SentryId * _Nullable eventId;
     [NullAllowed, Export ("eventId", ArgumentSemantic.Copy)]
     SentryId EventId { get; }
@@ -468,10 +356,6 @@ interface SentryEnvelopeHeader
     // @property (readonly, copy, nonatomic) SentrySdkInfo * _Nullable sdkInfo;
     [NullAllowed, Export ("sdkInfo", ArgumentSemantic.Copy)]
     SentrySdkInfo SdkInfo { get; }
-
-    // // @property (readonly, copy, nonatomic) SentryTraceContext * _Nullable traceContext;
-    // [NullAllowed, Export ("traceContext", ArgumentSemantic.Copy)]
-    // SentryTraceContext TraceContext { get; }
 }
 
 // @interface SentryEnvelopeItemHeader : NSObject
@@ -588,6 +472,13 @@ interface SentryEnvelope
     // @property (readonly, nonatomic, strong) NSArray<SentryEnvelopeItem *> * _Nonnull items;
     [Export ("items", ArgumentSemantic.Strong)]
     SentryEnvelopeItem[] Items { get; }
+}
+
+partial interface Constants
+{
+    // extern NSString *const _Nonnull SentryErrorDomain __attribute__((visibility("default")));
+    [Field ("SentryErrorDomain", "__Internal")]
+    NSString SentryErrorDomain { get; }
 }
 
 // @interface SentryEvent : NSObject <SentrySerializable>
@@ -1052,8 +943,7 @@ interface SentryOptions
     bool EnableAutoBreadcrumbTracking { get; set; }
 
     // @property (retain, nonatomic) NSArray * _Nonnull tracePropagationTargets;
-    [Export ("tracePropagationTargets", ArgumentSemantic.Retain)]
-    NSObject[] TracePropagationTargets { get; set; }
+    [Export ("tracePropagationTargets", ArgumentSemantic.Retain)]    NSObject[] TracePropagationTargets { get; set; }
 
     // @property (assign, nonatomic) BOOL enableCaptureFailedRequests;
     [Export ("enableCaptureFailedRequests")]
@@ -1064,8 +954,7 @@ interface SentryOptions
     SentryHttpStatusCodeRange[] FailedRequestStatusCodes { get; set; }
 
     // @property (nonatomic, strong) NSArray * _Nonnull failedRequestTargets;
-    [Export ("failedRequestTargets", ArgumentSemantic.Strong)]
-    NSObject[] FailedRequestTargets { get; set; }
+    [Export ("failedRequestTargets", ArgumentSemantic.Strong)]    NSObject[] FailedRequestTargets { get; set; }
 }
 
 // @protocol SentryIntegrationProtocol <NSObject>
@@ -1149,9 +1038,10 @@ interface SentrySpanContext : SentrySerializable
 }
 
 // @protocol SentrySpan <SentrySerializable>
-[Protocol, Model]
-[BaseType (typeof(NSObject))]
+[Protocol]
+[Model]
 [Internal]
+[BaseType (typeof(NSObject))]
 interface SentrySpan : SentrySerializable
 {
     // @required @property (readonly, nonatomic) SentrySpanContext * _Nonnull context;
@@ -1399,7 +1289,7 @@ interface SentryId
 [BaseType (typeof(NSObject))]
 [DisableDefaultCtor]
 [Internal]
-interface SentryMeasurementUnit // : INSCopying
+interface SentryMeasurementUnit 
 {
     // -(instancetype _Nonnull)initWithUnit:(NSString * _Nonnull)unit;
     [Export ("initWithUnit:")]
@@ -1686,10 +1576,10 @@ interface SentryRequest : SentrySerializable
 }
 
 // @interface SentrySDK : NSObject
-[BaseType (typeof(NSObject), Name="SentrySDK")]
+[BaseType (typeof(NSObject))]
 [DisableDefaultCtor]
 [Internal]
-interface SentrySdk
+interface SentrySDK
 {
     // @property (readonly, nonatomic, class) id<SentrySpan> _Nullable span;
     [Static]
@@ -2054,7 +1944,7 @@ interface SentrySdkInfo : SentrySerializable
 [BaseType (typeof(NSObject))]
 [DisableDefaultCtor]
 [Internal]
-interface SentrySession : SentrySerializable //, INSCopying
+interface SentrySession : SentrySerializable
 {
     // -(instancetype _Nonnull)initWithReleaseName:(NSString * _Nonnull)releaseName;
     [Export ("initWithReleaseName:")]
@@ -2136,7 +2026,7 @@ interface SentrySession : SentrySerializable //, INSCopying
 // @interface SentrySpanId : NSObject <NSCopying>
 [BaseType (typeof(NSObject))]
 [Internal]
-interface SentrySpanId // : INSCopying
+interface SentrySpanId 
 {
     // -(instancetype _Nonnull)initWithUUID:(NSUUID * _Nonnull)uuid;
     [Export ("initWithUUID:")]
@@ -2279,7 +2169,7 @@ interface SentryTransactionContext
 // @interface SentryUser : NSObject <SentrySerializable, NSCopying>
 [BaseType (typeof(NSObject))]
 [Internal]
-interface SentryUser : SentrySerializable //, INSCopying
+interface SentryUser : SentrySerializable
 {
     // @property (copy, atomic) NSString * _Nullable userId;
     [NullAllowed, Export ("userId")]
@@ -2308,10 +2198,6 @@ interface SentryUser : SentrySerializable //, INSCopying
     // -(instancetype _Nonnull)initWithUserId:(NSString * _Nonnull)userId;
     [Export ("initWithUserId:")]
     NativeHandle Constructor (string userId);
-
-    // // -(BOOL)isEqual:(id _Nullable)other;
-    // [Export ("isEqual:")]
-    // bool IsEqual ([NullAllowed] NSObject other);
 
     // -(BOOL)isEqualToUser:(SentryUser * _Nonnull)user;
     [Export ("isEqualToUser:")]
@@ -2347,4 +2233,100 @@ interface SentryUserFeedback : SentrySerializable
     // @property (copy, nonatomic) NSString * _Nonnull comments;
     [Export ("comments")]
     string Comments { get; set; }
+}
+
+// typedef void (^SentryOnAppStartMeasurementAvailable)(SentryAppStartMeasurement * _Nullable);
+[Internal]
+delegate void SentryOnAppStartMeasurementAvailable ([NullAllowed] SentryAppStartMeasurement appStartMeasurement);
+
+// @interface PrivateSentrySDKOnly : NSObject
+[BaseType (typeof(NSObject))]
+[Internal]
+interface PrivateSentrySDKOnly
+{
+    // +(void)storeEnvelope:(SentryEnvelope * _Nonnull)envelope;
+    [Static]
+    [Export ("storeEnvelope:")]
+    void StoreEnvelope (SentryEnvelope envelope);
+
+    // +(void)captureEnvelope:(SentryEnvelope * _Nonnull)envelope;
+    [Static]
+    [Export ("captureEnvelope:")]
+    void CaptureEnvelope (SentryEnvelope envelope);
+
+    // +(SentryEnvelope * _Nullable)envelopeWithData:(NSData * _Nonnull)data;
+    [Static]
+    [Export ("envelopeWithData:")]
+    [return: NullAllowed]
+    SentryEnvelope EnvelopeWithData (NSData data);
+
+    // +(NSArray<SentryDebugMeta *> * _Nonnull)getDebugImages;
+    [Static]
+    [Export ("getDebugImages")]
+    SentryDebugMeta[] DebugImages { get; }
+
+    // +(void)setSdkName:(NSString * _Nonnull)sdkName andVersionString:(NSString * _Nonnull)versionString;
+    [Static]
+    [Export ("setSdkName:andVersionString:")]
+    void SetSdkName (string sdkName, string versionString);
+
+    // +(void)setSdkName:(NSString * _Nonnull)sdkName;
+    [Static]
+    [Export ("setSdkName:")]
+    void SetSdkName (string sdkName);
+
+    // +(NSString * _Nonnull)getSdkName;
+    [Static]
+    [Export ("getSdkName")]
+    string SdkName { get; }
+
+    // +(NSString * _Nonnull)getSdkVersionString;
+    [Static]
+    [Export ("getSdkVersionString")]
+    string SdkVersionString { get; }
+
+    // @property (copy, nonatomic, class) SentryOnAppStartMeasurementAvailable _Nullable onAppStartMeasurementAvailable;
+    [Static]
+    [NullAllowed, Export ("onAppStartMeasurementAvailable", ArgumentSemantic.Copy)]
+    SentryOnAppStartMeasurementAvailable OnAppStartMeasurementAvailable { get; set; }
+
+    // @property (readonly, nonatomic, class) SentryAppStartMeasurement * _Nullable appStartMeasurement;
+    [Static]
+    [NullAllowed, Export ("appStartMeasurement")]
+    SentryAppStartMeasurement AppStartMeasurement { get; }
+
+    // @property (readonly, copy, nonatomic, class) NSString * _Nonnull installationID;
+    [Static]
+    [Export ("installationID")]
+    string InstallationID { get; }
+
+    // @property (readonly, copy, nonatomic, class) SentryOptions * _Nonnull options;
+    [Static]
+    [Export ("options", ArgumentSemantic.Copy)]
+    SentryOptions Options { get; }
+
+    // @property (assign, nonatomic, class) BOOL appStartMeasurementHybridSDKMode;
+    [Static]
+    [Export ("appStartMeasurementHybridSDKMode")]
+    bool AppStartMeasurementHybridSDKMode { get; set; }
+
+    // @property (assign, nonatomic, class) BOOL framesTrackingMeasurementHybridSDKMode;
+    [Static]
+    [Export ("framesTrackingMeasurementHybridSDKMode")]
+    bool FramesTrackingMeasurementHybridSDKMode { get; set; }
+
+    // @property (readonly, assign, nonatomic, class) BOOL isFramesTrackingRunning;
+    [Static]
+    [Export ("isFramesTrackingRunning")]
+    bool IsFramesTrackingRunning { get; }
+
+    // @property (readonly, assign, nonatomic, class) SentryScreenFrames * _Nonnull currentScreenFrames;
+    [Static]
+    [Export ("currentScreenFrames", ArgumentSemantic.Assign)]
+    SentryScreenFrames CurrentScreenFrames { get; }
+
+    // +(NSArray<NSData *> * _Nonnull)captureScreenshots;
+    [Static]
+    [Export ("captureScreenshots")]
+    NSData[] CaptureScreenshots();
 }

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -53,49 +53,6 @@ delegate NSNumber SentryTracesSamplerCallback (SentrySamplingContext samplingCon
 [Internal]
 delegate void SentrySpanCallback ([NullAllowed] SentrySpan span);
 
-// @interface SentryAppStartMeasurement : NSObject
-[BaseType (typeof(NSObject))]
-[DisableDefaultCtor]
-[Internal]
-interface SentryAppStartMeasurement
-{
-    // -(instancetype _Nonnull)initWithType:(SentryAppStartType)type appStartTimestamp:(NSDate * _Nonnull)appStartTimestamp duration:(NSTimeInterval)duration runtimeInitTimestamp:(NSDate * _Nonnull)runtimeInitTimestamp didFinishLaunchingTimestamp:(NSDate * _Nonnull)didFinishLaunchingTimestamp __attribute__((deprecated("Use initWithType:appStartTimestamp:duration:mainTimestamp:runtimeInitTimestamp:didFinishLaunchingTimestamp instead.")));
-    [Export ("initWithType:appStartTimestamp:duration:runtimeInitTimestamp:didFinishLaunchingTimestamp:")]
-    NativeHandle Constructor (SentryAppStartType type, NSDate appStartTimestamp, double duration, NSDate runtimeInitTimestamp, NSDate didFinishLaunchingTimestamp);
-
-    // -(instancetype _Nonnull)initWithType:(SentryAppStartType)type isPreWarmed:(BOOL)isPreWarmed appStartTimestamp:(NSDate * _Nonnull)appStartTimestamp duration:(NSTimeInterval)duration runtimeInitTimestamp:(NSDate * _Nonnull)runtimeInitTimestamp moduleInitializationTimestamp:(NSDate * _Nonnull)moduleInitializationTimestamp didFinishLaunchingTimestamp:(NSDate * _Nonnull)didFinishLaunchingTimestamp;
-    [Export ("initWithType:isPreWarmed:appStartTimestamp:duration:runtimeInitTimestamp:moduleInitializationTimestamp:didFinishLaunchingTimestamp:")]
-    NativeHandle Constructor (SentryAppStartType type, bool isPreWarmed, NSDate appStartTimestamp, double duration, NSDate runtimeInitTimestamp, NSDate moduleInitializationTimestamp, NSDate didFinishLaunchingTimestamp);
-
-    // @property (readonly, assign, nonatomic) SentryAppStartType type;
-    [Export ("type", ArgumentSemantic.Assign)]
-    SentryAppStartType Type { get; }
-
-    // @property (readonly, assign, nonatomic) BOOL isPreWarmed;
-    [Export ("isPreWarmed")]
-    bool IsPreWarmed { get; }
-
-    // @property (readonly, assign, nonatomic) NSTimeInterval duration;
-    [Export ("duration")]
-    double Duration { get; }
-
-    // @property (readonly, nonatomic, strong) NSDate * _Nonnull appStartTimestamp;
-    [Export ("appStartTimestamp", ArgumentSemantic.Strong)]
-    NSDate AppStartTimestamp { get; }
-
-    // @property (readonly, nonatomic, strong) NSDate * _Nonnull runtimeInitTimestamp;
-    [Export ("runtimeInitTimestamp", ArgumentSemantic.Strong)]
-    NSDate RuntimeInitTimestamp { get; }
-
-    // @property (readonly, nonatomic, strong) NSDate * _Nonnull moduleInitializationTimestamp;
-    [Export ("moduleInitializationTimestamp", ArgumentSemantic.Strong)]
-    NSDate ModuleInitializationTimestamp { get; }
-
-    // @property (readonly, nonatomic, strong) NSDate * _Nonnull didFinishLaunchingTimestamp;
-    [Export ("didFinishLaunchingTimestamp", ArgumentSemantic.Strong)]
-    NSDate DidFinishLaunchingTimestamp { get; }
-}
-
 // @protocol SentrySerializable <NSObject>
 [Protocol]
 [Model]
@@ -120,9 +77,9 @@ interface SentryAttachment
     [Export ("initWithData:filename:")]
     NativeHandle Constructor (NSData data, string filename);
 
-    // -(instancetype _Nonnull)initWithData:(NSData * _Nonnull)data filename:(NSString * _Nonnull)filename contentType:(NSString * _Nonnull)contentType;
+    // -(instancetype _Nonnull)initWithData:(NSData * _Nonnull)data filename:(NSString * _Nonnull)filename contentType:(NSString * _Nullable)contentType;
     [Export ("initWithData:filename:contentType:")]
-    NativeHandle Constructor (NSData data, string filename, string contentType);
+    NativeHandle Constructor (NSData data, string filename, [NullAllowed] string contentType);
 
     // -(instancetype _Nonnull)initWithPath:(NSString * _Nonnull)path;
     [Export ("initWithPath:")]
@@ -132,9 +89,9 @@ interface SentryAttachment
     [Export ("initWithPath:filename:")]
     NativeHandle Constructor (string path, string filename);
 
-    // -(instancetype _Nonnull)initWithPath:(NSString * _Nonnull)path filename:(NSString * _Nonnull)filename contentType:(NSString * _Nonnull)contentType;
+    // -(instancetype _Nonnull)initWithPath:(NSString * _Nonnull)path filename:(NSString * _Nonnull)filename contentType:(NSString * _Nullable)contentType;
     [Export ("initWithPath:filename:contentType:")]
-    NativeHandle Constructor (string path, string filename, string contentType);
+    NativeHandle Constructor (string path, string filename, [NullAllowed] string contentType);
 
     // @property (readonly, nonatomic, strong) NSData * _Nullable data;
     [NullAllowed, Export ("data", ArgumentSemantic.Strong)]
@@ -148,8 +105,8 @@ interface SentryAttachment
     [Export ("filename")]
     string Filename { get; }
 
-    // @property (readonly, copy, nonatomic) NSString * _Nonnull contentType;
-    [Export ("contentType")]
+    // @property (readonly, copy, nonatomic) NSString * _Nullable contentType;
+    [NullAllowed, Export ("contentType")]
     string ContentType { get; }
 }
 
@@ -205,6 +162,10 @@ interface SentryBreadcrumb : SentrySerializable
 [Internal]
 interface SentryClient
 {
+    // @property (readonly, assign, nonatomic) BOOL isEnabled;
+    [Export ("isEnabled")]
+    bool IsEnabled { get; }
+
     // @property (nonatomic, strong) SentryOptions * _Nonnull options;
     [Export ("options", ArgumentSemantic.Strong)]
     SentryOptions Options { get; set; }
@@ -249,17 +210,13 @@ interface SentryClient
     [Export ("captureUserFeedback:")]
     void CaptureUserFeedback (SentryUserFeedback userFeedback);
 
-    // -(void)captureSession:(SentrySession * _Nonnull)session __attribute__((swift_name("capture(session:)")));
-    [Export ("captureSession:")]
-    void CaptureSession (SentrySession session);
-
-    // -(void)captureEnvelope:(SentryEnvelope * _Nonnull)envelope __attribute__((swift_name("capture(envelope:)")));
-    [Export ("captureEnvelope:")]
-    void CaptureEnvelope (SentryEnvelope envelope);
-
     // -(void)flush:(NSTimeInterval)timeout __attribute__((swift_name("flush(timeout:)")));
     [Export ("flush:")]
     void Flush (double timeout);
+
+    // -(void)close;
+    [Export ("close")]
+    void Close ();
 }
 
 // @interface SentryCrashExceptionApplication : NSObject
@@ -278,6 +235,10 @@ interface SentryDebugImageProvider
     [Export ("getDebugImagesForThreads:")]
     SentryDebugMeta[] GetDebugImagesForThreads (SentryThread[] threads);
 
+    // -(NSArray<SentryDebugMeta *> * _Nonnull)getDebugImagesForFrames:(NSArray<SentryFrame *> * _Nonnull)frames;
+    [Export ("getDebugImagesForFrames:")]
+    SentryDebugMeta[] GetDebugImagesForFrames (SentryFrame[] frames);
+
     // -(NSArray<SentryDebugMeta *> * _Nonnull)getDebugImages;
     [Export ("getDebugImages")]
     SentryDebugMeta[] DebugImages { get; }
@@ -291,6 +252,10 @@ interface SentryDebugMeta : SentrySerializable
     // @property (copy, nonatomic) NSString * _Nullable uuid;
     [NullAllowed, Export ("uuid")]
     string Uuid { get; set; }
+
+    // @property (copy, nonatomic) NSString * _Nullable debugID;
+    [NullAllowed, Export ("debugID")]
+    string DebugID { get; set; }
 
     // @property (copy, nonatomic) NSString * _Nullable type;
     [NullAllowed, Export ("type")]
@@ -311,6 +276,10 @@ interface SentryDebugMeta : SentrySerializable
     // @property (copy, nonatomic) NSString * _Nullable imageVmAddress;
     [NullAllowed, Export ("imageVmAddress")]
     string ImageVmAddress { get; set; }
+
+    // @property (copy, nonatomic) NSString * _Nullable codeFile;
+    [NullAllowed, Export ("codeFile")]
+    string CodeFile { get; set; }
 }
 
 // @interface SentryDsn : NSObject
@@ -339,30 +308,11 @@ interface SentryDsn
     NSUrl EnvelopeEndpoint { get; }
 }
 
-// @interface SentryEnvelopeHeader : NSObject
+// @interface SentryEnvelopeItemHeader : NSObject <SentrySerializable>
 [BaseType (typeof(NSObject))]
 [DisableDefaultCtor]
 [Internal]
-interface SentryEnvelopeHeader
-{
-    // -(instancetype _Nonnull)initWithId:(SentryId * _Nullable)eventId;
-    [Export ("initWithId:")]
-    NativeHandle Constructor ([NullAllowed] SentryId eventId);
-
-    // @property (readonly, copy, nonatomic) SentryId * _Nullable eventId;
-    [NullAllowed, Export ("eventId", ArgumentSemantic.Copy)]
-    SentryId EventId { get; }
-
-    // @property (readonly, copy, nonatomic) SentrySdkInfo * _Nullable sdkInfo;
-    [NullAllowed, Export ("sdkInfo", ArgumentSemantic.Copy)]
-    SentrySdkInfo SdkInfo { get; }
-}
-
-// @interface SentryEnvelopeItemHeader : NSObject
-[BaseType (typeof(NSObject))]
-[DisableDefaultCtor]
-[Internal]
-interface SentryEnvelopeItemHeader
+interface SentryEnvelopeItemHeader : SentrySerializable
 {
     // -(instancetype _Nonnull)initWithType:(NSString * _Nonnull)type length:(NSUInteger)length __attribute__((objc_designated_initializer));
     [Export ("initWithType:length:")]
@@ -388,90 +338,6 @@ interface SentryEnvelopeItemHeader
     // @property (readonly, copy, nonatomic) NSString * _Nullable contentType;
     [NullAllowed, Export ("contentType")]
     string ContentType { get; }
-}
-
-// @interface SentryEnvelopeItem : NSObject
-[BaseType (typeof(NSObject))]
-[DisableDefaultCtor]
-[Internal]
-interface SentryEnvelopeItem
-{
-    // -(instancetype _Nonnull)initWithEvent:(SentryEvent * _Nonnull)event;
-    [Export ("initWithEvent:")]
-    NativeHandle Constructor (SentryEvent @event);
-
-    // -(instancetype _Nonnull)initWithSession:(SentrySession * _Nonnull)session;
-    [Export ("initWithSession:")]
-    NativeHandle Constructor (SentrySession session);
-
-    // -(instancetype _Nonnull)initWithUserFeedback:(SentryUserFeedback * _Nonnull)userFeedback;
-    [Export ("initWithUserFeedback:")]
-    NativeHandle Constructor (SentryUserFeedback userFeedback);
-
-    // -(instancetype _Nullable)initWithAttachment:(SentryAttachment * _Nonnull)attachment maxAttachmentSize:(NSUInteger)maxAttachmentSize;
-    [Export ("initWithAttachment:maxAttachmentSize:")]
-    NativeHandle Constructor (SentryAttachment attachment, nuint maxAttachmentSize);
-
-    // -(instancetype _Nonnull)initWithHeader:(SentryEnvelopeItemHeader * _Nonnull)header data:(NSData * _Nonnull)data __attribute__((objc_designated_initializer));
-    [Export ("initWithHeader:data:")]
-    [DesignatedInitializer]
-    NativeHandle Constructor (SentryEnvelopeItemHeader header, NSData data);
-
-    // @property (readonly, nonatomic, strong) SentryEnvelopeItemHeader * _Nonnull header;
-    [Export ("header", ArgumentSemantic.Strong)]
-    SentryEnvelopeItemHeader Header { get; }
-
-    // @property (readonly, nonatomic, strong) NSData * _Nonnull data;
-    [Export ("data", ArgumentSemantic.Strong)]
-    NSData Data { get; }
-}
-
-// @interface SentryEnvelope : NSObject
-[BaseType (typeof(NSObject))]
-[DisableDefaultCtor]
-[Internal]
-interface SentryEnvelope
-{
-    // -(instancetype _Nonnull)initWithId:(SentryId * _Nullable)id singleItem:(SentryEnvelopeItem * _Nonnull)item;
-    [Export ("initWithId:singleItem:")]
-    NativeHandle Constructor ([NullAllowed] SentryId id, SentryEnvelopeItem item);
-
-    // -(instancetype _Nonnull)initWithHeader:(SentryEnvelopeHeader * _Nonnull)header singleItem:(SentryEnvelopeItem * _Nonnull)item;
-    [Export ("initWithHeader:singleItem:")]
-    NativeHandle Constructor (SentryEnvelopeHeader header, SentryEnvelopeItem item);
-
-    // -(instancetype _Nonnull)initWithId:(SentryId * _Nullable)id items:(NSArray<SentryEnvelopeItem *> * _Nonnull)items;
-    [Export ("initWithId:items:")]
-    NativeHandle Constructor ([NullAllowed] SentryId id, SentryEnvelopeItem[] items);
-
-    // -(instancetype _Nonnull)initWithSession:(SentrySession * _Nonnull)session;
-    [Export ("initWithSession:")]
-    NativeHandle Constructor (SentrySession session);
-
-    // -(instancetype _Nonnull)initWithSessions:(NSArray<SentrySession *> * _Nonnull)sessions;
-    [Export ("initWithSessions:")]
-    NativeHandle Constructor (SentrySession[] sessions);
-
-    // -(instancetype _Nonnull)initWithHeader:(SentryEnvelopeHeader * _Nonnull)header items:(NSArray<SentryEnvelopeItem *> * _Nonnull)items __attribute__((objc_designated_initializer));
-    [Export ("initWithHeader:items:")]
-    [DesignatedInitializer]
-    NativeHandle Constructor (SentryEnvelopeHeader header, SentryEnvelopeItem[] items);
-
-    // -(instancetype _Nonnull)initWithEvent:(SentryEvent * _Nonnull)event;
-    [Export ("initWithEvent:")]
-    NativeHandle Constructor (SentryEvent @event);
-
-    // -(instancetype _Nonnull)initWithUserFeedback:(SentryUserFeedback * _Nonnull)userFeedback;
-    [Export ("initWithUserFeedback:")]
-    NativeHandle Constructor (SentryUserFeedback userFeedback);
-
-    // @property (readonly, nonatomic, strong) SentryEnvelopeHeader * _Nonnull header;
-    [Export ("header", ArgumentSemantic.Strong)]
-    SentryEnvelopeHeader Header { get; }
-
-    // @property (readonly, nonatomic, strong) NSArray<SentryEnvelopeItem *> * _Nonnull items;
-    [Export ("items", ArgumentSemantic.Strong)]
-    SentryEnvelopeItem[] Items { get; }
 }
 
 partial interface Constants
@@ -721,10 +587,6 @@ interface SentryHttpStatusCodeRange
 [Internal]
 interface SentryOptions
 {
-    // -(instancetype _Nullable)initWithDict:(NSDictionary<NSString *,id> * _Nonnull)options didFailWithError:(NSError * _Nullable * _Nullable)error;
-    [Export ("initWithDict:didFailWithError:")]
-    NativeHandle Constructor (NSDictionary<NSString, NSObject> options, [NullAllowed] out NSError error);
-
     // @property (nonatomic, strong) NSString * _Nullable dsn;
     [NullAllowed, Export ("dsn", ArgumentSemantic.Strong)]
     string Dsn { get; set; }
@@ -749,13 +611,17 @@ interface SentryOptions
     [NullAllowed, Export ("dist")]
     string Dist { get; set; }
 
-    // @property (copy, nonatomic) NSString * _Nullable environment;
-    [NullAllowed, Export ("environment")]
+    // @property (copy, nonatomic) NSString * _Nonnull environment;
+    [Export ("environment")]
     string Environment { get; set; }
 
     // @property (assign, nonatomic) BOOL enabled;
     [Export ("enabled")]
     bool Enabled { get; set; }
+
+    // @property (assign, nonatomic) NSTimeInterval shutdownTimeInterval;
+    [Export ("shutdownTimeInterval")]
+    double ShutdownTimeInterval { get; set; }
 
     // @property (assign, nonatomic) BOOL enableCrashHandler;
     [Export ("enableCrashHandler")]
@@ -802,9 +668,9 @@ interface SentryOptions
     [Export ("enableAutoSessionTracking")]
     bool EnableAutoSessionTracking { get; set; }
 
-    // @property (assign, nonatomic) BOOL enableOutOfMemoryTracking;
-    [Export ("enableOutOfMemoryTracking")]
-    bool EnableOutOfMemoryTracking { get; set; }
+    // @property (assign, nonatomic) BOOL enableWatchdogTerminationTracking;
+    [Export ("enableWatchdogTerminationTracking")]
+    bool EnableWatchdogTerminationTracking { get; set; }
 
     // @property (assign, nonatomic) NSUInteger sessionTrackingIntervalMillis;
     [Export ("sessionTrackingIntervalMillis")]
@@ -818,10 +684,6 @@ interface SentryOptions
     [Export ("stitchAsyncCode")]
     bool StitchAsyncCode { get; set; }
 
-    // @property (readonly, nonatomic, strong) DEPRECATED_MSG_ATTRIBUTE("This property will be removed in a future version of the SDK") SentrySdkInfo * sdkInfo __attribute__((deprecated("This property will be removed in a future version of the SDK")));
-    [Export ("sdkInfo", ArgumentSemantic.Strong)]
-    SentrySdkInfo SdkInfo { get; }
-
     // @property (assign, nonatomic) NSUInteger maxAttachmentSize;
     [Export ("maxAttachmentSize")]
     nuint MaxAttachmentSize { get; set; }
@@ -830,13 +692,13 @@ interface SentryOptions
     [Export ("sendDefaultPii")]
     bool SendDefaultPii { get; set; }
 
-    // @property (assign, nonatomic) BOOL enableAutoPerformanceTracking;
-    [Export ("enableAutoPerformanceTracking")]
-    bool EnableAutoPerformanceTracking { get; set; }
+    // @property (assign, nonatomic) BOOL enableAutoPerformanceTracing;
+    [Export ("enableAutoPerformanceTracing")]
+    bool EnableAutoPerformanceTracing { get; set; }
 
-    // @property (assign, nonatomic) BOOL enableUIViewControllerTracking;
-    [Export ("enableUIViewControllerTracking")]
-    bool EnableUIViewControllerTracking { get; set; }
+    // @property (assign, nonatomic) BOOL enableUIViewControllerTracing;
+    [Export ("enableUIViewControllerTracing")]
+    bool EnableUIViewControllerTracing { get; set; }
 
     // @property (assign, nonatomic) BOOL attachScreenshot;
     [Export ("attachScreenshot")]
@@ -854,17 +716,17 @@ interface SentryOptions
     [Export ("idleTimeout")]
     double IdleTimeout { get; set; }
 
-    // @property (assign, nonatomic) BOOL enablePreWarmedAppStartTracking;
-    [Export ("enablePreWarmedAppStartTracking")]
-    bool EnablePreWarmedAppStartTracking { get; set; }
+    // @property (assign, nonatomic) BOOL enablePreWarmedAppStartTracing;
+    [Export ("enablePreWarmedAppStartTracing")]
+    bool EnablePreWarmedAppStartTracing { get; set; }
 
     // @property (assign, nonatomic) BOOL enableNetworkTracking;
     [Export ("enableNetworkTracking")]
     bool EnableNetworkTracking { get; set; }
 
-    // @property (assign, nonatomic) BOOL enableFileIOTracking;
-    [Export ("enableFileIOTracking")]
-    bool EnableFileIOTracking { get; set; }
+    // @property (assign, nonatomic) BOOL enableFileIOTracing;
+    [Export ("enableFileIOTracing")]
+    bool EnableFileIOTracing { get; set; }
 
     // @property (nonatomic, strong) NSNumber * _Nullable tracesSampleRate;
     [NullAllowed, Export ("tracesSampleRate", ArgumentSemantic.Strong)]
@@ -906,9 +768,9 @@ interface SentryOptions
     [Export ("enableSwizzling")]
     bool EnableSwizzling { get; set; }
 
-    // @property (assign, nonatomic) BOOL enableCoreDataTracking;
-    [Export ("enableCoreDataTracking")]
-    bool EnableCoreDataTracking { get; set; }
+    // @property (assign, nonatomic) BOOL enableCoreDataTracing;
+    [Export ("enableCoreDataTracing")]
+    bool EnableCoreDataTracing { get; set; }
 
     // @property (nonatomic, strong) NSNumber * _Nullable profilesSampleRate;
     [NullAllowed, Export ("profilesSampleRate", ArgumentSemantic.Strong)]
@@ -955,6 +817,11 @@ interface SentryOptions
 
     // @property (nonatomic, strong) NSArray * _Nonnull failedRequestTargets;
     [Export ("failedRequestTargets", ArgumentSemantic.Strong)]    NSObject[] FailedRequestTargets { get; set; }
+
+    // @property (assign, nonatomic) BOOL enableMetricKit __attribute__((availability(ios, introduced=15.0))) __attribute__((availability(macos, introduced=12.0))) __attribute__((availability(maccatalyst, introduced=15.0))) __attribute__((availability(tvos, unavailable))) __attribute__((availability(watchos, unavailable)));
+    [NoWatch, NoTV, Introduced (PlatformName.MacCatalyst, 15, 0), Introduced (PlatformName.MacOSX, 12, 0), Introduced (PlatformName.iOS, 15, 0)]
+    [Export ("enableMetricKit")]
+    bool EnableMetricKit { get; set; }
 }
 
 // @protocol SentryIntegrationProtocol <NSObject>
@@ -991,25 +858,17 @@ interface SentrySpanContext : SentrySerializable
     [NullAllowed, Export ("parentSpanId")]
     SentrySpanId ParentSpanId { get; }
 
-    // @property (nonatomic) SentrySampleDecision sampled;
-    [Export ("sampled", ArgumentSemantic.Assign)]
-    SentrySampleDecision Sampled { get; set; }
+    // @property (readonly, nonatomic) SentrySampleDecision sampled;
+    [Export ("sampled")]
+    SentrySampleDecision Sampled { get; }
 
-    // @property (copy, nonatomic) NSString * _Nonnull operation;
+    // @property (readonly, copy, nonatomic) NSString * _Nonnull operation;
     [Export ("operation")]
-    string Operation { get; set; }
+    string Operation { get; }
 
-    // @property (copy, nonatomic) NSString * _Nullable spanDescription;
+    // @property (readonly, copy, nonatomic) NSString * _Nullable spanDescription;
     [NullAllowed, Export ("spanDescription")]
-    string SpanDescription { get; set; }
-
-    // @property (nonatomic) SentrySpanStatus status;
-    [Export ("status", ArgumentSemantic.Assign)]
-    SentrySpanStatus Status { get; set; }
-
-    // @property (readonly, nonatomic) NSDictionary<NSString *,NSString *> * _Nonnull tags;
-    [Export ("tags")]
-    NSDictionary<NSString, NSString> Tags { get; }
+    string SpanDescription { get; }
 
     // -(instancetype _Nonnull)initWithOperation:(NSString * _Nonnull)operation;
     [Export ("initWithOperation:")]
@@ -1023,18 +882,9 @@ interface SentrySpanContext : SentrySerializable
     [Export ("initWithTraceId:spanId:parentId:operation:sampled:")]
     NativeHandle Constructor (SentryId traceId, SentrySpanId spanId, [NullAllowed] SentrySpanId parentId, string operation, SentrySampleDecision sampled);
 
-    // -(void)setTagValue:(NSString * _Nonnull)value forKey:(NSString * _Nonnull)key __attribute__((swift_name("setTag(value:key:)")));
-    [Export ("setTagValue:forKey:")]
-    void SetTagValue (string value, string key);
-
-    // -(void)removeTagForKey:(NSString * _Nonnull)key __attribute__((swift_name("removeTag(key:)")));
-    [Export ("removeTagForKey:")]
-    void RemoveTagForKey (string key);
-
-    // @property (readonly, copy, nonatomic, class) NSString * _Nonnull type;
-    [Static]
-    [Export ("type")]
-    string Type { get; }
+    // -(instancetype _Nonnull)initWithTraceId:(SentryId * _Nonnull)traceId spanId:(SentrySpanId * _Nonnull)spanId parentId:(SentrySpanId * _Nullable)parentId operation:(NSString * _Nonnull)operation spanDescription:(NSString * _Nullable)description sampled:(SentrySampleDecision)sampled;
+    [Export ("initWithTraceId:spanId:parentId:operation:spanDescription:sampled:")]
+    NativeHandle Constructor (SentryId traceId, SentrySpanId spanId, [NullAllowed] SentrySpanId parentId, string operation, [NullAllowed] string description, SentrySampleDecision sampled);
 }
 
 // @protocol SentrySpan <SentrySerializable>
@@ -1044,10 +894,40 @@ interface SentrySpanContext : SentrySerializable
 [BaseType (typeof(NSObject))]
 interface SentrySpan : SentrySerializable
 {
-    // @required @property (readonly, nonatomic) SentrySpanContext * _Nonnull context;
+    // @required @property (nonatomic, strong) SentryId * _Nonnull traceId;
     [Abstract]
-    [Export ("context")]
-    SentrySpanContext Context { get; }
+    [Export ("traceId", ArgumentSemantic.Strong)]
+    SentryId TraceId { get; set; }
+
+    // @required @property (nonatomic, strong) SentrySpanId * _Nonnull spanId;
+    [Abstract]
+    [Export ("spanId", ArgumentSemantic.Strong)]
+    SentrySpanId SpanId { get; set; }
+
+    // @required @property (nonatomic, strong) SentrySpanId * _Nullable parentSpanId;
+    [Abstract]
+    [NullAllowed, Export ("parentSpanId", ArgumentSemantic.Strong)]
+    SentrySpanId ParentSpanId { get; set; }
+
+    // @required @property (nonatomic) SentrySampleDecision sampled;
+    [Abstract]
+    [Export ("sampled", ArgumentSemantic.Assign)]
+    SentrySampleDecision Sampled { get; set; }
+
+    // @required @property (copy, nonatomic) NSString * _Nonnull operation;
+    [Abstract]
+    [Export ("operation")]
+    string Operation { get; set; }
+
+    // @required @property (copy, nonatomic) NSString * _Nullable spanDescription;
+    [Abstract]
+    [NullAllowed, Export ("spanDescription")]
+    string SpanDescription { get; set; }
+
+    // @required @property (nonatomic) SentrySpanStatus status;
+    [Abstract]
+    [Export ("status", ArgumentSemantic.Assign)]
+    SentrySpanStatus Status { get; set; }
 
     // @required @property (nonatomic, strong) NSDate * _Nullable timestamp;
     [Abstract]
@@ -1059,9 +939,9 @@ interface SentrySpan : SentrySerializable
     [NullAllowed, Export ("startTimestamp", ArgumentSemantic.Strong)]
     NSDate StartTimestamp { get; set; }
 
-    // @required @property (readonly) NSDictionary<NSString *,id> * _Nullable data;
+    // @required @property (readonly) NSDictionary<NSString *,id> * _Nonnull data;
     [Abstract]
-    [NullAllowed, Export ("data")]
+    [Export ("data")]
     NSDictionary<NSString, NSObject> Data { get; }
 
     // @required @property (readonly) NSDictionary<NSString *,NSString *> * _Nonnull tags;
@@ -1089,7 +969,7 @@ interface SentrySpan : SentrySerializable
     [Export ("setDataValue:forKey:")]
     void SetDataValue ([NullAllowed] NSObject value, string key);
 
-    // @required -(void)setExtraValue:(id _Nullable)value forKey:(NSString * _Nonnull)key __attribute__((swift_name("setExtra(value:key:)")));
+    // @required -(void)setExtraValue:(id _Nullable)value forKey:(NSString * _Nonnull)key __attribute__((deprecated(""))) __attribute__((swift_name("setExtra(value:key:)")));
     [Abstract]
     [Export ("setExtraValue:forKey:")]
     void SetExtraValue ([NullAllowed] NSObject value, string key);
@@ -1144,10 +1024,6 @@ interface SentryHub
     // -(instancetype _Nonnull)initWithClient:(SentryClient * _Nullable)client andScope:(SentryScope * _Nullable)scope;
     [Export ("initWithClient:andScope:")]
     NativeHandle Constructor ([NullAllowed] SentryClient client, [NullAllowed] SentryScope scope);
-
-    // @property (readonly, nonatomic, strong) SentrySession * _Nullable session;
-    [NullAllowed, Export ("session", ArgumentSemantic.Strong)]
-    SentrySession Session { get; }
 
     // -(void)startSession;
     [Export ("startSession")]
@@ -1253,13 +1129,13 @@ interface SentryHub
     [Export ("setUser:")]
     void SetUser ([NullAllowed] SentryUser user);
 
-    // -(void)captureEnvelope:(SentryEnvelope * _Nonnull)envelope __attribute__((swift_name("capture(envelope:)")));
-    [Export ("captureEnvelope:")]
-    void CaptureEnvelope (SentryEnvelope envelope);
-
     // -(void)flush:(NSTimeInterval)timeout __attribute__((swift_name("flush(timeout:)")));
     [Export ("flush:")]
     void Flush (double timeout);
+
+    // -(void)close;
+    [Export ("close")]
+    void Close ();
 }
 
 // @interface SentryId : NSObject
@@ -1289,7 +1165,7 @@ interface SentryId
 [BaseType (typeof(NSObject))]
 [DisableDefaultCtor]
 [Internal]
-interface SentryMeasurementUnit 
+interface SentryMeasurementUnit
 {
     // -(instancetype _Nonnull)initWithUnit:(NSString * _Nonnull)unit;
     [Export ("initWithUnit:")]
@@ -1468,6 +1344,10 @@ interface SentryMechanism : SentrySerializable
     [NullAllowed, Export ("handled", ArgumentSemantic.Copy)]
     NSNumber Handled { get; set; }
 
+    // @property (copy, nonatomic) NSNumber * _Nullable synthetic;
+    [NullAllowed, Export ("synthetic", ArgumentSemantic.Copy)]
+    NSNumber Synthetic { get; set; }
+
     // @property (copy, nonatomic) NSString * _Nullable helpLink;
     [NullAllowed, Export ("helpLink")]
     string HelpLink { get; set; }
@@ -1591,15 +1471,10 @@ interface SentrySDK
     [Export ("isEnabled")]
     bool IsEnabled { get; }
 
-    // +(void)startWithOptions:(NSDictionary<NSString *,id> * _Nonnull)optionsDict __attribute__((swift_name("start(options:)")));
+    // +(void)startWithOptions:(SentryOptions * _Nonnull)options __attribute__((swift_name("start(options:)")));
     [Static]
     [Export ("startWithOptions:")]
-    void StartWithOptions (NSDictionary<NSString, NSObject> optionsDict);
-
-    // +(void)startWithOptionsObject:(SentryOptions * _Nonnull)options __attribute__((swift_name("start(options:)")));
-    [Static]
-    [Export ("startWithOptionsObject:")]
-    void StartWithOptionsObject (SentryOptions options);
+    void StartWithOptions (SentryOptions options);
 
     // +(void)startWithConfigureOptions:(void (^ _Nonnull)(SentryOptions * _Nonnull))configureOptions __attribute__((swift_name("start(configureOptions:)")));
     [Static]
@@ -1701,7 +1576,7 @@ interface SentrySDK
     [Export ("captureUserFeedback:")]
     void CaptureUserFeedback (SentryUserFeedback userFeedback);
 
-    // +(void)addBreadcrumb:(SentryBreadcrumb * _Nonnull)crumb __attribute__((swift_name("addBreadcrumb(crumb:)")));
+    // +(void)addBreadcrumb:(SentryBreadcrumb * _Nonnull)crumb __attribute__((swift_name("addBreadcrumb(_:)")));
     [Static]
     [Export ("addBreadcrumb:")]
     void AddBreadcrumb (SentryBreadcrumb crumb);
@@ -1831,9 +1706,13 @@ interface SentryScope : SentrySerializable
     [Export ("setLevel:")]
     void SetLevel (SentryLevel level);
 
-    // -(void)addBreadcrumb:(SentryBreadcrumb * _Nonnull)crumb;
+    // -(void)addBreadcrumb:(SentryBreadcrumb * _Nonnull)crumb __attribute__((swift_name("addBreadcrumb(_:)")));
     [Export ("addBreadcrumb:")]
     void AddBreadcrumb (SentryBreadcrumb crumb);
+
+    // -(void)add:(SentryBreadcrumb * _Nonnull)crumb __attribute__((deprecated("use `addBreadcrumb` instead"))) __attribute__((swift_name("add(_:)")));
+    [Export ("add:")]
+    void Add (SentryBreadcrumb crumb);
 
     // -(void)clearBreadcrumbs;
     [Export ("clearBreadcrumbs")]
@@ -1843,15 +1722,6 @@ interface SentryScope : SentrySerializable
     [Export ("serialize")]
     NSDictionary<NSString, NSObject> Serialize();
 
-    // -(SentryEvent * _Nullable)applyToEvent:(SentryEvent * _Nonnull)event maxBreadcrumb:(NSUInteger)maxBreadcrumbs;
-    [Export ("applyToEvent:maxBreadcrumb:")]
-    [return: NullAllowed]
-    SentryEvent ApplyToEvent (SentryEvent @event, nuint maxBreadcrumbs);
-
-    // -(void)applyToSession:(SentrySession * _Nonnull)session;
-    [Export ("applyToSession:")]
-    void ApplyToSession (SentrySession session);
-
     // -(void)setContextValue:(NSDictionary<NSString *,id> * _Nonnull)value forKey:(NSString * _Nonnull)key __attribute__((swift_name("setContext(value:key:)")));
     [Export ("setContextValue:forKey:")]
     void SetContextValue (NSDictionary<NSString, NSObject> value, string key);
@@ -1860,9 +1730,13 @@ interface SentryScope : SentrySerializable
     [Export ("removeContextForKey:")]
     void RemoveContextForKey (string key);
 
-    // -(void)addAttachment:(SentryAttachment * _Nonnull)attachment;
+    // -(void)addAttachment:(SentryAttachment * _Nonnull)attachment __attribute__((swift_name("addAttachment(_:)")));
     [Export ("addAttachment:")]
     void AddAttachment (SentryAttachment attachment);
+
+    // -(void)includeAttachment:(SentryAttachment * _Nonnull)attachment __attribute__((deprecated("use `addAttachment` instead"))) __attribute__((swift_name("add(_:)")));
+    [Export ("includeAttachment:")]
+    void IncludeAttachment (SentryAttachment attachment);
 
     // -(void)clearAttachments;
     [Export ("clearAttachments")]
@@ -1877,156 +1751,10 @@ interface SentryScope : SentrySerializable
     void UseSpan (SentrySpanCallback callback);
 }
 
-// @interface SentryScreenFrames : NSObject
-[BaseType (typeof(NSObject))]
-[DisableDefaultCtor]
-[Internal]
-interface SentryScreenFrames
-{
-    // -(instancetype _Nonnull)initWithTotal:(NSUInteger)total frozen:(NSUInteger)frozen slow:(NSUInteger)slow;
-    [Export ("initWithTotal:frozen:slow:")]
-    NativeHandle Constructor (nuint total, nuint frozen, nuint slow);
-
-    // -(instancetype _Nonnull)initWithTotal:(NSUInteger)total frozen:(NSUInteger)frozen slow:(NSUInteger)slow frameTimestamps:(SentryFrameInfoTimeSeries * _Nonnull)frameTimestamps frameRateTimestamps:(SentryFrameInfoTimeSeries * _Nonnull)frameRateTimestamps;
-    [Export ("initWithTotal:frozen:slow:frameTimestamps:frameRateTimestamps:")]
-    NativeHandle Constructor (nuint total, nuint frozen, nuint slow, NSDictionary<NSString, NSNumber>[] frameTimestamps, NSDictionary<NSString, NSNumber>[] frameRateTimestamps);
-
-    // @property (readonly, assign, nonatomic) NSUInteger total;
-    [Export ("total")]
-    nuint Total { get; }
-
-    // @property (readonly, assign, nonatomic) NSUInteger frozen;
-    [Export ("frozen")]
-    nuint Frozen { get; }
-
-    // @property (readonly, assign, nonatomic) NSUInteger slow;
-    [Export ("slow")]
-    nuint Slow { get; }
-
-    // @property (readonly, copy, nonatomic) SentryFrameInfoTimeSeries * _Nonnull frameTimestamps;
-    [Export ("frameTimestamps", ArgumentSemantic.Copy)]
-    NSDictionary<NSString, NSNumber>[] FrameTimestamps { get; }
-
-    // @property (readonly, copy, nonatomic) SentryFrameInfoTimeSeries * _Nonnull frameRateTimestamps;
-    [Export ("frameRateTimestamps", ArgumentSemantic.Copy)]
-    NSDictionary<NSString, NSNumber>[] FrameRateTimestamps { get; }
-}
-
-// @interface SentrySdkInfo : NSObject <SentrySerializable>
-[BaseType (typeof(NSObject))]
-[DisableDefaultCtor]
-[Internal]
-interface SentrySdkInfo : SentrySerializable
-{
-    // @property (readonly, copy, nonatomic) NSString * _Nonnull name;
-    [Export ("name")]
-    string Name { get; }
-
-    // @property (readonly, copy, nonatomic) NSString * _Nonnull version;
-    [Export ("version")]
-    string Version { get; }
-
-    // -(instancetype _Nonnull)initWithName:(NSString * _Nonnull)name andVersion:(NSString * _Nonnull)version __attribute__((objc_designated_initializer));
-    [Export ("initWithName:andVersion:")]
-    [DesignatedInitializer]
-    NativeHandle Constructor (string name, string version);
-
-    // -(instancetype _Nonnull)initWithDict:(NSDictionary * _Nonnull)dict;
-    [Export ("initWithDict:")]
-    NativeHandle Constructor (NSDictionary dict);
-
-    // -(instancetype _Nonnull)initWithDict:(NSDictionary * _Nonnull)dict orDefaults:(SentrySdkInfo * _Nonnull)info;
-    [Export ("initWithDict:orDefaults:")]
-    NativeHandle Constructor (NSDictionary dict, SentrySdkInfo info);
-}
-
-// @interface SentrySession : NSObject <SentrySerializable, NSCopying>
-[BaseType (typeof(NSObject))]
-[DisableDefaultCtor]
-[Internal]
-interface SentrySession : SentrySerializable
-{
-    // -(instancetype _Nonnull)initWithReleaseName:(NSString * _Nonnull)releaseName;
-    [Export ("initWithReleaseName:")]
-    NativeHandle Constructor (string releaseName);
-
-    // -(instancetype _Nullable)initWithJSONObject:(NSDictionary * _Nonnull)jsonObject;
-    [Export ("initWithJSONObject:")]
-    NativeHandle Constructor (NSDictionary jsonObject);
-
-    // -(void)endSessionExitedWithTimestamp:(NSDate * _Nonnull)timestamp;
-    [Export ("endSessionExitedWithTimestamp:")]
-    void EndSessionExitedWithTimestamp (NSDate timestamp);
-
-    // -(void)endSessionCrashedWithTimestamp:(NSDate * _Nonnull)timestamp;
-    [Export ("endSessionCrashedWithTimestamp:")]
-    void EndSessionCrashedWithTimestamp (NSDate timestamp);
-
-    // -(void)endSessionAbnormalWithTimestamp:(NSDate * _Nonnull)timestamp;
-    [Export ("endSessionAbnormalWithTimestamp:")]
-    void EndSessionAbnormalWithTimestamp (NSDate timestamp);
-
-    // -(void)incrementErrors;
-    [Export ("incrementErrors")]
-    void IncrementErrors ();
-
-    // @property (readonly, nonatomic, strong) NSUUID * _Nonnull sessionId;
-    [Export ("sessionId", ArgumentSemantic.Strong)]
-    NSUuid SessionId { get; }
-
-    // @property (readonly, nonatomic, strong) NSDate * _Nonnull started;
-    [Export ("started", ArgumentSemantic.Strong)]
-    NSDate Started { get; }
-
-    // @property (readonly, nonatomic) enum SentrySessionStatus status;
-    [Export ("status")]
-    SentrySessionStatus Status { get; }
-
-    // @property (readonly, nonatomic) NSUInteger errors;
-    [Export ("errors")]
-    nuint Errors { get; }
-
-    // @property (readonly, nonatomic) NSUInteger sequence;
-    [Export ("sequence")]
-    nuint Sequence { get; }
-
-    // @property (readonly, nonatomic, strong) NSString * _Nonnull distinctId;
-    [Export ("distinctId", ArgumentSemantic.Strong)]
-    string DistinctId { get; }
-
-    // @property (readonly, copy, nonatomic) NSNumber * _Nullable flagInit;
-    [NullAllowed, Export ("flagInit", ArgumentSemantic.Copy)]
-    NSNumber FlagInit { get; }
-
-    // @property (readonly, nonatomic, strong) NSDate * _Nullable timestamp;
-    [NullAllowed, Export ("timestamp", ArgumentSemantic.Strong)]
-    NSDate Timestamp { get; }
-
-    // @property (readonly, nonatomic, strong) NSNumber * _Nullable duration;
-    [NullAllowed, Export ("duration", ArgumentSemantic.Strong)]
-    NSNumber Duration { get; }
-
-    // @property (readonly, copy, nonatomic) NSString * _Nullable releaseName;
-    [NullAllowed, Export ("releaseName")]
-    string ReleaseName { get; }
-
-    // @property (copy, nonatomic) NSString * _Nullable environment;
-    [NullAllowed, Export ("environment")]
-    string Environment { get; set; }
-
-    // @property (copy, nonatomic) SentryUser * _Nullable user;
-    [NullAllowed, Export ("user", ArgumentSemantic.Copy)]
-    SentryUser User { get; set; }
-
-    // -(NSDictionary<NSString *,id> * _Nonnull)serialize;
-    [Export ("serialize")]
-    NSDictionary<NSString, NSObject> Serialize();
-}
-
 // @interface SentrySpanId : NSObject <NSCopying>
 [BaseType (typeof(NSObject))]
 [Internal]
-interface SentrySpanId 
+interface SentrySpanId
 {
     // -(instancetype _Nonnull)initWithUUID:(NSUUID * _Nonnull)uuid;
     [Export ("initWithUUID:")]
@@ -2098,6 +1826,10 @@ interface SentryThread : SentrySerializable
     // @property (copy, nonatomic) NSNumber * _Nullable current;
     [NullAllowed, Export ("current", ArgumentSemantic.Copy)]
     NSNumber Current { get; set; }
+
+    // @property (copy, nonatomic) NSNumber * _Nullable isMain;
+    [NullAllowed, Export ("isMain", ArgumentSemantic.Copy)]
+    NSNumber IsMain { get; set; }
 
     // -(instancetype _Nonnull)initWithThreadId:(NSNumber * _Nonnull)threadId;
     [Export ("initWithThreadId:")]
@@ -2235,6 +1967,88 @@ interface SentryUserFeedback : SentrySerializable
     string Comments { get; set; }
 }
 
+// @interface SentryAppStartMeasurement : NSObject
+[BaseType (typeof(NSObject))]
+[DisableDefaultCtor]
+[Internal]
+interface SentryAppStartMeasurement
+{
+    // -(instancetype _Nonnull)initWithType:(SentryAppStartType)type appStartTimestamp:(NSDate * _Nonnull)appStartTimestamp duration:(NSTimeInterval)duration runtimeInitTimestamp:(NSDate * _Nonnull)runtimeInitTimestamp didFinishLaunchingTimestamp:(NSDate * _Nonnull)didFinishLaunchingTimestamp __attribute__((deprecated("Use initWithType:appStartTimestamp:duration:mainTimestamp:runtimeInitTimestamp:didFinishLaunchingTimestamp instead.")));
+    [Export ("initWithType:appStartTimestamp:duration:runtimeInitTimestamp:didFinishLaunchingTimestamp:")]
+    NativeHandle Constructor (SentryAppStartType type, NSDate appStartTimestamp, double duration, NSDate runtimeInitTimestamp, NSDate didFinishLaunchingTimestamp);
+
+    // -(instancetype _Nonnull)initWithType:(SentryAppStartType)type isPreWarmed:(BOOL)isPreWarmed appStartTimestamp:(NSDate * _Nonnull)appStartTimestamp duration:(NSTimeInterval)duration runtimeInitTimestamp:(NSDate * _Nonnull)runtimeInitTimestamp moduleInitializationTimestamp:(NSDate * _Nonnull)moduleInitializationTimestamp didFinishLaunchingTimestamp:(NSDate * _Nonnull)didFinishLaunchingTimestamp;
+    [Export ("initWithType:isPreWarmed:appStartTimestamp:duration:runtimeInitTimestamp:moduleInitializationTimestamp:didFinishLaunchingTimestamp:")]
+    NativeHandle Constructor (SentryAppStartType type, bool isPreWarmed, NSDate appStartTimestamp, double duration, NSDate runtimeInitTimestamp, NSDate moduleInitializationTimestamp, NSDate didFinishLaunchingTimestamp);
+
+    // @property (readonly, assign, nonatomic) SentryAppStartType type;
+    [Export ("type", ArgumentSemantic.Assign)]
+    SentryAppStartType Type { get; }
+
+    // @property (readonly, assign, nonatomic) BOOL isPreWarmed;
+    [Export ("isPreWarmed")]
+    bool IsPreWarmed { get; }
+
+    // @property (readonly, assign, nonatomic) NSTimeInterval duration;
+    [Export ("duration")]
+    double Duration { get; }
+
+    // @property (readonly, nonatomic, strong) NSDate * _Nonnull appStartTimestamp;
+    [Export ("appStartTimestamp", ArgumentSemantic.Strong)]
+    NSDate AppStartTimestamp { get; }
+
+    // @property (readonly, nonatomic, strong) NSDate * _Nonnull runtimeInitTimestamp;
+    [Export ("runtimeInitTimestamp", ArgumentSemantic.Strong)]
+    NSDate RuntimeInitTimestamp { get; }
+
+    // @property (readonly, nonatomic, strong) NSDate * _Nonnull moduleInitializationTimestamp;
+    [Export ("moduleInitializationTimestamp", ArgumentSemantic.Strong)]
+    NSDate ModuleInitializationTimestamp { get; }
+
+    // @property (readonly, nonatomic, strong) NSDate * _Nonnull didFinishLaunchingTimestamp;
+    [Export ("didFinishLaunchingTimestamp", ArgumentSemantic.Strong)]
+    NSDate DidFinishLaunchingTimestamp { get; }
+}
+
+// @interface SentryScreenFrames : NSObject
+[BaseType (typeof(NSObject))]
+[DisableDefaultCtor]
+[Internal]
+interface SentryScreenFrames
+{
+    // -(instancetype _Nonnull)initWithTotal:(NSUInteger)total frozen:(NSUInteger)frozen slow:(NSUInteger)slow;
+    [Export ("initWithTotal:frozen:slow:")]
+    NativeHandle Constructor (nuint total, nuint frozen, nuint slow);
+
+    // -(instancetype _Nonnull)initWithTotal:(NSUInteger)total frozen:(NSUInteger)frozen slow:(NSUInteger)slow slowFrameTimestamps:(SentryFrameInfoTimeSeries * _Nonnull)slowFrameTimestamps frozenFrameTimestamps:(SentryFrameInfoTimeSeries * _Nonnull)frozenFrameTimestamps frameRateTimestamps:(SentryFrameInfoTimeSeries * _Nonnull)frameRateTimestamps;
+    [Export ("initWithTotal:frozen:slow:slowFrameTimestamps:frozenFrameTimestamps:frameRateTimestamps:")]
+    NativeHandle Constructor (nuint total, nuint frozen, nuint slow, NSDictionary<NSString, NSNumber>[] slowFrameTimestamps, NSDictionary<NSString, NSNumber>[] frozenFrameTimestamps, NSDictionary<NSString, NSNumber>[] frameRateTimestamps);
+
+    // @property (readonly, assign, nonatomic) NSUInteger total;
+    [Export ("total")]
+    nuint Total { get; }
+
+    // @property (readonly, assign, nonatomic) NSUInteger frozen;
+    [Export ("frozen")]
+    nuint Frozen { get; }
+
+    // @property (readonly, assign, nonatomic) NSUInteger slow;
+    [Export ("slow")]
+    nuint Slow { get; }
+
+    // @property (readonly, copy, nonatomic) SentryFrameInfoTimeSeries * _Nonnull slowFrameTimestamps;
+    [Export ("slowFrameTimestamps", ArgumentSemantic.Copy)]
+    NSDictionary<NSString, NSNumber>[] SlowFrameTimestamps { get; }
+
+    // @property (readonly, copy, nonatomic) SentryFrameInfoTimeSeries * _Nonnull frozenFrameTimestamps;
+    [Export ("frozenFrameTimestamps", ArgumentSemantic.Copy)]
+    NSDictionary<NSString, NSNumber>[] FrozenFrameTimestamps { get; }
+
+    // @property (readonly, copy, nonatomic) SentryFrameInfoTimeSeries * _Nonnull frameRateTimestamps;
+    [Export ("frameRateTimestamps", ArgumentSemantic.Copy)]
+    NSDictionary<NSString, NSNumber>[] FrameRateTimestamps { get; }
+}
+
 // typedef void (^SentryOnAppStartMeasurementAvailable)(SentryAppStartMeasurement * _Nullable);
 [Internal]
 delegate void SentryOnAppStartMeasurementAvailable ([NullAllowed] SentryAppStartMeasurement appStartMeasurement);
@@ -2244,22 +2058,6 @@ delegate void SentryOnAppStartMeasurementAvailable ([NullAllowed] SentryAppStart
 [Internal]
 interface PrivateSentrySDKOnly
 {
-    // +(void)storeEnvelope:(SentryEnvelope * _Nonnull)envelope;
-    [Static]
-    [Export ("storeEnvelope:")]
-    void StoreEnvelope (SentryEnvelope envelope);
-
-    // +(void)captureEnvelope:(SentryEnvelope * _Nonnull)envelope;
-    [Static]
-    [Export ("captureEnvelope:")]
-    void CaptureEnvelope (SentryEnvelope envelope);
-
-    // +(SentryEnvelope * _Nullable)envelopeWithData:(NSData * _Nonnull)data;
-    [Static]
-    [Export ("envelopeWithData:")]
-    [return: NullAllowed]
-    SentryEnvelope EnvelopeWithData (NSData data);
-
     // +(NSArray<SentryDebugMeta *> * _Nonnull)getDebugImages;
     [Static]
     [Export ("getDebugImages")]
@@ -2329,4 +2127,9 @@ interface PrivateSentrySDKOnly
     [Static]
     [Export ("captureScreenshots")]
     NSData[] CaptureScreenshots();
+
+    // +(NSData * _Nonnull)captureViewHierarchy;
+    [Static]
+    [Export ("captureViewHierarchy")]
+    NSData CaptureViewHierarchy();
 }

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -1647,7 +1647,7 @@ interface SentrySamplingContext
 // @interface SentryScope : NSObject <SentrySerializable>
 [BaseType (typeof(NSObject))]
 [Internal]
-interface SentryScope : SentrySerializable
+partial interface SentryScope : SentrySerializable
 {
     // @property (nonatomic, strong) id<SentrySpan> _Nullable span;
     [NullAllowed, Export ("span", ArgumentSemantic.Strong)]

--- a/src/Sentry.Bindings.Cocoa/PrivateApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/PrivateApiDefinitions.cs
@@ -1,0 +1,13 @@
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace Sentry.CocoaSdk;
+
+partial interface SentryScope
+{
+    // -(SentryEvent * _Nullable)applyToEvent:(SentryEvent * _Nonnull)event maxBreadcrumb:(NSUInteger)maxBreadcrumbs;
+    [Export ("applyToEvent:maxBreadcrumb:")]
+    [return: NullAllowed]
+    SentryEvent ApplyToEvent (SentryEvent @event, nuint maxBreadcrumbs);
+}

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -12,6 +12,7 @@
 
     <!-- Set up the binding project. -->
     <ObjcBindingApiDefinition Include="ApiDefinitions.cs" />
+    <ObjcBindingApiDefinition Include="PrivateApiDefinitions.cs" />
     <ObjcBindingCoreSource Include="StructsAndEnums.cs" />
     <NativeReference Include="$(SentryCocoaFramework)" Kind="Framework" />
 

--- a/src/Sentry.Bindings.Cocoa/StructsAndEnums.cs
+++ b/src/Sentry.Bindings.Cocoa/StructsAndEnums.cs
@@ -25,15 +25,6 @@ internal enum SentryLevel : ulong
 }
 
 [Native]
-internal enum SentryPermissionStatus : long
-{
-    Unknown = 0,
-    Granted,
-    Partial,
-    Denied
-}
-
-[Native]
 internal enum SentryTransactionNameSource : long
 {
     Custom = 0,
@@ -42,14 +33,6 @@ internal enum SentryTransactionNameSource : long
     View,
     Component,
     Task
-}
-
-[Native]
-internal enum SentryAppStartType : ulong
-{
-    Warm,
-    Cold,
-    Unknown
 }
 
 [Native]
@@ -63,7 +46,9 @@ internal enum SentryError : long
     JsonConversionError = 104,
     CouldNotFindDirectory = 105,
     RequestError = 106,
-    EventNotSent = 107
+    EventNotSent = 107,
+    FileIO = 108,
+    Kernel = 109
 }
 
 [Native]
@@ -98,10 +83,9 @@ internal enum SentrySpanStatus : ulong
 }
 
 [Native]
-internal enum SentrySessionStatus : ulong
+internal enum SentryAppStartType : ulong
 {
-    Ok = 0,
-    Exited = 1,
-    Crashed = 2,
-    Abnormal = 3
+    Warm,
+    Cold,
+    Unknown
 }

--- a/src/Sentry.Bindings.Cocoa/StructsAndEnums.cs
+++ b/src/Sentry.Bindings.Cocoa/StructsAndEnums.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+using Foundation;
 using ObjCRuntime;
 
 namespace Sentry.CocoaSdk;
@@ -63,7 +65,6 @@ internal enum SentryError : long
     RequestError = 106,
     EventNotSent = 107
 }
-
 
 [Native]
 internal enum SentrySampleDecision : ulong

--- a/src/Sentry.Bindings.Cocoa/sharpie.md
+++ b/src/Sentry.Bindings.Cocoa/sharpie.md
@@ -1,20 +1,7 @@
 The files in this folder aren't "normal" C# files, but rather they are [Xamarin Objective-C bindings][1].
-They were originally generated with [Objective Sharpie][2], using the following command:
+They are generated using [Objective Sharpie][2], using the script in `../scripts/generate-cocoa-bindings.ps1`.
 
-```
-sharpie bind <path to sentry-cocoa sdk root>/Sentry.xcodeproj -sdk iphoneos
-```
-
-However, the files are not purely auto-generated.  Several modifications have been made:
-
-- Everything has been made internal, either via the `internal` keyword, or the `[Internal]` binding attribute.
-- Named delegates have been replaced with `Func<T>` or `Action<T>` to work around https://github.com/xamarin/xamarin-macios/issues/15299
-- `INSCopying` interfaces have been commented out, to resolve nullability error
-- Items that Sharpie marked with `[Verify]` have been resolved, except for:
-  - `NSErrorFromSentryError` and its containing class has been commented out, as we aren't using it presently and it needs verification
-
-Be careful when updating these files.  They control additional code generation that happens at compile time,
-which ends up under `obj/Debug/net6.0-ios/iOS/SentryCocoa`.
+Do not modify the `.cs` files directly.  Instead, update the script as needed and re-generate.
 
 [1]: https://docs.microsoft.com/xamarin/cross-platform/macios/binding/objective-c-libraries
 [2]: https://docs.microsoft.com/xamarin/cross-platform/macios/binding/objective-sharpie

--- a/src/Sentry/Platforms/iOS/Facades/TransactionContextFacade.cs
+++ b/src/Sentry/Platforms/iOS/Facades/TransactionContextFacade.cs
@@ -27,7 +27,8 @@ internal class TransactionContextFacade : ITransactionContext
 
     public string Description => _context.Description;
 
-    public SpanStatus? Status => _context.Status.ToSpanStatus();
+    // Note: SentrySpanContext.Status was removed from the Cocoa SDK in 8.0.0
+    public SpanStatus? Status => null; // _context.Status.ToSpanStatus();
 
     public bool? IsSampled => _context.Sampled.ToNullableBoolean();
 }

--- a/src/Sentry/Platforms/iOS/IosEventProcessor.cs
+++ b/src/Sentry/Platforms/iOS/IosEventProcessor.cs
@@ -36,6 +36,7 @@ internal class IosEventProcessor : ISentryEventProcessor, IDisposable
         var @event = new CocoaSdk.SentryEvent();
         SentryCocoaSdk.ConfigureScope(scope =>
         {
+            // TODO: As of Sentry Cocoa 8.0.0, this is a private API.  Find a better way!
             scope.ApplyToEvent(@event, 0);
         });
 

--- a/src/Sentry/Platforms/iOS/Sentry.iOS.props
+++ b/src/Sentry/Platforms/iOS/Sentry.iOS.props
@@ -7,7 +7,8 @@
   <ItemGroup>
     <Using Include="Foundation" />
     <Using Include="Sentry.CocoaSdk.SentryOptions" Alias="SentryCocoaOptions" />
-    <Using Include="Sentry.CocoaSdk.SentrySdk" Alias="SentryCocoaSdk" />
+    <Using Include="Sentry.CocoaSdk.SentrySDK" Alias="SentryCocoaSdk" />
+    <Using Include="Sentry.CocoaSdk.PrivateSentrySDKOnly" Alias="SentryCocoaHybridSdk" />
   </ItemGroup>
 
 </Project>

--- a/src/Sentry/Platforms/iOS/SentryOptions.cs
+++ b/src/Sentry/Platforms/iOS/SentryOptions.cs
@@ -69,12 +69,12 @@ public partial class SentryOptions
         /// <summary>
         /// When enabled, the SDK tracks when the application stops responding for a specific amount of
         /// time defined by the <see cref="AppHangTimeoutInterval"/> option.
-        /// The default value is <c>false</c> (disabled).
+        /// The default value is <c>true</c> (enabled).
         /// </summary>
         /// <remarks>
         /// See https://docs.sentry.io/platforms/apple/configuration/app-hangs/
         /// </remarks>
-        public bool EnableAppHangTracking { get; set; } = false;
+        public bool EnableAppHangTracking { get; set; } = true;
 
         /// <summary>
         /// When enabled, the SDK adds breadcrumbs for various system events.
@@ -95,30 +95,76 @@ public partial class SentryOptions
         /// See: https://docs.sentry.io/platforms/apple/performance/
         /// And: https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#opt-out
         /// </remarks>
-        public bool EnableAutoPerformanceTracking { get; set; } = true;
+        public bool EnableAutoPerformanceTracing { get; set; } = true;
 
         /// <summary>
-        /// This feature is experimental.
+        /// When enabled, the SDK tracks performance for <see cref="UIViewController"/> subclasses and HTTP requests
+        /// automatically. It also measures the app start and slow and frozen frames.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        /// <remarks>
+        /// Performance Monitoring must be enabled for this option to take effect.
+        /// See: https://docs.sentry.io/platforms/apple/performance/
+        /// And: https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#opt-out
+        /// </remarks>
+        [Obsolete("Use EnableAutoPerformanceTracing instead.  This property will be removed in a future version.")]
+        public bool EnableAutoPerformanceTracking
+        {
+            get => EnableAutoPerformanceTracing;
+            set => EnableAutoPerformanceTracing = value;
+        }
+
+        /// <summary>
         /// When enabled, the SDK tracks the performance of Core Data operations.
         /// It requires enabling performance monitoring.
-        /// The default value is <c>false</c> (disabled).
+        /// The default value is <c>true</c> (enabled).
         /// </summary>
         /// <remarks>
         /// Performance Monitoring must be enabled for this option to take effect.
         /// See https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#core-data-instrumentation
         /// </remarks>
-        public bool EnableCoreDataTracking { get; set; } = false;
+        public bool EnableCoreDataTracing { get; set; } = true;
 
         /// <summary>
-        /// This feature is experimental.
+        /// When enabled, the SDK tracks the performance of Core Data operations.
+        /// It requires enabling performance monitoring.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        /// <remarks>
+        /// Performance Monitoring must be enabled for this option to take effect.
+        /// See https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#core-data-instrumentation
+        /// </remarks>
+        [Obsolete("Use EnableCoreDataTracing instead.  This property will be removed in a future version.")]
+        public bool EnableCoreDataTracking
+        {
+            get => EnableCoreDataTracing;
+            set => EnableCoreDataTracing = value;
+        }
+
+        /// <summary>
         /// When enabled, the SDK tracks performance for file IO reads and writes with <see cref="NSData"/>
         /// if auto performance tracking and <see cref="EnableSwizzling"/> are enabled.
-        /// The default value is <c>false</c> (disabled).
+        /// The default value is <c>true</c> (enabled).
         /// </summary>
         /// <remarks>
         /// See https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#file-io-instrumentation
         /// </remarks>
-        public bool EnableFileIOTracking { get; set; } = false;
+        public bool EnableFileIOTracing { get; set; } = true;
+
+        /// <summary>
+        /// When enabled, the SDK tracks performance for file IO reads and writes with <see cref="NSData"/>
+        /// if auto performance tracking and <see cref="EnableSwizzling"/> are enabled.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        /// <remarks>
+        /// See https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#file-io-instrumentation
+        /// </remarks>
+        [Obsolete("Use EnableFileIOTracing instead.  This property will be removed in a future version.")]
+        public bool EnableFileIOTracking
+        {
+            get => EnableFileIOTracing;
+            set => EnableFileIOTracing = value;
+        }
 
         /// <summary>
         /// When enabled, the SDK adds breadcrumbs for each network request
@@ -138,13 +184,27 @@ public partial class SentryOptions
         public bool EnableNetworkTracking { get; set; } = true;
 
         /// <summary>
+        /// Whether to enable watchdog termination tracking or not.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        /// <remarks>
+        /// https://docs.sentry.io/platforms/apple/configuration/watchdog-terminations/
+        /// </remarks>
+        public bool EnableWatchdogTerminationTracking { get; set; } = true;
+
+        /// <summary>
         /// Whether to enable out of memory tracking or not.
         /// The default value is <c>true</c> (enabled).
         /// </summary>
         /// <remarks>
         /// https://docs.sentry.io/platforms/apple/configuration/out-of-memory/
         /// </remarks>
-        public bool EnableOutOfMemoryTracking { get; set; } = true;
+        [Obsolete("Use EnableWatchdogTerminationTracking instead.  This property will be removed in a future version.")]
+        public bool EnableOutOfMemoryTracking
+        {
+            get => EnableWatchdogTerminationTracking;
+            set => EnableWatchdogTerminationTracking = value;
+        }
 
         /// <summary>
         /// Whether the SDK should use swizzling or not.
@@ -166,10 +226,23 @@ public partial class SentryOptions
         /// <remarks>
         /// See https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-instrumentation
         /// </remarks>
-        public bool EnableUIViewControllerTracking { get; set; } = true;
+        public bool EnableUIViewControllerTracing { get; set; } = true;
 
         /// <summary>
-        /// This feature is experimental.
+        /// When enabled, the SDK tracks performance for <see cref="UIViewController"/> subclasses.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        /// <remarks>
+        /// See https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-instrumentation
+        /// </remarks>
+        [Obsolete("Use EnableUIViewControllerTracing instead.")]
+        public bool EnableUIViewControllerTracking
+        {
+            get => EnableUIViewControllerTracing;
+            set => EnableUIViewControllerTracing = value;
+        }
+
+        /// <summary>
         /// When enabled, the SDK creates transactions for UI events like buttons clicks, switch toggles,
         /// and other UI elements that uses <see cref="UIControl.SendAction(Selector, NSObject?, UIEvent?)"/>.
         /// The default value is <c>false</c> (disabled).

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -27,7 +27,6 @@ public static partial class SentrySdk
         cocoaOptions.DiagnosticLevel = options.DiagnosticLevel.ToCocoaSentryLevel();
         cocoaOptions.Dsn = options.Dsn;
         cocoaOptions.EnableAutoSessionTracking = options.AutoSessionTracking;
-        cocoaOptions.Environment = options.Environment;
         cocoaOptions.MaxAttachmentSize = (nuint) options.MaxAttachmentSize;
         cocoaOptions.MaxBreadcrumbs = (nuint) options.MaxBreadcrumbs;
         cocoaOptions.MaxCacheItems = (nuint) options.MaxCacheItems;
@@ -36,6 +35,11 @@ public static partial class SentrySdk
         cocoaOptions.SendClientReports = options.SendClientReports;
         cocoaOptions.SendDefaultPii = options.SendDefaultPii;
         cocoaOptions.SessionTrackingIntervalMillis = (nuint) options.AutoSessionTrackingInterval.TotalMilliseconds;
+
+        if (options.Environment is { } environment)
+        {
+            cocoaOptions.Environment = environment;
+        }
 
         // These options are not available in the Sentry Cocoa SDK
         // cocoaOptions.? = options.InitCacheFlushTimeout;
@@ -111,14 +115,14 @@ public static partial class SentrySdk
         cocoaOptions.Dist = options.Distribution;
         cocoaOptions.EnableAppHangTracking = options.iOS.EnableAppHangTracking;
         cocoaOptions.EnableAutoBreadcrumbTracking = options.iOS.EnableAutoBreadcrumbTracking;
-        cocoaOptions.EnableAutoPerformanceTracking = options.iOS.EnableAutoPerformanceTracking;
-        cocoaOptions.EnableCoreDataTracking = options.iOS.EnableCoreDataTracking;
-        cocoaOptions.EnableFileIOTracking = options.iOS.EnableFileIOTracking;
+        cocoaOptions.EnableAutoPerformanceTracing = options.iOS.EnableAutoPerformanceTracing;
+        cocoaOptions.EnableCoreDataTracing = options.iOS.EnableCoreDataTracing;
+        cocoaOptions.EnableFileIOTracing = options.iOS.EnableFileIOTracing;
         cocoaOptions.EnableNetworkBreadcrumbs = options.iOS.EnableNetworkBreadcrumbs;
         cocoaOptions.EnableNetworkTracking = options.iOS.EnableNetworkTracking;
-        cocoaOptions.EnableOutOfMemoryTracking = options.iOS.EnableOutOfMemoryTracking;
+        cocoaOptions.EnableWatchdogTerminationTracking = options.iOS.EnableWatchdogTerminationTracking;
         cocoaOptions.EnableSwizzling = options.iOS.EnableSwizzling;
-        cocoaOptions.EnableUIViewControllerTracking = options.iOS.EnableUIViewControllerTracking;
+        cocoaOptions.EnableUIViewControllerTracing = options.iOS.EnableUIViewControllerTracing;
         cocoaOptions.EnableUserInteractionTracing = options.iOS.EnableUserInteractionTracing;
         cocoaOptions.StitchAsyncCode = options.iOS.StitchAsyncCode;
         cocoaOptions.UrlSessionDelegate = options.iOS.UrlSessionDelegate;
@@ -164,7 +168,7 @@ public static partial class SentrySdk
         SentryCocoaHybridSdk.SetSdkName("sentry.cocoa.dotnet");
 
         // Now initialize the Cocoa SDK
-        SentryCocoaSdk.StartWithOptionsObject(cocoaOptions);
+        SentryCocoaSdk.StartWithOptions(cocoaOptions);
 
         // Set options for the managed SDK that depend on the Cocoa SDK. (The user will not be able to modify these.)
         options.AddEventProcessor(new IosEventProcessor(cocoaOptions));

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -161,7 +161,7 @@ public static partial class SentrySdk
         };
 
         // Set hybrid SDK name
-        CocoaSdk.PrivateSentrySdkOnly.SetSdkName("sentry.cocoa.dotnet");
+        SentryCocoaHybridSdk.SetSdkName("sentry.cocoa.dotnet");
 
         // Now initialize the Cocoa SDK
         SentryCocoaSdk.StartWithOptionsObject(cocoaOptions);


### PR DESCRIPTION
- Adds a new `generate-cocoa-bindings.ps1` script that generates the Cocoa bindings and patches them automatically to apply our various modifications.  This drastically reduces the fragility of updating the Cocoa SDK. 
- Updates the Sentry Cocoa SDK from 7.31.5 to 8.2.0 and applies all of the required breaking changes

From the .NET developer's perspective, minor changes for iOS and MacCatalyst targets are as follows:
- Several properties on `SentryOptions.iOS` have been renamed to match the Cocoa SDK.  The original properties remain, and are marked `[Obsolete]` with appropriate messages to guide any required changes.
- Also on `SentryOptions.iOS`, properties `EnableAppHangTracking`, `EnableCoreDataTracing`, and `EnableFileIOTracing` are now enabled by default to match the Cocoa SDK's default behavior.

Fixes #2148
Replaces #2198 