### PR TITLE
Fix context object with circular reference prevents event from being sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixes
 
 - Fix assembly not found on Android in Debug configuration ([#2175](https://github.com/getsentry/sentry-dotnet/pull/2175))
+- Fix context object with circular reference prevents event from being sent ([#2210](https://github.com/getsentry/sentry-dotnet/pull/2210))
 
 ### Dependencies
 

--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -463,6 +463,20 @@ internal static class JsonExtensions
         {
             writer.WriteStringValue(dto);
         }
+        else if (value is TimeSpan timeSpan)
+        {
+            writer.WriteStringValue(timeSpan.ToString("g", CultureInfo.InvariantCulture));
+        }
+#if NET6_0_OR_GREATER
+        else if (value is DateOnly date)
+        {
+            writer.WriteStringValue(date.ToString("O", CultureInfo.InvariantCulture));
+        }
+        else if (value is TimeOnly time)
+        {
+            writer.WriteStringValue(time.ToString("HH:mm:ss.FFFFFFF", CultureInfo.InvariantCulture));
+        }
+#endif
         else if (value is IFormattable formattable)
         {
             writer.WriteStringValue(formattable.ToString(null, CultureInfo.InvariantCulture));

--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -448,10 +448,19 @@ internal static class JsonExtensions
             // Render an empty JSON object instead of null. This allows a round trip where this property name is the
             // key to a map which would otherwise not be set and result in a different object.
             // This affects envelope size which isn't recomputed after a roundtrip.
-            if (originalPropertyDepth == writer.CurrentDepth)
+
+            // If the last token written was ":", then we must write a property value.
+            // If the last token written was "{", then we can't write a property value.
+            // Since either could happen, we will *try* to write a "{" and ignore any failure.
+            try
             {
                 writer.WriteStartObject();
             }
+            catch (InvalidOperationException)
+            {
+            }
+
+            // Now we can close each open object until we get back to the original depth.
             while (originalPropertyDepth < writer.CurrentDepth)
             {
                 writer.WriteEndObject();

--- a/src/Sentry/Internal/Polyfills.cs
+++ b/src/Sentry/Internal/Polyfills.cs
@@ -138,3 +138,14 @@ internal static partial class PolyfillExtensions
     }
 }
 #endif
+
+#if !NET6_0_OR_GREATER
+internal static partial class PolyfillExtensions
+{
+    public static void WriteRawValue(this Utf8JsonWriter writer, byte[] utf8Json)
+    {
+        using var document = JsonDocument.Parse(utf8Json);
+        document.RootElement.WriteTo(writer);
+    }
+}
+#endif

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -58,7 +58,7 @@
   </ItemGroup>
 
   <!-- Prefer bundled version of System.Text.Json to avoid extra dependencies -->
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) or '$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) or '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netcoreapp3.0'">
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -81,7 +81,7 @@
       <SentryCLIDownload Include="sentry-cli-Linux-i686" FileHash="e13aa44c84860ab3e47fc3a52aa576685f25c792d3d74ee32c42a0bb3b873266" />
       <SentryCLIDownload Include="sentry-cli-Linux-x86_64" FileHash="0de8f58be0687d8c0cc78591c3ba33ced93b5976eac1ddb713c1074f1d3403e0" />
       <SentryCLIDownload Include="sentry-cli-Windows-i686.exe" FileHash="a5d48ba4145c6be807456e3e24381994b0082746572494155724dd18b1c6330b" />
-      <SentryCLIDownload Include="sentry-cli-Windows-x86_64.exe" FileHash="981d0a882cca003fd144ce0f91530247f52ecace62e9acf17ad436de578a1a90"/>
+      <SentryCLIDownload Include="sentry-cli-Windows-x86_64.exe" FileHash="981d0a882cca003fd144ce0f91530247f52ecace62e9acf17ad436de578a1a90" />
     </ItemGroup>
 
     <!-- Download the files -->

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -801,28 +801,24 @@ public class SentryOptions
             throw new ArgumentNullException(nameof(converter));
         }
 
-        // only add if we don't have this instance already
-        var converters = JsonExtensions.SerializerOptions.Converters;
-        if (converters.Contains(converter))
-        {
-            return;
-        }
+        JsonExtensions.AddJsonConverter(converter);
+    }
 
-        try
-        {
-            converters.Add(converter);
-        }
-        catch (InvalidOperationException)
-        {
-            // If we've already started using the serializer, then it's too late to add more converters.
-            // The following exception message may occur (depending on STJ version):
-            // "Serializer options cannot be changed once serialization or deserialization has occurred."
-            // We'll swallow this, because it's likely to only have occurred in our own unit tests,
-            // or in a scenario where the Sentry SDK has been initialized multiple times,
-            // in which case we have the converter from the first initialization already.
-            // TODO: .NET 8 is getting an IsReadOnly flag we could check instead of catching
-            // See https://github.com/dotnet/runtime/pull/74431
-        }
+    /// <summary>
+    /// When <c>true</c>, if an object being serialized to JSON contains references to other objects, and the
+    /// serialized object graph exceed the maximum allowable depth, the object will instead be serialized using
+    /// <see cref="ReferenceHandler.Preserve"/> (from System.Text.Json) - which adds <c>$id</c> and <c>$ref</c>
+    /// metadata to the JSON.  When <c>false</c>, an object graph exceeding the maximum depth will be truncated.
+    /// The default value is <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// This option applies only to complex objects being added to Sentry events as contexts or extras, which do not
+    /// implement <see cref="IJsonSerializable"/>.
+    /// </remarks>
+    public bool JsonPreserveReferences
+    {
+        get => JsonExtensions.JsonPreserveReferences;
+        set => JsonExtensions.JsonPreserveReferences = value;
     }
 
     /// <summary>

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -569,6 +569,7 @@ namespace Sentry
         public System.TimeSpan InitCacheFlushTimeout { get; set; }
         public bool IsEnvironmentUser { get; set; }
         public bool IsGlobalModeEnabled { get; set; }
+        public bool JsonPreserveReferences { get; set; }
         public bool KeepAggregateException { get; set; }
         public long MaxAttachmentSize { get; set; }
         public int MaxBreadcrumbs { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -569,6 +569,7 @@ namespace Sentry
         public System.TimeSpan InitCacheFlushTimeout { get; set; }
         public bool IsEnvironmentUser { get; set; }
         public bool IsGlobalModeEnabled { get; set; }
+        public bool JsonPreserveReferences { get; set; }
         public bool KeepAggregateException { get; set; }
         public long MaxAttachmentSize { get; set; }
         public int MaxBreadcrumbs { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -569,6 +569,7 @@ namespace Sentry
         public System.TimeSpan InitCacheFlushTimeout { get; set; }
         public bool IsEnvironmentUser { get; set; }
         public bool IsGlobalModeEnabled { get; set; }
+        public bool JsonPreserveReferences { get; set; }
         public bool KeepAggregateException { get; set; }
         public long MaxAttachmentSize { get; set; }
         public int MaxBreadcrumbs { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -568,6 +568,7 @@ namespace Sentry
         public System.TimeSpan InitCacheFlushTimeout { get; set; }
         public bool IsEnvironmentUser { get; set; }
         public bool IsGlobalModeEnabled { get; set; }
+        public bool JsonPreserveReferences { get; set; }
         public bool KeepAggregateException { get; set; }
         public long MaxAttachmentSize { get; set; }
         public int MaxBreadcrumbs { get; set; }

--- a/test/Sentry.Tests/SerializationTests.verify.cs
+++ b/test/Sentry.Tests/SerializationTests.verify.cs
@@ -32,7 +32,7 @@ public class SerializationTests
         yield return new object[] {"nested nullable UIntPtr", new {Value = (IntPtr?)3}};
 
         JsonExtensions.ResetSerializerOptions();
-        new SentryOptions().AddJsonConverter(new CustomObjectConverter());
+        JsonExtensions.AddJsonConverter(new CustomObjectConverter());
         yield return new object[] {"custom object with value", new CustomObject("test")};
         yield return new object[] {"custom object with null", new CustomObject(null)};
     }


### PR DESCRIPTION
When a circular reference exists in an object being added to an event as contexts or extras, the SDK will now do the following:

- If the object graph can be serialized without error, and without reaching the default max depth limit set by `System.Text.Json` (depth = 64), then it will be serialized normally.  This is covers the majority of cases.
- If serializing the object graph would error due to exceeding the max depth, then we will retry while using the [`ReferenceHandler.Preserve`](https://learn.microsoft.com/dotnet/api/system.text.json.serialization.referencehandler.preserve) option provided by `System.Text.Json`.  This results in a much smaller object graph, but one that has been tagged with `$id` and `$ref` metadata instead of materializing the references.

To opt out of this behavior, set `SentryOptions.JsonPreserveReferences = false`.  If serialization were to fail due to  exceeding the max depth, then the object graph will be truncated at that depth.  This was the intended behavior of the previous implementation, though it had a bug which has now been fixed as well.

In any case, the net result is that such an object no longer prevents the event from being sent to Sentry.

Fixes #2209

Also:
- I added `TimeSpan`, `DateOnly`, and `TimeOnly` to the list of directly-serializable types, since they were in the same code path.
- `ReferenceHandler.Preserve` requires a minimum dependency on STJ 5.  We already had `5.0.2` as the min dependency on .NET Framework and .NET Standard, but we are still building for .NET Core 3.0 so we need to bump the STJ dependency there as well.  This only affects the `netcoreapp3.0` target.  .NET 5+ will continue to use the STJ provided with the .NET SDK.  (We'll drop  these old targets in the next major.)
- I performed some other minor refactoring along the way, as necessary.
