### PR TITLE
Attach stack trace when events have captured an exception without a stack trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add `FileDiagnosticLogger` to assist with debugging the SDK ([#2242](https://github.com/getsentry/sentry-dotnet/pull/2242))
+- Attach stack trace when events have captured an exception without a stack trace ([#2266](https://github.com/getsentry/sentry-dotnet/pull/2266))
 
 ### Fixes
 

--- a/src/Sentry/Internal/MainSentryEventProcessor.cs
+++ b/src/Sentry/Internal/MainSentryEventProcessor.cs
@@ -1,4 +1,5 @@
 using Sentry.Extensibility;
+using Sentry.Internal.Extensions;
 using Sentry.Reflection;
 
 namespace Sentry.Internal;
@@ -83,9 +84,9 @@ internal class MainSentryEventProcessor : ISentryEventProcessor
         @event.Release ??= Release;
         @event.Distribution ??= Distribution;
 
-        if (@event.Exception == null)
+        // if there's no exception with a stack trace, then get the current stack trace
+        if (@event.Exception?.StackTrace is null)
         {
-            // if there's no exception, get the current stack trace
             var stackTrace = SentryStackTraceFactoryAccessor().Create();
             if (stackTrace != null)
             {

--- a/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
@@ -467,6 +467,18 @@ public class MainSentryEventProcessorTests
     }
 
     [Fact]
+    public void Process_AttachStacktraceTrueAndExceptionInEventHasNoStackTrace_CallsStacktraceFactory()
+    {
+        _fixture.SentryOptions.AttachStacktrace = true;
+        var sut = _fixture.GetSut();
+
+        var evt = new SentryEvent(new Exception());
+        _ = sut.Process(evt);
+
+        _ = _fixture.SentryStackTraceFactory.Received(1).Create();
+    }
+
+    [Fact]
     public void Process_AttachStacktraceTrueAndExistentThreadInEvent_AddsNewThread()
     {
         var expected = new SentryStackTrace();
@@ -481,18 +493,6 @@ public class MainSentryEventProcessorTests
         Assert.Equal(2, evt.SentryThreads.Count());
         Assert.Equal("first", evt.SentryThreads.First().Name);
         Assert.Equal("second", evt.SentryThreads.Last().Name);
-    }
-
-    [Fact]
-    public void Process_AttachStacktraceTrueAndExceptionInEvent_DoesNotCallStacktraceFactory()
-    {
-        _fixture.SentryOptions.AttachStacktrace = true;
-        var sut = _fixture.GetSut();
-
-        var evt = new SentryEvent(new Exception());
-        _ = sut.Process(evt);
-
-        _ = _fixture.SentryStackTraceFactory.DidNotReceive().Create();
     }
 
     [Fact]


### PR DESCRIPTION
When `AttachStackTrace` is `true` (the default behavior), we now ensure that a stack trace exists on all events.

Previously, we'd only have a stack trace on events with a _thrown_exception, or events that had no exception.   This expands the feature to include a stack trace when an exception is captured without being thrown.

An stack trace like this will be sent to Sentry separately from the exception, but the Sentry issue details UI will still show them together.  If source context is available, the highlighted call site is the location where the exception was captured.  For example:

<img width="963" alt="image" src="https://user-images.githubusercontent.com/1396388/228440778-aa74529d-8267-49f9-8336-b62b02872d83.png">

Resolves #2262