### PR TITLE
Add `FileDiagnosticLogger` to assist with debugging the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add `FileDiagnosticLogger` to assist with debugging the SDK ([#2242](https://github.com/getsentry/sentry-dotnet/pull/2242))
+
 ### Fixes
 
 - Normalize StackFrame in-app resolution for modules & function prefixes ([#2234](https://github.com/getsentry/sentry-dotnet/pull/2234))

--- a/src/Sentry/Infrastructure/FileDiagnosticLogger.cs
+++ b/src/Sentry/Infrastructure/FileDiagnosticLogger.cs
@@ -1,0 +1,54 @@
+namespace Sentry.Infrastructure;
+
+/// <summary>
+/// File logger used by the SDK to report its internal logging to a file.
+/// </summary>
+/// <remarks>
+/// Primarily used to capture debug information to troubleshoot the SDK itself.
+/// </remarks>
+public class FileDiagnosticLogger : DiagnosticLogger
+{
+    private readonly bool _alsoWriteToConsole;
+    private readonly StreamWriter _writer;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="FileDiagnosticLogger"/>.
+    /// </summary>
+    /// <param name="path">The path to the file to write logs to.  Will overwrite any existing file.</param>
+    /// <param name="alsoWriteToConsole">If <c>true</c>, will write to the console as well as the file.</param>
+    public FileDiagnosticLogger(string path, bool alsoWriteToConsole = false)
+        : this(path, SentryLevel.Debug, alsoWriteToConsole)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="FileDiagnosticLogger"/>.
+    /// </summary>
+    /// <param name="path">The path to the file to write logs to.  Will overwrite any existing file.</param>
+    /// <param name="minimalLevel">The minimal level to log.</param>
+    /// <param name="alsoWriteToConsole">If <c>true</c>, will write to the console as well as the file.</param>
+    public FileDiagnosticLogger(string path, SentryLevel minimalLevel, bool alsoWriteToConsole = false)
+        : base(minimalLevel)
+    {
+        var stream = File.OpenWrite(path);
+        _writer = new StreamWriter(stream);
+        _alsoWriteToConsole = alsoWriteToConsole;
+
+        AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+        {
+            _writer.Flush();
+            _writer.Dispose();
+        };
+    }
+
+    /// <inheritdoc />
+    protected override void LogMessage(string message)
+    {
+        _writer.WriteLine(message);
+
+        if (_alsoWriteToConsole)
+        {
+            Console.WriteLine(message);
+        }
+    }
+}

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1280,6 +1280,12 @@ namespace Sentry.Infrastructure
         public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
         protected abstract void LogMessage(string message);
     }
+    public class FileDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
+    {
+        public FileDiagnosticLogger(string path, bool alsoWriteToConsole = false) { }
+        public FileDiagnosticLogger(string path, Sentry.SentryLevel minimalLevel, bool alsoWriteToConsole = false) { }
+        protected override void LogMessage(string message) { }
+    }
     public interface ISystemClock
     {
         System.DateTimeOffset GetUtcNow();

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1280,6 +1280,12 @@ namespace Sentry.Infrastructure
         public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
         protected abstract void LogMessage(string message);
     }
+    public class FileDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
+    {
+        public FileDiagnosticLogger(string path, bool alsoWriteToConsole = false) { }
+        public FileDiagnosticLogger(string path, Sentry.SentryLevel minimalLevel, bool alsoWriteToConsole = false) { }
+        protected override void LogMessage(string message) { }
+    }
     public interface ISystemClock
     {
         System.DateTimeOffset GetUtcNow();

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1280,6 +1280,12 @@ namespace Sentry.Infrastructure
         public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
         protected abstract void LogMessage(string message);
     }
+    public class FileDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
+    {
+        public FileDiagnosticLogger(string path, bool alsoWriteToConsole = false) { }
+        public FileDiagnosticLogger(string path, Sentry.SentryLevel minimalLevel, bool alsoWriteToConsole = false) { }
+        protected override void LogMessage(string message) { }
+    }
     public interface ISystemClock
     {
         System.DateTimeOffset GetUtcNow();

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -1279,6 +1279,12 @@ namespace Sentry.Infrastructure
         public void Log(Sentry.SentryLevel logLevel, string message, System.Exception? exception = null, params object?[] args) { }
         protected abstract void LogMessage(string message);
     }
+    public class FileDiagnosticLogger : Sentry.Infrastructure.DiagnosticLogger
+    {
+        public FileDiagnosticLogger(string path, bool alsoWriteToConsole = false) { }
+        public FileDiagnosticLogger(string path, Sentry.SentryLevel minimalLevel, bool alsoWriteToConsole = false) { }
+        protected override void LogMessage(string message) { }
+    }
     public interface ISystemClock
     {
         System.DateTimeOffset GetUtcNow();


### PR DESCRIPTION
Sometimes when debugging, I want to capture the log output to a file.  Copy/paste from console isn't always possible (depending on app type), and even when it is, It could be mixed with other console output, or it could be truncated due to size of the console buffer.

This adds a `FileDiagnosticLogger` that writes diagnostic info to the specified file.  For example:

```csharp
    options.Debug = true;
    options.DiagnosticLogger = new FileDiagnosticLogger("log.txt");
```

Optional parameters can be used to set log level, or to write to both file and console simultaneously.