### PR TITLE
Improvements to exception mechanism data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - Add `FileDiagnosticLogger` to assist with debugging the SDK ([#2242](https://github.com/getsentry/sentry-dotnet/pull/2242))
 - Attach stack trace when events have captured an exception without a stack trace ([#2266](https://github.com/getsentry/sentry-dotnet/pull/2266))
-- Add Scope.Clear and Scope.ClearBreadcrumbs methods ([#2284](https://github.com/getsentry/sentry-dotnet/pull/2284))
+- Add `Scope.Clear` and `Scope.ClearBreadcrumbs` methods ([#2284](https://github.com/getsentry/sentry-dotnet/pull/2284))
+- Improvements to exception mechanism data ([#2294](https://github.com/getsentry/sentry-dotnet/pull/2294))
 
 ### Fixes
 

--- a/src/Sentry.AspNet/SentryHttpServerUtilityExtensions.cs
+++ b/src/Sentry.AspNet/SentryHttpServerUtilityExtensions.cs
@@ -21,8 +21,12 @@ public static class SentryHttpServerUtilityExtensions
     {
         if (server.GetLastError() is { } exception)
         {
-            exception.Data[Mechanism.HandledKey] = false;
-            exception.Data[Mechanism.MechanismKey] = "HttpApplication.Application_Error";
+            exception.SetSentryMechanism(
+                "HttpApplication.Application_Error",
+                "This exception was caught by the ASP.NET global error handler. " +
+                "The web server likely returned a 5xx error code as a result of this exception.",
+                handled: false);
+
             return hub.CaptureException(exception);
         }
         return SentryId.Empty;

--- a/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
@@ -31,8 +31,11 @@ internal class AppDomainUnhandledExceptionIntegration : ISdkIntegration
 
         if (e.ExceptionObject is Exception ex)
         {
-            ex.Data[Mechanism.HandledKey] = false;
-            ex.Data[Mechanism.MechanismKey] = "AppDomain.UnhandledException";
+            ex.SetSentryMechanism(
+                "AppDomain.UnhandledException",
+                "This exception was caught by the .NET Application Domain global error handler. " +
+                "The application likely crashed as a result of this exception.",
+                handled: false);
 
             // Call the internal implementation, so that we still capture even if the hub has been disabled.
             _hub?.CaptureExceptionInternal(ex);

--- a/src/Sentry/Integrations/UnobservedTaskExceptionIntegration.cs
+++ b/src/Sentry/Integrations/UnobservedTaskExceptionIntegration.cs
@@ -34,8 +34,12 @@ internal class UnobservedTaskExceptionIntegration : ISdkIntegration
 #else
         var ex = e.Exception!;
 #endif
-        ex.Data[Mechanism.HandledKey] = false;
-        ex.Data[Mechanism.MechanismKey] = MechanismKey;
+
+        ex.SetSentryMechanism(
+            MechanismKey,
+            "This exception was thrown from a task that was unobserved, such as from an async void method, or " +
+            "a Task.Run that was not awaited. This exception was unhandled, but likely did not crash the application.",
+            handled: false);
 
         // Call the internal implementation, so that we still capture even if the hub has been disabled.
         _hub.CaptureExceptionInternal(ex);

--- a/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
@@ -116,8 +116,13 @@ internal class WinUIUnhandledExceptionIntegration : ISdkIntegration
         }
 
         // Set some useful data and capture the exception
-        exception.Data[Protocol.Mechanism.HandledKey] = handled;
-        exception.Data[Protocol.Mechanism.MechanismKey] = "Microsoft.UI.Xaml.UnhandledException";
+        var description = "This exception was caught by the Windows UI global error handler.";
+        if (!handled)
+        {
+            description += " The application likely crashed as a result of this exception.";
+        }
+
+        exception.SetSentryMechanism("Microsoft.UI.Xaml.UnhandledException", description, handled);
 
         // Call the internal implementation, so that we still capture even if the hub has been disabled.
         _hub.CaptureExceptionInternal(exception);

--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -556,6 +556,17 @@ internal static class JsonExtensions
         }
     }
 
+    public static void WriteBooleanIfTrue(
+        this Utf8JsonWriter writer,
+        string propertyName,
+        bool? value)
+    {
+        if (value is true)
+        {
+            writer.WriteBoolean(propertyName, value.Value);
+        }
+    }
+
     public static void WriteNumberIfNotNull(
         this Utf8JsonWriter writer,
         string propertyName,

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -143,8 +143,21 @@ internal class MainExceptionProcessor : ISentryEventExceptionProcessor
 
         if (exception.Data[Mechanism.HandledKey] is bool handled)
         {
+            // The mechanism handled flag was set by an integration.
             mechanism.Handled = handled;
             exception.Data.Remove(Mechanism.HandledKey);
+        }
+        else if (exception.StackTrace != null)
+        {
+            // The exception was thrown, but it was caught by the user, not an integration.
+            // Thus, we can mark it as handled.
+            mechanism.Handled = true;
+        }
+        else
+        {
+            // The exception was never thrown.  It was just constructed and then captured.
+            // Thus, it is neither handled nor unhandled.
+            mechanism.Handled = null;
         }
 
         if (exception.Data[Mechanism.MechanismKey] is string mechanismName)

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -149,10 +149,16 @@ internal class MainExceptionProcessor : ISentryEventExceptionProcessor
             mechanism.Handled = null;
         }
 
-        if (exception.Data[Mechanism.MechanismKey] is string mechanismName)
+        if (exception.Data[Mechanism.MechanismKey] is string mechanismType)
         {
-            mechanism.Type = mechanismName;
+            mechanism.Type = mechanismType;
             exception.Data.Remove(Mechanism.MechanismKey);
+        }
+
+        if (exception.Data[Mechanism.DescriptionKey] is string mechanismDescription)
+        {
+            mechanism.Description = mechanismDescription;
+            exception.Data.Remove(Mechanism.DescriptionKey);
         }
 
         // Copy remaining exception data to mechanism data.

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -108,9 +108,14 @@ internal class MainExceptionProcessor : ISentryEventExceptionProcessor
             Type = innerException.GetType().FullName,
             Module = innerException.GetType().Assembly.FullName,
             Value = innerException.Message,
-            ThreadId = Environment.CurrentManagedThreadId,
-            Mechanism = GetMechanism(innerException)
+            ThreadId = Environment.CurrentManagedThreadId
         };
+
+        var mechanism = GetMechanism(innerException);
+        if (!mechanism.IsDefaultOrEmpty())
+        {
+            sentryEx.Mechanism = mechanism;
+        }
 
         if (innerException.Data.Count != 0)
         {

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -186,9 +186,16 @@ public static partial class SentrySdk
 
     private static void AndroidEnvironment_UnhandledExceptionRaiser(object? _, RaiseThrowableEventArgs e)
     {
-        e.Exception.Data[Mechanism.HandledKey] = e.Handled;
-        e.Exception.Data[Mechanism.MechanismKey] = "UnhandledExceptionRaiser";
+        var description = "This exception was caught by the Android global error handler.";
+        if (!e.Handled)
+        {
+            description += " The application likely crashed as a result of this exception.";
+        }
+
+        e.Exception.SetSentryMechanism("UnhandledExceptionRaiser", description, e.Handled);
+
         CaptureException(e.Exception);
+
         if (!e.Handled)
         {
             Close();

--- a/src/Sentry/Protocol/Mechanism.cs
+++ b/src/Sentry/Protocol/Mechanism.cs
@@ -62,6 +62,11 @@ public sealed class Mechanism : IJsonSerializable
     public bool? Handled { get; set; }
 
     /// <summary>
+    /// Optional flag indicating whether the exception is synthetic.
+    /// </summary>
+    public bool Synthetic { get; set; }
+
+    /// <summary>
     /// Optional information from the operating system or runtime on the exception mechanism.
     /// </summary>
     /// <remarks>
@@ -87,6 +92,7 @@ public sealed class Mechanism : IJsonSerializable
         writer.WriteStringIfNotWhiteSpace("description", Description);
         writer.WriteStringIfNotWhiteSpace("help_link", HelpLink);
         writer.WriteBooleanIfNotNull("handled", Handled);
+        writer.WriteBooleanIfTrue("synthetic", Synthetic);
         writer.WriteDictionaryIfNotEmpty("data", InternalData!, logger);
         writer.WriteDictionaryIfNotEmpty("meta", InternalMeta!, logger);
 
@@ -102,6 +108,7 @@ public sealed class Mechanism : IJsonSerializable
         var description = json.GetPropertyOrNull("description")?.GetString();
         var helpLink = json.GetPropertyOrNull("help_link")?.GetString();
         var handled = json.GetPropertyOrNull("handled")?.GetBoolean();
+        var synthetic = json.GetPropertyOrNull("synthetic")?.GetBoolean() ?? false;
         var data = json.GetPropertyOrNull("data")?.GetDictionaryOrNull();
         var meta = json.GetPropertyOrNull("meta")?.GetDictionaryOrNull();
 
@@ -111,6 +118,7 @@ public sealed class Mechanism : IJsonSerializable
             Description = description,
             HelpLink = helpLink,
             Handled = handled,
+            Synthetic = synthetic,
             InternalData = data?.WhereNotNullValue().ToDictionary(),
             InternalMeta = meta?.WhereNotNullValue().ToDictionary()
         };
@@ -118,6 +126,7 @@ public sealed class Mechanism : IJsonSerializable
 
     internal bool IsDefaultOrEmpty() =>
         Handled is null &&
+        Synthetic == false &&
         Type == DefaultType &&
         string.IsNullOrWhiteSpace(Description) &&
         string.IsNullOrWhiteSpace(HelpLink) &&

--- a/src/Sentry/Protocol/Mechanism.cs
+++ b/src/Sentry/Protocol/Mechanism.cs
@@ -15,14 +15,19 @@ namespace Sentry.Protocol;
 public sealed class Mechanism : IJsonSerializable
 {
     /// <summary>
-    /// Keys found inside of the Exception Dictionary to inform if the exception was handled and which mechanism tracked it.
+    /// Key found inside of <c>Exception.Data</c> to inform if the exception was handled.
     /// </summary>
     public static readonly string HandledKey = "Sentry:Handled";
 
     /// <summary>
-    /// Key found inside of the Exception.Data to inform if the exception which mechanism tracked it.
+    /// Key found inside of <c>Exception.Data</c> to inform which mechanism captured the exception.
     /// </summary>
     public static readonly string MechanismKey = "Sentry:Mechanism";
+
+    /// <summary>
+    /// Key found inside of <c>Exception.Data</c> to provide a description of the mechanism.
+    /// </summary>
+    public static readonly string DescriptionKey = "Sentry:Description";
 
     internal Dictionary<string, object>? InternalData { get; private set; }
 

--- a/src/Sentry/Protocol/SentryException.cs
+++ b/src/Sentry/Protocol/SentryException.cs
@@ -44,13 +44,13 @@ public sealed class SentryException : IJsonSerializable
     public Mechanism? Mechanism { get; set; }
 
     /// <summary>
-    /// Arbitrary extra data that related to this error
+    /// Arbitrary extra data that is related to this error.
     /// </summary>
     /// <remarks>
-    /// The protocol does not yet support data at this level.
-    /// For this reason this property is not serialized.
-    /// The data is moved to the event level on Extra until such support is added
+    /// This property is obsolete and should no longer be used.
+    /// Anything added here will be ignored and not sent to Sentry.
     /// </remarks>
+    [Obsolete("Use SentryException.Mechanism.Data instead. This property will be removed in a future version.")]
     public IDictionary<string, object?> Data { get; } = new Dictionary<string, object?>(StringComparer.Ordinal);
 
     /// <inheritdoc />

--- a/src/Sentry/Protocol/SentryException.cs
+++ b/src/Sentry/Protocol/SentryException.cs
@@ -63,7 +63,11 @@ public sealed class SentryException : IJsonSerializable
         writer.WriteStringIfNotWhiteSpace("module", Module);
         writer.WriteNumberIfNotNull("thread_id", ThreadId.NullIfDefault());
         writer.WriteSerializableIfNotNull("stacktrace", Stacktrace, logger);
-        writer.WriteSerializableIfNotNull("mechanism", Mechanism, logger);
+
+        if (Mechanism?.IsDefaultOrEmpty() == false)
+        {
+            writer.WriteSerializableIfNotNull("mechanism", Mechanism, logger);
+        }
 
         writer.WriteEndObject();
     }
@@ -79,6 +83,11 @@ public sealed class SentryException : IJsonSerializable
         var threadId = json.GetPropertyOrNull("thread_id")?.GetInt32() ?? 0;
         var stacktrace = json.GetPropertyOrNull("stacktrace")?.Pipe(SentryStackTrace.FromJson);
         var mechanism = json.GetPropertyOrNull("mechanism")?.Pipe(Mechanism.FromJson);
+
+        if (mechanism?.IsDefaultOrEmpty() == true)
+        {
+            mechanism = null;
+        }
 
         return new SentryException
         {

--- a/src/Sentry/SentryExceptionExtensions.cs
+++ b/src/Sentry/SentryExceptionExtensions.cs
@@ -1,5 +1,6 @@
 using Sentry;
 using Sentry.Internal;
+using Sentry.Protocol;
 
 /// <summary>
 /// Extends Exception with formatted data that can be used by Sentry SDK.
@@ -8,13 +9,53 @@ using Sentry.Internal;
 public static class SentryExceptionExtensions
 {
     /// <summary>
-    /// Set a Sentry's Tag to the Exception.
+    /// Set a tag that will be added to the event when the exception is captured.
     /// </summary>
     /// <param name="ex">The exception.</param>
     /// <param name="name">The name of the tag.</param>
     /// <param name="value">The value of the key.</param>
     public static void AddSentryTag(this Exception ex, string name, string value)
         => ex.Data.Add($"{MainExceptionProcessor.ExceptionDataTagKey}{name}", value);
+
+    /// <summary>
+    /// Set context data that will be added to the event when the exception is captured.
+    /// </summary>
+    /// <param name="ex">The exception.</param>
+    /// <param name="name">The context name.</param>
+    /// <param name="data">The context data.</param>
+    public static void AddSentryContext(this Exception ex, string name, IReadOnlyDictionary<string, object> data)
+        => ex.Data.Add($"{MainExceptionProcessor.ExceptionDataContextKey}{name}", data);
+
+    /// <summary>
+    /// Set mechanism information that will be included with the exception when it is captured.
+    /// </summary>
+    /// <param name="ex">The exception.</param>
+    /// <param name="type">A required short string that identifies the mechanism.</param>
+    /// <param name="description">An optional human-readable description of the mechanism.</param>
+    /// <param name="handled">An optional flag indicating whether the exception was handled by the mechanism.</param>
+    public static void SetSentryMechanism(this Exception ex, string type, string? description = null,
+        bool? handled = null)
+    {
+        ex.Data[Mechanism.MechanismKey] = type;
+
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            ex.Data.Remove(Mechanism.DescriptionKey);
+        }
+        else
+        {
+            ex.Data[Mechanism.DescriptionKey] = description;
+        }
+
+        if (handled == null)
+        {
+            ex.Data.Remove(Mechanism.HandledKey);
+        }
+        else
+        {
+            ex.Data[Mechanism.HandledKey] = handled;
+        }
+    }
 
     /// <summary>
     /// Recursively enumerates all <see cref="AggregateException.InnerExceptions"/> and <see cref="Exception.InnerException"/>
@@ -51,13 +92,4 @@ public static class SentryExceptionExtensions
         return aggregateException.InnerExceptions
             .SelectMany(exception => exception.EnumerateChainedExceptions(options));
     }
-
-    /// <summary>
-    /// Set a Sentry's structured Context to the Exception.
-    /// </summary>
-    /// <param name="ex">The exception.</param>
-    /// <param name="name">The context name.</param>
-    /// <param name="data">The context data.</param>
-    public static void AddSentryContext(this Exception ex, string name, IReadOnlyDictionary<string, object> data)
-        => ex.Data.Add($"{MainExceptionProcessor.ExceptionDataContextKey}{name}", data);
 }

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.Core3_1.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.Core3_1.verified.txt
@@ -10,8 +10,7 @@
       SentryExceptions: [
         {
           Type: System.Exception,
-          Value: my exception,
-          Mechanism: {}
+          Value: my exception
         }
       ],
       Level: error,

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.DotNet6_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.DotNet6_0.verified.txt
@@ -10,8 +10,7 @@
       SentryExceptions: [
         {
           Type: System.Exception,
-          Value: my exception,
-          Mechanism: {}
+          Value: my exception
         }
       ],
       Level: error,

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.DotNet7_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.DotNet7_0.verified.txt
@@ -10,8 +10,7 @@
       SentryExceptions: [
         {
           Type: System.Exception,
-          Value: my exception,
-          Mechanism: {}
+          Value: my exception
         }
       ],
       Level: error,

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.Net4_8.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEf.Net4_8.verified.txt
@@ -10,8 +10,7 @@
       SentryExceptions: [
         {
           Type: System.Exception,
-          Value: my exception,
-          Mechanism: {}
+          Value: my exception
         }
       ],
       Level: error,

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsSql.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsSql.verified.txt
@@ -10,8 +10,7 @@
       SentryExceptions: [
         {
           Type: System.Exception,
-          Value: my exception,
-          Mechanism: {}
+          Value: my exception
         }
       ],
       Level: error,

--- a/test/Sentry.EntityFramework.Tests/IntegrationTests.Simple.verified.txt
+++ b/test/Sentry.EntityFramework.Tests/IntegrationTests.Simple.verified.txt
@@ -10,8 +10,7 @@
       SentryExceptions: [
         {
           Type: System.Exception,
-          Value: my exception,
-          Mechanism: {}
+          Value: my exception
         }
       ],
       Level: error,

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.Core3_1.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.Core3_1.verified.txt
@@ -49,8 +49,7 @@
                       FunctionId: ____
                     }
                   ]
-                },
-                Mechanism: {}
+                }
               }
             ],
             DebugImages: [

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.Core3_1.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.Core3_1.verified.txt
@@ -49,6 +49,11 @@
                       FunctionId: ____
                     }
                   ]
+                },
+                Mechanism: {
+                  Type: generic,
+                  Handled: true,
+                  Synthetic: false
                 }
               }
             ],

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
@@ -49,8 +49,7 @@
                       FunctionId: ____
                     }
                   ]
