### PR TITLE
Use C# 11 for raw string literals

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 * text=auto
-*.cs text=auto diff=csharp
+*.cs text=auto eol=lf diff=csharp
 *.sln text=auto eol=crlf
 *.sh eol=lf
 CHANGELOG.md merge=union

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>3.30.0</Version>
-    <LangVersion>10</LangVersion>
+    <LangVersion>11</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory).assets\Sentry.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/MauiTestUtils/Directory.Build.props
+++ b/test/MauiTestUtils/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <LangVersion>10</LangVersion>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <!-- these are needed because the versions that are brought in transitively have vulnerability warnings -->

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsSql.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsSql.verified.txt
@@ -51,7 +51,7 @@
           IsSampled: true,
           Extra: {
             bytes_received: 167,
-            bytes_sent : 542,
+            bytes_sent : 536,
             db.connection_id: Guid_1,
             db.operation_id: Guid_2,
             rows_sent: 1
@@ -60,9 +60,7 @@
         {
           IsFinished: true,
           Operation: db.query,
-          Description:
-insert into MyTable (Value)
-values (@value);,
+          Description: insert into MyTable (Value) values (@value);,
           Status: Ok,
           IsSampled: true,
           Extra: {

--- a/test/Sentry.DiagnosticSource.IntegrationTests/TestDbBuilder.cs
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/TestDbBuilder.cs
@@ -56,9 +56,7 @@ public static class TestDbBuilder
 #endif
 
         command.Parameters.AddWithValue("value", "SHOULD NOT APPEAR IN PAYLOAD");
-        command.CommandText = @"
-insert into MyTable (Value)
-values (@value);";
+        command.CommandText = "insert into MyTable (Value) values (@value);";
         await command.ExecuteNonQueryAsync();
     }
 

--- a/test/Sentry.Testing/JsonSerializableExtensions.cs
+++ b/test/Sentry.Testing/JsonSerializableExtensions.cs
@@ -1,18 +1,23 @@
 internal static class JsonSerializableExtensions
 {
-    public static string ToJsonString(this IJsonSerializable serializable, IDiagnosticLogger logger = null) =>
-        WriteToJsonString(writer => writer.WriteSerializableValue(serializable, logger));
+    public static string ToJsonString(this IJsonSerializable serializable, IDiagnosticLogger logger = null, bool indented = false) =>
+        WriteToJsonString(writer => writer.WriteSerializableValue(serializable, logger), indented);
 
-    public static string ToJsonString(this object @object, IDiagnosticLogger logger = null) =>
-        WriteToJsonString(writer => writer.WriteDynamicValue(@object, logger));
+    public static string ToJsonString(this object @object, IDiagnosticLogger logger = null, bool indented = false) =>
+        WriteToJsonString(writer => writer.WriteDynamicValue(@object, logger), indented);
 
-    private static string WriteToJsonString(Action<Utf8JsonWriter> writeAction)
+    private static string WriteToJsonString(Action<Utf8JsonWriter> writeAction, bool indented)
     {
+        var options = new JsonWriterOptions
+        {
+            Indented = indented
+        };
+
 #if NETCOREAPP3_0_OR_GREATER
         // This implementation is better, as it uses fewer allocations
         var buffer = new ArrayBufferWriter<byte>();
 
-        using var writer = new Utf8JsonWriter(buffer);
+        using var writer = new Utf8JsonWriter(buffer, options);
         writeAction(writer);
         writer.Flush();
 
@@ -21,7 +26,7 @@ internal static class JsonSerializableExtensions
         // This implementation is compatible with older targets
         using var stream = new MemoryStream();
 
-        using var writer = new Utf8JsonWriter(stream);
+        using var writer = new Utf8JsonWriter(stream, options);
         writeAction(writer);
         writer.Flush();
 

--- a/test/Sentry.Tests/Internals/ClientReportTests.cs
+++ b/test/Sentry.Tests/Internals/ClientReportTests.cs
@@ -4,13 +4,29 @@ public class ClientReportTests
 {
     private readonly IDiagnosticLogger _testOutputLogger;
     private readonly ClientReport _testClientReport;
-    private const string TestJsonString =
-        "{" +
-        "\"timestamp\":\"9999-12-31T23:59:59.9999999+00:00\"," + "\"discarded_events\":[" +
-        "{\"reason\":\"before_send\",\"category\":\"attachment\",\"quantity\":1}," +
-        "{\"reason\":\"cache_overflow\",\"category\":\"error\",\"quantity\":2}," +
-        "{\"reason\":\"event_processor\",\"category\":\"security\",\"quantity\":3}]" +
-        "}";
+
+    private const string TestJsonString = """
+    {
+      "timestamp": "9999-12-31T23:59:59.9999999+00:00",
+      "discarded_events": [
+        {
+          "reason": "before_send",
+          "category": "attachment",
+          "quantity": 1
+        },
+        {
+          "reason": "cache_overflow",
+          "category": "error",
+          "quantity": 2
+        },
+        {
+          "reason": "event_processor",
+          "category": "security",
+          "quantity": 3
+        }
+      ]
+    }
+    """;
 
     public ClientReportTests(ITestOutputHelper output)
     {
@@ -29,7 +45,7 @@ public class ClientReportTests
     [Fact]
     public void Serializes()
     {
-        var jsonString = _testClientReport.ToJsonString(_testOutputLogger);
+        var jsonString = _testClientReport.ToJsonString(_testOutputLogger, indented: true);
         Assert.Equal(TestJsonString, jsonString);
     }
 

--- a/test/Sentry.Tests/Protocol/BreadcrumbTests.cs
+++ b/test/Sentry.Tests/Protocol/BreadcrumbTests.cs
@@ -31,15 +31,20 @@ public class BreadcrumbTests : ImmutableTests<Breadcrumb>
             "category1",
             BreadcrumbLevel.Warning);
 
-        var actual = sut.ToJsonString(_testOutputLogger);
+        var actual = sut.ToJsonString(_testOutputLogger, indented: true);
 
-        Assert.Equal(
-            "{\"timestamp\":\"9999-12-31T23:59:59.999Z\"," +
-            "\"message\":\"message1\"," +
-            "\"type\":\"type1\"," +
-            "\"data\":{\"key\":\"val\"}," +
-            "\"category\":\"category1\"," +
-            "\"level\":\"warning\"}",
+        Assert.Equal("""
+            {
+              "timestamp": "9999-12-31T23:59:59.999Z",
+              "message": "message1",
+              "type": "type1",
+              "data": {
+                "key": "val"
+              },
+              "category": "category1",
+              "level": "warning"
+            }
+            """,
             actual);
     }
 
@@ -54,16 +59,11 @@ public class BreadcrumbTests : ImmutableTests<Breadcrumb>
 
     public static IEnumerable<object[]> TestCases()
     {
-        // Timestamp is included in every breadcrumb
-        var expectedTimestamp = DateTimeOffset.MaxValue;
-        var expectedTimestampString = "9999-12-31T23:59:59.999Z";
-        var timestampString = $"\"timestamp\":\"{expectedTimestampString}\"";
-
-        yield return new object[] { (new Breadcrumb(expectedTimestamp), $"{{{timestampString}}}") };
-        yield return new object[] { (new Breadcrumb(expectedTimestamp, "message"), $"{{{timestampString},\"message\":\"message\"}}") };
-        yield return new object[] { (new Breadcrumb(expectedTimestamp, type: "type"), $"{{{timestampString},\"type\":\"type\"}}") };
-        yield return new object[] { (new Breadcrumb(expectedTimestamp, data: new Dictionary<string, string> { { "key", "val" } }), $"{{{timestampString},\"data\":{{\"key\":\"val\"}}}}") };
-        yield return new object[] { (new Breadcrumb(expectedTimestamp, category: "category"), $"{{{timestampString},\"category\":\"category\"}}") };
-        yield return new object[] { (new Breadcrumb(expectedTimestamp, level: BreadcrumbLevel.Critical), $"{{{timestampString},\"level\":\"critical\"}}") };
+        yield return new object[] { (new Breadcrumb(DateTimeOffset.MaxValue), """{"timestamp":"9999-12-31T23:59:59.999Z"}""") };
+        yield return new object[] { (new Breadcrumb(DateTimeOffset.MaxValue, "message"), """{"timestamp":"9999-12-31T23:59:59.999Z","message":"message"}""") };
+        yield return new object[] { (new Breadcrumb(DateTimeOffset.MaxValue, type: "type"), """{"timestamp":"9999-12-31T23:59:59.999Z","type":"type"}""") };
+        yield return new object[] { (new Breadcrumb(DateTimeOffset.MaxValue, data: new Dictionary<string, string> { { "key", "val" } }), """{"timestamp":"9999-12-31T23:59:59.999Z","data":{"key":"val"}}""") };
+        yield return new object[] { (new Breadcrumb(DateTimeOffset.MaxValue, category: "category"), """{"timestamp":"9999-12-31T23:59:59.999Z","category":"category"}""") };
+        yield return new object[] { (new Breadcrumb(DateTimeOffset.MaxValue, level: BreadcrumbLevel.Critical), """{"timestamp":"9999-12-31T23:59:59.999Z","level":"critical"}""") };
     }
 }

--- a/test/Sentry.Tests/Protocol/Context/AppTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/AppTests.cs
@@ -64,13 +64,13 @@ public class AppTests
 
     public static IEnumerable<object[]> TestCases()
     {
-        yield return new object[] { (new App(), "{\"type\":\"app\"}") };
-        yield return new object[] { (new App { Name = "some name" }, "{\"type\":\"app\",\"app_name\":\"some name\"}") };
-        yield return new object[] { (new App { Build = "some build" }, "{\"type\":\"app\",\"app_build\":\"some build\"}") };
-        yield return new object[] { (new App { BuildType = "some build type" }, "{\"type\":\"app\",\"build_type\":\"some build type\"}") };
-        yield return new object[] { (new App { Hash = "some hash" }, "{\"type\":\"app\",\"device_app_hash\":\"some hash\"}") };
-        yield return new object[] { (new App { StartTime = DateTimeOffset.MaxValue }, "{\"type\":\"app\",\"app_start_time\":\"9999-12-31T23:59:59.9999999+00:00\"}") };
-        yield return new object[] { (new App { Version = "some version" }, "{\"type\":\"app\",\"app_version\":\"some version\"}") };
-        yield return new object[] { (new App { Identifier = "some identifier" }, "{\"type\":\"app\",\"app_identifier\":\"some identifier\"}") };
+        yield return new object[] { (new App(), """{"type":"app"}""") };
+        yield return new object[] { (new App { Name = "some name" }, """{"type":"app","app_name":"some name"}""") };
+        yield return new object[] { (new App { Build = "some build" }, """{"type":"app","app_build":"some build"}""") };
+        yield return new object[] { (new App { BuildType = "some build type" }, """{"type":"app","build_type":"some build type"}""") };
+        yield return new object[] { (new App { Hash = "some hash" }, """{"type":"app","device_app_hash":"some hash"}""") };
+        yield return new object[] { (new App { StartTime = DateTimeOffset.MaxValue }, """{"type":"app","app_start_time":"9999-12-31T23:59:59.9999999+00:00"}""") };
+        yield return new object[] { (new App { Version = "some version" }, """{"type":"app","app_version":"some version"}""") };
+        yield return new object[] { (new App { Identifier = "some identifier" }, """{"type":"app","app_identifier":"some identifier"}""") };
     }
 }

--- a/test/Sentry.Tests/Protocol/Context/BrowserTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/BrowserTests.cs
@@ -50,8 +50,8 @@ public class BrowserTests
 
     public static IEnumerable<object[]> TestCases()
     {
-        yield return new object[] { (new Browser(), "{\"type\":\"browser\"}") };
-        yield return new object[] { (new Browser { Name = "some name" }, "{\"type\":\"browser\",\"name\":\"some name\"}") };
-        yield return new object[] { (new Browser { Version = "some version" }, "{\"type\":\"browser\",\"version\":\"some version\"}") };
+        yield return new object[] { (new Browser(), """{"type":"browser"}""") };
+        yield return new object[] { (new Browser { Name = "some name" }, """{"type":"browser","name":"some name"}""") };
+        yield return new object[] { (new Browser { Version = "some version" }, """{"type":"browser","version":"some version"}""") };
     }
 }

--- a/test/Sentry.Tests/Protocol/Context/ContextsTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/ContextsTests.cs
@@ -39,7 +39,7 @@ public class ContextsTests
         var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
-        Assert.Equal("{\"server\":{\"type\":\"os\",\"name\":\"Linux\"}}", actualString);
+        Assert.Equal("""{"server":{"type":"os","name":"Linux"}}""", actualString);
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class ContextsTests
         var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
-        Assert.Equal("{\"device\":{\"type\":\"device\",\"arch\":\"x86\"}}", actualString);
+        Assert.Equal("""{"device":{"type":"device","arch":"x86"}}""", actualString);
     }
 
     [Fact]
@@ -77,7 +77,7 @@ public class ContextsTests
         var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
-        Assert.Equal("{\"app\":{\"type\":\"app\",\"app_name\":\"My.App\"}}", actualString);
+        Assert.Equal("""{"app":{"type":"app","app_name":"My.App"}}""", actualString);
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class ContextsTests
         var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
-        Assert.Equal("{\"gpu\":{\"type\":\"gpu\",\"name\":\"My.Gpu\"}}", actualString);
+        Assert.Equal("""{"gpu":{"type":"gpu","name":"My.Gpu"}}""", actualString);
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public class ContextsTests
         var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
-        Assert.Equal("{\"runtime\":{\"type\":\"runtime\",\"version\":\"2.1.1.100\"}}", actualString);
+        Assert.Equal("""{"runtime":{"type":"runtime","version":"2.1.1.100"}}""", actualString);
     }
 
     [Fact]
