### PR TITLE
Reduce Sentry CLI usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,13 @@ jobs:
       - name: Restore .NET Dependencies
         run: dotnet restore Sentry-CI-Build-${{ runner.os }}.slnf --nologo
 
-      - name: Build
-        run: dotnet build Sentry-CI-Build-${{ runner.os }}.slnf -c Release --no-restore --nologo /p:CopyLocalLockFileAssemblies=true
+      - name: Build (for non-release branch)
+        if: env.CI_PUBLISHING_BUILD != 'true'
+        run: dotnet build Sentry-CI-Build-${{ runner.os }}.slnf -c Release --no-restore --nologo
+
+     - name: Build (for release branch)
+        if: env.CI_PUBLISHING_BUILD == 'true'
+        run: dotnet build Sentry-CI-Build-${{ runner.os }}.slnf -c Release --no-restore --nologo -p:CopyLocalLockFileAssemblies=true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
@@ -64,11 +69,11 @@ jobs:
 
       # To save time and disk space, we only create and archive the Nuget packages when we're actually releasing.
 
-      - name: Create Nuget Packages (release only)
+      - name: Create Nuget Packages (release branch only)
         if: env.CI_PUBLISHING_BUILD == 'true'
         run: dotnet pack Sentry-CI-Pack.slnf -c Release --no-build --nologo
 
-      - name: Archive Nuget Packages (release only)
+      - name: Archive Nuget Packages (release branch only)
         if: env.CI_PUBLISHING_BUILD == 'true'
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         if: env.CI_PUBLISHING_BUILD != 'true'
         run: dotnet build Sentry-CI-Build-${{ runner.os }}.slnf -c Release --no-restore --nologo
 
-     - name: Build (for release branch)
+      - name: Build (for release branch)
         if: env.CI_PUBLISHING_BUILD == 'true'
         run: dotnet build Sentry-CI-Build-${{ runner.os }}.slnf -c Release --no-restore --nologo -p:CopyLocalLockFileAssemblies=true
         env:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,11 +24,20 @@
     There is also a a `SentryAuthToken` msbuild property, but it should be used sparingly.
     If using it, be careful that the auth token does not get committed to source control.
   -->
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+  <PropertyGroup>
     <SentryOrg>sentry-sdks</SentryOrg>
     <SentryProject>sentry-dotnet</SentryProject>
+  </PropertyGroup>
+
+  <!-- By default we'll only upload with Sentry CLI in Release configuration. -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <SentryUploadSymbols>true</SentryUploadSymbols>
     <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
+  <!-- If running in CI and auth token is not set, disable SentryCLI completely (to avoid logging warnings). -->
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true' And '$(SENTRY_AUTH_TOKEN)' == ''">
+    <UseSentryCLI>false</UseSentryCLI>
   </PropertyGroup>
 
   <!--

--- a/benchmarks/Directory.Build.props
+++ b/benchmarks/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+
+  <Import Project="..\Directory.Build.props" />
+
+  <!-- Never use Sentry CLI for benchmark projects. -->
+  <PropertyGroup>
+    <UseSentryCLI>false</UseSentryCLI>
+  </PropertyGroup>
+
+</Project>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -6,4 +6,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <!-- Never use Sentry CLI for sample projects when building in CI. -->
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <UseSentryCLI>false</UseSentryCLI>
+  </PropertyGroup>
+
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -9,6 +9,11 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <!-- Never use Sentry CLI for test projects. -->
+  <PropertyGroup>
+    <UseSentryCLI>false</UseSentryCLI>
+  </PropertyGroup>
+
   <!--
     Workaround for Verify issue with scrubbing when running in Rider on Windows.
     Ensures that the volume label is upper cased ("C:" instead of "c:"), which is read


### PR DESCRIPTION
We only should run Sentry CLI on our release builds.  Not just when `Configuration=Release`, but when actually publishing from a release branch.  Even then, we don't need to upload symbols or sources from samples.  And we _never_  need to use SentryCLI on tests or benchmarks.

#skip-changelog