### PR TITLE
Sentry.AspNetCore fix transaction name when path base is used and route starts with a slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Normalize StackFrame in-app resolution for modules & function prefixes ([#2234](https://github.com/getsentry/sentry-dotnet/pull/2234))
 - Calling `AddAspNet` more than once should not block all errors from being sent ([#2253](https://github.com/getsentry/sentry-dotnet/pull/2253))
 - Fix Sentry CLI arguments when using custom URL or auth token parameters ([#2259](https://github.com/getsentry/sentry-dotnet/pull/2259))
+- Sentry.AspNetCore fix transaction name when path base is used and route starts with a slash ([#](https://github.com/getsentry/sentry-dotnet/pull/))
 
 ### Dependencies
 

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -50,7 +50,9 @@ internal static class HttpContextExtensions
         }
         else
         {
-            builder.Append(routePattern);
+            builder.Append(routePattern.StartsWith("/", StringComparison.OrdinalIgnoreCase)
+                ? routePattern[1..]
+                : routePattern);
         }
 
         return builder.ToString();

--- a/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
@@ -147,6 +147,7 @@ public class HttpContextExtensionsTests
     [Theory]
     [InlineData("myPath/some/Path", "/myPath", "some/Path")]
     [InlineData("some/Path", null, "some/Path")]
+    [InlineData("api/health", "/api", "/health")]
     [InlineData(null, null, "")]
     [InlineData(null, null, null)]
     public void NewRouteFormat_WithPathBase_MatchesExpectedRoute(string expectedRoute, string pathBase, string rawRoute)


### PR DESCRIPTION
When a path base is used (`/api`) and a route start with a slash (`/healthz`) generate correct transaction name `[HTTP VERB] api/healthz`

Fixes #2256 