### PR TITLE
Calling AddAspNet more than once should not block all errors from being sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Normalize StackFrame in-app resolution for modules & function prefixes ([#2234](https://github.com/getsentry/sentry-dotnet/pull/2234))
+- Calling AddAspNet more than once should not block all errors from being sent ([2253](https://github.com/getsentry/sentry-dotnet/pull/2253))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixes
 
 - Normalize StackFrame in-app resolution for modules & function prefixes ([#2234](https://github.com/getsentry/sentry-dotnet/pull/2234))
-- Calling AddAspNet more than once should not block all errors from being sent ([2253](https://github.com/getsentry/sentry-dotnet/pull/2253))
+- Calling `AddAspNet` more than once should not block all errors from being sent ([#2253](https://github.com/getsentry/sentry-dotnet/pull/2253))
 
 ### Dependencies
 

--- a/src/Sentry.AspNet/Internal/SystemWebRequestEventProcessor.cs
+++ b/src/Sentry.AspNet/Internal/SystemWebRequestEventProcessor.cs
@@ -63,7 +63,7 @@ internal class SystemWebRequestEventProcessor : ISentryEventProcessor
             @event.Request.Headers[key] = context.Request.Headers[key];
         }
 
-        if (_options?.SendDefaultPii == true)
+        if (_options.SendDefaultPii)
         {
             if (@event.User.Username == Environment.UserName)
             {
@@ -76,7 +76,7 @@ internal class SystemWebRequestEventProcessor : ISentryEventProcessor
             if (context.User.Identity is { } identity)
             {
                 @event.User.Username = identity.Name;
-                @event.User.Other.Add("IsAuthenticated", identity.IsAuthenticated.ToString());
+                @event.User.Other["IsAuthenticated"] = identity.IsAuthenticated.ToString();
             }
             if (context.User is ClaimsPrincipal claimsPrincipal)
             {

--- a/src/Sentry.AspNet/SentryAspNetOptionsExtensions.cs
+++ b/src/Sentry.AspNet/SentryAspNetOptionsExtensions.cs
@@ -13,12 +13,13 @@ public static class SentryAspNetOptionsExtensions
     /// <summary>
     /// Adds ASP.NET classic integration.
     /// </summary>
-    public static void AddAspNet(this SentryOptions options, RequestSize maxRequestBodySize = RequestSize.None)
+    public static SentryOptions AddAspNet(this SentryOptions options, RequestSize maxRequestBodySize = RequestSize.None)
     {
         if (options.EventProcessors?.OfType<SystemWebRequestEventProcessor>().Any() is true)
         {
             options.LogWarning($"{nameof(AddAspNet)} has already been called. Subsequent call will be ignored.");
-            return;
+
+            return options;
         }
 
         var payloadExtractor = new RequestBodyExtractionDispatcher(
@@ -35,5 +36,7 @@ public static class SentryAspNetOptionsExtensions
         options.Release ??= SystemWebVersionLocator.Resolve(options, HttpContext.Current);
         options.AddEventProcessor(eventProcessor);
         options.AddDiagnosticSourceIntegration();
+
+        return options;
     }
 }

--- a/src/Sentry.AspNet/SentryAspNetOptionsExtensions.cs
+++ b/src/Sentry.AspNet/SentryAspNetOptionsExtensions.cs
@@ -15,6 +15,12 @@ public static class SentryAspNetOptionsExtensions
     /// </summary>
     public static void AddAspNet(this SentryOptions options, RequestSize maxRequestBodySize = RequestSize.None)
     {
+        if (options.EventProcessors?.OfType<SystemWebRequestEventProcessor>().Any() is true)
+        {
+            options.LogWarning($"{nameof(AddAspNet)} has already been called. Subsequent call will be ignored.");
+            return;
+        }
+
         var payloadExtractor = new RequestBodyExtractionDispatcher(
             new IRequestPayloadExtractor[] { new FormRequestPayloadExtractor(), new DefaultRequestPayloadExtractor() },
             options,

--- a/src/Sentry.EntityFramework/SentryOptionsExtensions.cs
+++ b/src/Sentry.EntityFramework/SentryOptionsExtensions.cs
@@ -15,6 +15,12 @@ public static class SentryOptionsExtensions
     /// <param name="sentryOptions">The sentry options.</param>
     public static SentryOptions AddEntityFramework(this SentryOptions sentryOptions)
     {
+        if (sentryOptions.ExceptionProcessors?.OfType<DbEntityValidationExceptionProcessor>().Any() is true)
+        {
+            sentryOptions.LogWarning($"{nameof(AddEntityFramework)} has already been called. Subsequent call will be ignored.");
+            return sentryOptions;
+        }
+
         try
         {
             _ = SentryDatabaseLogging.UseBreadcrumbs(diagnosticLogger: sentryOptions.DiagnosticLogger);

--- a/test/Sentry.AspNet.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.AspNet.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -7,7 +7,7 @@
     }
     public static class SentryAspNetOptionsExtensions
     {
-        public static void AddAspNet(this Sentry.SentryOptions options, Sentry.Extensibility.RequestSize maxRequestBodySize = 0) { }
+        public static Sentry.SentryOptions AddAspNet(this Sentry.SentryOptions options, Sentry.Extensibility.RequestSize maxRequestBodySize = 0) { }
     }
     public static class SentryHttpServerUtilityExtensions
     {

--- a/test/Sentry.AspNet.Tests/SentryAspNetOptionsExtensionsTests.cs
+++ b/test/Sentry.AspNet.Tests/SentryAspNetOptionsExtensionsTests.cs
@@ -22,4 +22,31 @@ public class SentryAspNetOptionsExtensionsTests :
         Assert.Contains(extractor.Extractors, p => p.GetType() == typeof(FormRequestPayloadExtractor));
         Assert.Contains(extractor.Extractors, p => p.GetType() == typeof(DefaultRequestPayloadExtractor));
     }
+
+    [Fact]
+    public void AddAspNet_UsedMoreThanOnce_RegisterOnce()
+    {
+        var options = new SentryOptions();
+
+        options.AddAspNet();
+        options.AddAspNet();
+
+        Assert.Single(options.EventProcessors!, _ => _ is SystemWebRequestEventProcessor);
+    }
+
+    [Fact]
+    public void AddAspNet_UsedMoreThanOnce_LogWarning()
+    {
+        var options = new SentryOptions();
+        var logger = new InMemoryDiagnosticLogger();
+
+        options.DiagnosticLogger = logger;
+        options.Debug = true;
+
+        options.AddAspNet();
+        options.AddAspNet();
+
+        Assert.Single(logger.Entries, x => x.Level == SentryLevel.Warning
+                                           && x.Message.Contains("Subsequent call will be ignored."));
+    }
 }

--- a/test/Sentry.EntityFramework.Tests/SentryOptionsExtensionsTests.cs
+++ b/test/Sentry.EntityFramework.Tests/SentryOptionsExtensionsTests.cs
@@ -1,0 +1,31 @@
+namespace Sentry.EntityFramework.Tests;
+
+public class SentryOptionsExtensionsTests
+{
+    [Fact]
+    public void AddEntityFramework_UsedMoreThanOnce_RegisterOnce()
+    {
+        var options = new SentryOptions();
+
+        options.AddEntityFramework();
+        options.AddEntityFramework();
+
+        Assert.Single(options.ExceptionProcessors!, _ => _ is DbEntityValidationExceptionProcessor);
+    }
+
+    [Fact]
+    public void AddEntityFramework_UsedMoreThanOnce_LogWarning()
+    {
+        var options = new SentryOptions();
+        var logger = new InMemoryDiagnosticLogger();
+
+        options.DiagnosticLogger = logger;
+        options.Debug = true;
+
+        options.AddEntityFramework();
+        options.AddEntityFramework();
+
+        Assert.Single(logger.Entries, x => x.Level == SentryLevel.Warning
+                                           && x.Message.Contains("Subsequent call will be ignored."));
+    }
+}


### PR DESCRIPTION
Fixes #2236 