@@ -132,7 +132,7 @@ public class ContextsTests
         var roundtrip = Json.Parse(json, Contexts.FromJson);
 
         // Assert
-        json.Should().Be("{\"foo\":{\"Bar\":42,\"Baz\":\"kek\"}}");
+        json.Should().Be("""{"foo":{"Bar":42,"Baz":"kek"}}""");
 
         roundtrip["foo"].Should().BeEquivalentTo(new Dictionary<string, object>
         {
@@ -152,7 +152,7 @@ public class ContextsTests
         };
 
         var actualString = sut.ToJsonString(_testOutputLogger);
-        Assert.Equal("{\"a\":\"1\",\"b\":\"2\",\"c\":\"3\"}", actualString);
+        Assert.Equal("""{"a":"1","b":"2","c":"3"}""", actualString);
     }
 
     [Fact]
@@ -190,7 +190,7 @@ public class ContextsTests
         var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
-        Assert.Equal("{\"browser\":{\"type\":\"browser\",\"name\":\"Netscape 1\"}}", actualString);
+        Assert.Equal("""{"browser":{"type":"browser","name":"Netscape 1"}}""", actualString);
     }
 
     [Fact]
@@ -209,7 +209,7 @@ public class ContextsTests
         var actual = Json.Parse(actualString, Contexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
-        Assert.Equal("{\"os\":{\"type\":\"os\",\"name\":\"BeOS 1\"}}", actualString);
+        Assert.Equal("""{"os":{"type":"os","name":"BeOS 1"}}""", actualString);
     }
 
     [Fact]

--- a/test/Sentry.Tests/Protocol/Context/DeviceTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/DeviceTests.cs
@@ -16,7 +16,7 @@ public class DeviceTests
 
         var actual = sut.ToJsonString(_testOutputLogger);
 
-        Assert.Equal("{\"type\":\"device\"}", actual);
+        Assert.Equal("""{"type":"device"}""", actual);
     }
 
     [Fact]
@@ -67,46 +67,49 @@ public class DeviceTests
             SupportsLocationService = true
         };
 
-        var actual = sut.ToJsonString(_testOutputLogger);
+        var actual = sut.ToJsonString(_testOutputLogger, indented: true);
 
-        Assert.Equal(
-            "{\"type\":\"device\"," +
-            "\"timezone\":\"tz_id\"," +
-            "\"timezone_display_name\":\"my timezone\"," +
-            "\"name\":\"testing.sentry.io\"," +
-            "\"manufacturer\":\"Manufacturer\"," +
-            "\"brand\":\"Brand\"," +
-            "\"family\":\"Windows\"," +
-            "\"model\":\"Windows Server 2012 R2\"," +
-            "\"model_id\":\"0921309128012\"," +
-            "\"arch\":\"x64\"," +
-            "\"battery_level\":99," +
-            "\"charging\":true," +
-            "\"orientation\":\"portrait\"," +
-            "\"simulator\":false," +
-            "\"memory_size\":500000000000," +
-            "\"free_memory\":200000000000," +
-            "\"usable_memory\":100," +
-            "\"low_memory\":true," +
-            "\"storage_size\":100000000," +
-            "\"free_storage\":0," +
-            "\"external_storage_size\":1000000000000000," +
-            "\"external_free_storage\":100000000000000," +
-            "\"screen_resolution\":\"800x600\"," +
-            "\"screen_density\":42," +
-            "\"screen_dpi\":42," +
-            "\"boot_time\":\"9999-12-31T23:59:59.9999999+00:00\"," +
-            "\"processor_count\":8," +
-            "\"cpu_description\":\"Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz\"," +
-            "\"processor_frequency\":2500," +
-            "\"device_type\":\"Console\"," +
-            "\"battery_status\":\"Charging\"," +
-            "\"device_unique_identifier\":\"d610540d-11d6-4daa-a98c-b71030acae4d\"," +
-            "\"supports_vibration\":false," +
-            "\"supports_accelerometer\":true," +
-            "\"supports_gyroscope\":true," +
-            "\"supports_audio\":true," +
-            "\"supports_location_service\":true}",
+        Assert.Equal("""
+            {
+              "type": "device",
+              "timezone": "tz_id",
+              "timezone_display_name": "my timezone",
+              "name": "testing.sentry.io",
+              "manufacturer": "Manufacturer",
+              "brand": "Brand",
+              "family": "Windows",
+              "model": "Windows Server 2012 R2",
+              "model_id": "0921309128012",
+              "arch": "x64",
+              "battery_level": 99,
+              "charging": true,
+              "orientation": "portrait",
+              "simulator": false,
+              "memory_size": 500000000000,
+              "free_memory": 200000000000,
+              "usable_memory": 100,
+              "low_memory": true,
+              "storage_size": 100000000,
+              "free_storage": 0,
+              "external_storage_size": 1000000000000000,
+              "external_free_storage": 100000000000000,
+              "screen_resolution": "800x600",
+              "screen_density": 42,
+              "screen_dpi": 42,
+              "boot_time": "9999-12-31T23:59:59.9999999+00:00",
+              "processor_count": 8,
+              "cpu_description": "Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz",
+              "processor_frequency": 2500,
+              "device_type": "Console",
+              "battery_status": "Charging",
+              "device_unique_identifier": "d610540d-11d6-4daa-a98c-b71030acae4d",
+              "supports_vibration": false,
+              "supports_accelerometer": true,
+              "supports_gyroscope": true,
+              "supports_audio": true,
+              "supports_location_service": true
+            }
+            """,
             actual);
     }
 
