### PR TITLE
Fix WithScope overloads on HubAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Initial work to support profiling in a future release. ([#2206](https://github.com/getsentry/sentry-dotnet/pull/2206))
-- Improve `WithScope` and add `WithScopeAsync` ([#2303](https://github.com/getsentry/sentry-dotnet/pull/2303))
+- Improve `WithScope` and add `WithScopeAsync` ([#2303](https://github.com/getsentry/sentry-dotnet/pull/2303)) ([#2309](https://github.com/getsentry/sentry-dotnet/pull/2309))
 
 ### Fixes
 

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -1,4 +1,5 @@
 using Sentry.Infrastructure;
+using Sentry.Internal;
 
 namespace Sentry.Extensibility;
 
@@ -11,7 +12,7 @@ namespace Sentry.Extensibility;
 /// </remarks>
 /// <inheritdoc cref="IHub" />
 [DebuggerStepThrough]
-public sealed class HubAdapter : IHub
+public sealed class HubAdapter : IHub, IHubEx
 {
     /// <summary>
     /// The single instance which forwards all calls to <see cref="SentrySdk"/>
@@ -170,6 +171,12 @@ public sealed class HubAdapter : IHub
         => SentrySdk.CaptureEvent(evt);
 
     /// <summary>
+    /// Forwards the call to <see cref="SentrySdk"/>
+    /// </summary>
+    SentryId IHubEx.CaptureEventInternal(SentryEvent evt, Scope? scope)
+        => SentrySdk.CaptureEventInternal(evt, scope);
+
+    /// <summary>
     /// Forwards the call to <see cref="SentrySdk"/>.
     /// </summary>
     [DebuggerStepThrough]
@@ -223,4 +230,22 @@ public sealed class HubAdapter : IHub
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void CaptureUserFeedback(UserFeedback sentryUserFeedback)
         => SentrySdk.CaptureUserFeedback(sentryUserFeedback);
+
+    /// <summary>
+    /// Forwards the call to <see cref="SentrySdk"/>
+    /// </summary>
+    public T? WithScope<T>(Func<Scope, T?> scopeCallback)
+        => SentrySdk.WithScope(scopeCallback);
+
+    /// <summary>
+    /// Forwards the call to <see cref="SentrySdk"/>
+    /// </summary>
+    public Task WithScopeAsync(Func<Scope, Task> scopeCallback)
+        => SentrySdk.WithScopeAsync(scopeCallback);
+
+    /// <summary>
+    /// Forwards the call to <see cref="SentrySdk"/>
+    /// </summary>
+    public Task<T?> WithScopeAsync<T>(Func<Scope, Task<T?>> scopeCallback)
+        => SentrySdk.WithScopeAsync(scopeCallback);
 }

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -97,17 +97,7 @@ internal class Hub : IHubEx, IDisposable
 
     public IDisposable PushScope<TState>(TState state) => ScopeManager.PushScope(state);
 
-    public void WithScope(Action<Scope> scopeCallback)
-    {
-        try
-        {
-            ScopeManager.WithScope(scopeCallback);
-        }
-        catch (Exception e)
-        {
-            _options.LogError("Failure to run callback WithScope", e);
-        }
-    }
+    public void WithScope(Action<Scope> scopeCallback) => ScopeManager.WithScope(scopeCallback);
 
     public void BindClient(ISentryClient client) => ScopeManager.BindClient(client);
 

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -99,6 +99,12 @@ internal class Hub : IHubEx, IDisposable
 
     public void WithScope(Action<Scope> scopeCallback) => ScopeManager.WithScope(scopeCallback);
 
+    public T? WithScope<T>(Func<Scope, T?> scopeCallback) => ScopeManager.WithScope(scopeCallback);
+
+    public Task WithScopeAsync(Func<Scope, Task> scopeCallback) => ScopeManager.WithScopeAsync(scopeCallback);
+
+    public Task<T?> WithScopeAsync<T>(Func<Scope, Task<T?>> scopeCallback) => ScopeManager.WithScopeAsync(scopeCallback);
+
     public void BindClient(ISentryClient client) => ScopeManager.BindClient(client);
 
     public ITransaction StartTransaction(

--- a/src/Sentry/Internal/IHubEx.cs
+++ b/src/Sentry/Internal/IHubEx.cs
@@ -3,4 +3,7 @@ namespace Sentry.Internal;
 internal interface IHubEx : IHub
 {
     SentryId CaptureEventInternal(SentryEvent evt, Scope? scope = null);
+    T? WithScope<T>(Func<Scope, T?> scopeCallback);
+    Task WithScopeAsync(Func<Scope, Task> scopeCallback);
+    Task<T?> WithScopeAsync<T>(Func<Scope, Task<T?>> scopeCallback);
 }

--- a/src/Sentry/SentryScopeManagerExtensions.cs
+++ b/src/Sentry/SentryScopeManagerExtensions.cs
@@ -1,3 +1,4 @@
+using Sentry.Extensibility;
 using Sentry.Internal;
 
 namespace Sentry;
@@ -24,7 +25,7 @@ public static class SentryScopeManagerExtensions
     public static T? WithScope<T>(this ISentryScopeManager scopeManager, Func<Scope, T?> scopeCallback) =>
         scopeManager switch
         {
-            Hub hub => hub.ScopeManager.WithScope(scopeCallback),
+            IHubEx hub => hub.WithScope(scopeCallback),
             IInternalScopeManager manager => manager.WithScope(scopeCallback),
             _ => default
         };
@@ -46,7 +47,7 @@ public static class SentryScopeManagerExtensions
     public static Task WithScopeAsync(this ISentryScopeManager scopeManager, Func<Scope, Task> scopeCallback) =>
         scopeManager switch
         {
-            Hub hub => hub.ScopeManager.WithScopeAsync(scopeCallback),
+            IHubEx hub => hub.WithScopeAsync(scopeCallback),
             IInternalScopeManager manager => manager.WithScopeAsync(scopeCallback),
             _ => Task.CompletedTask
         };
@@ -68,7 +69,7 @@ public static class SentryScopeManagerExtensions
     public static Task<T?> WithScopeAsync<T>(this ISentryScopeManager scopeManager, Func<Scope, Task<T?>> scopeCallback) =>
         scopeManager switch
         {
-            Hub hub => hub.ScopeManager.WithScopeAsync(scopeCallback),
+            IHubEx hub => hub.WithScopeAsync(scopeCallback),
             IInternalScopeManager manager => manager.WithScopeAsync(scopeCallback),
             _ => Task.FromResult(default(T))
         };

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -298,7 +298,7 @@ public static partial class SentrySdk
     /// <returns>The result from the callback.</returns>
     [DebuggerStepThrough]
     public static T? WithScope<T>(Func<Scope, T?> scopeCallback)
-        => CurrentHub.WithScope(scopeCallback);
+        => CurrentHub is IHubEx hub ? hub.WithScope(scopeCallback) : default;
 
     /// <summary>
     /// Runs the asynchronous callback within a new scope.
@@ -314,7 +314,7 @@ public static partial class SentrySdk
     /// <returns>An async task to await the callback.</returns>
     [DebuggerStepThrough]
     public static Task WithScopeAsync(Func<Scope, Task> scopeCallback)
-        => CurrentHub.WithScopeAsync(scopeCallback);
+        => CurrentHub is IHubEx hub ? hub.WithScopeAsync(scopeCallback) : Task.CompletedTask;
 
     /// <summary>
     /// Runs the asynchronous callback within a new scope.
@@ -330,7 +330,7 @@ public static partial class SentrySdk
     /// <returns>An async task to await the result of the callback.</returns>
     [DebuggerStepThrough]
     public static Task<T?> WithScopeAsync<T>(Func<Scope, Task<T?>> scopeCallback)
-        => CurrentHub.WithScopeAsync(scopeCallback);
+        => CurrentHub is IHubEx hub ? hub.WithScopeAsync(scopeCallback) : Task.FromResult(default(T));
 
     /// <summary>
     /// Configures the scope through the callback.
@@ -368,6 +368,11 @@ public static partial class SentrySdk
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static SentryId CaptureEvent(SentryEvent evt, Scope? scope)
         => CurrentHub.CaptureEvent(evt, scope);
+
+    internal static SentryId CaptureEventInternal(SentryEvent evt, Scope? scope)
+        => CurrentHub is IHubEx hub
+            ? hub.CaptureEventInternal(evt, scope)
+            : CurrentHub.CaptureEvent(evt, scope);
 
     /// <summary>
     /// Captures an event with a configurable scope.

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1173,6 +1173,9 @@ namespace Sentry.Extensibility
         public void StartSession() { }
         public Sentry.ITransaction StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
+        public T? WithScope<T>(System.Func<Sentry.Scope, T?> scopeCallback) { }
+        public System.Threading.Tasks.Task WithScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> scopeCallback) { }
+        public System.Threading.Tasks.Task<T?> WithScopeAsync<T>(System.Func<Sentry.Scope, System.Threading.Tasks.Task<T?>> scopeCallback) { }
     }
     public interface IBackgroundWorker
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1173,6 +1173,9 @@ namespace Sentry.Extensibility
         public void StartSession() { }
         public Sentry.ITransaction StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
+        public T? WithScope<T>(System.Func<Sentry.Scope, T?> scopeCallback) { }
+        public System.Threading.Tasks.Task WithScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> scopeCallback) { }
+        public System.Threading.Tasks.Task<T?> WithScopeAsync<T>(System.Func<Sentry.Scope, System.Threading.Tasks.Task<T?>> scopeCallback) { }
     }
     public interface IBackgroundWorker
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1173,6 +1173,9 @@ namespace Sentry.Extensibility
         public void StartSession() { }
         public Sentry.ITransaction StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
+        public T? WithScope<T>(System.Func<Sentry.Scope, T?> scopeCallback) { }
+        public System.Threading.Tasks.Task WithScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> scopeCallback) { }
+        public System.Threading.Tasks.Task<T?> WithScopeAsync<T>(System.Func<Sentry.Scope, System.Threading.Tasks.Task<T?>> scopeCallback) { }
     }
     public interface IBackgroundWorker
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -1172,6 +1172,9 @@ namespace Sentry.Extensibility
         public void StartSession() { }
         public Sentry.ITransaction StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
         public void WithScope(System.Action<Sentry.Scope> scopeCallback) { }
+        public T? WithScope<T>(System.Func<Sentry.Scope, T?> scopeCallback) { }
+        public System.Threading.Tasks.Task WithScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> scopeCallback) { }
+        public System.Threading.Tasks.Task<T?> WithScopeAsync<T>(System.Func<Sentry.Scope, System.Threading.Tasks.Task<T?>> scopeCallback) { }
     }
     public interface IBackgroundWorker
     {

--- a/test/Sentry.Tests/Extensibility/HubAdapterTests.cs
+++ b/test/Sentry.Tests/Extensibility/HubAdapterTests.cs
@@ -3,11 +3,11 @@ namespace Sentry.Tests.Extensibility;
 [Collection(nameof(SentrySdkCollection))]
 public class HubAdapterTests : IDisposable
 {
-    private IHub Hub { get; }
+    private IHubEx Hub { get; }
 
     public HubAdapterTests()
     {
-        Hub = Substitute.For<IHub>();
+        Hub = Substitute.For<IHubEx>();
         SentrySdk.UseHub(Hub);
     }
 
@@ -34,7 +34,7 @@ public class HubAdapterTests : IDisposable
         var expected = new Exception();
         Hub.IsEnabled.Returns(true);
         HubAdapter.Instance.CaptureException(expected);
-        Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(s => s.Exception == expected));
+        Hub.Received(1).CaptureEventInternal(Arg.Is<SentryEvent>(s => s.Exception == expected));
     }
 
     [Fact]


### PR DESCRIPTION
Follow up to #2303.

Makes sure the `WithScope` overloads added in #2303 work on `HubAdapter` instances, by adding them to the `IHubEx` interface and implementing that on `HubAdapter`.  (This also required implementing `CaptureEventInternal` in a few places.)

Also, the original `Hub.WithScope` was swallowing exceptions.  It should not, as that would hide any unhandled exceptions in the user-supplied callback.