### PR TITLE
fix: normalize frame in-app resolution for modules & function prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Normalize StackFrame in-app resolution for modules & function prefixes ([#2234](https://github.com/getsentry/sentry-dotnet/pull/2234))
+
 ## 3.29.1
 
 ### Fixes
@@ -260,7 +266,7 @@ _Includes Sentry.Maui Preview 3_
 
 ### Features
 
-- Use `sent_at` instead of `sentry_timestamp` to reduce clock skew ([#1690](https://github.com/getsentry/sentry-dotnet/pull/1690)) 
+- Use `sent_at` instead of `sentry_timestamp` to reduce clock skew ([#1690](https://github.com/getsentry/sentry-dotnet/pull/1690))
 - Send project root path with events ([#1739](https://github.com/getsentry/sentry-dotnet/pull/1739))
 
 ### Fixes
@@ -764,6 +770,7 @@ _Includes Sentry.Maui Preview 1_
 - Enrich transactions with more data (#875) @Tyrrrz
 
 ### Fixes
+
 - Don't add version prefix in release if it's already set (#877) @Tyrrrz
 
 ## 3.0.8
@@ -782,6 +789,7 @@ _Includes Sentry.Maui Preview 1_
 ## 3.0.7
 
 ### Changes
+
 - Don't write timezone_display_name if it's the same as the ID (#837) @Tyrrrz
 - Serialize arbitrary objects in contexts (#838) @Tyrrrz
 
@@ -888,75 +896,75 @@ _Includes Sentry.Maui Preview 1_
 
 ## 3.0.0-alpha.7
 
-* Ref moved SentryId from namespace Sentry.Protocol to Sentry (#643) @lucas-zimerman
-* Ref renamed `CacheFlushTimeout` to `InitCacheFlushTimeout` (#638) @lucas-zimerman
-* Add support for performance. ([#633](https://github.com/getsentry/sentry-dotnet/pull/633))
-* Transaction (of type `string`) on Scope and Event now is called TransactionName. ([#633](https://github.com/getsentry/sentry-dotnet/pull/633))
+- Ref moved SentryId from namespace Sentry.Protocol to Sentry (#643) @lucas-zimerman
+- Ref renamed `CacheFlushTimeout` to `InitCacheFlushTimeout` (#638) @lucas-zimerman
+- Add support for performance. ([#633](https://github.com/getsentry/sentry-dotnet/pull/633))
+- Transaction (of type `string`) on Scope and Event now is called TransactionName. ([#633](https://github.com/getsentry/sentry-dotnet/pull/633))
 
 ## 3.0.0-alpha.6
 
-* Abandon ValueTask #611
-* Fix Cache deleted on HttpTransport exception. (#610) @lucas-zimerman
-* Add `SentryScopeStateProcessor` #603
-* Add net5.0 TFM to libraries #606
-* Add more logging to CachingTransport #619
-* Bump Microsoft.Bcl.AsyncInterfaces to 5.0.0 #618
-* Bump `Microsoft.Bcl.AsyncInterfaces` to 5.0.0 #618
-* `DefaultTags` moved from `SentryLoggingOptions` to `SentryOptions` (#637) @PureKrome
-* `Sentry.Serilog` can accept DefaultTags (#637) @PureKrome
+- Abandon ValueTask #611
+- Fix Cache deleted on HttpTransport exception. (#610) @lucas-zimerman
+- Add `SentryScopeStateProcessor` #603
+- Add net5.0 TFM to libraries #606
+- Add more logging to CachingTransport #619
+- Bump Microsoft.Bcl.AsyncInterfaces to 5.0.0 #618
+- Bump `Microsoft.Bcl.AsyncInterfaces` to 5.0.0 #618
+- `DefaultTags` moved from `SentryLoggingOptions` to `SentryOptions` (#637) @PureKrome
+- `Sentry.Serilog` can accept DefaultTags (#637) @PureKrome
 
 ## 3.0.0-alpha.5
 
-* Replaced `BaseScope` with `IScope`. (#590) @Tyrrrz
-* Removed code coverage report from the test folder. (#592) @lucas-zimerman
-* Add target framework NET5.0 on Sentry.csproj. Change the type of `Extra` where value parameter become nullable. @lucas-zimerman
-* Implement envelope caching. (#576) @Tyrrrz
-* Add a list of .NET Frameworks installed when available. (#531) @lucas-zimerman
-* Parse Mono and IL2CPP stacktraces for Unity and Xamarin (#578) @bruno-garcia
-* Update TFMs and dependency min version (#580) @bruno-garcia
-* Run all tests on .NET 5 (#583) @bruno-garcia
+- Replaced `BaseScope` with `IScope`. (#590) @Tyrrrz
+- Removed code coverage report from the test folder. (#592) @lucas-zimerman
+- Add target framework NET5.0 on Sentry.csproj. Change the type of `Extra` where value parameter become nullable. @lucas-zimerman
+- Implement envelope caching. (#576) @Tyrrrz
+- Add a list of .NET Frameworks installed when available. (#531) @lucas-zimerman
+- Parse Mono and IL2CPP stacktraces for Unity and Xamarin (#578) @bruno-garcia
+- Update TFMs and dependency min version (#580) @bruno-garcia
+- Run all tests on .NET 5 (#583) @bruno-garcia
 
 ## 3.0.0-alpha.4
 
-* Add the client user ip if both SendDefaultPii and IsEnvironmentUser are set. (#1015) @lucas-zimerman
-* Replace Task with ValueTask where possible. (#564) @Tyrrrz
-* Add support for ASP.NET Core gRPC (#563) @Mitch528
-* Push API docs to GitHub Pages GH Actions (#570) @bruno-garcia
-* Refactor envelopes
+- Add the client user ip if both SendDefaultPii and IsEnvironmentUser are set. (#1015) @lucas-zimerman
+- Replace Task with ValueTask where possible. (#564) @Tyrrrz
+- Add support for ASP.NET Core gRPC (#563) @Mitch528
+- Push API docs to GitHub Pages GH Actions (#570) @bruno-garcia
+- Refactor envelopes
 
 ## 3.0.0-alpha.3
 
-* Add support for user feedback. (#559) @lucas-zimerman
-* Add support for envelope deserialization (#558) @Tyrrrz
-* Add package description and tags to Sentry.AspNet @Tyrrrz
-* Fix internal url references for the new Sentry documentation. (#562) @lucas-zimerman
+- Add support for user feedback. (#559) @lucas-zimerman
+- Add support for envelope deserialization (#558) @Tyrrrz
+- Add package description and tags to Sentry.AspNet @Tyrrrz
+- Fix internal url references for the new Sentry documentation. (#562) @lucas-zimerman
 
 ## 3.0.0-alpha.2
 
-* Set the Environment setting to 'production' if none was provided. (#550) @PureKrome
-* ASPNET.Core hosting environment is set to 'production' / 'development' (notice lower casing) if no custom options.Enviroment is set. (#554) @PureKrome
-* Add most popular libraries to InAppExclude #555 (@bruno-garcia)
-* Add support for individual rate limits.
-* Extend `SentryOptions.BeforeBreadcrumb` signature to accept returning nullable values.
-* Add support for envelope deserialization.
+- Set the Environment setting to 'production' if none was provided. (#550) @PureKrome
+- ASPNET.Core hosting environment is set to 'production' / 'development' (notice lower casing) if no custom options.Enviroment is set. (#554) @PureKrome
+- Add most popular libraries to InAppExclude #555 (@bruno-garcia)
+- Add support for individual rate limits.
+- Extend `SentryOptions.BeforeBreadcrumb` signature to accept returning nullable values.
+- Add support for envelope deserialization.
 
 ## 3.0.0-alpha.1
 
-* Rename `LogEntry` to `SentryMessage`. Change type of `SentryEvent.Message` from `string` to `SentryMessage`.
-* Change the type of `Gpu.VendorId` from `int` to `string`.
-* Add support for envelopes.
-* Publishing symbols package (snupkg) to nuget.org with sourcelink
+- Rename `LogEntry` to `SentryMessage`. Change type of `SentryEvent.Message` from `string` to `SentryMessage`.
+- Change the type of `Gpu.VendorId` from `int` to `string`.
+- Add support for envelopes.
+- Publishing symbols package (snupkg) to nuget.org with sourcelink
 
 ## 3.0.0-alpha.0
 
-* Move aspnet-classic integration to Sentry.AspNet (#528) @Tyrrrz
-* Merge Sentry.Protocol into Sentry (#527) @Tyrrrz
-* Framework and runtime info (#526) @bruno-garcia
-* Add NRTS to Sentry.Extensions.Logging (#524) @Tyrrrz
-* Add NRTs to Sentry.Serilog, Sentry.NLog, Sentry.Log4Net (#521) @Tyrrrz
-* Add NRTs to Sentry.AspNetCore (#520) @Tyrrrz
-* Fix CI build on GitHub Actions (#523) @Tyrrrz
-* Add GitHubActionsTestLogger (#511) @Tyrrrz
+- Move aspnet-classic integration to Sentry.AspNet (#528) @Tyrrrz
+- Merge Sentry.Protocol into Sentry (#527) @Tyrrrz
+- Framework and runtime info (#526) @bruno-garcia
+- Add NRTS to Sentry.Extensions.Logging (#524) @Tyrrrz
+- Add NRTs to Sentry.Serilog, Sentry.NLog, Sentry.Log4Net (#521) @Tyrrrz
+- Add NRTs to Sentry.AspNetCore (#520) @Tyrrrz
+- Fix CI build on GitHub Actions (#523) @Tyrrrz
+- Add GitHubActionsTestLogger (#511) @Tyrrrz
 
 We'd love to get feedback.
 
@@ -980,36 +988,36 @@ build(deps): bump Microsoft.Extensions.Configuration.Json (#467) @dependabot-pre
 
 ## 2.1.5
 
-* fix: MEL don't init if enabled (#460) @bruno-garcia
-* feat: Device Calendar, Timezone, CultureInfo (#457) @bruno-garcia
-* ref: Log out debug disabled (#459) @bruno-garcia
-* dep: Bump PlatformAbstractions (#458) @bruno-garcia
-* feat: Exception filter (#456) @bruno-garcia
+- fix: MEL don't init if enabled (#460) @bruno-garcia
+- feat: Device Calendar, Timezone, CultureInfo (#457) @bruno-garcia
+- ref: Log out debug disabled (#459) @bruno-garcia
+- dep: Bump PlatformAbstractions (#458) @bruno-garcia
+- feat: Exception filter (#456) @bruno-garcia
 
 ## 2.1.5-beta
 
-* fix: MEL don't init if enabled (#460) @bruno-garcia
-* feat: Device Calendar, Timezone, CultureInfo (#457) @bruno-garcia
-* ref: Log out debug disabled (#459) @bruno-garcia
-* dep: Bump PlatformAbstractions (#458) @bruno-garcia
-* feat: Exception filter (#456) @bruno-garcia
+- fix: MEL don't init if enabled (#460) @bruno-garcia
+- feat: Device Calendar, Timezone, CultureInfo (#457) @bruno-garcia
+- ref: Log out debug disabled (#459) @bruno-garcia
+- dep: Bump PlatformAbstractions (#458) @bruno-garcia
+- feat: Exception filter (#456) @bruno-garcia
 
 ## 2.1.4
 
-* NLog SentryTarget - NLogDiagnosticLogger for writing to NLog InternalLogger (#450) @snakefoot
-* fix: SentryScopeManager dispose message (#449) @bruno-garcia
-* fix: dont use Sentry namespace on sample (#447) @bruno-garcia
-* Remove obsolete API from benchmarks (#445) @bruno-garcia
-* build(deps): bump Microsoft.Extensions.Logging.Debug from 2.1.1 to 3.1.4 (#421) @dependabot-preview
-* build(deps): bump Microsoft.AspNetCore.Diagnostics from 2.1.1 to 2.2.0 (#431) @dependabot-preview
-* build(deps): bump Microsoft.CodeAnalysis.CSharp.Workspaces from 3.1.0 to 3.6.0 (#437) @dependabot-preview
+- NLog SentryTarget - NLogDiagnosticLogger for writing to NLog InternalLogger (#450) @snakefoot
+- fix: SentryScopeManager dispose message (#449) @bruno-garcia
+- fix: dont use Sentry namespace on sample (#447) @bruno-garcia
+- Remove obsolete API from benchmarks (#445) @bruno-garcia
+- build(deps): bump Microsoft.Extensions.Logging.Debug from 2.1.1 to 3.1.4 (#421) @dependabot-preview
+- build(deps): bump Microsoft.AspNetCore.Diagnostics from 2.1.1 to 2.2.0 (#431) @dependabot-preview
+- build(deps): bump Microsoft.CodeAnalysis.CSharp.Workspaces from 3.1.0 to 3.6.0 (#437) @dependabot-preview
 
 ## 2.1.3
 
-* SentryScopeManager - Fixed clone of Stack so it does not reverse order (#420) @snakefoot
-* build(deps): bump Serilog.AspNetCore from 2.1.1 to 3.2.0 (#411) @dependabot-preview
-* Removed dependency on System.Collections.Immutable (#405) @snakefoot
-* Fix Sentry.Microsoft.Logging Filter now drops also breadcrumbs (#440)
+- SentryScopeManager - Fixed clone of Stack so it does not reverse order (#420) @snakefoot
+- build(deps): bump Serilog.AspNetCore from 2.1.1 to 3.2.0 (#411) @dependabot-preview
+- Removed dependency on System.Collections.Immutable (#405) @snakefoot
+- Fix Sentry.Microsoft.Logging Filter now drops also breadcrumbs (#440)
 
 ## 2.1.2-beta5
 
@@ -1027,12 +1035,12 @@ Fixed ASP.NET System.Web catch HttpException to prevent the request processor fr
 
 ## 2.1.2-beta2
 
-* Ignore WCF error and capture (#391)
+- Ignore WCF error and capture (#391)
 
 ### 2.1.2-beta
 
-* Serilog Sentry sink does not load all options from IConfiguration (#380)
-* UnhandledException sets Handled=false (#382)
+- Serilog Sentry sink does not load all options from IConfiguration (#380)
+- UnhandledException sets Handled=false (#382)
 
 ## 2.1.1
 
@@ -1040,10 +1048,10 @@ Bug fix:  Don't overwrite server name set via configuration with machine name on
 
 ## 2.1.0
 
-* Set score url to fully constructed url #367 Thanks @christopher-taormina-zocdoc
-* Don't dedupe from inner exception #363 - Note this might change groupings. It's opt-in.
-* Expose FlushAsync to intellisense #362
-* Protocol monorepo #325 - new protocol version whenever there's a new SDK release
+- Set score url to fully constructed url #367 Thanks @christopher-taormina-zocdoc
+- Don't dedupe from inner exception #363 - Note this might change groupings. It's opt-in.
+- Expose FlushAsync to intellisense #362
+- Protocol monorepo #325 - new protocol version whenever there's a new SDK release
 
 ## 2.0.3
 
@@ -1062,117 +1070,121 @@ Removed `-beta` from dependencies.
 
 ## 2.0.0
 
-* SentryTarget - GetTagsFromLogEvent with null check (#326)
-* handled process corrupted (#328)
-* sourcelink GA (#330)
-* Adds ability to specify user values via NLog configuration (#336)
-* Add option to ASP.NET Core to flush events after response complete (#288)
-* Fixed race on `BackgroundWorker`  (#293)
-* Exclude `Sentry.` frames from InApp (#272)
-* NLog SentryTarget with less overhead for breadcrumb (#273)
-* Logging on body not extracted (#246)
-* Add support to DefaultTags for ASP.NET Core and M.E.Logging (#268)
-* Don't use ValueTuple (#263)
-* All public members were documented: #252
-* Use EnableBuffering to keep request payload around: #250
-* Serilog default levels: #237
-* Removed dev dependency from external dependencies 4d92ab0
-* Use new `Sentry.Protocol` 836fb07e
-* Use new `Sentry.PlatformAbsrtractions` #226
-* Debug logging for ASP.NET Classic #209
-* Reading request body throws on ASP.NET Core 3 (#324)
-* NLog: null check contextProp.Value during IncludeEventDataOnBreadcrumbs (#323)
-* JsonSerializerSettings - ReferenceLoopHandling.Ignore (#312)
-* Fixed error when reading request body affects collecting other request data (#299)
-* `Microsoft.Extensions.Logging` `ConfigureScope` invocation. #208, #210, #224 Thanks @dbraillon
-* `Sentry.Serilog` Verbose level. #213, #217. Thanks @kanadaj
-* AppDomain.ProcessExit will close the SDK: #242
-* Adds PublicApiAnalyzers to public projects: #234
-* NLog: Utilizes Flush functionality in NLog target: #228
-* NLog: Set the logger via the log event info in SentryTarget.Write, #227
-* Multi-target .NET Core 3.0 (#308)
+- SentryTarget - GetTagsFromLogEvent with null check (#326)
+- handled process corrupted (#328)
+- sourcelink GA (#330)
+- Adds ability to specify user values via NLog configuration (#336)
+- Add option to ASP.NET Core to flush events after response complete (#288)
+- Fixed race on `BackgroundWorker`  (#293)
+- Exclude `Sentry.` frames from InApp (#272)
+- NLog SentryTarget with less overhead for breadcrumb (#273)
+- Logging on body not extracted (#246)
+- Add support to DefaultTags for ASP.NET Core and M.E.Logging (#268)
+- Don't use ValueTuple (#263)
+- All public members were documented: #252
+- Use EnableBuffering to keep request payload around: #250
+- Serilog default levels: #237
+- Removed dev dependency from external dependencies 4d92ab0
+- Use new `Sentry.Protocol` 836fb07e
+- Use new `Sentry.PlatformAbsrtractions` #226
+- Debug logging for ASP.NET Classic #209
+- Reading request body throws on ASP.NET Core 3 (#324)
+- NLog: null check contextProp.Value during IncludeEventDataOnBreadcrumbs (#323)
+- JsonSerializerSettings - ReferenceLoopHandling.Ignore (#312)
+- Fixed error when reading request body affects collecting other request data (#299)
+- `Microsoft.Extensions.Logging` `ConfigureScope` invocation. #208, #210, #224 Thanks @dbraillon
+- `Sentry.Serilog` Verbose level. #213, #217. Thanks @kanadaj
+- AppDomain.ProcessExit will close the SDK: #242
+- Adds PublicApiAnalyzers to public projects: #234
+- NLog: Utilizes Flush functionality in NLog target: #228
+- NLog: Set the logger via the log event info in SentryTarget.Write, #227
+- Multi-target .NET Core 3.0 (#308)
 
 Major version bumped due to these breaking changes:
+
 1. `Sentry.Protocol` version 2.0.0
+
 * Remove StackTrace from SentryEvent [#38](https://github.com/getsentry/sentry-dotnet-protocol/pull/38) - StackTrace is either part of Thread or SentryException.
+
 2. Removed `ContextLine` #223
 3. Use `StackTrace` from `Threads` #222
 4. `FlushAsync` added to `ISentryClient` #214
 
 ## 2.0.0-beta8
 
-* SentryTarget - GetTagsFromLogEvent with null check (#326)
-* handled process corrupted (#328)
-* sourcelink GA (#330)
-* Adds ability to specify user values via NLog configuration (#336)
+- SentryTarget - GetTagsFromLogEvent with null check (#326)
+- handled process corrupted (#328)
+- sourcelink GA (#330)
+- Adds ability to specify user values via NLog configuration (#336)
 
 ## 2.0.0-beta7
 
 Fixes:
 
-* Reading request body throws on ASP.NET Core 3 (#324)
-* NLog: null check contextProp.Value during IncludeEventDataOnBreadcrumbs (#323)
-* JsonSerializerSettings - ReferenceLoopHandling.Ignore (#312)
+- Reading request body throws on ASP.NET Core 3 (#324)
+- NLog: null check contextProp.Value during IncludeEventDataOnBreadcrumbs (#323)
+- JsonSerializerSettings - ReferenceLoopHandling.Ignore (#312)
 
 Features:
 
-* Multi-target .NET Core 3.0 (#308)
+- Multi-target .NET Core 3.0 (#308)
 
 ## 2.0.0-beta6
 
-* Fixed error when reading request body affects collecting other request data (#299)
+- Fixed error when reading request body affects collecting other request data (#299)
 
 ## 2.0.0-beta5
 
-* Add option to ASP.NET Core to flush events after response complete (#288)
-* Fixed race on `BackgroundWorker`  (#293)
-* Exclude `Sentry.` frames from InApp (#272)
-* NLog SentryTarget with less overhead for breadcrumb (#273)
+- Add option to ASP.NET Core to flush events after response complete (#288)
+- Fixed race on `BackgroundWorker`  (#293)
+- Exclude `Sentry.` frames from InApp (#272)
+- NLog SentryTarget with less overhead for breadcrumb (#273)
 
 ## 2.0.0-beta4
 
-* Logging on body not extracted (#246)
-* Add support to DefaultTags for ASP.NET Core and M.E.Logging (#268)
-* Don't use ValueTuple (#263)
+- Logging on body not extracted (#246)
+- Add support to DefaultTags for ASP.NET Core and M.E.Logging (#268)
+- Don't use ValueTuple (#263)
 
 ## 2.0.0-beta3
 
-* All public members were documented: #252
-* Use EnableBuffering to keep request payload around: #250
-* Serilog default levels: #237
+- All public members were documented: #252
+- Use EnableBuffering to keep request payload around: #250
+- Serilog default levels: #237
 
 Thanks @josh-degraw for:
 
-* AppDomain.ProcessExit will close the SDK: #242
-* Adds PublicApiAnalyzers to public projects: #234
-* NLog: Utilizes Flush functionality in NLog target: #228
-* NLog: Set the logger via the log event info in SentryTarget.Write, #227
+- AppDomain.ProcessExit will close the SDK: #242
+- Adds PublicApiAnalyzers to public projects: #234
+- NLog: Utilizes Flush functionality in NLog target: #228
+- NLog: Set the logger via the log event info in SentryTarget.Write, #227
 
 ## 2.0.0-beta2
 
-* Removed dev dependency from external dependencies 4d92ab0
-* Use new `Sentry.Protocol` 836fb07e
-* Use new `Sentry.PlatformAbsrtractions` #226
+- Removed dev dependency from external dependencies 4d92ab0
+- Use new `Sentry.Protocol` 836fb07e
+- Use new `Sentry.PlatformAbsrtractions` #226
 
 ## 2.0.0-beta
 
 Major version bumped due to these breaking changes:
 
 1. `Sentry.Protocol` version 2.0.0
+
 * Remove StackTrace from SentryEvent [#38](https://github.com/getsentry/sentry-dotnet-protocol/pull/38) - StackTrace is either part of Thread or SentryException.
+
 2. Removed `ContextLine` #223
 3. Use `StackTrace` from `Threads` #222
 4. `FlushAsync` added to `ISentryClient` #214
 
-
 Other Features:
 
-* Debug logging for ASP.NET Classic #209
+- Debug logging for ASP.NET Classic #209
 
 Fixes:
 
-* `Microsoft.Extensions.Logging` `ConfigureScope` invocation. #208, #210, #224 Thanks @dbraillon
-* `Sentry.Serilog` Verbose level. #213, #217. Thanks @kanadaj
+- `Microsoft.Extensions.Logging` `ConfigureScope` invocation. #208, #210, #224 Thanks @dbraillon
+- `Sentry.Serilog` Verbose level. #213, #217. Thanks @kanadaj
 
 ## 1.2.1-beta
 
@@ -1182,18 +1194,18 @@ Fixes and improvements to the NLog integration: #207 by @josh-degraw
 
 ### Features
 
-* Optionally skip module registrations #202 - (Thanks @josh-degraw)
-* First NLog integration release #188 (Thanks @josh-degraw)
-* Extensible stack trace #184 (Thanks @pengweiqhca)
-* MaxRequestSize for ASP.NET and ASP.NET Core #174
-* InAppInclude #171
-* Overload to AddSentry #163 by (Thanks @f1nzer)
-* ASP.NET Core AddSentry has now ConfigureScope: #160
+- Optionally skip module registrations #202 - (Thanks @josh-degraw)
+- First NLog integration release #188 (Thanks @josh-degraw)
+- Extensible stack trace #184 (Thanks @pengweiqhca)
+- MaxRequestSize for ASP.NET and ASP.NET Core #174
+- InAppInclude #171
+- Overload to AddSentry #163 by (Thanks @f1nzer)
+- ASP.NET Core AddSentry has now ConfigureScope: #160
 
 ### Bug fixes
 
-* Don't override user #199
-* Read the hub to take latest Client: 8f4b5ba
+- Don't override user #199
+- Read the hub to take latest Client: 8f4b5ba
 
 ## 1.1.3-beta4
 
@@ -1201,26 +1213,26 @@ Bug fix: Don't override user  #199
 
 ## 1.1.3-beta3
 
-* First NLog integration release #188 (Thanks @josh-degraw)
-* Extensible stack trace #184 (Thanks @pengweiqhca)
+- First NLog integration release #188 (Thanks @josh-degraw)
+- Extensible stack trace #184 (Thanks @pengweiqhca)
 
 ## 1.1.3-beta2
 
 Feature:
-* MaxRequestSize for ASP.NET and ASP.NET Core #174
-* InAppInclude #171
+- MaxRequestSize for ASP.NET and ASP.NET Core #174
+- InAppInclude #171
 
 Fix: Diagnostic log order: #173 by @scolestock
 
 ## 1.1.3-beta
 
 Fixed:
-* Read the hub to take latest Client: 8f4b5ba1a3
-* Uses Sentry.Protocol 1.0.4 4035e25
+- Read the hub to take latest Client: 8f4b5ba1a3
+- Uses Sentry.Protocol 1.0.4 4035e25
 
 Feature
-* Overload to `AddSentry` #163 by @F1nZeR
-* ASP.NET Core `AddSentry` has now `ConfigureScope`: #160
+- Overload to `AddSentry` #163 by @F1nZeR
+- ASP.NET Core `AddSentry` has now `ConfigureScope`: #160
 
 ## 1.1.2
 
@@ -1233,15 +1245,15 @@ ASP.NET Core integration issue when containers are built on the ServiceCollectio
 ## 1.1.2-beta
 
 Fixed:
-* ASP.NET Core integration issue when containers are built on the ServiceCollection after SDK is initialized (#157, #103 )
+- ASP.NET Core integration issue when containers are built on the ServiceCollection after SDK is initialized (#157, #103 )
 
 ## 1.1.1
 
 Fixed:
-* Serilog bug that self log would recurse #156
+- Serilog bug that self log would recurse #156
 
 Feature:
-* log4net environment via xml configuration #150 (Thanks Sébastien Pierre)
+- log4net environment via xml configuration #150 (Thanks Sébastien Pierre)
 
 ## 1.1.0
 
@@ -1249,32 +1261,32 @@ Includes all features and bug fixes of previous beta releases:
 
 Features:
 
-* Use log entry to improve grouping #125
-* Use .NET Core SDK 2.1.401
-* Make AddProcessors extension methods on Options public #115
-* Format InternalsVisibleTo to avoid iOS issue: 94e28b3
-* Serilog Integration #118, #145
-* Capture methods return SentryId #139, #140
-* MEL integration keeps properties as tags #146
-* Sentry package Includes net461 target #135
+- Use log entry to improve grouping #125
+- Use .NET Core SDK 2.1.401
+- Make AddProcessors extension methods on Options public #115
+- Format InternalsVisibleTo to avoid iOS issue: 94e28b3
+- Serilog Integration #118, #145
+- Capture methods return SentryId #139, #140
+- MEL integration keeps properties as tags #146
+- Sentry package Includes net461 target #135
 
 Bug fixes:
 
-* Disabled SDK throws on shutdown: #124
-* Log4net only init if current hub is disabled #119
+- Disabled SDK throws on shutdown: #124
+- Log4net only init if current hub is disabled #119
 
 Thanks to our growing list of [contributors](https://github.com/getsentry/sentry-dotnet/graphs/contributors).
 
 ## 1.0.1-beta5
 
-* Added `net461` target to Serilog package #148
+- Added `net461` target to Serilog package #148
 
 ## 1.0.1-beta4
 
-* Serilog Integration #118, #145
-* `Capture` methods return `SentryId` #139, #140
-* MEL integration keeps properties as tags #146
-* Revert reducing Json.NET requirements https://github.com/getsentry/sentry-dotnet/commit/1aed4a5c76ead2f4d39f1c2979eda02d068bfacd
+- Serilog Integration #118, #145
+- `Capture` methods return `SentryId` #139, #140
+- MEL integration keeps properties as tags #146
+- Revert reducing Json.NET requirements <https://github.com/getsentry/sentry-dotnet/commit/1aed4a5c76ead2f4d39f1c2979eda02d068bfacd>
 
 Thanks to our growing [list of contributors](https://github.com/getsentry/sentry-dotnet/graphs/contributors).
 
@@ -1289,83 +1301,83 @@ Lowering Newtonsoft.Json requirements; #138
 ## 1.0.1-beta
 
 Features:
-* Use log entry to improve grouping #125
-* Use .NET Core SDK 2.1.401
-* Make `AddProcessors` extension methods on Options public  #115
-* Format InternalsVisibleTo to avoid iOS issue: 94e28b3
+- Use log entry to improve grouping #125
+- Use .NET Core SDK 2.1.401
+- Make `AddProcessors` extension methods on Options public  #115
+- Format InternalsVisibleTo to avoid iOS issue: 94e28b3
 
 Bug fixes:
-* Disabled SDK throws on shutdown: #124
-* Log4net only init if current hub is disabled #119
+- Disabled SDK throws on shutdown: #124
+- Log4net only init if current hub is disabled #119
 
 ## 1.0.0
 
-### First major release of the new .NET SDK.
+### First major release of the new .NET SDK
 
 #### Main features
 
 ##### Sentry package
 
-* Automatic Captures global unhandled exceptions (AppDomain)
-* Scope management
-* Duplicate events automatically dropped
-* Events from the same exception automatically dropped
-* Web proxy support
-* HttpClient/HttpClientHandler configuration callback
-* Compress request body
-* Event sampling opt-in
-* Event flooding protection (429 retry-after and internal bound queue)
-* Release automatically set (AssemblyInformationalVersionAttribute, AssemblyVersion or env var)
-* DSN discovered via environment variable
-* Release (version) reported automatically
-* CLS Compliant
-* Strong named
-* BeforeSend and BeforeBreadcrumb callbacks
-* Event and Exception processors
-* SourceLink (including PDB in nuget package)
-* Device OS info sent
-* Device Runtime info sent
-* Enable SDK debug mode (opt-in)
-* Attach stack trace for captured messages (opt-in)
+- Automatic Captures global unhandled exceptions (AppDomain)
+- Scope management
+- Duplicate events automatically dropped
+- Events from the same exception automatically dropped
+- Web proxy support
+- HttpClient/HttpClientHandler configuration callback
+- Compress request body
+- Event sampling opt-in
+- Event flooding protection (429 retry-after and internal bound queue)
+- Release automatically set (AssemblyInformationalVersionAttribute, AssemblyVersion or env var)
+- DSN discovered via environment variable
+- Release (version) reported automatically
+- CLS Compliant
+- Strong named
+- BeforeSend and BeforeBreadcrumb callbacks
+- Event and Exception processors
+- SourceLink (including PDB in nuget package)
+- Device OS info sent
+- Device Runtime info sent
+- Enable SDK debug mode (opt-in)
+- Attach stack trace for captured messages (opt-in)
 
 ##### Sentry.Extensions.Logging
 
-* Includes all features from the `Sentry` package.
-* BeginScope data added to Sentry scope, sent with events
-* LogInformation or higher added as breadcrumb, sent with next events.
-* LogError or higher automatically captures an event
-* Minimal levels are configurable.
+- Includes all features from the `Sentry` package.
+- BeginScope data added to Sentry scope, sent with events
+- LogInformation or higher added as breadcrumb, sent with next events.
+- LogError or higher automatically captures an event
+- Minimal levels are configurable.
 
 ##### Sentry.AspNetCore
 
-* Includes all features from the `Sentry` package.
-* Includes all features from the `Sentry.Extensions.Logging` package.
-* Easy ASP.NET Core integration, single line: `UseSentry`.
-* Captures unhandled exceptions in the middleware pipeline
-* Captures exceptions handled by the framework `UseExceptionHandler` and Error page display.
-* Any event sent will include relevant application log messages
-* RequestId as tag
-* URL as tag
-* Environment is automatically set (`IHostingEnvironment`)
-* Request payload can be captured if opt-in
-* Support for EventProcessors registered with DI
-* Support for ExceptionProcessors registered with DI
-* Captures logs from the request (using Microsoft.Extensions.Logging)
-* Supports configuration system (e.g: appsettings.json)
-* Server OS info sent
-* Server Runtime info sent
-* Request headers sent
-* Request body compressed
+- Includes all features from the `Sentry` package.
+- Includes all features from the `Sentry.Extensions.Logging` package.
+- Easy ASP.NET Core integration, single line: `UseSentry`.
+- Captures unhandled exceptions in the middleware pipeline
+- Captures exceptions handled by the framework `UseExceptionHandler` and Error page display.
+- Any event sent will include relevant application log messages
+- RequestId as tag
+- URL as tag
+- Environment is automatically set (`IHostingEnvironment`)
+- Request payload can be captured if opt-in
+- Support for EventProcessors registered with DI
+- Support for ExceptionProcessors registered with DI
+- Captures logs from the request (using Microsoft.Extensions.Logging)
+- Supports configuration system (e.g: appsettings.json)
+- Server OS info sent
+- Server Runtime info sent
+- Request headers sent
+- Request body compressed
 
 All packages are:
-* Strong named
-* Tested on Windows, Linux and macOS
-* Tested on .NET Core, .NET Framework and Mono
+- Strong named
+- Tested on Windows, Linux and macOS
+- Tested on .NET Core, .NET Framework and Mono
 
-##### Learn more:
+##### Learn more
 
-* [Code samples](https://github.com/getsentry/sentry-dotnet/tree/master/samples)
-* [Sentry docs](https://docs.sentry.io/quickstart/?platform=csharp)
+- [Code samples](https://github.com/getsentry/sentry-dotnet/tree/master/samples)
+- [Sentry docs](https://docs.sentry.io/quickstart/?platform=csharp)
 
 Sample event using the log4net integration:
 ![Sample event in Sentry](https://github.com/getsentry/sentry-dotnet/blob/master/samples/Sentry.Samples.Log4Net/.assets/log4net-sample.gif?raw=true)
@@ -1378,18 +1390,19 @@ Download it directly from GitHub or using NuGet:
 |     **Sentry.AspNetCore**     |   [![NuGet](https://img.shields.io/nuget/vpre/Sentry.AspNetCore.svg)](https://www.nuget.org/packages/Sentry.AspNetCore)   |
 | **Sentry.Extensions.Logging** | [![NuGet](https://img.shields.io/nuget/vpre/Sentry.Extensions.Logging.svg)](https://www.nuget.org/packages/Sentry.Extensions.Logging)   |
 | **Sentry.Log4Net** | [![NuGet](https://img.shields.io/nuget/vpre/Sentry.Log4Net.svg)](https://www.nuget.org/packages/Sentry.Log4Net)   |
+
 # 1.0.0-rc2
 
 Features and improvements:
 
-* `SentrySdk.LastEventId` to get scoped id
-* `BeforeBreadcrumb` to allow dropping or modifying a breadcrumb
-* Event processors on scope #58
-* Event processor as `Func<SentryEvent,SentryEvent>`
+- `SentrySdk.LastEventId` to get scoped id
+- `BeforeBreadcrumb` to allow dropping or modifying a breadcrumb
+- Event processors on scope #58
+- Event processor as `Func<SentryEvent,SentryEvent>`
 
 Bug fixes:
 
-* #97 Sentry environment takes precedence over ASP.NET Core
+- #97 Sentry environment takes precedence over ASP.NET Core
 
 Download it directly below from GitHub or using NuGet:
 
@@ -1399,21 +1412,22 @@ Download it directly below from GitHub or using NuGet:
 |     **Sentry.AspNetCore**     |   [![NuGet](https://img.shields.io/nuget/vpre/Sentry.AspNetCore.svg)](https://www.nuget.org/packages/Sentry.AspNetCore)   |
 | **Sentry.Extensions.Logging** | [![NuGet](https://img.shields.io/nuget/vpre/Sentry.Extensions.Logging.svg)](https://www.nuget.org/packages/Sentry.Extensions.Logging)   |
 | **Sentry.Log4Net** | [![NuGet](https://img.shields.io/nuget/vpre/Sentry.Log4Net.svg)](https://www.nuget.org/packages/Sentry.Log4Net)   |
+
 # 1.0.0-rc
 
 Features and improvements:
 
-* Microsoft.Extensions.Logging (MEL) use framework configuration system #79 (Thanks @pengweiqhca)
-* Use IOptions on Logging and ASP.NET Core integrations #81
-* Send PII (personal identifier info, opt-in `SendDefaultPii`): #83
-* When SDK is disabled SentryMiddleware passes through to next in pipeline: #84
-* SDK diagnostic logging (option: `Debug`): #85
-* Sending Stack trace for events without exception (like CaptureMessage, opt-in `AttachStackTrace`) #86
+- Microsoft.Extensions.Logging (MEL) use framework configuration system #79 (Thanks @pengweiqhca)
+- Use IOptions on Logging and ASP.NET Core integrations #81
+- Send PII (personal identifier info, opt-in `SendDefaultPii`): #83
+- When SDK is disabled SentryMiddleware passes through to next in pipeline: #84
+- SDK diagnostic logging (option: `Debug`): #85
+- Sending Stack trace for events without exception (like CaptureMessage, opt-in `AttachStackTrace`) #86
 
 Bug fixes:
 
-* MEL: Only call Init if DSN was provided https://github.com/getsentry/sentry-dotnet/commit/097c6a9c6f4348d87282c92d9267879d90879e2a
-* Correct namespace for `AddSentry` https://github.com/getsentry/sentry-dotnet/commit/2498ab4081f171dc78e7f74e4f1f781a557c5d4f
+- MEL: Only call Init if DSN was provided <https://github.com/getsentry/sentry-dotnet/commit/097c6a9c6f4348d87282c92d9267879d90879e2a>
+- Correct namespace for `AddSentry` <https://github.com/getsentry/sentry-dotnet/commit/2498ab4081f171dc78e7f74e4f1f781a557c5d4f>
 
 Breaking changes:
 
@@ -1430,24 +1444,25 @@ Download it directly below from GitHub or using NuGet:
 |     **Sentry.AspNetCore**     |   [![NuGet](https://img.shields.io/nuget/vpre/Sentry.AspNetCore.svg)](https://www.nuget.org/packages/Sentry.AspNetCore)   |
 | **Sentry.Extensions.Logging** | [![NuGet](https://img.shields.io/nuget/vpre/Sentry.Extensions.Logging.svg)](https://www.nuget.org/packages/Sentry.Extensions.Logging)   |
 | **Sentry.Log4Net** | [![NuGet](https://img.shields.io/nuget/vpre/Sentry.Log4Net.svg)](https://www.nuget.org/packages/Sentry.Log4Net)   |
+
 # 0.0.1-preview5
 
 Features:
 
-* Support buffered gzip request #73
-* Reduced dependencies from the ASP.NET Core integraiton
-* InAppExclude configurable #75
-* Duplicate event detects inner exceptions #76
-* HttpClientHandler configuration callback #72
-* Event sampling opt-in
-* ASP.NET Core sends server name
+- Support buffered gzip request #73
+- Reduced dependencies from the ASP.NET Core integraiton
+- InAppExclude configurable #75
+- Duplicate event detects inner exceptions #76
+- HttpClientHandler configuration callback #72
+- Event sampling opt-in
+- ASP.NET Core sends server name
 
 Bug fixes:
 
-* On-prem without chuncked support for gzip #71
-* Exception.Data key is not string #77
+- On-prem without chuncked support for gzip #71
+- Exception.Data key is not string #77
 
-##### [Watch on youtube](https://www.youtube.com/watch?v=xK6a1goK_w0) how to use the ASP.NET Core integration.
+##### [Watch on youtube](https://www.youtube.com/watch?v=xK6a1goK_w0) how to use the ASP.NET Core integration
 
 Download it directly below from GitHub or using NuGet:
 
@@ -1462,25 +1477,25 @@ Download it directly below from GitHub or using NuGet:
 
 Features:
 
-* Using [Sentry Protocol](https://github.com/getsentry/sentry-dotnet-protocol) as a dependency
-* Environment can be set via `SentryOptions` #49
-* Compress request body (configurable: Fastest, Optimal, Off) #63
-* log4net integration
-* SDK honors Sentry's 429 HTTP Status with Retry After header #61
+- Using [Sentry Protocol](https://github.com/getsentry/sentry-dotnet-protocol) as a dependency
+- Environment can be set via `SentryOptions` #49
+- Compress request body (configurable: Fastest, Optimal, Off) #63
+- log4net integration
+- SDK honors Sentry's 429 HTTP Status with Retry After header #61
 
 Bug fixes:
 
-* `Init` pushes the first scope #55, #54
-* `Exception.Data` copied to `SentryEvent.Data` while storing the index of originating error.
-* Demangling code ensures Function name available #64
-* ASP.NET Core integration throws when Serilog added #65, #68, #67
+- `Init` pushes the first scope #55, #54
+- `Exception.Data` copied to `SentryEvent.Data` while storing the index of originating error.
+- Demangling code ensures Function name available #64
+- ASP.NET Core integration throws when Serilog added #65, #68, #67
 
 Improvements to [the docs](https://getsentry.github.io/sentry-dotnet) like:
-* Release discovery
-* `ConfigureScope` clarifications
-* Documenting samples
+- Release discovery
+- `ConfigureScope` clarifications
+- Documenting samples
 
-### [Watch on youtube](https://www.youtube.com/watch?v=xK6a1goK_w0) how to use the ASP.NET Core integration.
+### [Watch on youtube](https://www.youtube.com/watch?v=xK6a1goK_w0) how to use the ASP.NET Core integration
 
 Download it directly from GitHub or using NuGet:
 
@@ -1497,20 +1512,20 @@ This third preview includes bug fixes and more features. Test coverage increased
 
 Features and improvements:
 
-* Filter duplicate events/exceptions #43
-* EventProcessors can be added (sample [1](https://github.com/getsentry/sentry-dotnet/blob/dbb5a3af054d0ca6f801de37fb7db3632ca2c65a/samples/Sentry.Samples.Console.Customized/Program.cs#L151), [2](https://github.com/getsentry/sentry-dotnet/blob/dbb5a3af054d0ca6f801de37fb7db3632ca2c65a/samples/Sentry.Samples.Console.Customized/Program.cs#L41))
-* ExceptionProcessors can be added #36 (sample [1](https://github.com/getsentry/sentry-dotnet/blob/dbb5a3af054d0ca6f801de37fb7db3632ca2c65a/samples/Sentry.Samples.Console.Customized/Program.cs#L172), [2](https://github.com/getsentry/sentry-dotnet/blob/dbb5a3af054d0ca6f801de37fb7db3632ca2c65a/samples/Sentry.Samples.Console.Customized/Program.cs#L42))
-* Release is automatically discovered/reported #35
-* Contexts is a dictionary - allows custom data #37
-* ASP.NET integration reports context as server: server-os, server-runtime #37
-* Assemblies strong named #41
-* Scope exposes IReadOnly members instead of Immutables
-* Released a [documentation site](https://getsentry.github.io/sentry-dotnet/)
+- Filter duplicate events/exceptions #43
+- EventProcessors can be added (sample [1](https://github.com/getsentry/sentry-dotnet/blob/dbb5a3af054d0ca6f801de37fb7db3632ca2c65a/samples/Sentry.Samples.Console.Customized/Program.cs#L151), [2](https://github.com/getsentry/sentry-dotnet/blob/dbb5a3af054d0ca6f801de37fb7db3632ca2c65a/samples/Sentry.Samples.Console.Customized/Program.cs#L41))
+- ExceptionProcessors can be added #36 (sample [1](https://github.com/getsentry/sentry-dotnet/blob/dbb5a3af054d0ca6f801de37fb7db3632ca2c65a/samples/Sentry.Samples.Console.Customized/Program.cs#L172), [2](https://github.com/getsentry/sentry-dotnet/blob/dbb5a3af054d0ca6f801de37fb7db3632ca2c65a/samples/Sentry.Samples.Console.Customized/Program.cs#L42))
+- Release is automatically discovered/reported #35
+- Contexts is a dictionary - allows custom data #37
+- ASP.NET integration reports context as server: server-os, server-runtime #37
+- Assemblies strong named #41
+- Scope exposes IReadOnly members instead of Immutables
+- Released a [documentation site](https://getsentry.github.io/sentry-dotnet/)
 
 Bug fixes:
 
-#46 Strong name
-#40 Logger provider gets disposed/flushes events
+# 46 Strong name
+# 40 Logger provider gets disposed/flushes events
 
 [Watch on youtube](https://www.youtube.com/watch?v=xK6a1goK_w0) how to use the ASP.NET Core integration.
 
@@ -1521,22 +1536,23 @@ Download it directly from GitHub or using NuGet:
 |         **Sentry**            |    [![NuGet](https://img.shields.io/nuget/vpre/Sentry.svg)](https://www.nuget.org/packages/Sentry)   |
 |     **Sentry.AspNetCore**     |   [![NuGet](https://img.shields.io/nuget/vpre/Sentry.AspNetCore.svg)](https://www.nuget.org/packages/Sentry.AspNetCore)   |
 | **Sentry.Extensions.Logging** | [![NuGet](https://img.shields.io/nuget/vpre/Sentry.Extensions.Logging.svg)](https://www.nuget.org/packages/Sentry.Extensions.Logging)   |
+
 ## 0.0.1-preview2
 
 This second release includes bug fixes and more features. Test coverage increased to 93%
 
 Features and improvements:
-* Added `CaptureMessage`
-* `BeforeSend` callback errors are sent as breadcrumbs
-* `ASP.NET Core` integration doesn't add tags added by `Microsoft.Extensions.Logging`
-* SDK name is reported depending on the package added
-* Integrations API allows user-defined SDK integration
-* Unhandled exception handler can be configured via integrations
-* Filter kestrel log eventid 13 (application error) when already captured by the middleware
+- Added `CaptureMessage`
+- `BeforeSend` callback errors are sent as breadcrumbs
+- `ASP.NET Core` integration doesn't add tags added by `Microsoft.Extensions.Logging`
+- SDK name is reported depending on the package added
+- Integrations API allows user-defined SDK integration
+- Unhandled exception handler can be configured via integrations
+- Filter kestrel log eventid 13 (application error) when already captured by the middleware
 
 Bugs fixed:
-* Fixed #28
-* HTTP Proxy set to HTTP message handler
+- Fixed #28
+- HTTP Proxy set to HTTP message handler
 
 Download it directly from GitHub or using NuGet:
 
@@ -1551,16 +1567,16 @@ Download it directly from GitHub or using NuGet:
 Our first preview of the SDK:
 
 Main features:
-* Easy ASP.NET Core integration, single line: `UseSentry`.
-* Captures unhandled exceptions in the middleware pipeline
-* Captures exceptions handled by the framework `UseExceptionHandler` and Error page display.
-* Captures process-wide unhandled exceptions (AppDomain)
-* Captures logger.Error or logger.Critical
-* When an event is sent, data from the current request augments the event.
-* Sends information about the server running the app (OS, Runtime, etc)
-* Informational logs written by the app or framework augment events sent to Sentry
-* Optional include of the request body
-* HTTP Proxy configuration
+- Easy ASP.NET Core integration, single line: `UseSentry`.
+- Captures unhandled exceptions in the middleware pipeline
+- Captures exceptions handled by the framework `UseExceptionHandler` and Error page display.
+- Captures process-wide unhandled exceptions (AppDomain)
+- Captures logger.Error or logger.Critical
+- When an event is sent, data from the current request augments the event.
+- Sends information about the server running the app (OS, Runtime, etc)
+- Informational logs written by the app or framework augment events sent to Sentry
+- Optional include of the request body
+- HTTP Proxy configuration
 
 Also available via NuGet:
 

--- a/benchmarks/Sentry.Benchmarks/BenchmarkDotNet.Artifacts/results/Sentry.Benchmarks.StackFrameBenchmarks-report-github.md
+++ b/benchmarks/Sentry.Benchmarks/BenchmarkDotNet.Artifacts/results/Sentry.Benchmarks.StackFrameBenchmarks-report-github.md
@@ -1,0 +1,14 @@
+``` ini
+
+BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1265/22H2/2022Update/SunValley2)
+12th Gen Intel Core i7-12700K, 1 CPU, 20 logical and 12 physical cores
+.NET SDK=7.0.200
+  [Host]     : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT AVX2
+  Job-BDSZNV : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT AVX2
+
+Runtime=.NET 6.0  InvocationCount=1  UnrollFactor=1  
+
+```
+|            Method |    N |     Mean |    Error |   StdDev | Allocated |
+|------------------ |----- |---------:|---------:|---------:|----------:|
+| ConfigureAppFrame | 1000 | 97.71 μs | 1.930 μs | 4.070 μs | 125.63 KB |

--- a/benchmarks/Sentry.Benchmarks/BenchmarkDotNet.Artifacts/results/Sentry.Benchmarks.StackFrameBenchmarks-report-github.md
+++ b/benchmarks/Sentry.Benchmarks/BenchmarkDotNet.Artifacts/results/Sentry.Benchmarks.StackFrameBenchmarks-report-github.md
@@ -4,11 +4,11 @@ BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1265/22H2/2022Update/SunValle
 12th Gen Intel Core i7-12700K, 1 CPU, 20 logical and 12 physical cores
 .NET SDK=7.0.200
   [Host]     : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT AVX2
-  Job-BDSZNV : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT AVX2
+  Job-OZOGBN : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT AVX2
 
 Runtime=.NET 6.0  InvocationCount=1  UnrollFactor=1  
 
 ```
 |            Method |    N |     Mean |    Error |   StdDev | Allocated |
 |------------------ |----- |---------:|---------:|---------:|----------:|
-| ConfigureAppFrame | 1000 | 97.71 μs | 1.930 μs | 4.070 μs | 125.63 KB |
+| ConfigureAppFrame | 1000 | 97.30 μs | 1.929 μs | 2.575 μs | 133.44 KB |

--- a/benchmarks/Sentry.Benchmarks/Program.cs
+++ b/benchmarks/Sentry.Benchmarks/Program.cs
@@ -16,8 +16,7 @@ internal class Program
     {
         public Config()
         {
-            AddJob(Job.Default.WithRuntime(CoreRuntime.Core21));
-            AddJob(Job.Default.WithRuntime(CoreRuntime.Core31));
+            AddJob(Job.Default.WithRuntime(CoreRuntime.Core60));
             AddDiagnoser(MemoryDiagnoser.Default);
             AddExporter(MarkdownExporter.GitHub);
             AddLogger(DefaultConfig.Instance.GetLoggers().ToArray());

--- a/benchmarks/Sentry.Benchmarks/README.md
+++ b/benchmarks/Sentry.Benchmarks/README.md
@@ -1,0 +1,7 @@
+# Benchmarks
+
+To run benchmarks in a single class:
+
+```shell-script
+dotnet run -c Release -- --filter *StackFrameBenchmarks*
+```

--- a/benchmarks/Sentry.Benchmarks/StackFrameBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/StackFrameBenchmarks.cs
@@ -1,0 +1,1016 @@
+using BenchmarkDotNet.Attributes;
+using Sentry.Extensibility;
+
+namespace Sentry.Benchmarks;
+
+public class StackFrameBenchmarks
+{
+    private SentryOptions _options = new();
+    private SentryStackFrame[] data;
+
+    [Params(1000)]
+    public int N;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        data = new SentryStackFrame[N];
+        var rand = new Random(42);
+        for (var i = 0; i < N; i++)
+        {
+            var proto = _framePrototypes[rand.NextInt64(0, _framePrototypes.Length)];
+            data[i] = new()
+            {
+                Function = proto.Function,
+                Module = rand.NextSingle() < 0.5 ? null : proto.Module
+            };
+        }
+    }
+
+    [IterationCleanup]
+    public void IterationCleanup()
+    {
+        for (var i = 0; i < N; i++)
+        {
+            data[i].InApp = null;
+        }
+    }
+
+
+    [Benchmark]
+    public void ConfigureAppFrame()
+    {
+        for (var i = 0; i < N; i++)
+        {
+            data[i].ConfigureAppFrame(_options);
+        }
+    }
+
+    // These are real frames captured by a profiler session on Sentry.Samples.Console.Customized.
+    private SentryStackFrame[] _framePrototypes = new SentryStackFrame[] {
+        new SentryStackFrame() {
+          Function ="System.Threading.Monitor.Wait(class System.Object,int32)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.ManualResetEventSlim.Wait(int32,value class System.Threading.CancellationToken)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task.SpinThenBlockingWait(int32,value class System.Threading.CancellationToken)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task.InternalWaitCore(int32,value class System.Threading.CancellationToken)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(class System.Threading.Tasks.Task)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.TaskAwaiter.GetResult()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.LowLevelLifoSemaphore.WaitForSignal(int32)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.LowLevelLifoSemaphore.Wait(int32,bool)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.PortableThreadPool+WorkerThread.WorkerThreadStart()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Thread.StartCallback()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.WaitHandle.WaitOneNoCheck(int32)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.WaitHandle.WaitOne(int32)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.PortableThreadPool+GateThread.GateThreadStart()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.IO.Pipes.PipeStream.ReadCore(value class System.Span`1<unsigned int8>)",
+          Module ="System.IO.Pipes.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.IO.Pipes.PipeStream.Read(unsigned int8[],int32,int32)",
+          Module ="System.IO.Pipes.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.IO.BinaryReader.ReadBytes(int32)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="Microsoft.Diagnostics.NETCore.Client.IpcHeader.Parse(class System.IO.BinaryReader) {QuickJitted}",
+          Module ="Microsoft.Diagnostics.NETCore.Client"
+        },
+        new SentryStackFrame() {
+          Function ="Microsoft.Diagnostics.NETCore.Client.IpcMessage.Parse(class System.IO.Stream) {QuickJitted}",
+          Module ="Microsoft.Diagnostics.NETCore.Client"
+        },
+        new SentryStackFrame() {
+          Function ="Microsoft.Diagnostics.NETCore.Client.IpcClient.Read(class System.IO.Stream) {QuickJitted}",
+          Module ="Microsoft.Diagnostics.NETCore.Client"
+        },
+        new SentryStackFrame() {
+          Function ="Microsoft.Diagnostics.NETCore.Client.IpcClient.SendMessageGetContinuation(class Microsoft.Diagnostics.NETCore.Client.IpcEndpoint,class Microsoft.Diagnostics.NETCore.Client.IpcMessage) {QuickJitted}",
+          Module ="Microsoft.Diagnostics.NETCore.Client"
+        },
+        new SentryStackFrame() {
+          Function ="Microsoft.Diagnostics.NETCore.Client.EventPipeSession.Start(class Microsoft.Diagnostics.NETCore.Client.IpcEndpoint,class System.Collections.Generic.IEnumerable`1<class Microsoft.Diagnostics.NETCore.Client.EventPipeProvider>,bool,int32) {QuickJitted}",
+          Module ="Microsoft.Diagnostics.NETCore.Client"
+        },
+        new SentryStackFrame() {
+          Function ="Microsoft.Diagnostics.NETCore.Client.DiagnosticsClient.StartEventPipeSession(class System.Collections.Generic.IEnumerable`1<class Microsoft.Diagnostics.NETCore.Client.EventPipeProvider>,bool,int32) {QuickJitted}",
+          Module ="Microsoft.Diagnostics.NETCore.Client"
+        },
+        new SentryStackFrame() {
+          Function ="ProfilerSession..ctor(class System.Object) {QuickJitted}",
+          Module ="Sentry.Extensions.Profiling"
+        },
+        new SentryStackFrame() {
+          Function ="SamplingTransactionProfiler.OnTransactionStart(class Sentry.ITransaction) {QuickJitted}",
+          Module ="Sentry.Extensions.Profiling"
+        },
+        new SentryStackFrame() {
+          Function ="Sentry.Internal.Hub.StartTransaction(class Sentry.ITransactionContext,class System.Collections.Generic.IReadOnlyDictionary`2<class System.String,class System.Object>,class Sentry.DynamicSamplingContext) {QuickJitted}",
+          Module ="Sentry"
+        },
+        new SentryStackFrame() {
+          Function ="Sentry.Internal.Hub.StartTransaction(class Sentry.ITransactionContext,class System.Collections.Generic.IReadOnlyDictionary`2<class System.String,class System.Object>) {QuickJitted}",
+          Module ="Sentry"
+        },
+        new SentryStackFrame() {
+          Function ="Program+<Main>d__2.MoveNext() {Optimized}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,Program+<Main>d__2].ExecutionContextCallback(class System.Object) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(class System.Threading.Thread,class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,Program+<Main>d__2].MoveNext(class System.Threading.Thread) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,Program+<Main>d__2].ExecuteFromThreadPool(class System.Threading.Thread) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.ThreadPoolWorkQueue.Dispatch()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.PortableThreadPool+WorkerThread.WorkerThreadStart()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="Sentry.Internal.Http.GzipBufferedRequestBodyHandler+<SendAsync>d__3.MoveNext() {QuickJitted}",
+          Module ="Sentry"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.__Canon].Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="Sentry.Internal.Http.GzipBufferedRequestBodyHandler.SendAsync(class System.Net.Http.HttpRequestMessage,value class System.Threading.CancellationToken) {QuickJitted}",
+          Module ="Sentry"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.DelegatingHandler.SendAsync(class System.Net.Http.HttpRequestMessage,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="Sentry.Internal.Http.RetryAfterHandler.<>n__0(class System.Net.Http.HttpRequestMessage,value class System.Threading.CancellationToken) {QuickJitted}",
+          Module ="Sentry"
+        },
+        new SentryStackFrame() {
+          Function ="Sentry.Internal.Http.RetryAfterHandler+<SendAsync>d__8.MoveNext() {QuickJitted}",
+          Module ="Sentry"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.__Canon].Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="Sentry.Internal.Http.RetryAfterHandler.SendAsync(class System.Net.Http.HttpRequestMessage,value class System.Threading.CancellationToken) {QuickJitted}",
+          Module ="Sentry"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpMessageInvoker.SendAsync(class System.Net.Http.HttpRequestMessage,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpClient+<<SendAsync>g__Core|83_0>d.MoveNext()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.__Canon].Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(class System.Net.Http.HttpRequestMessage,value class System.Net.Http.HttpCompletionOption,class System.Threading.CancellationTokenSource,bool,class System.Threading.CancellationTokenSource,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpClient.SendAsync(class System.Net.Http.HttpRequestMessage,value class System.Net.Http.HttpCompletionOption,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpClient.SendAsync(class System.Net.Http.HttpRequestMessage,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="Sentry.Internal.Http.HttpTransport+<SendEnvelopeAsync>d__3.MoveNext() {QuickJitted}",
+          Module ="Sentry"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="Sentry.Internal.Http.HttpTransport.SendEnvelopeAsync(class Sentry.Protocol.Envelopes.Envelope,value class System.Threading.CancellationToken) {QuickJitted}",
+          Module ="Sentry"
+        },
+        new SentryStackFrame() {
+          Function ="Sentry.Internal.BackgroundWorker+<DoWorkAsync>d__20.MoveNext() {Optimized}",
+          Module ="Sentry"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,Sentry.Internal.BackgroundWorker+<DoWorkAsync>d__20].ExecutionContextCallback(class System.Object) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.ExecutionContext.RunInternal(class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,Sentry.Internal.BackgroundWorker+<DoWorkAsync>d__20].MoveNext(class System.Threading.Thread) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,Sentry.Internal.BackgroundWorker+<DoWorkAsync>d__20].MoveNext() {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(class System.Runtime.CompilerServices.IAsyncStateMachineBox,bool)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task.RunContinuations(class System.Object)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task.FinishContinuations()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task`1[System.Boolean].TrySetResult(!0)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Boolean].SetExistingTaskResult(class System.Threading.Tasks.Task`1<!0>,!0)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.SemaphoreSlim+<WaitUntilCountOrTimeoutAsync>d__31.MoveNext()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Boolean,System.Threading.SemaphoreSlim+<WaitUntilCountOrTimeoutAsync>d__31].ExecutionContextCallback(class System.Object) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Boolean,System.Threading.SemaphoreSlim+<WaitUntilCountOrTimeoutAsync>d__31].MoveNext(class System.Threading.Thread) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Boolean,System.Threading.SemaphoreSlim+<WaitUntilCountOrTimeoutAsync>d__31].MoveNext() {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(class System.Action,bool)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task.RunContinuations(class System.Object)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task+CancellationPromise`1[System.Boolean].System.Threading.Tasks.ITaskCompletionAction.Invoke(class System.Threading.Tasks.Task)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.CompletionActionInvoker.System.Threading.IThreadPoolWorkItem.Execute()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.ThreadPoolWorkQueue.Dispatch()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.FindPrimeNumber(int32) {Optimized}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program+<Main>d__2.MoveNext() {Optimized}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.WinInetProxyHelper..ctor()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpWindowsProxy.TryCreate(class System.Net.IWebProxy&)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.SystemProxyInfo.ConstructSystemProxy()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Lazy`1[System.__Canon].ViaFactory(value class System.Threading.LazyThreadSafetyMode)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Lazy`1[System.__Canon].ExecutionAndPublication(class System.LazyHelper,bool)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Lazy`1[System.__Canon].CreateValue()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Lazy`1[System.__Canon].get_Value()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpClient+<>c.<get_DefaultProxy>b__15_0()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.LazyInitializer.EnsureInitializedCore(!!0&,class System.Func`1<!!0>)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.LazyInitializer.EnsureInitialized(!!0&,class System.Func`1<!!0>)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpClient.get_DefaultProxy()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPoolManager..ctor(class System.Net.Http.HttpConnectionSettings)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.SocketsHttpHandler.SetupHandlerChain()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.SocketsHttpHandler.SendAsync(class System.Net.Http.HttpRequestMessage,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.DelegatingHandler.SendAsync(class System.Net.Http.HttpRequestMessage,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="Sentry.Internal.Http.GzipBufferedRequestBodyHandler.<>n__0(class System.Net.Http.HttpRequestMessage,value class System.Threading.CancellationToken) {QuickJitted}",
+          Module ="Sentry"
+        },
+        new SentryStackFrame() {
+          Function ="System.IO.Stream+<>c.<BeginReadInternal>b__40_0(class System.Object)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task`1[System.Int32].InnerInvoke()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task+<>c.<.cctor>b__272_0(class System.Object)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task.ExecuteWithThreadLocal(class System.Threading.Tasks.Task&,class System.Threading.Thread)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task.ExecuteEntryUnsafe(class System.Threading.Thread)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task.ExecuteFromThreadPool(class System.Threading.Thread)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="Program+<>c.<Main>b__2_9() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task`1[System.Int64].InnerInvoke()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.ValueTuple`2[System.__Canon,System.__Canon]].Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(class System.String,int32,class System.Net.Http.HttpRequestMessage,bool,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPool+<ConnectAsync>d__97.MoveNext()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.ValueTuple`3[System.__Canon,System.__Canon,System.__Canon]].Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPool.ConnectAsync(class System.Net.Http.HttpRequestMessage,bool,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPool+<CreateHttp11ConnectionAsync>d__99.MoveNext()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.__Canon].Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(class System.Net.Http.HttpRequestMessage,bool,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPool+<AddHttp11ConnectionAsync>d__74.MoveNext()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPool.AddHttp11ConnectionAsync(class System.Net.Http.HttpRequestMessage)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPool+<>c__DisplayClass75_0.<CheckForHttp11ConnectionInjection>b__0()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task`1[System.__Canon].InnerInvoke()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.__Canon].AwaitUnsafeOnCompleted(!!0&,!!1&,class System.Threading.Tasks.Task`1<!0>&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.__Canon].AwaitUnsafeOnCompleted(!!0&,!!1&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPool+<GetHttp11ConnectionAsync>d__76.MoveNext()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.__Canon].Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPool.GetHttp11ConnectionAsync(class System.Net.Http.HttpRequestMessage,bool,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPool+<SendWithVersionDetectionAndRetryAsync>d__84.MoveNext()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.__Canon].Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(class System.Net.Http.HttpRequestMessage,bool,bool,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPoolManager.SendAsyncCore(class System.Net.Http.HttpRequestMessage,class System.Uri,bool,bool,bool,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPoolManager.SendAsync(class System.Net.Http.HttpRequestMessage,bool,bool,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionHandler.SendAsync(class System.Net.Http.HttpRequestMessage,bool,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpMessageHandlerStage.SendAsync(class System.Net.Http.HttpRequestMessage,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.DiagnosticsHandler.SendAsync(class System.Net.Http.HttpRequestMessage,bool,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.RedirectHandler+<SendAsync>d__4.MoveNext()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.__Canon].Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.RedirectHandler.SendAsync(class System.Net.Http.HttpRequestMessage,bool,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.DecompressionHandler+<SendAsync>d__16.MoveNext()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.__Canon].Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.DecompressionHandler.SendAsync(class System.Net.Http.HttpRequestMessage,bool,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.SocketsHttpHandler.SendAsync(class System.Net.Http.HttpRequestMessage,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SecureChannel.AcquireClientCredentials(unsigned int8[]&)",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SecureChannel.GenerateToken(value class System.ReadOnlySpan`1<unsigned int8>,unsigned int8[]&)",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SecureChannel.NextMessage(value class System.ReadOnlySpan`1<unsigned int8>)",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SslStream+<ForceAuthenticationAsync>d__175`1[System.Net.Security.AsyncReadWriteAdapter].MoveNext()",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SslStream.ForceAuthenticationAsync(!!0,bool,unsigned int8[],bool)",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SslStream.ProcessAuthenticationAsync(bool,bool,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SslStream.AuthenticateAsClientAsync(class System.Net.Security.SslClientAuthenticationOptions,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.ConnectHelper+<EstablishSslConnectionAsync>d__2.MoveNext()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.__Canon].Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.ConnectHelper.EstablishSslConnectionAsync(class System.Net.Security.SslClientAuthenticationOptions,class System.Net.Http.HttpRequestMessage,bool,class System.IO.Stream,value class System.Threading.CancellationToken)",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPool+<ConnectAsync>d__97.MoveNext()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.ValueTuple`3[System.__Canon,System.__Canon,System.__Canon],System.Net.Http.HttpConnectionPool+<ConnectAsync>d__97].ExecutionContextCallback(class System.Object) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.ValueTuple`3[System.__Canon,System.__Canon,System.__Canon],System.Net.Http.HttpConnectionPool+<ConnectAsync>d__97].MoveNext(class System.Threading.Thread) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.ValueTuple`3[System.__Canon,System.__Canon,System.__Canon],System.Net.Http.HttpConnectionPool+<ConnectAsync>d__97].MoveNext() {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task`1[System.ValueTuple`2[System.__Canon,System.__Canon]].TrySetResult(!0)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.ValueTuple`2[System.__Canon,System.__Canon]].SetResult(!0)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Http.HttpConnectionPool+<ConnectToTcpHostAsync>d__98.MoveNext()",
+          Module ="System.Net.Http.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.ValueTuple`2[System.__Canon,System.__Canon],System.Net.Http.HttpConnectionPool+<ConnectToTcpHostAsync>d__98].ExecutionContextCallback(class System.Object) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.ValueTuple`2[System.__Canon,System.__Canon],System.Net.Http.HttpConnectionPool+<ConnectToTcpHostAsync>d__98].MoveNext(class System.Threading.Thread) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.ValueTuple`2[System.__Canon,System.__Canon],System.Net.Http.HttpConnectionPool+<ConnectToTcpHostAsync>d__98].MoveNext() {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task`1[System.Threading.Tasks.VoidTaskResult].TrySetResult(!0)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Threading.Tasks.VoidTaskResult].SetExistingTaskResult(class System.Threading.Tasks.Task`1<!0>,!0)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.SetResult()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Sockets.Socket+<<ConnectAsync>g__WaitForConnectWithCancellation|277_0>d.MoveNext()",
+          Module ="System.Net.Sockets.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,System.Net.Sockets.Socket+<<ConnectAsync>g__WaitForConnectWithCancellation|277_0>d].ExecutionContextCallback(class System.Object) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,System.Net.Sockets.Socket+<<ConnectAsync>g__WaitForConnectWithCancellation|277_0>d].MoveNext(class System.Threading.Thread) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,System.Net.Sockets.Socket+<<ConnectAsync>g__WaitForConnectWithCancellation|277_0>d].MoveNext() {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.ThreadPool+<>c.<.cctor>b__87_0(class System.Object)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Sockets.Socket+AwaitableSocketAsyncEventArgs.InvokeContinuation(class System.Action`1<class System.Object>,class System.Object,bool,bool)",
+          Module ="System.Net.Sockets.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Sockets.Socket+AwaitableSocketAsyncEventArgs.OnCompleted(class System.Net.Sockets.SocketAsyncEventArgs)",
+          Module ="System.Net.Sockets.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Sockets.SocketAsyncEventArgs+<<DnsConnectAsync>g__Core|112_0>d.MoveNext()",
+          Module ="System.Net.Sockets.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,System.Net.Sockets.SocketAsyncEventArgs+<<DnsConnectAsync>g__Core|112_0>d].ExecutionContextCallback(class System.Object) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,System.Net.Sockets.SocketAsyncEventArgs+<<DnsConnectAsync>g__Core|112_0>d].MoveNext(class System.Threading.Thread) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,System.Net.Sockets.SocketAsyncEventArgs+<<DnsConnectAsync>g__Core|112_0>d].MoveNext() {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1[System.Boolean].SignalCompletion()",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1[System.Boolean].SetResult(!0)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Sockets.SocketAsyncEventArgs+MultiConnectSocketAsyncEventArgs.OnCompleted(class System.Net.Sockets.SocketAsyncEventArgs)",
+          Module ="System.Net.Sockets.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Sockets.SocketAsyncEventArgs.OnCompletedInternal()",
+          Module ="System.Net.Sockets.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Sockets.SocketAsyncEventArgs.ExecutionCallback(class System.Object)",
+          Module ="System.Net.Sockets.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.ExecutionContext.Run(class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Sockets.SocketAsyncEventArgs+<>c.<.cctor>b__179_0(unsigned int32,unsigned int32,value class System.Threading.NativeOverlapped*)",
+          Module ="System.Net.Sockets.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.ThreadPoolBoundHandleOverlapped.CompletionCallback(unsigned int32,unsigned int32,value class System.Threading.NativeOverlapped*)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading._IOCompletionCallback.PerformIOCompletionCallback(unsigned int32,unsigned int32,value class System.Threading.NativeOverlapped*)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.__Canon].AwaitUnsafeOnCompleted(!!0&,!!1&,class System.Threading.Tasks.Task`1<!0>&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.__Canon].AwaitUnsafeOnCompleted(!!0&,!!1&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SslStream+<ReceiveBlobAsync>d__176`1[System.Net.Security.AsyncReadWriteAdapter].MoveNext()",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.__Canon].Start(!!0&) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SslStream.ReceiveBlobAsync(!!0)",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SslStream+<ForceAuthenticationAsync>d__175`1[System.Net.Security.AsyncReadWriteAdapter].MoveNext()",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Internal.Cryptography.Pal.ChainPal.BuildChain(bool,class Internal.Cryptography.ICertificatePal,class System.Security.Cryptography.X509Certificates.X509Certificate2Collection,class System.Security.Cryptography.OidCollection,class System.Security.Cryptography.OidCollection,value class System.Security.Cryptography.X509Certificates.X509RevocationMode,value class System.Security.Cryptography.X509Certificates.X509RevocationFlag,class System.Security.Cryptography.X509Certificates.X509Certificate2Collection,value class System.Security.Cryptography.X509Certificates.X509ChainTrustMode,value class System.DateTime,value class System.TimeSpan,bool)",
+          Module ="System.Security.Cryptography.X509Certificates.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Security.Cryptography.X509Certificates.X509Chain.Build(class System.Security.Cryptography.X509Certificates.X509Certificate2,bool)",
+          Module ="System.Security.Cryptography.X509Certificates.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Security.Cryptography.X509Certificates.X509Chain.Build(class System.Security.Cryptography.X509Certificates.X509Certificate2)",
+          Module ="System.Security.Cryptography.X509Certificates.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.CertificateValidation.BuildChainAndVerifyProperties(class System.Security.Cryptography.X509Certificates.X509Chain,class System.Security.Cryptography.X509Certificates.X509Certificate2,bool,bool,class System.String)",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SecureChannel.VerifyRemoteCertificate(class System.Net.Security.RemoteCertificateValidationCallback,class System.Net.Security.SslCertificateTrust,class System.Net.Security.ProtocolToken&,value class System.Net.Security.SslPolicyErrors&,value class System.Security.Cryptography.X509Certificates.X509ChainStatusFlags&)",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SslStream.CompleteHandshake(class System.Net.Security.ProtocolToken&,value class System.Net.Security.SslPolicyErrors&,value class System.Security.Cryptography.X509Certificates.X509ChainStatusFlags&)",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SslStream.CompleteHandshake(class System.Net.Security.SslAuthenticationOptions)",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SslStream+<ForceAuthenticationAsync>d__175`1[System.Net.Security.AsyncReadWriteAdapter].MoveNext()",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,System.Net.Security.SslStream+<ForceAuthenticationAsync>d__175`1[System.Net.Security.AsyncReadWriteAdapter]].ExecutionContextCallback(class System.Object) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,System.Net.Security.SslStream+<ForceAuthenticationAsync>d__175`1[System.Net.Security.AsyncReadWriteAdapter]].MoveNext(class System.Threading.Thread) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,System.Net.Security.SslStream+<ForceAuthenticationAsync>d__175`1[System.Net.Security.AsyncReadWriteAdapter]].MoveNext() {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task`1[System.__Canon].TrySetResult(!0)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.__Canon].SetExistingTaskResult(class System.Threading.Tasks.Task`1<!0>,!0)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.__Canon].SetResult(!0)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SslStream+<ReceiveBlobAsync>d__176`1[System.Net.Security.AsyncReadWriteAdapter].MoveNext()",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.__Canon,System.Net.Security.SslStream+<ReceiveBlobAsync>d__176`1[System.Net.Security.AsyncReadWriteAdapter]].ExecutionContextCallback(class System.Object) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.__Canon,System.Net.Security.SslStream+<ReceiveBlobAsync>d__176`1[System.Net.Security.AsyncReadWriteAdapter]].MoveNext(class System.Threading.Thread) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.__Canon,System.Net.Security.SslStream+<ReceiveBlobAsync>d__176`1[System.Net.Security.AsyncReadWriteAdapter]].MoveNext() {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.Tasks.Task`1[System.Int32].TrySetResult(!0)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Int32].SetExistingTaskResult(class System.Threading.Tasks.Task`1<!0>,!0)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.Int32].SetResult(!0)",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Security.SslStream+<<FillHandshakeBufferAsync>g__InternalFillHandshakeBufferAsync|189_0>d`1[System.Net.Security.AsyncReadWriteAdapter].MoveNext()",
+          Module ="System.Net.Security.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Int32,System.Net.Security.SslStream+<<FillHandshakeBufferAsync>g__InternalFillHandshakeBufferAsync|189_0>d`1[System.Net.Security.AsyncReadWriteAdapter]].ExecutionContextCallback(class System.Object) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Int32,System.Net.Security.SslStream+<<FillHandshakeBufferAsync>g__InternalFillHandshakeBufferAsync|189_0>d`1[System.Net.Security.AsyncReadWriteAdapter]].MoveNext(class System.Threading.Thread) {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Int32,System.Net.Security.SslStream+<<FillHandshakeBufferAsync>g__InternalFillHandshakeBufferAsync|189_0>d`1[System.Net.Security.AsyncReadWriteAdapter]].MoveNext() {QuickJitted}",
+          Module ="System.Private.CoreLib.il"
+        },
+        new SentryStackFrame() {
+          Function ="System.Net.Sockets.SocketAsyncEventArgs+<>c.<.cctor>b__179_0(unsigned int32,unsigned int32,value class System.Threading.NativeOverlapped*)",
+          Module ="System.Net.Sockets.il"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="Program.<Main>() {QuickJitted}",
+          Module ="Sentry.Samples.Console.Customized"
+        },
+        new SentryStackFrame() {
+          Function ="System.Threading.PortableThreadPool+WorkerThread.WorkerThreadStart()",
+          Module = "System.Private.CoreLib.il"
+        }
+    };
+}

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -628,7 +628,7 @@ public class SentryOptions
 
     // The default propagation list will match anything, but adding to the list should clear that.
     private IList<TracePropagationTarget> _tracePropagationTargets = new AutoClearingList<TracePropagationTarget>
-        (new[] {new TracePropagationTarget(".*")}, clearOnNextAdd: true);
+        (new[] { new TracePropagationTarget(".*") }, clearOnNextAdd: true);
 
     /// <summary>
     /// A customizable list of <see cref="TracePropagationTarget"/> objects, each containing either a
@@ -861,15 +861,15 @@ public class SentryOptions
     {
         SettingLocator = new SettingLocator(this);
 
-        EventProcessorsProviders = new () {
+        EventProcessorsProviders = new() {
             () => EventProcessors ?? Enumerable.Empty<ISentryEventProcessor>()
         };
 
-        TransactionProcessorsProviders = new () {
+        TransactionProcessorsProviders = new() {
             () => TransactionProcessors ?? Enumerable.Empty<ISentryTransactionProcessor>()
         };
 
-        ExceptionProcessorsProviders = new () {
+        ExceptionProcessorsProviders = new() {
             () => ExceptionProcessors ?? Enumerable.Empty<ISentryEventExceptionProcessor>()
         };
 
@@ -879,17 +879,17 @@ public class SentryOptions
 
         ISentryStackTraceFactory SentryStackTraceFactoryAccessor() => SentryStackTraceFactory;
 
-        EventProcessors = new (){
+        EventProcessors = new(){
             // De-dupe to be the first to run
             new DuplicateEventDetectionEventProcessor(this),
             new MainSentryEventProcessor(this, SentryStackTraceFactoryAccessor)
         };
 
-        ExceptionProcessors = new (){
+        ExceptionProcessors = new(){
             new MainExceptionProcessor(this, SentryStackTraceFactoryAccessor)
         };
 
-        Integrations = new () {
+        Integrations = new() {
             // Auto-session tracking to be the first to run
             new AutoSessionTrackingIntegration(),
             new AppDomainUnhandledExceptionIntegration(),
@@ -920,16 +920,16 @@ public class SentryOptions
         iOS = new IosOptions(this);
 #endif
 
-        InAppExclude = new () {
-                "System.",
-                "Mono.",
-                "Sentry.",
-                "Microsoft.",
+        InAppExclude = new() {
+                "System",
+                "Mono",
+                "Sentry",
+                "Microsoft",
                 "MS", // MS.Win32, MS.Internal, etc: Desktop apps
                 "Newtonsoft.Json",
-                "FSharp.",
+                "FSharp",
                 "Serilog",
-                "Giraffe.",
+                "Giraffe",
                 "NLog",
                 "Npgsql",
                 "RabbitMQ",
@@ -947,9 +947,9 @@ public class SentryOptions
                 "IdentityModel",
                 "SqlitePclRaw",
                 "Xamarin",
-                "Android.", // Ex: Android.Runtime.JNINativeWrapper...
-                "Google.",
-                "MongoDB.",
+                "Android", // Ex: Android.Runtime.JNINativeWrapper...
+                "Google",
+                "MongoDB",
                 "Remotion.Linq",
                 "AutoMapper",
                 "Nest",
@@ -963,7 +963,7 @@ public class SentryOptions
 #if DEBUG
         InAppInclude = new()
         {
-            "Sentry.Samples."
+            "Sentry.Samples"
         };
 #endif
     }

--- a/src/Sentry/SentryStackFrame.cs
+++ b/src/Sentry/SentryStackFrame.cs
@@ -182,12 +182,12 @@ public sealed class SentryStackFrame : IJsonSerializable
     /// <remarks><see cref="InApp"/> will remain with the same value if previously set.</remarks>
     public void ConfigureAppFrame(SentryOptions options)
     {
-        var parameterName = Module ?? Function;
         if (InApp != null)
         {
             return;
         }
 
+        var parameterName = Module ?? Function;
         if (string.IsNullOrEmpty(parameterName))
         {
             InApp = true;

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
@@ -151,6 +151,42 @@ public class SentryStackFrameTests
     }
 
     [Fact]
+    public void ConfigureAppFrame_WithDefaultOptions_RecognizesInAppFrame()
+    {
+        var options = new SentryOptions();
+        var sut = new SentryStackFrame()
+        {
+            Function = "Program.<Main>() {QuickJitted}",
+            Module = "Console.Customized"
+        };
+
+        // Act
+        sut.ConfigureAppFrame(options);
+
+        // Assert
+        Assert.True(sut.InApp);
+    }
+
+    // Sentry internal frame is marked properly with default options.
+    // This is an actual frame as captured by Sentry.Profiling.
+    [Fact]
+    public void ConfigureAppFrame_WithDefaultOptions_RecognizesSentryInternalFrame()
+    {
+        var options = new SentryOptions();
+        var sut = new SentryStackFrame()
+        {
+            Function = "Sentry.Internal.Hub.StartTransaction(class Sentry.ITransactionContext,class System.Collections.Generic.IReadOnlyDictionary`2<class System.String,class System.Object>) {QuickJitted}",
+            Module = "Sentry"
+        };
+
+        // Act
+        sut.ConfigureAppFrame(options);
+
+        // Assert
+        Assert.False(sut.InApp);
+    }
+
+    [Fact]
     public void ConfigureAppFrame_InAppAlreadySet_InAppIgnored()
     {
         // Arrange

--- a/test/Sentry.Tests/SentryOptionsExtensionsTests.cs
+++ b/test/Sentry.Tests/SentryOptionsExtensionsTests.cs
@@ -295,10 +295,10 @@ public class SentryOptionsExtensionsTests
     }
 
     [Theory]
-    [InlineData("Microsoft.")]
-    [InlineData("System.")]
-    [InlineData("FSharp.")]
-    [InlineData("Giraffe.")]
+    [InlineData("Microsoft")]
+    [InlineData("System")]
+    [InlineData("FSharp")]
+    [InlineData("Giraffe")]
     [InlineData("Newtonsoft.Json")]
     public void Integrations_Includes_MajorSystemPrefixes(string expected)
     {


### PR DESCRIPTION
Originally, I was concerned about the in-app resolution [implementation ](https://github.com/getsentry/sentry-dotnet/blob/c8ad13d7a96c85726fec02cc2ef9dec4430aab4a/src/Sentry/SentryStackFrame.cs#L197-L198) not using binary prefix search especially since it would be used in profiling where there are easily thousands of frames. I've added a micro-benchmark to measure the current implementation but it looks good enough to me at the moment. 

Then, I noticed some frames in profiling are recognized in-app even though they're coming from Sentry so I've added test cases to cover that and updated the resolution code.

Forgive me for mixing up concerns in this PR, I just didn't want to add it to the Profiling one to make it even less digestable.