@@ -206,7 +209,7 @@ public class DeviceTests
     public void FromJson_NonSystemTimeZone_NoException()
     {
         // Arrange
-        const string json = "{\"type\":\"device\",\"timezone\":\"tz_id\",\"timezone_display_name\":\"tz_name\"}";
+        const string json = """{"type":"device","timezone":"tz_id","timezone_display_name":"tz_name"}""";
 
         // Act
         var device = Json.Parse(json, Device.FromJson);
@@ -219,43 +222,43 @@ public class DeviceTests
 
     public static IEnumerable<object[]> TestCases()
     {
-        yield return new object[] { (new Device(), "{\"type\":\"device\"}") };
-        yield return new object[] { (new Device { Name = "some name" }, "{\"type\":\"device\",\"name\":\"some name\"}") };
-        yield return new object[] { (new Device { Orientation = DeviceOrientation.Landscape }, "{\"type\":\"device\",\"orientation\":\"landscape\"}") };
-        yield return new object[] { (new Device { Brand = "some brand" }, "{\"type\":\"device\",\"brand\":\"some brand\"}") };
-        yield return new object[] { (new Device { Manufacturer = "some manufacturer" }, "{\"type\":\"device\",\"manufacturer\":\"some manufacturer\"}") };
-        yield return new object[] { (new Device { Family = "some family" }, "{\"type\":\"device\",\"family\":\"some family\"}") };
-        yield return new object[] { (new Device { Model = "some model" }, "{\"type\":\"device\",\"model\":\"some model\"}") };
-        yield return new object[] { (new Device { ModelId = "some model id" }, "{\"type\":\"device\",\"model_id\":\"some model id\"}") };
-        yield return new object[] { (new Device { Architecture = "some arch" }, "{\"type\":\"device\",\"arch\":\"some arch\"}") };
-        yield return new object[] { (new Device { BatteryLevel = 1 }, "{\"type\":\"device\",\"battery_level\":1}") };
-        yield return new object[] { (new Device { IsCharging = true }, "{\"type\":\"device\",\"charging\":true}") };
-        yield return new object[] { (new Device { IsOnline = true }, "{\"type\":\"device\",\"online\":true}") };
-        yield return new object[] { (new Device { Simulator = false }, "{\"type\":\"device\",\"simulator\":false}") };
-        yield return new object[] { (new Device { MemorySize = 1 }, "{\"type\":\"device\",\"memory_size\":1}") };
-        yield return new object[] { (new Device { FreeMemory = 1 }, "{\"type\":\"device\",\"free_memory\":1}") };
-        yield return new object[] { (new Device { UsableMemory = 1 }, "{\"type\":\"device\",\"usable_memory\":1}") };
-        yield return new object[] { (new Device { LowMemory = true }, "{\"type\":\"device\",\"low_memory\":true}") };
-        yield return new object[] { (new Device { StorageSize = 1 }, "{\"type\":\"device\",\"storage_size\":1}") };
-        yield return new object[] { (new Device { FreeStorage = 1 }, "{\"type\":\"device\",\"free_storage\":1}") };
-        yield return new object[] { (new Device { ExternalStorageSize = 1 }, "{\"type\":\"device\",\"external_storage_size\":1}") };
-        yield return new object[] { (new Device { ExternalFreeStorage = 1 }, "{\"type\":\"device\",\"external_free_storage\":1}") };
-        yield return new object[] { (new Device { ScreenResolution = "1x1" }, "{\"type\":\"device\",\"screen_resolution\":\"1x1\"}") };
-        yield return new object[] { (new Device { ScreenDensity = 1 }, "{\"type\":\"device\",\"screen_density\":1}") };
-        yield return new object[] { (new Device { ScreenDpi = 1 }, "{\"type\":\"device\",\"screen_dpi\":1}") };
-        yield return new object[] { (new Device { BootTime = DateTimeOffset.MaxValue }, "{\"type\":\"device\",\"boot_time\":\"9999-12-31T23:59:59.9999999+00:00\"}") };
-        yield return new object[] { (new Device { Timezone = TimeZoneInfo.CreateCustomTimeZone("tz_id", TimeSpan.Zero, "tz_name", "tz_name") }, "{\"type\":\"device\",\"timezone\":\"tz_id\",\"timezone_display_name\":\"tz_name\"}") };
-        yield return new object[] { (new Device { Timezone = TimeZoneInfo.CreateCustomTimeZone("tz_id", TimeSpan.Zero, "tz_id", "tz_id") }, "{\"type\":\"device\",\"timezone\":\"tz_id\"}") };
-        yield return new object[] { (new Device { ProcessorCount = 8 }, "{\"type\":\"device\",\"processor_count\":8}") };
-        yield return new object[] { (new Device { CpuDescription = "Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz" }, "{\"type\":\"device\",\"cpu_description\":\"Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz\"}") };
-        yield return new object[] { (new Device { ProcessorFrequency = 2500 }, "{\"type\":\"device\",\"processor_frequency\":2500}") };
-        yield return new object[] { (new Device { DeviceType = "Handheld" }, "{\"type\":\"device\",\"device_type\":\"Handheld\"}") };
-        yield return new object[] { (new Device { BatteryStatus = "Charging" }, "{\"type\":\"device\",\"battery_status\":\"Charging\"}") };
-        yield return new object[] { (new Device { DeviceUniqueIdentifier = "d610540d-11d6-4daa-a98c-b71030acae4d" }, "{\"type\":\"device\",\"device_unique_identifier\":\"d610540d-11d6-4daa-a98c-b71030acae4d\"}") };
-        yield return new object[] { (new Device { SupportsVibration = false }, "{\"type\":\"device\",\"supports_vibration\":false}") };
-        yield return new object[] { (new Device { SupportsAccelerometer = true }, "{\"type\":\"device\",\"supports_accelerometer\":true}") };
-        yield return new object[] { (new Device { SupportsGyroscope = true }, "{\"type\":\"device\",\"supports_gyroscope\":true}") };
-        yield return new object[] { (new Device { SupportsAudio = true }, "{\"type\":\"device\",\"supports_audio\":true}") };
-        yield return new object[] { (new Device { SupportsLocationService = true }, "{\"type\":\"device\",\"supports_location_service\":true}") };
+        yield return new object[] { (new Device(), """{"type":"device"}""") };
+        yield return new object[] { (new Device { Name = "some name" }, """{"type":"device","name":"some name"}""") };
+        yield return new object[] { (new Device { Orientation = DeviceOrientation.Landscape }, """{"type":"device","orientation":"landscape"}""") };
+        yield return new object[] { (new Device { Brand = "some brand" }, """{"type":"device","brand":"some brand"}""") };
+        yield return new object[] { (new Device { Manufacturer = "some manufacturer" }, """{"type":"device","manufacturer":"some manufacturer"}""") };
+        yield return new object[] { (new Device { Family = "some family" }, """{"type":"device","family":"some family"}""") };
+        yield return new object[] { (new Device { Model = "some model" }, """{"type":"device","model":"some model"}""") };
+        yield return new object[] { (new Device { ModelId = "some model id" }, """{"type":"device","model_id":"some model id"}""") };
+        yield return new object[] { (new Device { Architecture = "some arch" }, """{"type":"device","arch":"some arch"}""") };
+        yield return new object[] { (new Device { BatteryLevel = 1 }, """{"type":"device","battery_level":1}""") };
+        yield return new object[] { (new Device { IsCharging = true }, """{"type":"device","charging":true}""") };
+        yield return new object[] { (new Device { IsOnline = true }, """{"type":"device","online":true}""") };
+        yield return new object[] { (new Device { Simulator = false }, """{"type":"device","simulator":false}""") };
+        yield return new object[] { (new Device { MemorySize = 1 }, """{"type":"device","memory_size":1}""") };
+        yield return new object[] { (new Device { FreeMemory = 1 }, """{"type":"device","free_memory":1}""") };
+        yield return new object[] { (new Device { UsableMemory = 1 }, """{"type":"device","usable_memory":1}""") };
+        yield return new object[] { (new Device { LowMemory = true }, """{"type":"device","low_memory":true}""") };
+        yield return new object[] { (new Device { StorageSize = 1 }, """{"type":"device","storage_size":1}""") };
+        yield return new object[] { (new Device { FreeStorage = 1 }, """{"type":"device","free_storage":1}""") };
+        yield return new object[] { (new Device { ExternalStorageSize = 1 }, """{"type":"device","external_storage_size":1}""") };
+        yield return new object[] { (new Device { ExternalFreeStorage = 1 }, """{"type":"device","external_free_storage":1}""") };
+        yield return new object[] { (new Device { ScreenResolution = "1x1" }, """{"type":"device","screen_resolution":"1x1"}""") };
+        yield return new object[] { (new Device { ScreenDensity = 1 }, """{"type":"device","screen_density":1}""") };
+        yield return new object[] { (new Device { ScreenDpi = 1 }, """{"type":"device","screen_dpi":1}""") };
+        yield return new object[] { (new Device { BootTime = DateTimeOffset.MaxValue }, """{"type":"device","boot_time":"9999-12-31T23:59:59.9999999+00:00"}""") };
+        yield return new object[] { (new Device { Timezone = TimeZoneInfo.CreateCustomTimeZone("tz_id", TimeSpan.Zero, "tz_name", "tz_name") }, """{"type":"device","timezone":"tz_id","timezone_display_name":"tz_name"}""") };
+        yield return new object[] { (new Device { Timezone = TimeZoneInfo.CreateCustomTimeZone("tz_id", TimeSpan.Zero, "tz_id", "tz_id") }, """{"type":"device","timezone":"tz_id"}""") };
+        yield return new object[] { (new Device { ProcessorCount = 8 }, """{"type":"device","processor_count":8}""") };
+        yield return new object[] { (new Device { CpuDescription = "Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz" }, """{"type":"device","cpu_description":"Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz"}""") };
+        yield return new object[] { (new Device { ProcessorFrequency = 2500 }, """{"type":"device","processor_frequency":2500}""") };
+        yield return new object[] { (new Device { DeviceType = "Handheld" }, """{"type":"device","device_type":"Handheld"}""") };
+        yield return new object[] { (new Device { BatteryStatus = "Charging" }, """{"type":"device","battery_status":"Charging"}""") };
+        yield return new object[] { (new Device { DeviceUniqueIdentifier = "d610540d-11d6-4daa-a98c-b71030acae4d" }, """{"type":"device","device_unique_identifier":"d610540d-11d6-4daa-a98c-b71030acae4d"}""") };
+        yield return new object[] { (new Device { SupportsVibration = false }, """{"type":"device","supports_vibration":false}""") };
+        yield return new object[] { (new Device { SupportsAccelerometer = true }, """{"type":"device","supports_accelerometer":true}""") };
+        yield return new object[] { (new Device { SupportsGyroscope = true }, """{"type":"device","supports_gyroscope":true}""") };
+        yield return new object[] { (new Device { SupportsAudio = true }, """{"type":"device","supports_audio":true}""") };
+        yield return new object[] { (new Device { SupportsLocationService = true }, """{"type":"device","supports_location_service":true}""") };
     }
 }

