### PR TITLE
Fix Cocoa Bindings Failure

### DIFF
--- a/scripts/generate-cocoa-bindings.ps1
+++ b/scripts/generate-cocoa-bindings.ps1
@@ -23,7 +23,7 @@ if (!(Get-Command sharpie -ErrorAction SilentlyContinue)) {
 }
 
 # Get iPhone SDK version
-$iPhoneSdkVersion = sharpie xcode -sdks | grep -o 'iphoneos\S*'
+$iPhoneSdkVersion = sharpie xcode -sdks | grep -o -m 1 'iphoneos\S*'
 
 # Generate bindings
 Write-Output 'Generating bindings with Objective Sharpie.'


### PR DESCRIPTION
This fixes the failing build.  Basically, was a simple error on my part with script changes added in #2310 because the grep command returned multiple results in CI:

```
iphoneos16.1
iphoneos16.0
iphoneos15.5
iphoneos15.4
iphoneos15.2
iphoneos15.0
```

We only want the first match, which is what `-m 1` gives.

#skip-changelog