-                },
-                Mechanism: {}
+                }
               }
             ],
             DebugImages: [

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
@@ -49,6 +49,11 @@
                       FunctionId: ____
                     }
                   ]
+                },
+                Mechanism: {
+                  Type: generic,
+                  Handled: true,
+                  Synthetic: false
                 }
               }
             ],

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
@@ -49,8 +49,7 @@
                       FunctionId: ____
                     }
                   ]
-                },
-                Mechanism: {}
+                }
               }
             ],
             DebugImages: [

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
@@ -49,6 +49,11 @@
                       FunctionId: ____
                     }
                   ]
+                },
+                Mechanism: {
+                  Type: generic,
+                  Handled: true,
+                  Synthetic: false
                 }
               }
             ],

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.Mono4_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.Mono4_0.verified.txt
@@ -49,8 +49,7 @@
                       FunctionId: ____
                     }
                   ]
-                },
-                Mechanism: {}
+                }
               }
             ],
             DebugImages: [

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.Mono4_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.Mono4_0.verified.txt
@@ -49,6 +49,11 @@
                       FunctionId: ____
                     }
                   ]
+                },
+                Mechanism: {
+                  Type: generic,
+                  Handled: true,
+                  Synthetic: false
                 }
               }
             ],

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.Net4_8.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.Net4_8.verified.txt
@@ -49,8 +49,7 @@
                       FunctionId: ____
                     }
                   ]