--- a/test/Sentry.Tests/Protocol/Context/GpuTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/GpuTests.cs
@@ -31,25 +31,28 @@ public class GpuTests
             SupportsGeometryShaders = true
         };
 
-        var actual = sut.ToJsonString(_testOutputLogger);
+        var actual = sut.ToJsonString(_testOutputLogger, indented: true);
 
-        Assert.Equal(
-            "{\"type\":\"gpu\"," +
-            "\"name\":\"Sentry.Test.Gpu\"," +
-            "\"id\":123," +
-            "\"vendor_id\":\"321\"," +
-            "\"vendor_name\":\"Vendor name\"," +
-            "\"memory_size\":1000," +
-            "\"api_type\":\"API Type\"," +
-            "\"multi_threaded_rendering\":true," +
-            "\"version\":\"Version 3232\"," +
-            "\"npot_support\":\"Full NPOT\"," +
-            "\"max_texture_size\":10000," +
-            "\"graphics_shader_level\":\"Shader Model 2.0\"," +
-            "\"supports_draw_call_instancing\":true," +
-            "\"supports_ray_tracing\":false," +
-            "\"supports_compute_shaders\":true," +
-            "\"supports_geometry_shaders\":true}",
+        Assert.Equal("""
+            {
+              "type": "gpu",
+              "name": "Sentry.Test.Gpu",
+              "id": 123,
+              "vendor_id": "321",
+              "vendor_name": "Vendor name",
+              "memory_size": 1000,
+              "api_type": "API Type",
+              "multi_threaded_rendering": true,
+              "version": "Version 3232",
+              "npot_support": "Full NPOT",
+              "max_texture_size": 10000,
+              "graphics_shader_level": "Shader Model 2.0",
+              "supports_draw_call_instancing": true,
+              "supports_ray_tracing": false,
+              "supports_compute_shaders": true,
+              "supports_geometry_shaders": true
+            }
+            """,
             actual);
     }
 
@@ -104,21 +107,21 @@ public class GpuTests
 
     public static IEnumerable<object[]> TestCases()
     {
-        yield return new object[] { (new Gpu(), "{\"type\":\"gpu\"}") };
-        yield return new object[] { (new Gpu { Name = "some name" }, "{\"type\":\"gpu\",\"name\":\"some name\"}") };
-        yield return new object[] { (new Gpu { Id = 1 }, "{\"type\":\"gpu\",\"id\":1}") };
-        yield return new object[] { (new Gpu { VendorId = "1" }, "{\"type\":\"gpu\",\"vendor_id\":\"1\"}") };
-        yield return new object[] { (new Gpu { VendorName = "some name" }, "{\"type\":\"gpu\",\"vendor_name\":\"some name\"}") };
-        yield return new object[] { (new Gpu { MemorySize = 123 }, "{\"type\":\"gpu\",\"memory_size\":123}") };
-        yield return new object[] { (new Gpu { ApiType = "some ApiType" }, "{\"type\":\"gpu\",\"api_type\":\"some ApiType\"}") };
-        yield return new object[] { (new Gpu { MultiThreadedRendering = false }, "{\"type\":\"gpu\",\"multi_threaded_rendering\":false}") };
-        yield return new object[] { (new Gpu { Version = "some version" }, "{\"type\":\"gpu\",\"version\":\"some version\"}") };
-        yield return new object[] { (new Gpu { NpotSupport = "some npot_support" }, "{\"type\":\"gpu\",\"npot_support\":\"some npot_support\"}") };
-        yield return new object[] { (new Gpu { MaxTextureSize = 10000 }, "{\"type\":\"gpu\",\"max_texture_size\":10000}") };
-        yield return new object[] { (new Gpu { GraphicsShaderLevel = "Shader Model 2.0" }, "{\"type\":\"gpu\",\"graphics_shader_level\":\"Shader Model 2.0\"}") };
-        yield return new object[] { (new Gpu { SupportsDrawCallInstancing = true }, "{\"type\":\"gpu\",\"supports_draw_call_instancing\":true}") };
-        yield return new object[] { (new Gpu { SupportsRayTracing = false }, "{\"type\":\"gpu\",\"supports_ray_tracing\":false}") };
-        yield return new object[] { (new Gpu { SupportsComputeShaders = true }, "{\"type\":\"gpu\",\"supports_compute_shaders\":true}") };
-        yield return new object[] { (new Gpu { SupportsGeometryShaders = true }, "{\"type\":\"gpu\",\"supports_geometry_shaders\":true}") };
+        yield return new object[] { (new Gpu(), """{"type":"gpu"}""") };
+        yield return new object[] { (new Gpu { Name = "some name" }, """{"type":"gpu","name":"some name"}""") };
+        yield return new object[] { (new Gpu { Id = 1 }, """{"type":"gpu","id":1}""") };
+        yield return new object[] { (new Gpu { VendorId = "1" }, """{"type":"gpu","vendor_id":"1"}""") };
+        yield return new object[] { (new Gpu { VendorName = "some name" }, """{"type":"gpu","vendor_name":"some name"}""") };
+        yield return new object[] { (new Gpu { MemorySize = 123 }, """{"type":"gpu","memory_size":123}""") };
+        yield return new object[] { (new Gpu { ApiType = "some ApiType" }, """{"type":"gpu","api_type":"some ApiType"}""") };
+        yield return new object[] { (new Gpu { MultiThreadedRendering = false }, """{"type":"gpu","multi_threaded_rendering":false}""") };
+        yield return new object[] { (new Gpu { Version = "some version" }, """{"type":"gpu","version":"some version"}""") };
+        yield return new object[] { (new Gpu { NpotSupport = "some npot_support" }, """{"type":"gpu","npot_support":"some npot_support"}""") };
+        yield return new object[] { (new Gpu { MaxTextureSize = 10000 }, """{"type":"gpu","max_texture_size":10000}""") };
+        yield return new object[] { (new Gpu { GraphicsShaderLevel = """Shader Model 2.0""" }, """{"type":"gpu","graphics_shader_level":"Shader Model 2.0"}""") };
+        yield return new object[] { (new Gpu { SupportsDrawCallInstancing = true }, """{"type":"gpu","supports_draw_call_instancing":true}""") };
+        yield return new object[] { (new Gpu { SupportsRayTracing = false }, """{"type":"gpu","supports_ray_tracing":false}""") };
+        yield return new object[] { (new Gpu { SupportsComputeShaders = true }, """{"type":"gpu","supports_compute_shaders":true}""") };
+        yield return new object[] { (new Gpu { SupportsGeometryShaders = true }, """{"type":"gpu","supports_geometry_shaders":true}""") };
     }
 }

--- a/test/Sentry.Tests/Protocol/Context/OperatingSystemTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/OperatingSystemTests.cs
@@ -24,16 +24,20 @@ public class OperatingSystemTests
             Rooted = true
         };
 
-        var actual = sut.ToJsonString(_testOutputLogger);
+        var actual = sut.ToJsonString(_testOutputLogger, indented: true);
 
         Assert.Equal(
-            "{\"type\":\"os\"," +
-            "\"name\":\"Windows\"," +
-            "\"version\":\"2016\"," +
-            "\"raw_description\":\"Windows 2016\"," +
-            "\"build\":\"14393\"," +
-            "\"kernel_version\":\"who knows\"," +
-            "\"rooted\":true}",
+            """
+            {
+              "type": "os",
+              "name": "Windows",
+              "version": "2016",
+              "raw_description": "Windows 2016",
+              "build": "14393",
+              "kernel_version": "who knows",
+              "rooted": true
+            }
+            """,
             actual);
     }
 
