### PR TITLE
Envelope transaction received from SendBeforeTransaction, not the original one

### DIFF
--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -140,7 +140,7 @@ public class SentryClient : ISentryClient, IDisposable
             return;
         }
 
-        CaptureEnvelope(Envelope.FromTransaction(transaction));
+        CaptureEnvelope(Envelope.FromTransaction(processedTransaction));
     }
 
     private Transaction? BeforeSendTransaction(Transaction transaction)


### PR DESCRIPTION
This a follow-up to #2188

#skip-changelog