-                },
-                Mechanism: {}
+                }
               }
             ],
             DebugImages: [

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.Net4_8.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.Net4_8.verified.txt
@@ -49,6 +49,11 @@
                       FunctionId: ____
                     }
                   ]
+                },
+                Mechanism: {
+                  Type: generic,
+                  Handled: true,
+                  Synthetic: false
                 }
               }
             ],

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Core3_1.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Core3_1.verified.txt
@@ -180,7 +180,6 @@
                     }
                   ]
                 },
-                Mechanism: {},
                 Data: {
                   details: Do work always throws.
                 }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Core3_1.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Core3_1.verified.txt
@@ -183,10 +183,10 @@
                 Mechanism: {
                   Type: generic,
                   Handled: true,
-                  Synthetic: false
-                },
-                Data: {
-                  details: Do work always throws.
+                  Synthetic: false,
+                  Data: {
+                    details: Do work always throws.
+                  }
                 }
               }
             ],
@@ -225,7 +225,6 @@
               }
             ],
             Extra: {
-              Exception[0][details]: Do work always throws.,
               inventory: { SmallPotion = 3, BigPotion = 0, CheeseWheels = 512 },
               MyTaskId: 42
             }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Core3_1.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Core3_1.verified.txt
@@ -180,6 +180,11 @@
                     }
                   ]
                 },
