### PR TITLE
Improve `WithScope` and add `WithScopeAsync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Initial work to support profiling in a future release. ([#2206](https://github.com/getsentry/sentry-dotnet/pull/2206))
+- Improve `WithScope` and add `WithScopeAsync` ([#2303](https://github.com/getsentry/sentry-dotnet/pull/2303))
 
 ### Fixes
 

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -61,8 +61,6 @@ public sealed class HubAdapter : IHub
     /// <summary>
     /// Forwards the call to <see cref="SentrySdk"/>.
     /// </summary>
-    [Obsolete("This method is deprecated in favor of overloads of CaptureEvent, CaptureMessage and CaptureException " +
-              "that provide a callback to a configurable scope.")]
     [DebuggerStepThrough]
     public void WithScope(Action<Scope> scopeCallback)
         => SentrySdk.WithScope(scopeCallback);

--- a/src/Sentry/ISentryScopeManager.cs
+++ b/src/Sentry/ISentryScopeManager.cs
@@ -44,7 +44,7 @@ public interface ISentryScopeManager
     IDisposable PushScope<TState>(TState state);
 
     /// <summary>
-    /// Runs the callback with a new scope which gets dropped at the end.
+    /// Runs the callback within a new scope.
     /// </summary>
     /// <remarks>
     /// Pushes a new scope, runs the callback, then pops the scope. Use this when you have significant work to

--- a/src/Sentry/ISentryScopeManager.cs
+++ b/src/Sentry/ISentryScopeManager.cs
@@ -47,7 +47,9 @@ public interface ISentryScopeManager
     /// Runs the callback with a new scope which gets dropped at the end.
     /// </summary>
     /// <remarks>
-    /// Pushes a new scope, runs the callback, pops the scope.
+    /// Pushes a new scope, runs the callback, then pops the scope. Use this when you have significant work to
+    /// perform within an isolated scope.  If you just need to configure scope for a single event, use the overloads
+    /// of CaptureEvent, CaptureMessage and CaptureException that provide a callback to a configurable scope.
     /// </remarks>
     /// <see href="https://docs.sentry.io/platforms/dotnet/enriching-events/scopes/#local-scopes"/>
     /// <param name="scopeCallback">The callback to run with the one time scope.</param>

--- a/src/Sentry/Internal/IInternalScopeManager.cs
+++ b/src/Sentry/Internal/IInternalScopeManager.cs
@@ -6,4 +6,9 @@ internal interface IInternalScopeManager : ISentryScopeManager, IDisposable
 {
     KeyValuePair<Scope, ISentryClient> GetCurrent();
     IScopeStackContainer ScopeStackContainer { get; }
+
+    // TODO: Move The following to ISentryScopeManager in a future major version.
+    T? WithScope<T>(Func<Scope, T?> scopeCallback);
+    Task WithScopeAsync(Func<Scope, Task> scopeCallback);
+    Task<T?> WithScopeAsync<T>(Func<Scope, Task<T?>> scopeCallback);
 }

--- a/src/Sentry/Internal/SentryScopeManager.cs
+++ b/src/Sentry/Internal/SentryScopeManager.cs
@@ -115,7 +115,7 @@ internal sealed class SentryScopeManager : IInternalScopeManager
         using (PushScope())
         {
             var scope = GetCurrent();
-            await scopeCallback.Invoke(scope.Key);
+            await scopeCallback.Invoke(scope.Key).ConfigureAwait(false);
         }
     }
 
@@ -124,7 +124,7 @@ internal sealed class SentryScopeManager : IInternalScopeManager
         using (PushScope())
         {
             var scope = GetCurrent();
-            return await scopeCallback.Invoke(scope.Key);
+            return await scopeCallback.Invoke(scope.Key).ConfigureAwait(false);
         }
     }
 

--- a/src/Sentry/Internal/SentryScopeManager.cs
+++ b/src/Sentry/Internal/SentryScopeManager.cs
@@ -101,6 +101,33 @@ internal sealed class SentryScopeManager : IInternalScopeManager
         }
     }
 
+    public T? WithScope<T>(Func<Scope, T?> scopeCallback)
+    {
+        using (PushScope())
+        {
+            var scope = GetCurrent();
+            return scopeCallback.Invoke(scope.Key);
+        }
+    }
+
+    public async Task WithScopeAsync(Func<Scope, Task> scopeCallback)
+    {
+        using (PushScope())
+        {
+            var scope = GetCurrent();
+            await scopeCallback.Invoke(scope.Key);
+        }
+    }
+
+    public async Task<T?> WithScopeAsync<T>(Func<Scope, Task<T?>> scopeCallback)
+    {
+        using (PushScope())
+        {
+            var scope = GetCurrent();
+            return await scopeCallback.Invoke(scope.Key);
+        }
+    }
+
     public void BindClient(ISentryClient? client)
     {
         _options.LogDebug("Binding a new client to the current scope.");

--- a/src/Sentry/SentryScopeManagerExtensions.cs
+++ b/src/Sentry/SentryScopeManagerExtensions.cs
@@ -9,7 +9,7 @@ namespace Sentry;
 public static class SentryScopeManagerExtensions
 {
     /// <summary>
-    /// Runs the callback with a new scope which gets dropped at the end.
+    /// Runs the callback within a new scope.
     /// </summary>
     /// <remarks>
     /// Pushes a new scope, runs the callback, then pops the scope. Use this when you have significant work to
@@ -30,7 +30,7 @@ public static class SentryScopeManagerExtensions
         };
 
     /// <summary>
-    /// Runs the asynchronous callback with a new scope which gets dropped at the end.
+    /// Runs the asynchronous callback within a new scope.
     /// </summary>
     /// <remarks>
     /// Asynchronous version of <see cref="ISentryScopeManager.WithScope"/>.
@@ -52,7 +52,7 @@ public static class SentryScopeManagerExtensions
         };
 
     /// <summary>
-    /// Runs the asynchronous callback with a new scope which gets dropped at the end.
+    /// Runs the asynchronous callback within a new scope.
     /// </summary>
     /// <remarks>
     /// Asynchronous version of <see cref="ISentryScopeManager.WithScope"/>.

--- a/src/Sentry/SentryScopeManagerExtensions.cs
+++ b/src/Sentry/SentryScopeManagerExtensions.cs
@@ -1,0 +1,75 @@
+using Sentry.Internal;
+
+namespace Sentry;
+
+/// <summary>
+/// Extension methods for <see cref="ISentryScopeManager"/>.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class SentryScopeManagerExtensions
+{
+    /// <summary>
+    /// Runs the callback with a new scope which gets dropped at the end.
+    /// </summary>
+    /// <remarks>
+    /// Pushes a new scope, runs the callback, then pops the scope. Use this when you have significant work to
+    /// perform within an isolated scope.  If you just need to configure scope for a single event, use the overloads
+    /// of CaptureEvent, CaptureMessage and CaptureException that provide a callback to a configurable scope.
+    /// </remarks>
+    /// <see href="https://docs.sentry.io/platforms/dotnet/enriching-events/scopes/#local-scopes"/>
+    /// <param name="scopeManager">The scope manager (usually the hub).</param>
+    /// <param name="scopeCallback">The callback to run with the one time scope.</param>
+    /// <returns>The result from the callback.</returns>
+    [DebuggerStepThrough]
+    public static T? WithScope<T>(this ISentryScopeManager scopeManager, Func<Scope, T?> scopeCallback) =>
+        scopeManager switch
+        {
+            Hub hub => hub.ScopeManager.WithScope(scopeCallback),
+            IInternalScopeManager manager => manager.WithScope(scopeCallback),
+            _ => default
+        };
+
+    /// <summary>
+    /// Runs the asynchronous callback with a new scope which gets dropped at the end.
+    /// </summary>
+    /// <remarks>
+    /// Asynchronous version of <see cref="ISentryScopeManager.WithScope"/>.
+    /// Pushes a new scope, runs the callback, then pops the scope. Use this when you have significant work to
+    /// perform within an isolated scope.  If you just need to configure scope for a single event, use the overloads
+    /// of CaptureEvent, CaptureMessage and CaptureException that provide a callback to a configurable scope.
+    /// </remarks>
+    /// <see href="https://docs.sentry.io/platforms/dotnet/enriching-events/scopes/#local-scopes"/>
+    /// <param name="scopeManager">The scope manager (usually the hub).</param>
+    /// <param name="scopeCallback">The callback to run with the one time scope.</param>
+    /// <returns>An async task to await the callback.</returns>
+    [DebuggerStepThrough]
+    public static Task WithScopeAsync(this ISentryScopeManager scopeManager, Func<Scope, Task> scopeCallback) =>
+        scopeManager switch
+        {
+            Hub hub => hub.ScopeManager.WithScopeAsync(scopeCallback),
+            IInternalScopeManager manager => manager.WithScopeAsync(scopeCallback),
+            _ => Task.CompletedTask
+        };
+
+    /// <summary>
+    /// Runs the asynchronous callback with a new scope which gets dropped at the end.
+    /// </summary>
+    /// <remarks>
+    /// Asynchronous version of <see cref="ISentryScopeManager.WithScope"/>.
+    /// Pushes a new scope, runs the callback, then pops the scope. Use this when you have significant work to
+    /// perform within an isolated scope.  If you just need to configure scope for a single event, use the overloads
+    /// of CaptureEvent, CaptureMessage and CaptureException that provide a callback to a configurable scope.
+    /// </remarks>
+    /// <see href="https://docs.sentry.io/platforms/dotnet/enriching-events/scopes/#local-scopes"/>
+    /// <param name="scopeManager">The scope manager (usually the hub).</param>
+    /// <param name="scopeCallback">The callback to run with the one time scope.</param>
+    /// <returns>An async task to await the result of the callback.</returns>
+    [DebuggerStepThrough]
+    public static Task<T?> WithScopeAsync<T>(this ISentryScopeManager scopeManager, Func<Scope, Task<T?>> scopeCallback) =>
+        scopeManager switch
+        {
+            Hub hub => hub.ScopeManager.WithScopeAsync(scopeCallback),
+            IInternalScopeManager manager => manager.WithScopeAsync(scopeCallback),
+            _ => Task.FromResult(default(T))
+        };
+}

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -272,7 +272,7 @@ public static partial class SentrySdk
         => CurrentHub.AddBreadcrumb(clock, message, category, type, data, level);
 
     /// <summary>
-    /// Runs the callback with a new scope which gets dropped at the end.
+    /// Runs the callback within a new scope.
     /// </summary>
     /// <remarks>
     /// Pushes a new scope, runs the callback, then pops the scope. Use this when you have significant work to
@@ -286,7 +286,7 @@ public static partial class SentrySdk
         => CurrentHub.WithScope(scopeCallback);
 
     /// <summary>
-    /// Runs the callback with a new scope which gets dropped at the end.
+    /// Runs the callback within a new scope.
     /// </summary>
     /// <remarks>
     /// Pushes a new scope, runs the callback, then pops the scope. Use this when you have significant work to
@@ -301,7 +301,7 @@ public static partial class SentrySdk
         => CurrentHub.WithScope(scopeCallback);
 
     /// <summary>
-    /// Runs the asynchronous callback with a new scope which gets dropped at the end.
+    /// Runs the asynchronous callback within a new scope.
     /// </summary>
     /// <remarks>
     /// Asynchronous version of <see cref="ISentryScopeManager.WithScope"/>.
@@ -317,7 +317,7 @@ public static partial class SentrySdk
         => CurrentHub.WithScopeAsync(scopeCallback);
 
     /// <summary>
-    /// Runs the asynchronous callback with a new scope which gets dropped at the end.
+    /// Runs the asynchronous callback within a new scope.
     /// </summary>
     /// <remarks>
     /// Asynchronous version of <see cref="ISentryScopeManager.WithScope"/>.

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -275,13 +275,62 @@ public static partial class SentrySdk
     /// Runs the callback with a new scope which gets dropped at the end.
     /// </summary>
     /// <remarks>
-    /// Pushes a new scope, runs the callback, pops the scope.
+    /// Pushes a new scope, runs the callback, then pops the scope. Use this when you have significant work to
+    /// perform within an isolated scope.  If you just need to configure scope for a single event, use the overloads
+    /// of CaptureEvent, CaptureMessage and CaptureException that provide a callback to a configurable scope.
     /// </remarks>
     /// <see href="https://docs.sentry.io/platforms/dotnet/enriching-events/scopes/#local-scopes"/>
     /// <param name="scopeCallback">The callback to run with the one time scope.</param>
     [DebuggerStepThrough]
     public static void WithScope(Action<Scope> scopeCallback)
         => CurrentHub.WithScope(scopeCallback);
+
+    /// <summary>
+    /// Runs the callback with a new scope which gets dropped at the end.
+    /// </summary>
+    /// <remarks>
+    /// Pushes a new scope, runs the callback, then pops the scope. Use this when you have significant work to
+    /// perform within an isolated scope.  If you just need to configure scope for a single event, use the overloads
+    /// of CaptureEvent, CaptureMessage and CaptureException that provide a callback to a configurable scope.
+    /// </remarks>
+    /// <see href="https://docs.sentry.io/platforms/dotnet/enriching-events/scopes/#local-scopes"/>
+    /// <param name="scopeCallback">The callback to run with the one time scope.</param>
+    /// <returns>The result from the callback.</returns>
+    [DebuggerStepThrough]
+    public static T? WithScope<T>(Func<Scope, T?> scopeCallback)
+        => CurrentHub.WithScope(scopeCallback);
+
+    /// <summary>
+    /// Runs the asynchronous callback with a new scope which gets dropped at the end.
+    /// </summary>
+    /// <remarks>
+    /// Asynchronous version of <see cref="ISentryScopeManager.WithScope"/>.
+    /// Pushes a new scope, runs the callback, then pops the scope. Use this when you have significant work to
+    /// perform within an isolated scope.  If you just need to configure scope for a single event, use the overloads
+    /// of CaptureEvent, CaptureMessage and CaptureException that provide a callback to a configurable scope.
+    /// </remarks>
+    /// <see href="https://docs.sentry.io/platforms/dotnet/enriching-events/scopes/#local-scopes"/>
+    /// <param name="scopeCallback">The callback to run with the one time scope.</param>
+    /// <returns>An async task to await the callback.</returns>
+    [DebuggerStepThrough]
+    public static Task WithScopeAsync(Func<Scope, Task> scopeCallback)
+        => CurrentHub.WithScopeAsync(scopeCallback);
+
+    /// <summary>
+    /// Runs the asynchronous callback with a new scope which gets dropped at the end.
+    /// </summary>
+    /// <remarks>
+    /// Asynchronous version of <see cref="ISentryScopeManager.WithScope"/>.
+    /// Pushes a new scope, runs the callback, then pops the scope. Use this when you have significant work to
+    /// perform within an isolated scope.  If you just need to configure scope for a single event, use the overloads
+    /// of CaptureEvent, CaptureMessage and CaptureException that provide a callback to a configurable scope.
+    /// </remarks>
+    /// <see href="https://docs.sentry.io/platforms/dotnet/enriching-events/scopes/#local-scopes"/>
+    /// <param name="scopeCallback">The callback to run with the one time scope.</param>
+    /// <returns>An async task to await the result of the callback.</returns>
+    [DebuggerStepThrough]
+    public static Task<T?> WithScopeAsync<T>(Func<Scope, Task<T?>> scopeCallback)
+        => CurrentHub.WithScopeAsync(scopeCallback);
 
     /// <summary>
     /// Configures the scope through the callback.

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -279,8 +279,6 @@ public static partial class SentrySdk
     /// </remarks>
     /// <see href="https://docs.sentry.io/platforms/dotnet/enriching-events/scopes/#local-scopes"/>
     /// <param name="scopeCallback">The callback to run with the one time scope.</param>
-    [Obsolete("This method is deprecated in favor of overloads of CaptureEvent, CaptureMessage and CaptureException " +
-              "that provide a callback to a configurable scope.")]
     [DebuggerStepThrough]
     public static void WithScope(Action<Scope> scopeCallback)
         => CurrentHub.WithScope(scopeCallback);

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -632,6 +632,12 @@ namespace Sentry
             where TIntegration : Sentry.Integrations.ISdkIntegration { }
         public static Sentry.SentryOptions UseStackTraceFactory(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryStackTraceFactory sentryStackTraceFactory) { }
     }
+    public static class SentryScopeManagerExtensions
+    {
+        public static T? WithScope<T>(this Sentry.ISentryScopeManager scopeManager, System.Func<Sentry.Scope, T?> scopeCallback) { }
+        public static System.Threading.Tasks.Task WithScopeAsync(this Sentry.ISentryScopeManager scopeManager, System.Func<Sentry.Scope, System.Threading.Tasks.Task> scopeCallback) { }
+        public static System.Threading.Tasks.Task<T?> WithScopeAsync<T>(this Sentry.ISentryScopeManager scopeManager, System.Func<Sentry.Scope, System.Threading.Tasks.Task<T?>> scopeCallback) { }
+    }
     public static class SentrySdk
     {
         public static bool IsEnabled { get; }
@@ -678,9 +684,10 @@ namespace Sentry
         public static Sentry.ITransaction StartTransaction(string name, string operation) { }
         public static Sentry.ITransaction StartTransaction(string name, string operation, Sentry.SentryTraceHeader traceHeader) { }
         public static Sentry.ITransaction StartTransaction(string name, string operation, string? description) { }
-        [System.Obsolete("This method is deprecated in favor of overloads of CaptureEvent, CaptureMessage a" +
-            "nd CaptureException that provide a callback to a configurable scope.")]
         public static void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
+        public static T? WithScope<T>(System.Func<Sentry.Scope, T?> scopeCallback) { }
+        public static System.Threading.Tasks.Task WithScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> scopeCallback) { }
+        public static System.Threading.Tasks.Task<T?> WithScopeAsync<T>(System.Func<Sentry.Scope, System.Threading.Tasks.Task<T?>> scopeCallback) { }
     }
     public sealed class SentryStackFrame : Sentry.IJsonSerializable
     {
@@ -1165,8 +1172,6 @@ namespace Sentry.Extensibility
         public void ResumeSession() { }
         public void StartSession() { }
         public Sentry.ITransaction StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
-        [System.Obsolete("This method is deprecated in favor of overloads of CaptureEvent, CaptureMessage a" +
-            "nd CaptureException that provide a callback to a configurable scope.")]
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
     }
     public interface IBackgroundWorker

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -632,6 +632,12 @@ namespace Sentry
             where TIntegration : Sentry.Integrations.ISdkIntegration { }
         public static Sentry.SentryOptions UseStackTraceFactory(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryStackTraceFactory sentryStackTraceFactory) { }
     }
+    public static class SentryScopeManagerExtensions
+    {
+        public static T? WithScope<T>(this Sentry.ISentryScopeManager scopeManager, System.Func<Sentry.Scope, T?> scopeCallback) { }
+        public static System.Threading.Tasks.Task WithScopeAsync(this Sentry.ISentryScopeManager scopeManager, System.Func<Sentry.Scope, System.Threading.Tasks.Task> scopeCallback) { }
+        public static System.Threading.Tasks.Task<T?> WithScopeAsync<T>(this Sentry.ISentryScopeManager scopeManager, System.Func<Sentry.Scope, System.Threading.Tasks.Task<T?>> scopeCallback) { }
+    }
     public static class SentrySdk
     {
         public static bool IsEnabled { get; }
@@ -678,9 +684,10 @@ namespace Sentry
         public static Sentry.ITransaction StartTransaction(string name, string operation) { }
         public static Sentry.ITransaction StartTransaction(string name, string operation, Sentry.SentryTraceHeader traceHeader) { }
         public static Sentry.ITransaction StartTransaction(string name, string operation, string? description) { }
-        [System.Obsolete("This method is deprecated in favor of overloads of CaptureEvent, CaptureMessage a" +
-            "nd CaptureException that provide a callback to a configurable scope.")]
         public static void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
+        public static T? WithScope<T>(System.Func<Sentry.Scope, T?> scopeCallback) { }
+        public static System.Threading.Tasks.Task WithScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> scopeCallback) { }
+        public static System.Threading.Tasks.Task<T?> WithScopeAsync<T>(System.Func<Sentry.Scope, System.Threading.Tasks.Task<T?>> scopeCallback) { }
     }
     public sealed class SentryStackFrame : Sentry.IJsonSerializable
     {
@@ -1165,8 +1172,6 @@ namespace Sentry.Extensibility
         public void ResumeSession() { }
         public void StartSession() { }
         public Sentry.ITransaction StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
-        [System.Obsolete("This method is deprecated in favor of overloads of CaptureEvent, CaptureMessage a" +
-            "nd CaptureException that provide a callback to a configurable scope.")]
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
     }
     public interface IBackgroundWorker

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -632,6 +632,12 @@ namespace Sentry
             where TIntegration : Sentry.Integrations.ISdkIntegration { }
         public static Sentry.SentryOptions UseStackTraceFactory(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryStackTraceFactory sentryStackTraceFactory) { }
     }
+    public static class SentryScopeManagerExtensions
+    {
+        public static T? WithScope<T>(this Sentry.ISentryScopeManager scopeManager, System.Func<Sentry.Scope, T?> scopeCallback) { }
+        public static System.Threading.Tasks.Task WithScopeAsync(this Sentry.ISentryScopeManager scopeManager, System.Func<Sentry.Scope, System.Threading.Tasks.Task> scopeCallback) { }
+        public static System.Threading.Tasks.Task<T?> WithScopeAsync<T>(this Sentry.ISentryScopeManager scopeManager, System.Func<Sentry.Scope, System.Threading.Tasks.Task<T?>> scopeCallback) { }
+    }
     public static class SentrySdk
     {
         public static bool IsEnabled { get; }
@@ -678,9 +684,10 @@ namespace Sentry
         public static Sentry.ITransaction StartTransaction(string name, string operation) { }
         public static Sentry.ITransaction StartTransaction(string name, string operation, Sentry.SentryTraceHeader traceHeader) { }
         public static Sentry.ITransaction StartTransaction(string name, string operation, string? description) { }
-        [System.Obsolete("This method is deprecated in favor of overloads of CaptureEvent, CaptureMessage a" +
-            "nd CaptureException that provide a callback to a configurable scope.")]
         public static void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
+        public static T? WithScope<T>(System.Func<Sentry.Scope, T?> scopeCallback) { }
+        public static System.Threading.Tasks.Task WithScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> scopeCallback) { }
+        public static System.Threading.Tasks.Task<T?> WithScopeAsync<T>(System.Func<Sentry.Scope, System.Threading.Tasks.Task<T?>> scopeCallback) { }
     }
     public sealed class SentryStackFrame : Sentry.IJsonSerializable
     {
@@ -1165,8 +1172,6 @@ namespace Sentry.Extensibility
         public void ResumeSession() { }
         public void StartSession() { }
         public Sentry.ITransaction StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
-        [System.Obsolete("This method is deprecated in favor of overloads of CaptureEvent, CaptureMessage a" +
-            "nd CaptureException that provide a callback to a configurable scope.")]
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
     }
     public interface IBackgroundWorker

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -631,6 +631,12 @@ namespace Sentry
             where TIntegration : Sentry.Integrations.ISdkIntegration { }
         public static Sentry.SentryOptions UseStackTraceFactory(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryStackTraceFactory sentryStackTraceFactory) { }
     }
+    public static class SentryScopeManagerExtensions
+    {
+        public static T? WithScope<T>(this Sentry.ISentryScopeManager scopeManager, System.Func<Sentry.Scope, T?> scopeCallback) { }
+        public static System.Threading.Tasks.Task WithScopeAsync(this Sentry.ISentryScopeManager scopeManager, System.Func<Sentry.Scope, System.Threading.Tasks.Task> scopeCallback) { }
+        public static System.Threading.Tasks.Task<T?> WithScopeAsync<T>(this Sentry.ISentryScopeManager scopeManager, System.Func<Sentry.Scope, System.Threading.Tasks.Task<T?>> scopeCallback) { }
+    }
     public static class SentrySdk
     {
         public static bool IsEnabled { get; }
@@ -677,9 +683,10 @@ namespace Sentry
         public static Sentry.ITransaction StartTransaction(string name, string operation) { }
         public static Sentry.ITransaction StartTransaction(string name, string operation, Sentry.SentryTraceHeader traceHeader) { }
         public static Sentry.ITransaction StartTransaction(string name, string operation, string? description) { }
-        [System.Obsolete("This method is deprecated in favor of overloads of CaptureEvent, CaptureMessage a" +
-            "nd CaptureException that provide a callback to a configurable scope.")]
         public static void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
+        public static T? WithScope<T>(System.Func<Sentry.Scope, T?> scopeCallback) { }
+        public static System.Threading.Tasks.Task WithScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> scopeCallback) { }
+        public static System.Threading.Tasks.Task<T?> WithScopeAsync<T>(System.Func<Sentry.Scope, System.Threading.Tasks.Task<T?>> scopeCallback) { }
     }
     public sealed class SentryStackFrame : Sentry.IJsonSerializable
     {
@@ -1164,8 +1171,6 @@ namespace Sentry.Extensibility
         public void ResumeSession() { }
         public void StartSession() { }
         public Sentry.ITransaction StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
-        [System.Obsolete("This method is deprecated in favor of overloads of CaptureEvent, CaptureMessage a" +
-            "nd CaptureException that provide a callback to a configurable scope.")]
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
     }
     public interface IBackgroundWorker

--- a/test/Sentry.Tests/Extensibility/DisabledHubTests.cs
+++ b/test/Sentry.Tests/Extensibility/DisabledHubTests.cs
@@ -31,6 +31,15 @@ public class DisabledHubTests
     public void WithScope_NoOp() => DisabledHub.Instance.WithScope(null!);
 
     [Fact]
+    public void WithScopeT_NoOp() => DisabledHub.Instance.WithScope<bool>(null!);
+
+    [Fact]
+    public Task WithScopeAsync_NoOp() => DisabledHub.Instance.WithScopeAsync(null!);
+
+    [Fact]
+    public Task WithScopeAsyncT_NoOp() => DisabledHub.Instance.WithScopeAsync<bool>(null!);
+
+    [Fact]
     public void BindClient_NoOp() => DisabledHub.Instance.BindClient(null!);
 
     [Fact]

--- a/test/Sentry.Tests/Extensibility/HubAdapterTests.cs
+++ b/test/Sentry.Tests/Extensibility/HubAdapterTests.cs
@@ -78,13 +78,36 @@ public class HubAdapterTests : IDisposable
         Hub.Received(1).ConfigureScope(Expected);
     }
 
-    [Obsolete]
     [Fact]
     public void WithScope_MockInvoked()
     {
         void Expected(Scope _) { }
         HubAdapter.Instance.WithScope(Expected);
         Hub.Received(1).WithScope(Expected);
+    }
+
+    [Fact]
+    public void WithScopeT_MockInvoked()
+    {
+        object Expected(Scope _) => null;
+        HubAdapter.Instance.WithScope(Expected);
+        Hub.Received(1).WithScope(Expected);
+    }
+
+    [Fact]
+    public async Task WithScopeAsync_MockInvoked()
+    {
+        Task Expected(Scope _) => Task.CompletedTask;
+        await HubAdapter.Instance.WithScopeAsync(Expected);
+        await Hub.Received(1).WithScopeAsync(Expected);
+    }
+
+    [Fact]
+    public async Task WithScopeAsyncT_MockInvoked()
+    {
+        Task<object> Expected(Scope _) => Task.FromResult<object>(null);
+        await HubAdapter.Instance.WithScopeAsync(Expected);
+        await Hub.Received(1).WithScopeAsync(Expected);
     }
 
     [Fact]

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1147,4 +1147,84 @@ public partial class HubTests
         await transport.Received(1)
             .SendEnvelopeAsync(Arg.Any<Envelope>(), Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public void WithScope_Works()
+    {
+        var hub = _fixture.GetSut();
+        var originalScope = GetCurrentScope(hub);
+
+        hub.WithScope(scope =>
+        {
+            var newScope = GetCurrentScope(hub);
+            Assert.Same(newScope, scope);
+            Assert.NotSame(originalScope, scope);
+        });
+
+        var finalScope = GetCurrentScope(hub);
+        Assert.Same(originalScope, finalScope);
+    }
+
+    [Fact]
+    public void WithScopeT_Works()
+    {
+        var hub = _fixture.GetSut();
+        var originalScope = GetCurrentScope(hub);
+
+        var result = hub.WithScope(scope =>
+        {
+            var newScope = GetCurrentScope(hub);
+            Assert.Same(newScope, scope);
+            Assert.NotSame(originalScope, scope);
+
+            return true;
+        });
+
+        Assert.True(result);
+
+        var finalScope = GetCurrentScope(hub);
+        Assert.Same(originalScope, finalScope);
+    }
+
+    [Fact]
+    public async Task WithScopeAsync_Works()
+    {
+        var hub = _fixture.GetSut();
+        var originalScope = GetCurrentScope(hub);
+
+        await hub.WithScopeAsync(scope =>
+        {
+            var newScope = GetCurrentScope(hub);
+            Assert.Same(newScope, scope);
+            Assert.NotSame(originalScope, scope);
+
+            return Task.CompletedTask;
+        });
+
+        var finalScope = GetCurrentScope(hub);
+        Assert.Same(originalScope, finalScope);
+    }
+
+    [Fact]
+    public async Task WithScopeAsyncT_Works()
+    {
+        var hub = _fixture.GetSut();
+        var originalScope = GetCurrentScope(hub);
+
+        var result = await hub.WithScopeAsync(scope =>
+        {
+            var newScope = GetCurrentScope(hub);
+            Assert.Same(newScope, scope);
+            Assert.NotSame(originalScope, scope);
+
+            return Task.FromResult(true);
+        });
+
+        Assert.True(result);
+
+        var finalScope = GetCurrentScope(hub);
+        Assert.Same(originalScope, finalScope);
+    }
+
+    private static Scope GetCurrentScope(Hub hub) => hub.ScopeManager.GetCurrent().Key;
 }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1151,6 +1151,7 @@ public partial class HubTests
     [Fact]
     public void WithScope_Works()
     {
+        _fixture.Options.IsGlobalModeEnabled = false;
         var hub = _fixture.GetSut();
         var originalScope = GetCurrentScope(hub);
 
@@ -1168,6 +1169,7 @@ public partial class HubTests
     [Fact]
     public void WithScopeT_Works()
     {
+        _fixture.Options.IsGlobalModeEnabled = false;
         var hub = _fixture.GetSut();
         var originalScope = GetCurrentScope(hub);
 
@@ -1189,6 +1191,7 @@ public partial class HubTests
     [Fact]
     public async Task WithScopeAsync_Works()
     {
+        _fixture.Options.IsGlobalModeEnabled = false;
         var hub = _fixture.GetSut();
         var originalScope = GetCurrentScope(hub);
 
@@ -1208,6 +1211,7 @@ public partial class HubTests
     [Fact]
     public async Task WithScopeAsyncT_Works()
     {
+        _fixture.Options.IsGlobalModeEnabled = false;
         var hub = _fixture.GetSut();
         var originalScope = GetCurrentScope(hub);
 

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -477,7 +477,35 @@ public class SentrySdkTests : IDisposable
     public void WithScope_DisabledSdk_CallbackNeverInvoked()
     {
         var invoked = false;
-        SentrySdk.WithScope(_ => invoked = true);
+
+        // Note: Specifying void in the lambda ensures we are testing WithScope, rather than WithScope<T>.
+        SentrySdk.WithScope(void (_) => invoked = true);
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public void WithScopeT_DisabledSdk_CallbackNeverInvoked()
+    {
+        var invoked = SentrySdk.WithScope(_ => true);
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public async Task WithScopeAsync_DisabledSdk_CallbackNeverInvoked()
+    {
+        var invoked = false;
+        await SentrySdk.WithScopeAsync(_ =>
+        {
+            invoked = true;
+            return Task.CompletedTask;
+        });
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public async Task WithScopeAsyncT_DisabledSdk_CallbackNeverInvoked()
+    {
+        var invoked = await SentrySdk.WithScopeAsync(_ => Task.FromResult(true));
         Assert.False(invoked);
     }
 
@@ -499,7 +527,85 @@ public class SentrySdkTests : IDisposable
         SentrySdk.ConfigureScope(s => expected = s);
 
         Scope actual = null;
-        SentrySdk.WithScope(s => actual = s);
+        // Note: Specifying void in the lambda ensures we are testing WithScope, rather than WithScope<T>.
+        SentrySdk.WithScope(void (s) => actual = s);
+
+        Assert.NotNull(actual);
+        Assert.NotSame(expected, actual);
+        SentrySdk.ConfigureScope(s => Assert.Same(expected, s));
+    }
+
+    [Fact]
+    public void WithScopeT_InvokedWithNewScope()
+    {
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            IsGlobalModeEnabled = false,
+            AutoSessionTracking = false,
+            BackgroundWorker = Substitute.For<IBackgroundWorker>(),
+            InitNativeSdks = false
+        };
+
+        using var _ = SentrySdk.Init(options);
+
+        Scope expected = null;
+        SentrySdk.ConfigureScope(s => expected = s);
+
+        var actual = SentrySdk.WithScope(s => s);
+
+        Assert.NotNull(actual);
+        Assert.NotSame(expected, actual);
+        SentrySdk.ConfigureScope(s => Assert.Same(expected, s));
+    }
+
+    [Fact]
+    public async Task WithScopeAsync_InvokedWithNewScope()
+    {
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            IsGlobalModeEnabled = false,
+            AutoSessionTracking = false,
+            BackgroundWorker = Substitute.For<IBackgroundWorker>(),
+            InitNativeSdks = false
+        };
+
+        using var _ = SentrySdk.Init(options);
+
+        Scope expected = null;
+        SentrySdk.ConfigureScope(s => expected = s);
+
+        Scope actual = null;
+        await SentrySdk.WithScopeAsync(s =>
+        {
+            actual = s;
+            return Task.CompletedTask;
+        });
+
+        Assert.NotNull(actual);
+        Assert.NotSame(expected, actual);
+        SentrySdk.ConfigureScope(s => Assert.Same(expected, s));
+    }
+
+    [Fact]
+    public async Task WithScopeAsyncT_InvokedWithNewScope()
+    {
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            IsGlobalModeEnabled = false,
+            AutoSessionTracking = false,
+            BackgroundWorker = Substitute.For<IBackgroundWorker>(),
+            InitNativeSdks = false
+        };
+
+        using var _ = SentrySdk.Init(options);
+
+        Scope expected = null;
+        SentrySdk.ConfigureScope(s => expected = s);
+
+        var actual = await SentrySdk.WithScopeAsync(Task.FromResult);
 
         Assert.NotNull(actual);
         Assert.NotSame(expected, actual);

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -477,9 +477,7 @@ public class SentrySdkTests : IDisposable
     public void WithScope_DisabledSdk_CallbackNeverInvoked()
     {
         var invoked = false;
-#pragma warning disable CS0618
         SentrySdk.WithScope(_ => invoked = true);
-#pragma warning restore CS0618
         Assert.False(invoked);
     }
 
@@ -501,9 +499,7 @@ public class SentrySdkTests : IDisposable
         SentrySdk.ConfigureScope(s => expected = s);
 
         Scope actual = null;
-#pragma warning disable CS0618
         SentrySdk.WithScope(s => actual = s);
-#pragma warning restore CS0618
 
         Assert.NotNull(actual);
         Assert.NotSame(expected, actual);


### PR DESCRIPTION
- Un-obsoletes `WithScope`
- Adds `WithScope<T>`, `WithScopeAsync`, and `WithScopeAsync<T>`

Resolves #2300 