@@ -71,11 +75,11 @@ public class OperatingSystemTests
 
     public static IEnumerable<object[]> TestCases()
     {
-        yield return new object[] { (new OperatingSystem(), "{\"type\":\"os\"}") };
-        yield return new object[] { (new OperatingSystem { Name = "some name" }, "{\"type\":\"os\",\"name\":\"some name\"}") };
-        yield return new object[] { (new OperatingSystem { RawDescription = "some Name, some version" }, "{\"type\":\"os\",\"raw_description\":\"some Name, some version\"}") };
-        yield return new object[] { (new OperatingSystem { Build = "some build" }, "{\"type\":\"os\",\"build\":\"some build\"}") };
-        yield return new object[] { (new OperatingSystem { KernelVersion = "some kernel version" }, "{\"type\":\"os\",\"kernel_version\":\"some kernel version\"}") };
-        yield return new object[] { (new OperatingSystem { Rooted = false }, "{\"type\":\"os\",\"rooted\":false}") };
+        yield return new object[] { (new OperatingSystem(), """{"type":"os"}""") };
+        yield return new object[] { (new OperatingSystem { Name = "some name" }, """{"type":"os","name":"some name"}""") };
+        yield return new object[] { (new OperatingSystem { RawDescription = "some Name, some version" }, """{"type":"os","raw_description":"some Name, some version"}""") };
+        yield return new object[] { (new OperatingSystem { Build = "some build" }, """{"type":"os","build":"some build"}""") };
+        yield return new object[] { (new OperatingSystem { KernelVersion = "some kernel version" }, """{"type":"os","kernel_version":"some kernel version"}""") };
+        yield return new object[] { (new OperatingSystem { Rooted = false }, """{"type":"os","rooted":false}""") };
     }
 }

--- a/test/Sentry.Tests/Protocol/Context/RuntimeTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/RuntimeTests.cs
@@ -20,9 +20,17 @@ public class RuntimeTests
             RawDescription = ".NET Framework 4.7.2"
         };
 
-        var actual = sut.ToJsonString(_testOutputLogger);
+        var actual = sut.ToJsonString(_testOutputLogger, indented: true);
 
-        Assert.Equal("{\"type\":\"runtime\",\"name\":\".NET Framework\",\"version\":\"4.7.2\",\"raw_description\":\".NET Framework 4.7.2\",\"build\":\"461814\"}", actual);
+        Assert.Equal("""
+            {
+              "type": "runtime",
+              "name": ".NET Framework",
+              "version": "4.7.2",
+              "raw_description": ".NET Framework 4.7.2",
+              "build": "461814"
+            }
+            """, actual);
     }
 
     [Fact]
@@ -59,11 +67,11 @@ public class RuntimeTests
 
     public static IEnumerable<object[]> TestCases()
     {
-        yield return new object[] { (new Runtime(), "{\"type\":\"runtime\"}") };
-        yield return new object[] { (new Runtime { Name = "some name" }, "{\"type\":\"runtime\",\"name\":\"some name\"}") };
-        yield return new object[] { (new Runtime { Version = "some version" }, "{\"type\":\"runtime\",\"version\":\"some version\"}") };
-        yield return new object[] { (new Runtime { Identifier = "some identifier" }, "{\"type\":\"runtime\",\"identifier\":\"some identifier\"}") };
-        yield return new object[] { (new Runtime { Build = "some build" }, "{\"type\":\"runtime\",\"build\":\"some build\"}") };
-        yield return new object[] { (new Runtime { RawDescription = "some Name, some version" }, "{\"type\":\"runtime\",\"raw_description\":\"some Name, some version\"}") };
+        yield return new object[] { (new Runtime(), """{"type":"runtime"}""") };
+        yield return new object[] { (new Runtime { Name = "some name" }, """{"type":"runtime","name":"some name"}""") };
+        yield return new object[] { (new Runtime { Version = "some version" }, """{"type":"runtime","version":"some version"}""") };
+        yield return new object[] { (new Runtime { Identifier = "some identifier" }, """{"type":"runtime","identifier":"some identifier"}""") };
+        yield return new object[] { (new Runtime { Build = "some build" }, """{"type":"runtime","build":"some build"}""") };
+        yield return new object[] { (new Runtime { RawDescription = "some Name, some version" }, """{"type":"runtime","raw_description":"some Name, some version"}""") };
     }
 }

--- a/test/Sentry.Tests/Protocol/Context/TraceTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/TraceTests.cs
@@ -21,7 +21,7 @@ public class TraceTests
         var actual = trace.ToJsonString(_testOutputLogger);
 
         // Assert
-        Assert.Equal("{\"type\":\"trace\"}", actual);
+        Assert.Equal("""{"type":"trace"}""", actual);
     }
 
     [Fact]
@@ -39,18 +39,20 @@ public class TraceTests
         };
 
         // Act
-        var actual = trace.ToJsonString(_testOutputLogger);
+        var actual = trace.ToJsonString(_testOutputLogger, indented: true);
 
         // Assert
         Assert.Equal(
-            "{" +
-            "\"type\":\"trace\"," +
-            "\"span_id\":\"2000000000000000\"," +
-            "\"parent_span_id\":\"1000000000000000\"," +
-            "\"trace_id\":\"75302ac48a024bde9a3b3734a82e36c8\"," +
-            "\"op\":\"op123\"," +
-            "\"status\":\"aborted\"" +
-            "}",
+            """
+            {
+              "type": "trace",
+              "span_id": "2000000000000000",
+              "parent_span_id": "1000000000000000",
+              "trace_id": "75302ac48a024bde9a3b3734a82e36c8",
+              "op": "op123",
+              "status": "aborted"
+            }
+            """,
             actual);
     }
 

--- a/test/Sentry.Tests/Protocol/DebugImageTests.cs
+++ b/test/Sentry.Tests/Protocol/DebugImageTests.cs
@@ -23,18 +23,19 @@ public class DebugImageTests
             CodeFile = "libc.so"
         };
 
-        var actual = sut.ToJsonString(_testOutputLogger);
+        var actual = sut.ToJsonString(_testOutputLogger, indented: true);
 
-        Assert.Equal(
-            "{" +
-            "\"type\":\"elf\"," +
-            "\"image_addr\":\"0xffffffff\"," +
-            "\"image_size\":1234," +
-            "\"debug_id\":\"900f7d1b868432939de4457478f34720\"," +
-            "\"debug_file\":\"libc.debug\"," +
-            "\"code_id\":\"900f7d1b868432939de4457478f34720\"," +
-            "\"code_file\":\"libc.so\"" +
-            "}",
+        Assert.Equal("""
+            {
+              "type": "elf",
+              "image_addr": "0xffffffff",
+              "image_size": 1234,
+              "debug_id": "900f7d1b868432939de4457478f34720",
+              "debug_file": "libc.debug",
+              "code_id": "900f7d1b868432939de4457478f34720",
+              "code_file": "libc.so"
+            }
+            """,
             actual);
 
         var parsed = Json.Parse(actual, DebugImage.FromJson);

--- a/test/Sentry.Tests/Protocol/Exceptions/MechanismTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/MechanismTests.cs
@@ -24,16 +24,23 @@ public class MechanismTests
         sut.Data.Add("data-key", "data-value");
         sut.Meta.Add("meta-key", "meta-value");
 
-        var actual = sut.ToJsonString(_testOutputLogger);
+        var actual = sut.ToJsonString(_testOutputLogger, indented: true);
 
-        const string expected =
-            "{\"type\":\"mechanism type\"," +
-            "\"description\":\"mechanism description\"," +
-            "\"help_link\":\"https://helplink\"," +
-            "\"handled\":true," +
-            "\"synthetic\":true," +
-            "\"data\":{\"data-key\":\"data-value\"}," +
-            "\"meta\":{\"meta-key\":\"meta-value\"}}";
+        const string expected = """
+            {
+              "type": "mechanism type",
+              "description": "mechanism description",
+              "help_link": "https://helplink",
+              "handled": true,
+              "synthetic": true,
+              "data": {
+                "data-key": "data-value"
+              },
+              "meta": {
+                "meta-key": "meta-value"
+              }
+            }
+            """;
 
         Assert.Equal(expected, actual);
     }