+                Mechanism: {
+                  Type: generic,
+                  Handled: true,
+                  Synthetic: false
+                },
                 Data: {
                   details: Do work always throws.
                 }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
@@ -180,7 +180,6 @@
                     }
                   ]
                 },
-                Mechanism: {},
                 Data: {
                   details: Do work always throws.
                 }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
@@ -183,10 +183,10 @@
                 Mechanism: {
                   Type: generic,
                   Handled: true,
-                  Synthetic: false
-                },
-                Data: {
-                  details: Do work always throws.
+                  Synthetic: false,
+                  Data: {
+                    details: Do work always throws.
+                  }
                 }
               }
             ],
@@ -225,7 +225,6 @@
               }
             ],
             Extra: {
-              Exception[0][details]: Do work always throws.,
               inventory: { SmallPotion = 3, BigPotion = 0, CheeseWheels = 512 },
               MyTaskId: 42
             }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
@@ -180,6 +180,11 @@
                     }
                   ]
                 },
+                Mechanism: {
+                  Type: generic,
+                  Handled: true,
+                  Synthetic: false
+                },
                 Data: {
                   details: Do work always throws.
                 }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
@@ -180,7 +180,6 @@
                     }
                   ]
                 },
-                Mechanism: {},
                 Data: {
                   details: Do work always throws.
                 }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
@@ -183,10 +183,10 @@
                 Mechanism: {
                   Type: generic,
                   Handled: true,
-                  Synthetic: false
-                },
-                Data: {
-                  details: Do work always throws.
+                  Synthetic: false,
+                  Data: {
+                    details: Do work always throws.
+                  }
                 }
               }
             ],
@@ -225,7 +225,6 @@
               }
             ],
             Extra: {
-              Exception[0][details]: Do work always throws.,
               inventory: { SmallPotion = 3, BigPotion = 0, CheeseWheels = 512 },
               MyTaskId: 42
             }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
@@ -180,6 +180,11 @@
                     }
                   ]
                 },
+                Mechanism: {
+                  Type: generic,
+                  Handled: true,
+                  Synthetic: false
+                },
                 Data: {
                   details: Do work always throws.
                 }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Mono4_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Mono4_0.verified.txt
@@ -180,7 +180,6 @@
                     }
                   ]
                 },
-                Mechanism: {},
                 Data: {
                   details: Do work always throws.
                 }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Mono4_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Mono4_0.verified.txt
@@ -183,10 +183,10 @@
                 Mechanism: {
                   Type: generic,
                   Handled: true,
-                  Synthetic: false
-                },
-                Data: {
-                  details: Do work always throws.
+                  Synthetic: false,
+                  Data: {
+                    details: Do work always throws.
+                  }
                 }
               }
             ],
@@ -225,7 +225,6 @@
               }
             ],
             Extra: {
-              Exception[0][details]: Do work always throws.,
               inventory: { SmallPotion = 3, BigPotion = 0, CheeseWheels = 512 },
               MyTaskId: 42
             }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Mono4_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Mono4_0.verified.txt
