### PR TITLE
Fix Windows build

### DIFF
--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks />
-    <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net6.0-ios</TargetFrameworks>
-    <TargetFrameworks Condition="'$(NO_MACCATALYST)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net6.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="'$(NO_IOS)' == '' And '$(NO_MACCATALYST)' == ''">net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+    <TargetFramework Condition="'$(NO_IOS)' == '' And '$(NO_MACCATALYST)' == 'true'">net6.0-ios</TargetFramework>
+    <TargetFramework Condition="'$(NO_IOS)' == 'true' And '$(NO_MACCATALYST)' == ''">net6.0-maccatalyst</TargetFramework>
     <IsBindingProject>true</IsBindingProject>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
     <Description>.NET Bindings for the Sentry Cocoa SDK</Description>
@@ -10,7 +11,13 @@
     <SentryCocoaFramework>$(SentryCocoaSdkDirectory)Carthage\Build-$(TargetPlatformIdentifier)\Sentry.xcframework</SentryCocoaFramework>
   </PropertyGroup>
 
-  <ItemGroup>
+  <!-- Build empty assemblies when not on macOS, to pass the solution build. -->
+  <ItemGroup Condition="!$([MSBuild]::IsOSPlatform('OSX'))">
+    <Compile Remove="*" />
+    <Using Remove="*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
 
     <!-- Set up the binding project. -->
     <ObjcBindingApiDefinition Include="ApiDefinitions.cs" />

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And '$(NO_MACCATALYST)' == ''">net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-    <TargetFramework Condition="'$(NO_IOS)' == '' And '$(NO_MACCATALYST)' == 'true'">net6.0-ios</TargetFramework>
-    <TargetFramework Condition="'$(NO_IOS)' == 'true' And '$(NO_MACCATALYST)' == ''">net6.0-maccatalyst</TargetFramework>
+    <TargetFrameworks Condition="'$(NO_IOS)' == '' And '$(NO_MACCATALYST)' == 'true'">net6.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="'$(NO_IOS)' == 'true' And '$(NO_MACCATALYST)' == ''">net6.0-maccatalyst</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
     <Description>.NET Bindings for the Sentry Cocoa SDK</Description>


### PR DESCRIPTION
Resolves this error when building the solution on Windows:

```
C:\Program Files\dotnet\sdk\7.0.202\NuGet.targets(132,5): error : Invalid framework identifier ''. [...\Sentry.sln]
```

#skip-changelog