@@ -49,16 +56,14 @@ public class MechanismTests
 
     public static IEnumerable<object[]> TestCases()
     {
-        yield return new object[] { (new Mechanism(), "{\"type\":\"generic\"}") };
-        yield return new object[] { (new Mechanism { Type = "some type" }, "{\"type\":\"some type\"}") };
-        yield return new object[] { (new Mechanism { Handled = false }, "{\"type\":\"generic\",\"handled\":false}") };
-        yield return new object[] { (new Mechanism { Handled = true }, "{\"type\":\"generic\",\"handled\":true}") };
-        yield return new object[] { (new Mechanism { Synthetic = true }, "{\"type\":\"generic\",\"synthetic\":true}") };
-        yield return new object[] { (new Mechanism { HelpLink = "https://sentry.io/docs" }, "{\"type\":\"generic\",\"help_link\":\"https://sentry.io/docs\"}") };
-        yield return new object[] { (new Mechanism { Description = "some desc" }, "{\"type\":\"generic\",\"description\":\"some desc\"}") };
-        yield return new object[] { (new Mechanism { Data = { new KeyValuePair<string, object>("data-key", "data-value") } },
-            "{\"type\":\"generic\",\"data\":{\"data-key\":\"data-value\"}}") };
-        yield return new object[] { (new Mechanism { Meta = { new KeyValuePair<string, object>("meta-key", "meta-value") } },
-            "{\"type\":\"generic\",\"meta\":{\"meta-key\":\"meta-value\"}}") };
+        yield return new object[] { (new Mechanism(), """{"type":"generic"}""") };
+        yield return new object[] { (new Mechanism { Type = "some type" }, """{"type":"some type"}""") };
+        yield return new object[] { (new Mechanism { Handled = false }, """{"type":"generic","handled":false}""") };
+        yield return new object[] { (new Mechanism { Handled = true }, """{"type":"generic","handled":true}""") };
+        yield return new object[] { (new Mechanism { Synthetic = true }, """{"type":"generic","synthetic":true}""") };
+        yield return new object[] { (new Mechanism { HelpLink = "https://sentry.io/docs" }, """{"type":"generic","help_link":"https://sentry.io/docs"}""") };
+        yield return new object[] { (new Mechanism { Description = "some desc" }, """{"type":"generic","description":"some desc"}""") };
+        yield return new object[] { (new Mechanism { Data = { new KeyValuePair<string, object>("data-key", "data-value") } }, """{"type":"generic","data":{"data-key":"data-value"}}""") };
+        yield return new object[] { (new Mechanism { Meta = { new KeyValuePair<string, object>("meta-key", "meta-value") } }, """{"type":"generic","meta":{"meta-key":"meta-value"}}""") };
     }
 }

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryExceptionTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryExceptionTests.cs
@@ -31,15 +31,27 @@ public class SentryExceptionTests
             }
         };
 
-        var actual = sut.ToJsonString(_testOutputLogger);
+        var actual = sut.ToJsonString(_testOutputLogger, indented: true);
 
-        Assert.Equal(
-            "{\"type\":\"Type\"," +
-            "\"value\":\"Value\"," +
-            "\"module\":\"Module\"," +
-            "\"thread_id\":1," +
-            "\"stacktrace\":{\"frames\":[{\"filename\":\"FileName\"}]}," +
-            "\"mechanism\":{\"type\":\"generic\",\"description\":\"Description\"}}",
+        Assert.Equal("""
+            {
+              "type": "Type",
+              "value": "Value",
+              "module": "Module",
+              "thread_id": 1,
+              "stacktrace": {
+                "frames": [
+                  {
+                    "filename": "FileName"
+                  }
+                ]
+              },
+              "mechanism": {
+                "type": "generic",
+                "description": "Description"
+              }
+            }
+            """,
             actual);
     }
 }

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
@@ -35,30 +35,40 @@ public class SentryStackFrameTests
             AddressMode = "rel:0"
         };
 
-        var actual = sut.ToJsonString(_testOutputLogger);
+        var actual = sut.ToJsonString(_testOutputLogger, indented: true);
 
-        Assert.Equal(
-            "{" +
-            "\"pre_context\":[\"pre\"]," +
-            "\"post_context\":[\"post\"]," +
-            "\"vars\":{\"var\":\"val\"}," +
-            "\"frames_omitted\":[1,2]," +
-            "\"filename\":\"FileName\"," +
-            "\"function\":\"Function\"," +
-            "\"module\":\"Module\"," +
-            "\"lineno\":1," +
-            "\"colno\":2," +
-            "\"abs_path\":\"AbsolutePath\"," +
-            "\"context_line\":\"ContextLine\"," +
-            "\"in_app\":true," +
-            "\"package\":\"Package\"," +
-            "\"platform\":\"Platform\"," +
-            "\"image_addr\":\"0x3\"," +
-            "\"symbol_addr\":\"0x4\"," +
-            "\"instruction_addr\":\"0xffffffff\"," +
-            "\"instruction_offset\":5," +
-            "\"addr_mode\":\"rel:0\"" +
-            "}",
+        Assert.Equal("""
+            {
+              "pre_context": [
+                "pre"
+              ],
+              "post_context": [
+                "post"
+              ],
+              "vars": {
+                "var": "val"
+              },
+              "frames_omitted": [
+                1,
+                2
+              ],
+              "filename": "FileName",
+              "function": "Function",
+              "module": "Module",
+              "lineno": 1,
+              "colno": 2,
+              "abs_path": "AbsolutePath",
+              "context_line": "ContextLine",
+              "in_app": true,
+              "package": "Package",
+              "platform": "Platform",
+              "image_addr": "0x3",
+              "symbol_addr": "0x4",
+              "instruction_addr": "0xffffffff",
+              "instruction_offset": 5,
+              "addr_mode": "rel:0"
+            }
+            """,
             actual);
 
         var parsed = Json.Parse(actual, SentryStackFrame.FromJson);

--- a/test/Sentry.Tests/Protocol/MeasurementTests.cs
+++ b/test/Sentry.Tests/Protocol/MeasurementTests.cs
@@ -73,7 +73,7 @@ public partial class MeasurementTests
     {
         var m = new Measurement(int.MaxValue);
         var json = m.ToJsonString();
-        Assert.Equal("{\"value\":2147483647}", json);
+        Assert.Equal("""{"value":2147483647}""", json);
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public partial class MeasurementTests
     {
         var m = new Measurement(long.MaxValue);
         var json = m.ToJsonString();
-        Assert.Equal("{\"value\":9223372036854775807}", json);
+        Assert.Equal("""{"value":9223372036854775807}""", json);
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public partial class MeasurementTests
     {
         var m = new Measurement(ulong.MaxValue);
         var json = m.ToJsonString();
-        Assert.Equal("{\"value\":18446744073709551615}", json);
+        Assert.Equal("""{"value":18446744073709551615}""", json);
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public partial class MeasurementTests
     {
         var m = new Measurement(double.MaxValue);
         var json = m.ToJsonString();
-        Assert.Equal("{\"value\":1.7976931348623157E+308}", json);
+        Assert.Equal("""{"value":1.7976931348623157E+308}""", json);
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public partial class MeasurementTests
     {
         var m = new Measurement(int.MaxValue, MeasurementUnit.None);
         var json = m.ToJsonString();
-        Assert.Equal("{\"value\":2147483647,\"unit\":\"none\"}", json);
+        Assert.Equal("""{"value":2147483647,"unit":"none"}""", json);
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public partial class MeasurementTests
     {
         var m = new Measurement(long.MaxValue, MeasurementUnit.None);
         var json = m.ToJsonString();
-        Assert.Equal("{\"value\":9223372036854775807,\"unit\":\"none\"}", json);
+        Assert.Equal("""{"value":9223372036854775807,"unit":"none"}""", json);
     }
 
     [Fact]
@@ -121,7 +121,7 @@ public partial class MeasurementTests
     {
         var m = new Measurement(ulong.MaxValue, MeasurementUnit.None);
         var json = m.ToJsonString();
-        Assert.Equal("{\"value\":18446744073709551615,\"unit\":\"none\"}", json);
+        Assert.Equal("""{"value":18446744073709551615,"unit":"none"}""", json);
     }
 
     [Fact]
@@ -129,7 +129,7 @@ public partial class MeasurementTests
     {
         var m = new Measurement(double.MaxValue, MeasurementUnit.None);
         var json = m.ToJsonString();
-        Assert.Equal("{\"value\":1.7976931348623157E+308,\"unit\":\"none\"}", json);
+        Assert.Equal("""{"value":1.7976931348623157E+308,"unit":"none"}""", json);
     }
 
     [Fact]
@@ -137,7 +137,7 @@ public partial class MeasurementTests
     {
         var m = new Measurement(int.MaxValue, MeasurementUnit.Duration.Second);
         var json = m.ToJsonString();
-        Assert.Equal("{\"value\":2147483647,\"unit\":\"second\"}", json);
+        Assert.Equal("""{"value":2147483647,"unit":"second"}""", json);
     }
 
     [Fact]
@@ -145,7 +145,7 @@ public partial class MeasurementTests
     {
         var m = new Measurement(long.MaxValue, MeasurementUnit.Duration.Second);
         var json = m.ToJsonString();
-        Assert.Equal("{\"value\":9223372036854775807,\"unit\":\"second\"}", json);
+        Assert.Equal("""{"value":9223372036854775807,"unit":"second"}""", json);
     }
 
     [Fact]
@@ -153,7 +153,7 @@ public partial class MeasurementTests
     {
         var m = new Measurement(ulong.MaxValue, MeasurementUnit.Duration.Second);
         var json = m.ToJsonString();
-        Assert.Equal("{\"value\":18446744073709551615,\"unit\":\"second\"}", json);
+        Assert.Equal("""{"value":18446744073709551615,"unit":"second"}""", json);
     }
 
     [Fact]
@@ -161,7 +161,7 @@ public partial class MeasurementTests
     {
         var m = new Measurement(double.MaxValue, MeasurementUnit.Duration.Second);
         var json = m.ToJsonString();
-        Assert.Equal("{\"value\":1.7976931348623157E+308,\"unit\":\"second\"}", json);
+        Assert.Equal("""{"value":1.7976931348623157E+308,"unit":"second"}""", json);
     }
 
     [Fact]

--- a/test/Sentry.Tests/Protocol/PackageTests.cs
+++ b/test/Sentry.Tests/Protocol/PackageTests.cs
@@ -16,10 +16,7 @@ public class PackageTests
 
         var actual = sut.ToJsonString(_testOutputLogger);
 
-        Assert.Equal(
-            "{\"name\":\"nuget:Sentry\"," +
-            "\"version\":\"1.0.0-preview\"}",
-            actual);
+        Assert.Equal("""{"name":"nuget:Sentry","version":"1.0.0-preview"}""", actual);
     }
 
     [Theory]
@@ -34,7 +31,7 @@ public class PackageTests
     public static IEnumerable<object[]> TestCases()
     {
         yield return new object[] { (new Package(null, null), "{}") };
-        yield return new object[] { (new Package("nuget:Sentry", null), "{\"name\":\"nuget:Sentry\"}") };
-        yield return new object[] { (new Package(null, "0.0.0-alpha"), "{\"version\":\"0.0.0-alpha\"}") };
+        yield return new object[] { (new Package("nuget:Sentry", null), """{"name":"nuget:Sentry"}""") };
+        yield return new object[] { (new Package(null, "0.0.0-alpha"), """{"version":"0.0.0-alpha"}""") };
     }
 }

--- a/test/Sentry.Tests/Protocol/SdkVersionTests.cs
+++ b/test/Sentry.Tests/Protocol/SdkVersionTests.cs
@@ -40,12 +40,24 @@ public class SdkVersionTests
         sut.AddPackage("Sentry.AspNetCore", "2.0");
         sut.AddPackage("Sentry", "1.0");
 
-        var actual = sut.ToJsonString(_testOutputLogger);
+        var actual = sut.ToJsonString(_testOutputLogger, indented: true);
 
-        Assert.Equal(
-            "{\"packages\":[{\"name\":\"Sentry\",\"version\":\"1.0\"},{\"name\":\"Sentry.AspNetCore\",\"version\":\"2.0\"}]," +
-            "\"name\":\"Sentry.Test.SDK\"," +
-            "\"version\":\"0.0.1-preview1\"}",
+        Assert.Equal("""
+            {
+              "packages": [
+                {
+                  "name": "Sentry",
+                  "version": "1.0"
+                },
+                {
+                  "name": "Sentry.AspNetCore",
+                  "version": "2.0"
+                }
+              ],
+              "name": "Sentry.Test.SDK",
+              "version": "0.0.1-preview1"
+            }
+            """,
             actual);
     }
 
@@ -61,12 +73,12 @@ public class SdkVersionTests
     public static IEnumerable<object[]> TestCases()
     {
         yield return new object[] { (new SdkVersion(), "{}") };
-        yield return new object[] { (new SdkVersion { Name = "some name" }, "{\"name\":\"some name\"}") };
-        yield return new object[] { (new SdkVersion { Version = "some version" }, "{\"version\":\"some version\"}") };
+        yield return new object[] { (new SdkVersion { Name = "some name" }, """{"name":"some name"}""") };
+        yield return new object[] { (new SdkVersion { Version = "some version" }, """{"version":"some version"}""") };
         var sdk = new SdkVersion();
         sdk.AddPackage("b", "2");
         sdk.AddPackage("a", "1");
-        yield return new object[] { (sdk, "{\"packages\":[{\"name\":\"a\",\"version\":\"1\"},{\"name\":\"b\",\"version\":\"2\"}]}") };
+        yield return new object[] { (sdk, """{"packages":[{"name":"a","version":"1"},{"name":"b","version":"2"}]}""") };
     }
 
     [Fact]

--- a/test/Sentry.Tests/Protocol/SentryEventTests.verify.cs
+++ b/test/Sentry.Tests/Protocol/SentryEventTests.verify.cs
@@ -65,14 +65,20 @@ public partial class SentryEventTests
         sut.Fingerprint = new[] { "fingerprint" };
         sut.SetTag("tag_key", "tag_value");
 
-        var actualString = sut.ToJsonString(_testOutputLogger);
+        var actualString = sut.ToJsonString(_testOutputLogger, indented: true);
 
         await VerifyJson(actualString);
 
-        actualString.Should().Contain(
-            "\"debug_meta\":{\"images\":[" +
-            "{\"type\":\"wasm\",\"debug_id\":\"900f7d1b868432939de4457478f34720\"}" +
-            "]}");
+        actualString.Should().Contain("""
+              "debug_meta": {
+                "images": [
+                  {
+                    "type": "wasm",
+                    "debug_id": "900f7d1b868432939de4457478f34720"
+                  }
+                ]
+              }
+            """);
 
         var actual = Json.Parse(actualString, SentryEvent.FromJson);
 

--- a/test/Sentry.Tests/Protocol/SentryMessageTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryMessageTests.cs
@@ -19,12 +19,19 @@ public class SentryMessageTests
             Formatted = "Message 100 test-name"
         };
 
-        var actual = sut.ToJsonString(_testOutputLogger);
+        var actual = sut.ToJsonString(_testOutputLogger, indented: true);
 
         Assert.Equal(
-            "{\"message\":\"Message {eventId} {name}\"," +
-            "\"params\":[100,\"test-name\"]," +
-            "\"formatted\":\"Message 100 test-name\"}",
+            """
+            {
+              "message": "Message {eventId} {name}",
+              "params": [
+                100,
+                "test-name"
+              ],
+              "formatted": "Message 100 test-name"
+            }
+            """,
             actual);
     }
 
@@ -40,8 +47,8 @@ public class SentryMessageTests
     public static IEnumerable<object[]> TestCases()
     {
         yield return new object[] { (new SentryMessage(), "{}") };
-        yield return new object[] { (new SentryMessage { Message = "some message" }, "{\"message\":\"some message\"}") };
-        yield return new object[] { (new SentryMessage { Params = new[] { "param" } }, "{\"params\":[\"param\"]}") };
-        yield return new object[] { (new SentryMessage { Formatted = "some formatted" }, "{\"formatted\":\"some formatted\"}") };
+        yield return new object[] { (new SentryMessage { Message = "some message" }, """{"message":"some message"}""") };
+        yield return new object[] { (new SentryMessage { Params = new[] { "param" } }, """{"params":["param"]}""") };
+        yield return new object[] { (new SentryMessage { Formatted = "some formatted" }, """{"formatted":"some formatted"}""") };
     }
 }

--- a/test/Sentry.Tests/Protocol/SentryThreadTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryThreadTests.cs
@@ -27,14 +27,23 @@ public class SentryThreadTests
             }
         };
 