@@ -180,6 +180,11 @@
                     }
                   ]
                 },
+                Mechanism: {
+                  Type: generic,
+                  Handled: true,
+                  Synthetic: false
+                },
                 Data: {
                   details: Do work always throws.
                 }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Net4_8.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Net4_8.verified.txt
@@ -180,7 +180,6 @@
                     }
                   ]
                 },
-                Mechanism: {},
                 Data: {
                   details: Do work always throws.
                 }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Net4_8.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Net4_8.verified.txt
@@ -183,10 +183,10 @@
                 Mechanism: {
                   Type: generic,
                   Handled: true,
-                  Synthetic: false
-                },
-                Data: {
-                  details: Do work always throws.
+                  Synthetic: false,
+                  Data: {
+                    details: Do work always throws.
+                  }
                 }
               }
             ],
@@ -225,7 +225,6 @@
               }
             ],
             Extra: {
-              Exception[0][details]: Do work always throws.,
               inventory: { SmallPotion = 3, BigPotion = 0, CheeseWheels = 512 },
               MyTaskId: 42
             }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Net4_8.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.Net4_8.verified.txt
@@ -180,6 +180,11 @@
                     }
                   ]
                 },
+                Mechanism: {
+                  Type: generic,
+                  Handled: true,
+                  Synthetic: false
+                },
                 Data: {
                   details: Do work always throws.
                 }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1481,7 +1481,7 @@ namespace Sentry.Protocol
         public bool? Handled { get; set; }
         public string? HelpLink { get; set; }
         public System.Collections.Generic.IDictionary<string, object> Meta { get; }
-        public string? Type { get; set; }
+        public string Type { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Mechanism FromJson(System.Text.Json.JsonElement json) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1473,6 +1473,7 @@ namespace Sentry.Protocol
     }
     public sealed class Mechanism : Sentry.IJsonSerializable
     {
+        public static readonly string DescriptionKey;
         public static readonly string HandledKey;
         public static readonly string MechanismKey;
         public Mechanism() { }
@@ -1597,4 +1598,5 @@ public static class SentryExceptionExtensions
     public static void AddSentryContext(this System.Exception ex, string name, System.Collections.Generic.IReadOnlyDictionary<string, object> data) { }
     public static void AddSentryTag(this System.Exception ex, string name, string value) { }
     public static System.Collections.Generic.IEnumerable<System.Exception> EnumerateChainedExceptions(this System.Exception exception, Sentry.SentryOptions options) { }
+    public static void SetSentryMechanism(this System.Exception ex, string type, string? description = null, bool? handled = default) { }
 }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1481,6 +1481,7 @@ namespace Sentry.Protocol
         public bool? Handled { get; set; }
         public string? HelpLink { get; set; }
         public System.Collections.Generic.IDictionary<string, object> Meta { get; }
