### PR TITLE
Make `SentryUploadSymbols` strictly opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## Unreleased
 
+**Notice:** The `<SentryUploadSymbols>` MSBuild property previously defaulted to `true` for projects compiled in `Release` configuration.
+It is now `false` by default.  To continue uploading symbols, you must opt-in by setting it to `true`.
+See the [MSBuild Setup](https://docs.sentry.io/platforms/dotnet/configuration/msbuild/) docs for further details.
+
 ### Features
 
 - Added basic functionality to support `View Hierarchy` ([#2163](https://github.com/getsentry/sentry-dotnet/pull/2163))
 - Allow `SentryUploadSources` to work even when not uploading symbols ([#2197](https://github.com/getsentry/sentry-dotnet/pull/2197))
 - Add support for `BeforeSendTransaction` ([#2188](https://github.com/getsentry/sentry-dotnet/pull/2188))
 - Add `EnableTracing` option to simplify enabling tracing ([#2201](https://github.com/getsentry/sentry-dotnet/pull/2201))
+- Make `SentryUploadSymbols` strictly opt-in ([#2216](https://github.com/getsentry/sentry-dotnet/pull/2216))
 
 ### Fixes
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,16 @@
     <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
-  <!-- Configure Sentry CLI -->
+  <!--
+    Configure Sentry CLI
+    NOTE: Authentication is not set here.  Instead:
+    - In CI, `SENTRY_AUTH_TOKEN` is set as an environment variable via a GitHub Actions secret.
+    - In dev, you can either set `SENTRY_AUTH_TOKEN` manually, or you can set an auth token
+      in your ~/.sentryclirc file.  See https://docs.sentry.io/product/cli/configuration/
+
+    There is also a a `SentryAuthToken` msbuild property, but it should be used sparingly.
+    If using it, be careful that the auth token does not get committed to source control.
+  -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <SentryOrg>sentry-sdks</SentryOrg>
     <SentryProject>sentry-dotnet</SentryProject>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,12 +12,14 @@
 
     <!-- Allow references to unsigned assemblies (like MAUI) from signed projects -->
     <NoWarn>$(NoWarn);CS8002</NoWarn>
+  </PropertyGroup>
 
-    <!-- Configure Sentry CLI -->
+  <!-- Configure Sentry CLI -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <SentryOrg>sentry-sdks</SentryOrg>
     <SentryProject>sentry-dotnet</SentryProject>
-    <SentryUploadSources Condition="'$(Configuration)' == 'Release'">true</SentryUploadSources>
-
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
   </PropertyGroup>
 
   <!--

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -31,7 +31,7 @@
   <Target Name="CheckSentryCLI" AfterTargets="Build" Condition="'$(InnerTargets)' == ''">
     <PropertyGroup>
       <!-- Set defaults for the Sentry properties. -->
-      <SentryUploadSymbols Condition="'$(SentryUploadSymbols)' == '' And '$(Configuration)' == 'Release'">true</SentryUploadSymbols>
+      <SentryUploadSymbols Condition="'$(SentryUploadSymbols)' == ''">false</SentryUploadSymbols>
       <SentryUploadSources Condition="'$(SentryUploadSources)' == ''">false</SentryUploadSources>
 
       <!-- This property controls if the Sentry CLI is to be used at all.  Setting false will disable all Sentry CLI usage. -->


### PR DESCRIPTION
The `<SentryUploadSymbols>` MSBuild property previously defaulted to `true` for projects compiled in `Release` configuration.  This led to some confusion when combining it with other options.  It is now `false` by default.

Going forward, all features enabled by MSBuild properties will be disabled by default, and strictly opt-in.

To continue uploading symbols, opt-in by setting `<SentryUploadSymbols>true</SentryUploadSymbols>`.  We recommend you do this for `Release` configuration only (because it will slow down local debug builds), but that is at your discretion.

See the [MSBuild Setup](https://docs.sentry.io/platforms/dotnet/configuration/msbuild/) docs for further details.