-        var actual = sut.ToJsonString(_testOutputLogger);
+        var actual = sut.ToJsonString(_testOutputLogger, indented: true);
 
-        Assert.Equal(
-            "{\"id\":0," +
-            "\"name\":\"thread11\"," +
-            "\"crashed\":true," +
-            "\"current\":true," +
-            "\"stacktrace\":{\"frames\":[{\"filename\":\"test\"}]}}",
+        Assert.Equal("""
+            {
+              "id": 0,
+              "name": "thread11",
+              "crashed": true,
+              "current": true,
+              "stacktrace": {
+                "frames": [
+                  {
+                    "filename": "test"
+                  }
+                ]
+              }
+            }
+            """,
             actual);
     }
 
@@ -50,11 +59,11 @@ public class SentryThreadTests
     public static IEnumerable<object[]> TestCases()
     {
         yield return new object[] { (new SentryThread(), "{}") };
-        yield return new object[] { (new SentryThread { Name = "some name" }, "{\"name\":\"some name\"}") };
-        yield return new object[] { (new SentryThread { Crashed = false }, "{\"crashed\":false}") };
-        yield return new object[] { (new SentryThread { Current = false }, "{\"current\":false}") };
-        yield return new object[] { (new SentryThread { Id = 200 }, "{\"id\":200}") };
-        yield return new object[] { (new SentryThread { Stacktrace = new SentryStackTrace { Frames = { new SentryStackFrame { InApp = true } } } }
-            , "{\"stacktrace\":{\"frames\":[{\"in_app\":true}]}}") };
+        yield return new object[] { (new SentryThread { Name = "some name" }, """{"name":"some name"}""") };
+        yield return new object[] { (new SentryThread { Crashed = false }, """{"crashed":false}""") };
+        yield return new object[] { (new SentryThread { Current = false }, """{"current":false}""") };
+        yield return new object[] { (new SentryThread { Id = 200 }, """{"id":200}""") };
+        yield return new object[] { (new SentryThread { Stacktrace = new SentryStackTrace { Frames = { new SentryStackFrame { InApp = true } } } },
+            """{"stacktrace":{"frames":[{"in_app":true}]}}""") };
     }
 }

--- a/test/Sentry.Tests/Protocol/UserFeedbackTests.cs
+++ b/test/Sentry.Tests/Protocol/UserFeedbackTests.cs
@@ -18,15 +18,17 @@ public class UserFeedbackTests
         using var stream = new MemoryStream();
 
         // Act
-        var serializedContent = userFeedback.ToJsonString(_testOutputLogger);
+        var actual = userFeedback.ToJsonString(_testOutputLogger, indented: true);
 
         // Assert
-        serializedContent.Should().Be(
-            "{" +
-            "\"event_id\":\"acbe351c61494e7b807fd7e82a435ffc\"," +
-            "\"name\":\"myName\"," +
-            "\"email\":\"myEmail@service.com\"," +
-            "\"comments\":\"my comment\"" +
-            "}");
+        Assert.Equal("""
+            {
+              "event_id": "acbe351c61494e7b807fd7e82a435ffc",
+              "name": "myName",
+              "email": "myEmail@service.com",
+              "comments": "my comment"
+            }
+            """,
+            actual);
     }
 }