+        public bool Synthetic { get; set; }
         public string Type { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Mechanism FromJson(System.Text.Json.JsonElement json) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1516,6 +1516,8 @@ namespace Sentry.Protocol
     public sealed class SentryException : Sentry.IJsonSerializable
     {
         public SentryException() { }
+        [System.Obsolete("Use SentryException.Mechanism.Data instead. This property will be removed in a fu" +
+            "ture version.")]
         public System.Collections.Generic.IDictionary<string, object?> Data { get; }
         public Sentry.Protocol.Mechanism? Mechanism { get; set; }
         public string? Module { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1481,7 +1481,7 @@ namespace Sentry.Protocol
         public bool? Handled { get; set; }
         public string? HelpLink { get; set; }
         public System.Collections.Generic.IDictionary<string, object> Meta { get; }
-        public string? Type { get; set; }
+        public string Type { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Mechanism FromJson(System.Text.Json.JsonElement json) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1473,6 +1473,7 @@ namespace Sentry.Protocol
     }
     public sealed class Mechanism : Sentry.IJsonSerializable
     {
+        public static readonly string DescriptionKey;
         public static readonly string HandledKey;
         public static readonly string MechanismKey;
         public Mechanism() { }
@@ -1597,4 +1598,5 @@ public static class SentryExceptionExtensions
     public static void AddSentryContext(this System.Exception ex, string name, System.Collections.Generic.IReadOnlyDictionary<string, object> data) { }
     public static void AddSentryTag(this System.Exception ex, string name, string value) { }
     public static System.Collections.Generic.IEnumerable<System.Exception> EnumerateChainedExceptions(this System.Exception exception, Sentry.SentryOptions options) { }
+    public static void SetSentryMechanism(this System.Exception ex, string type, string? description = null, bool? handled = default) { }
 }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1481,6 +1481,7 @@ namespace Sentry.Protocol
         public bool? Handled { get; set; }
         public string? HelpLink { get; set; }
         public System.Collections.Generic.IDictionary<string, object> Meta { get; }
+        public bool Synthetic { get; set; }
         public string Type { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Mechanism FromJson(System.Text.Json.JsonElement json) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1516,6 +1516,8 @@ namespace Sentry.Protocol
     public sealed class SentryException : Sentry.IJsonSerializable
     {
         public SentryException() { }
+        [System.Obsolete("Use SentryException.Mechanism.Data instead. This property will be removed in a fu" +
+            "ture version.")]
         public System.Collections.Generic.IDictionary<string, object?> Data { get; }
         public Sentry.Protocol.Mechanism? Mechanism { get; set; }
         public string? Module { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1481,7 +1481,7 @@ namespace Sentry.Protocol
         public bool? Handled { get; set; }
         public string? HelpLink { get; set; }
         public System.Collections.Generic.IDictionary<string, object> Meta { get; }
-        public string? Type { get; set; }
+        public string Type { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Mechanism FromJson(System.Text.Json.JsonElement json) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1473,6 +1473,7 @@ namespace Sentry.Protocol
     }
     public sealed class Mechanism : Sentry.IJsonSerializable
     {
+        public static readonly string DescriptionKey;
         public static readonly string HandledKey;
         public static readonly string MechanismKey;
         public Mechanism() { }
@@ -1597,4 +1598,5 @@ public static class SentryExceptionExtensions
     public static void AddSentryContext(this System.Exception ex, string name, System.Collections.Generic.IReadOnlyDictionary<string, object> data) { }
     public static void AddSentryTag(this System.Exception ex, string name, string value) { }
     public static System.Collections.Generic.IEnumerable<System.Exception> EnumerateChainedExceptions(this System.Exception exception, Sentry.SentryOptions options) { }
+    public static void SetSentryMechanism(this System.Exception ex, string type, string? description = null, bool? handled = default) { }
 }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1481,6 +1481,7 @@ namespace Sentry.Protocol
         public bool? Handled { get; set; }
         public string? HelpLink { get; set; }
         public System.Collections.Generic.IDictionary<string, object> Meta { get; }
+        public bool Synthetic { get; set; }
         public string Type { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Mechanism FromJson(System.Text.Json.JsonElement json) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1516,6 +1516,8 @@ namespace Sentry.Protocol
     public sealed class SentryException : Sentry.IJsonSerializable
     {
         public SentryException() { }
+        [System.Obsolete("Use SentryException.Mechanism.Data instead. This property will be removed in a fu" +
+            "ture version.")]
         public System.Collections.Generic.IDictionary<string, object?> Data { get; }
         public Sentry.Protocol.Mechanism? Mechanism { get; set; }
         public string? Module { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -1481,7 +1481,7 @@ namespace Sentry.Protocol
         public bool? Handled { get; set; }
         public string? HelpLink { get; set; }
         public System.Collections.Generic.IDictionary<string, object> Meta { get; }
-        public string? Type { get; set; }
+        public string Type { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Mechanism FromJson(System.Text.Json.JsonElement json) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -1473,6 +1473,7 @@ namespace Sentry.Protocol
     }
     public sealed class Mechanism : Sentry.IJsonSerializable
     {
+        public static readonly string DescriptionKey;
         public static readonly string HandledKey;
         public static readonly string MechanismKey;
         public Mechanism() { }
@@ -1597,4 +1598,5 @@ public static class SentryExceptionExtensions
     public static void AddSentryContext(this System.Exception ex, string name, System.Collections.Generic.IReadOnlyDictionary<string, object> data) { }
     public static void AddSentryTag(this System.Exception ex, string name, string value) { }
     public static System.Collections.Generic.IEnumerable<System.Exception> EnumerateChainedExceptions(this System.Exception exception, Sentry.SentryOptions options) { }
+    public static void SetSentryMechanism(this System.Exception ex, string type, string? description = null, bool? handled = default) { }
 }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -1481,6 +1481,7 @@ namespace Sentry.Protocol
         public bool? Handled { get; set; }
         public string? HelpLink { get; set; }
         public System.Collections.Generic.IDictionary<string, object> Meta { get; }
+        public bool Synthetic { get; set; }
         public string Type { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Mechanism FromJson(System.Text.Json.JsonElement json) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -1516,6 +1516,8 @@ namespace Sentry.Protocol
     public sealed class SentryException : Sentry.IJsonSerializable
     {
         public SentryException() { }
+        [System.Obsolete("Use SentryException.Mechanism.Data instead. This property will be removed in a fu" +
+            "ture version.")]
         public System.Collections.Generic.IDictionary<string, object?> Data { get; }
         public Sentry.Protocol.Mechanism? Mechanism { get; set; }
         public string? Module { get; set; }

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.Core3_1.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.Core3_1.verified.txt
@@ -40,7 +40,8 @@
               {
                 Mechanism: {
                   Type: generic,
-                  Handled: false
+                  Handled: false,
+                  Synthetic: false
                 }
               }
             ],

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.Core3_1.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.Core3_1.verified.txt
@@ -39,6 +39,7 @@
             SentryExceptions: [
               {
                 Mechanism: {
+                  Type: generic,
                   Handled: false
                 }
               }

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet6_0.verified.txt
@@ -40,7 +40,8 @@
               {
                 Mechanism: {
                   Type: generic,
-                  Handled: false
+                  Handled: false,
+                  Synthetic: false
                 }
               }
             ],

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet6_0.verified.txt
@@ -39,6 +39,7 @@
             SentryExceptions: [
               {
                 Mechanism: {
+                  Type: generic,
                   Handled: false
                 }
               }

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet7_0.verified.txt
@@ -40,7 +40,8 @@
               {
                 Mechanism: {
                   Type: generic,
-                  Handled: false
+                  Handled: false,
+                  Synthetic: false
                 }
               }
             ],

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet7_0.verified.txt
@@ -39,6 +39,7 @@
             SentryExceptions: [
               {
                 Mechanism: {
+                  Type: generic,
                   Handled: false
                 }
               }

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.Mono4_0.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.Mono4_0.verified.txt
@@ -40,7 +40,8 @@
               {
                 Mechanism: {
                   Type: generic,
-                  Handled: false
+                  Handled: false,
+                  Synthetic: false
                 }
               }
             ],

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.Mono4_0.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.Mono4_0.verified.txt
@@ -39,6 +39,7 @@
             SentryExceptions: [
               {
                 Mechanism: {
+                  Type: generic,
                   Handled: false
                 }
               }

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.Net4_8.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.Net4_8.verified.txt
@@ -40,7 +40,8 @@
               {
                 Mechanism: {
                   Type: generic,
-                  Handled: false
+                  Handled: false,
+                  Synthetic: false
                 }
               }
             ],

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.Net4_8.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.Net4_8.verified.txt
@@ -39,6 +39,7 @@
             SentryExceptions: [
               {
                 Mechanism: {
+                  Type: generic,
                   Handled: false
                 }
               }

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate.verified.txt
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate.verified.txt
@@ -9,10 +9,10 @@
     Mechanism: {
       Type: AppDomain.UnhandledException,
       Handled: false,
-      Synthetic: false
-    },
-    Data: {
-      foo: bar
+      Synthetic: false,
+      Data: {
+        foo: bar
+      }
     }
   }
 ]

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate.verified.txt
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate.verified.txt
@@ -1,8 +1,7 @@
 [
   {
     Type: System.Exception,
-    Value: Inner message1,
-    Mechanism: {}
+    Value: Inner message1
   },
   {
     Type: System.Exception,

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate.verified.txt
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate.verified.txt
@@ -8,7 +8,8 @@
     Value: Inner message2,
     Mechanism: {
       Type: AppDomain.UnhandledException,
-      Handled: false
+      Handled: false,
+      Synthetic: false
     },
     Data: {
       foo: bar

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate_Keep.verified.txt
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate_Keep.verified.txt
@@ -13,10 +13,10 @@
     Mechanism: {
       Type: AppDomain.UnhandledException,
       Handled: false,
-      Synthetic: false
-    },
-    Data: {
-      foo: bar
+      Synthetic: false,
+      Data: {
+        foo: bar
+      }
     }
   }
 ]

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate_Keep.verified.txt
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate_Keep.verified.txt
@@ -12,7 +12,8 @@
     Value: ,
     Mechanism: {
       Type: AppDomain.UnhandledException,
-      Handled: false
+      Handled: false,
+      Synthetic: false
     },
     Data: {
       foo: bar

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate_Keep.verified.txt
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate_Keep.verified.txt
@@ -1,13 +1,11 @@
 [
   {
     Type: System.Exception,
-    Value: Inner message1,
-    Mechanism: {}
+    Value: Inner message1
   },
   {
     Type: System.Exception,
-    Value: Inner message2,
-    Mechanism: {}
+    Value: Inner message2
   },
   {
     Type: System.AggregateException,

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
@@ -116,7 +116,7 @@ public partial class MainExceptionProcessorTests
 
         sut.Process(exp, evt);
 
-        _ = Assert.Single(evt.SentryExceptions!.Where(p => p.Mechanism!.Handled == null));
+        Assert.Single(evt.SentryExceptions!.Where(p => p.Mechanism?.Handled == null));
     }
 
     [Fact]
@@ -131,7 +131,7 @@ public partial class MainExceptionProcessorTests
 
         sut.Process(exp, evt);
 
-        _ = Assert.Single(evt.SentryExceptions!.Where(p => p.Mechanism!.Handled == true));
+        Assert.Single(evt.SentryExceptions!.Where(p => p.Mechanism?.Handled == true));
     }
 
     [Fact]

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
@@ -120,6 +120,20 @@ public partial class MainExceptionProcessorTests
     }
 
     [Fact]
+    public void Process_ExceptionWith_HandledFalse()
+    {
+        var sut = _fixture.GetSut();
+        var evt = new SentryEvent();
+        var exp = new Exception();
+
+        exp.Data.Add(Mechanism.HandledKey, false);
+
+        sut.Process(exp, evt);
+
+        Assert.Single(evt.SentryExceptions!.Where(p => p.Mechanism?.Handled == false));
+    }
+
+    [Fact]
     public void Process_ExceptionWith_HandledTrue()
     {
         var sut = _fixture.GetSut();
@@ -127,7 +141,18 @@ public partial class MainExceptionProcessorTests
         var exp = new Exception();
 
         exp.Data.Add(Mechanism.HandledKey, true);
-        exp.Data.Add(Mechanism.MechanismKey, "Process_ExceptionWith_HandledTrue");
+
+        sut.Process(exp, evt);
+
+        Assert.Single(evt.SentryExceptions!.Where(p => p.Mechanism?.Handled == true));
+    }
+
+    [Fact]
+    public void Process_ExceptionWith_HandledTrue_WhenCaught()
+    {
+        var sut = _fixture.GetSut();
+        var evt = new SentryEvent();
+        var exp = GetHandledException();
 
         sut.Process(exp, evt);
 
@@ -330,5 +355,15 @@ public partial class MainExceptionProcessorTests
         Assert.Single(evt.Extra, expectedData2);
     }
 
-    // TODO: Test when the approach for parsing is finalized
+    private Exception GetHandledException()
+    {
+        try
+        {
+            throw new Exception();
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+    }
 }

--- a/test/Sentry.Tests/Protocol/Exceptions/MechanismTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/MechanismTests.cs
@@ -17,7 +17,7 @@ public class MechanismTests
             Type = "mechanism type",
             Description = "mechanism description",
             Handled = true,
-            HelpLink = "https://helplink",
+            HelpLink = "https://helplink"
         };
 
         sut.Data.Add("data-key", "data-value");
@@ -25,14 +25,15 @@ public class MechanismTests
 
         var actual = sut.ToJsonString(_testOutputLogger);
 
-        Assert.Equal(
-            "{\"data\":{\"data-key\":\"data-value\"}," +
-            "\"meta\":{\"meta-key\":\"meta-value\"}," +
-            "\"type\":\"mechanism type\"," +
+        const string expected =
+            "{\"type\":\"mechanism type\"," +
             "\"description\":\"mechanism description\"," +
             "\"help_link\":\"https://helplink\"," +
-            "\"handled\":true}",
-            actual);
+            "\"handled\":true," +
+            "\"data\":{\"data-key\":\"data-value\"}," +
+            "\"meta\":{\"meta-key\":\"meta-value\"}}";
+
+        Assert.Equal(expected, actual);
     }
 
     [Theory]
@@ -46,14 +47,14 @@ public class MechanismTests
 
     public static IEnumerable<object[]> TestCases()
     {
-        yield return new object[] { (new Mechanism(), "{}") };
+        yield return new object[] { (new Mechanism(), "{\"type\":\"generic\"}") };
         yield return new object[] { (new Mechanism { Type = "some type" }, "{\"type\":\"some type\"}") };
-        yield return new object[] { (new Mechanism { Handled = false }, "{\"handled\":false}") };
-        yield return new object[] { (new Mechanism { HelpLink = "https://sentry.io/docs" }, "{\"help_link\":\"https://sentry.io/docs\"}") };
-        yield return new object[] { (new Mechanism { Description = "some desc" }, "{\"description\":\"some desc\"}") };
+        yield return new object[] { (new Mechanism { Handled = false }, "{\"type\":\"generic\",\"handled\":false}") };
+        yield return new object[] { (new Mechanism { HelpLink = "https://sentry.io/docs" }, "{\"type\":\"generic\",\"help_link\":\"https://sentry.io/docs\"}") };
+        yield return new object[] { (new Mechanism { Description = "some desc" }, "{\"type\":\"generic\",\"description\":\"some desc\"}") };
         yield return new object[] { (new Mechanism { Data = { new KeyValuePair<string, object>("data-key", "data-value") } },
-            "{\"data\":{\"data-key\":\"data-value\"}}") };
+            "{\"type\":\"generic\",\"data\":{\"data-key\":\"data-value\"}}") };
         yield return new object[] { (new Mechanism { Meta = { new KeyValuePair<string, object>("meta-key", "meta-value") } },
-            "{\"meta\":{\"meta-key\":\"meta-value\"}}") };
+            "{\"type\":\"generic\",\"meta\":{\"meta-key\":\"meta-value\"}}") };
     }
 }

--- a/test/Sentry.Tests/Protocol/Exceptions/MechanismTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/MechanismTests.cs
@@ -17,6 +17,7 @@ public class MechanismTests
             Type = "mechanism type",
             Description = "mechanism description",
             Handled = true,
+            Synthetic = true,
             HelpLink = "https://helplink"
         };
 
@@ -30,6 +31,7 @@ public class MechanismTests
             "\"description\":\"mechanism description\"," +
             "\"help_link\":\"https://helplink\"," +
             "\"handled\":true," +
+            "\"synthetic\":true," +
             "\"data\":{\"data-key\":\"data-value\"}," +
             "\"meta\":{\"meta-key\":\"meta-value\"}}";
 
@@ -50,6 +52,7 @@ public class MechanismTests
         yield return new object[] { (new Mechanism(), "{\"type\":\"generic\"}") };
         yield return new object[] { (new Mechanism { Type = "some type" }, "{\"type\":\"some type\"}") };
         yield return new object[] { (new Mechanism { Handled = false }, "{\"type\":\"generic\",\"handled\":false}") };
+        yield return new object[] { (new Mechanism { Synthetic = true }, "{\"type\":\"generic\",\"synthetic\":true}") };
         yield return new object[] { (new Mechanism { HelpLink = "https://sentry.io/docs" }, "{\"type\":\"generic\",\"help_link\":\"https://sentry.io/docs\"}") };
         yield return new object[] { (new Mechanism { Description = "some desc" }, "{\"type\":\"generic\",\"description\":\"some desc\"}") };
         yield return new object[] { (new Mechanism { Data = { new KeyValuePair<string, object>("data-key", "data-value") } },

--- a/test/Sentry.Tests/Protocol/Exceptions/MechanismTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/MechanismTests.cs
@@ -52,6 +52,7 @@ public class MechanismTests
         yield return new object[] { (new Mechanism(), "{\"type\":\"generic\"}") };
         yield return new object[] { (new Mechanism { Type = "some type" }, "{\"type\":\"some type\"}") };
         yield return new object[] { (new Mechanism { Handled = false }, "{\"type\":\"generic\",\"handled\":false}") };
+        yield return new object[] { (new Mechanism { Handled = true }, "{\"type\":\"generic\",\"handled\":true}") };
         yield return new object[] { (new Mechanism { Synthetic = true }, "{\"type\":\"generic\",\"synthetic\":true}") };
         yield return new object[] { (new Mechanism { HelpLink = "https://sentry.io/docs" }, "{\"type\":\"generic\",\"help_link\":\"https://sentry.io/docs\"}") };
         yield return new object[] { (new Mechanism { Description = "some desc" }, "{\"type\":\"generic\",\"description\":\"some desc\"}") };

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryExceptionTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryExceptionTests.cs
@@ -25,7 +25,6 @@ public class SentryExceptionTests
                     FileName = "FileName"
                 }}
             },
-            Data = { new KeyValuePair<string, object>("data-key", "data-value") },
             Mechanism = new Mechanism
             {
                 Description = "Description"
@@ -42,12 +41,5 @@ public class SentryExceptionTests
             "\"stacktrace\":{\"frames\":[{\"filename\":\"FileName\"}]}," +
             "\"mechanism\":{\"type\":\"generic\",\"description\":\"Description\"}}",
             actual);
-    }
-
-    [Fact]
-    public void Data_Getter_NotNull()
-    {
-        var sut = new SentryException();
-        Assert.NotNull(sut.Data);
     }
 }

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryExceptionTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryExceptionTests.cs
@@ -40,7 +40,7 @@ public class SentryExceptionTests
             "\"module\":\"Module\"," +
             "\"thread_id\":1," +
             "\"stacktrace\":{\"frames\":[{\"filename\":\"FileName\"}]}," +
