### PR TITLE
Buffer payloads asynchronously when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Buffer payloads asynchronously when appropriate ([#2297](https://github.com/getsentry/sentry-dotnet/pull/2297))
+
 ## 3.30.0
 
 ### Features

--- a/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
@@ -76,6 +76,27 @@ public sealed class EnvelopeItem : ISerializable, IDisposable
     /// <returns>The file name or null.</returns>
     public string? TryGetFileName() => Header.GetValueOrDefault(FileNameKey) as string;
 
+    private async Task<MemoryStream> BufferPayloadAsync(IDiagnosticLogger? logger, CancellationToken cancellationToken)
+    {
+        var buffer = new MemoryStream();
+
+        if (Payload is JsonSerializable jsonSerializable)
+        {
+            // There's no advantage to buffer fully-materialized in-memory objects asynchronously,
+            // and there's some minor overhead in doing so.  Thus we will serialize synchronously.
+
+            // ReSharper disable once MethodHasAsyncOverloadWithCancellation
+            jsonSerializable.Serialize(buffer, logger);
+        }
+        else
+        {
+            await Payload.SerializeAsync(buffer, logger, cancellationToken).ConfigureAwait(false);
+        }
+
+        buffer.Seek(0, SeekOrigin.Begin);
+        return buffer;
+    }
+
     private MemoryStream BufferPayload(IDiagnosticLogger? logger)
     {
         var buffer = new MemoryStream();
@@ -117,9 +138,7 @@ public sealed class EnvelopeItem : ISerializable, IDisposable
         // in item headers. Don't trust any previously calculated value to be correct.
         // See https://github.com/getsentry/sentry-dotnet/issues/1956
 
-        // NOTE: Previously we used BufferPayloadAsync, but since we buffer from in-memory objects to a MemoryStream
-        // there's no advantage to doing so asynchronously.  We will get better perf from a synchronous approach.
-        var payloadBuffer = BufferPayload(logger);
+        var payloadBuffer = await BufferPayloadAsync(logger, cancellationToken).ConfigureAwait(false);
 #if NETFRAMEWORK || NETSTANDARD2_0
         using (payloadBuffer)
 #else


### PR DESCRIPTION
During serialization, we buffer payloads of `EnvelopeItems` into memory so we can calculate lengths to include in headers.

As part of #1965 (released in 3.22.0), I switched to synchronous buffering of these payloads - because serialization of a fully materialized object to a `MemoryStream` gains no advantage by being async, and doing so adds some minor overhead.

That is still true, however I didn't consider that not all payloads are fully materialized.  In particular, a `StreamSerializable` could be representing an attachment, in which case it would be reading from a `FileStream` or any other type of `Stream` (depending on how it was attached).  Also, we may need other types of async materialization in the future.

Thus, we should defer to synchronous buffering only when we _know_ the object is fully materialized - which is what our `JsonSerializable` class represents.