--- a/test/Sentry.Tests/Protocol/UserTests.cs
+++ b/test/Sentry.Tests/Protocol/UserTests.cs
@@ -22,17 +22,20 @@ public class UserTests
             Other = new Dictionary<string, string> { { "testCustomValueKey", "testCustomValue" } }
         };
 
-        var actual = sut.ToJsonString(_testOutputLogger);
+        var actual = sut.ToJsonString(_testOutputLogger, indented: true);
 
-        Assert.Equal(
-            "{" +
-            "\"id\":\"user-id\"," +
-            "\"username\":\"user-name\"," +
-            "\"email\":\"test@sentry.io\"," +
-            "\"ip_address\":\"::1\"," +
-            "\"segment\":\"A1\"," +
-            "\"other\":{\"testCustomValueKey\":\"testCustomValue\"}" +
-            "}",
+        Assert.Equal("""
+            {
+              "id": "user-id",
+              "username": "user-name",
+              "email": "test@sentry.io",
+              "ip_address": "::1",
+              "segment": "A1",
+              "other": {
+                "testCustomValueKey": "testCustomValue"
+              }
+            }
+            """,
             actual);
     }
 
@@ -73,13 +76,13 @@ public class UserTests
     public static IEnumerable<object[]> TestCases()
     {
         yield return new object[] { (new User(), "{}") };
-        yield return new object[] { (new User { Id = "some id" }, "{\"id\":\"some id\"}") };
-        yield return new object[] { (new User { Username = "some username" }, "{\"username\":\"some username\"}") };
-        yield return new object[] { (new User { Email = "some email" }, "{\"email\":\"some email\"}") };
-        yield return new object[] { (new User { IpAddress = "some ipAddress" }, "{\"ip_address\":\"some ipAddress\"}") };
-        yield return new object[] { (new User { Segment = "some segment" }, "{\"segment\":\"some segment\"}") };
+        yield return new object[] { (new User { Id = "some id" }, """{"id":"some id"}""") };
+        yield return new object[] { (new User { Username = "some username" }, """{"username":"some username"}""") };
+        yield return new object[] { (new User { Email = "some email" }, """{"email":"some email"}""") };
+        yield return new object[] { (new User { IpAddress = "some ipAddress" }, """{"ip_address":"some ipAddress"}""") };
+        yield return new object[] { (new User { Segment = "some segment" }, """{"segment":"some segment"}""") };
 
         var other = new Dictionary<string, string> {{"testCustomValueKey", "testCustomValue"}};
-        yield return new object[] { (new User { Other = other }, "{\"other\":{\"testCustomValueKey\":\"testCustomValue\"}}")};
+        yield return new object[] { (new User { Other = other }, """{"other":{"testCustomValueKey":"testCustomValue"}}""")};
     }
 }

--- a/test/Sentry.Tests/SessionTests.cs
+++ b/test/Sentry.Tests/SessionTests.cs
@@ -34,27 +34,28 @@ public class SessionTests
             SessionEndStatus.Crashed);
 
         // Act
-        var json = sessionUpdate.ToJsonString(_testOutputLogger);
+        var json = sessionUpdate.ToJsonString(_testOutputLogger, indented: true);
 
         // Assert
-        json.Should().Be(
-            "{" +
-            "\"sid\":\"75302ac48a024bde9a3b3734a82e36c8\"," +
-            "\"did\":\"bar\"," +
-            "\"init\":true," +
-            "\"started\":\"2020-01-01T00:00:00+00:00\"," +
-            "\"timestamp\":\"2020-01-02T00:00:00+00:00\"," +
-            "\"seq\":5," +
-            "\"duration\":86400," +
-            "\"errors\":3," +
-            "\"status\":\"crashed\"," +
-            "\"attrs\":{" +
-            "\"release\":\"release123\"," +
-            "\"environment\":\"env123\"," +
-            "\"ip_address\":\"192.168.0.1\"," +
-            "\"user_agent\":\"Google Chrome\"" +
-            "}" +
-            "}");
+        json.Should().Be("""
+            {
+              "sid": "75302ac48a024bde9a3b3734a82e36c8",
+              "did": "bar",
+              "init": true,
+              "started": "2020-01-01T00:00:00+00:00",
+              "timestamp": "2020-01-02T00:00:00+00:00",
+              "seq": 5,
+              "duration": 86400,
+              "errors": 3,
+              "status": "crashed",
+              "attrs": {
+                "release": "release123",
+                "environment": "env123",
+                "ip_address": "192.168.0.1",
+                "user_agent": "Google Chrome"
+              }
+            }
+            """);
     }
 
     [Fact]

--- a/test/Sentry.Tests/ViewHierarchyNodeTests.cs
+++ b/test/Sentry.Tests/ViewHierarchyNodeTests.cs
@@ -17,41 +17,34 @@ public class ViewHierarchyNodeTests
     public void WriteTo_ContainsTypeAndChildren()
     {
         // Arrange
-        using var stream = new MemoryStream();
-        using var writer = new Utf8JsonWriter(stream);
         var sut = new TestViewHierarchyNode("Test_Node");
         sut.Children.Add(new TestViewHierarchyNode("Child_Node"));
 
         // Act
-        sut.WriteTo(writer, null);
-
-        writer.Flush();
-        stream.Seek(0, SeekOrigin.Begin);
+        var actual = sut.ToJsonString(indented: true);
 
         // Assert
-        var serializedNode = new StreamReader(stream, Encoding.ASCII).ReadToEnd();
-        serializedNode.Should().Be(
-            "{" +
-                "\"type\":\"Test_Node\"," +
-                "\"children\":[" +
-                    "{" +
-                        "\"type\":\"Child_Node\"," +
-                        "\"children\":[]" +
-                    "}" +
-                "]" +
-            "}");
+        Assert.Equal("""
+            {
+              "type": "Test_Node",
+              "children": [
+                {
+                  "type": "Child_Node",
+                  "children": []
+                }
+              ]
+            }
+            """, actual);
     }
 
     [Fact]
     public void WriteAdditionalProperties_WriteTo_GetsCalled()
     {
         // Arrange
-        using var stream = new MemoryStream();
-        using var writer = new Utf8JsonWriter(stream);
         var sut = new TestViewHierarchyNode("Test_Node");
 
         // Act
-        sut.WriteTo(writer, null);
+        _ = sut.ToJsonString();
 
         // Assert
         Assert.True(sut.WriteAdditionalPropertiesGotCalled);

--- a/test/Sentry.Tests/ViewHierarchyTests.cs
+++ b/test/Sentry.Tests/ViewHierarchyTests.cs
@@ -6,48 +6,41 @@ public class ViewHierarchyTests
     public void WriteTo_ContainsRenderingSystemAndWindows()
     {
         // Arrange
-        using var stream = new MemoryStream();
-        using var writer = new Utf8JsonWriter(stream);
         var sut = new ViewHierarchy("Test_Rendering_System");
 
         // Act
-        sut.WriteTo(writer, null);
-
-        writer.Flush();
-        stream.Seek(0, SeekOrigin.Begin);
+        var actual = sut.ToJsonString(indented: true);
 
         // Assert
-        var serializedViewHierarchy = new StreamReader(stream, Encoding.ASCII).ReadToEnd();
-        serializedViewHierarchy.Should().Be(
-            "{" +
-                "\"rendering_system\":\"Test_Rendering_System\"," +
-                "\"windows\":[]" +
-            "}");
+        Assert.Equal("""
+            {
+              "rendering_system": "Test_Rendering_System",
+              "windows": []
+            }
+            """, actual);
     }
 
     [Fact]
     public void WriteTo_ContainsRenderingSystemAndOneWindow()
     {
         // Arrange
-        using var stream = new MemoryStream();
-        using var writer = new Utf8JsonWriter(stream);
         var sut = new ViewHierarchy("Test_Rendering_System");
         sut.Windows.Add(new ViewHierarchyNodeTests.TestViewHierarchyNode("Test_Node"));
 
         // Act
-        sut.WriteTo(writer, null);
-
-        writer.Flush();
-        stream.Seek(0, SeekOrigin.Begin);
+        var actual = sut.ToJsonString(indented: true);
 
         // Assert
-        var serializedViewHierarchy = new StreamReader(stream, Encoding.ASCII).ReadToEnd();
-        serializedViewHierarchy.Should().Be(
-            "{" +
-                "\"rendering_system\":\"Test_Rendering_System\"," +
-                "\"windows\":[" +
-                    "{\"type\":\"Test_Node\",\"children\":[]}" +
-                "]" +
-            "}");
+        Assert.Equal("""
+            {
+              "rendering_system": "Test_Rendering_System",
+              "windows": [
+                {
+                  "type": "Test_Node",
+                  "children": []
+                }
+              ]
+            }
+            """, actual);
     }
 }


### PR DESCRIPTION
We can update the project to use C# 11.  Here's a list of the new features available:

https://learn.microsoft.com/dotnet/csharp/whats-new/csharp-11

While we don't necessarily need to use all of these, we should have the ability to use them where it makes sense.

I've started this with using raw string literals in our tests where we have JSON strings for input or expected output.  This makes them much easier to read, and to copy/paste for validation.  I've also added support for producing indented JSON in our `ToJsonString` test helper method, so that we can use multi-line raw literal strings.

#skip-changelog - because there are no features or bugfixes here.