-            "\"mechanism\":{\"description\":\"Description\"}}",
+            "\"mechanism\":{\"type\":\"generic\",\"description\":\"Description\"}}",
             actual);
     }
 


### PR DESCRIPTION
This PR address several items related to the [`exception.mechanism`](https://develop.sentry.dev/sdk/event-payloads/exception/#exception-mechanism) data sent to Sentry.

- Prevents an empty mechanism.  Either `exception.mechanism` is omitted, or the `exception.mechanism.type` field will be set.  Defaults the mechanism type to `"generic"` when not set by another method.
  Fixes #2288.
- Moves extra data added to `System.Exception.Data` to the `exception.mechanism.data` collection, instead of placing it in `exception.extra`.  This places it near the exception in the issue details page, and renders it correctly.
  Fixes #2289.
- Adds descriptions to exception mechanisms for built-in integrations, and a new `SetSentryMechanism` extension method for convenience. Also adds a property for the `synthetic` field.  Omits it unless true.  The default is false.
  Fixes #2290.
- Sets `exception.mechanism.handled` to `true` in the case of an exception that was thrown, caught, and manually captured.  As an example:

  ```csharp
  try
  {
      // ... something that throws an exception
  }
  catch (Exception ex)
  {
      // this will now be correctly marked as handled:true
      SentrySdk.CaptureException(ex);
  }
  ```

  Fixes #1480. 