### PR TITLE
Update console sample

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -11,4 +11,26 @@
     <UseSentryCLI>false</UseSentryCLI>
   </PropertyGroup>
 
+  <!--
+    This sets the default DSN for all sample projects.  Sentry employees and contractors
+    can view events at https://sentry-sdks.sentry.io/projects/sentry-dotnet.
+
+    The DSN can easily be overwritten in the sample application by the end-user.
+    The order of precedence is:
+      - SentryOptions.Dsn property set in code
+      - Sentry:Dsn set in appsettings.json or other config (where applicable)
+      - SENTRY_DSN environment variable
+      - This [Sentry.Dsn] attribute
+
+    Thus, this DSN is applied only if no other mechanism is used to set the DSN.
+
+    Note - The below works because SentryAttributes is already being converted to
+           actual attributes in src/Sentry/buildTransitive/Sentry.targets.
+  -->
+  <ItemGroup>
+    <SentryAttributes Include="Sentry.DsnAttribute">
+      <_Parameter1>https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537</_Parameter1>
+    </SentryAttributes>
+  </ItemGroup>
+
 </Project>

--- a/samples/Sentry.Samples.Console.Basic/Program.cs
+++ b/samples/Sentry.Samples.Console.Basic/Program.cs
@@ -10,8 +10,8 @@
 
 using Sentry;
 
-// Initialize the Sentry SDK, disposing when the application is shutting down.
-using var _ = SentrySdk.Init(options =>
+// Initialize the Sentry SDK.  (It is not necessary to dispose it.)
+SentrySdk.Init(options =>
 {
     // A Sentry Data Source Name (DSN) is required.
     // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/

--- a/samples/Sentry.Samples.Console.Basic/Program.cs
+++ b/samples/Sentry.Samples.Console.Basic/Program.cs
@@ -40,33 +40,37 @@ var transaction = SentrySdk.StartTransaction("Program Main", "function");
 SentrySdk.ConfigureScope(scope => scope.Transaction = transaction);
 
 // Do some work. (This is where you'd have your own application logic.)
-FirstFunction();
-SecondFunction();
-ThirdFunction();
+await FirstFunctionAsync();
+await SecondFunctionAsync();
+await ThirdFunctionAsync();
 
 // Always try to finish the transaction successfully.
 // Unhandled exceptions will fail the transaction automatically.
 // Optionally, you can try/catch the exception, and call transaction.Finish(exception) on failure.
 transaction.Finish();
 
-void FirstFunction()
+async Task FirstFunctionAsync()
 {
     // This shows how you might instrument a particular function.
-    var span = transaction.StartChild("function", nameof(FirstFunction));
+    var span = transaction.StartChild("function", nameof(FirstFunctionAsync));
 
     // Simulate doing some work
-    Thread.Sleep(100);
+    await Task.Delay(100);
 
     // Finish the span successfully.
     span.Finish();
 }
 
-void SecondFunction()
+async Task SecondFunctionAsync()
 {
-    var span = transaction.StartChild("function", nameof(SecondFunction));
+    var span = transaction.StartChild("function", nameof(SecondFunctionAsync));
 
     try
     {
+        // Simulate doing some work
+        await Task.Delay(100);
+
+        // Throw an exception
         throw new ApplicationException("Something happened!");
     }
     catch (Exception exception)
@@ -79,9 +83,12 @@ void SecondFunction()
     span.Finish();
 }
 
-void ThirdFunction()
+async Task ThirdFunctionAsync()
 {
-    var span = transaction.StartChild("function", nameof(ThirdFunction));
+    var span = transaction.StartChild("function", nameof(ThirdFunctionAsync));
+
+    // Simulate doing some work
+    await Task.Delay(100);
 
     // This is an example of an unhandled exception.  It will be captured automatically.
     throw new InvalidOperationException("Something happened that crashed the app!");

--- a/samples/Sentry.Samples.Console.Basic/Program.cs
+++ b/samples/Sentry.Samples.Console.Basic/Program.cs
@@ -1,13 +1,91 @@
+/*
+ * This sample demonstrates the following basic features of Sentry, via a .NET console application:
+ * - Error Monitoring (both handled and unhandled exceptions)
+ * - Performance Tracing (Transactions / Spans)
+ * - Release Health (Sessions)
+ * - MSBuild integration for Source Context (see the csproj)
+ *
+ * For more advanced features of the SDK, see Sentry.Samples.Console.Customized.
+ */
+
 using Sentry;
 
-using var _ = SentrySdk.Init(o =>
+// Initialize the Sentry SDK, disposing when the application is shutting down.
+using var _ = SentrySdk.Init(options =>
 {
-    // The DSN is required.
-    o.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+    // A Sentry Data Source Name (DSN) is required.
+    // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+    // You can set it in the SENTRY_DSN environment variable, or you can set it in code here.
+    // options.Dsn = "... Your DSN ...";
 
     // When debug is enabled, the Sentry client will emit detailed debugging information to the console.
-    o.Debug = true;
+    // This might be helpful, or might interfere with the normal operation of your application.
+    // We enable it here for demonstration purposes.
+    // You should not do this in your applications unless you are troubleshooting issues with Sentry.
+    options.Debug = true;
+
+    // This option is recommended, which enables Sentry's "Release Health" feature.
+    options.AutoSessionTracking = true;
+
+    // This option is recommended for client applications only. It ensures all threads use the same global scope.
+    // If you are writing a background service of any kind, you should remove this.
+    options.IsGlobalModeEnabled = true;
+
+    // This option will enable Sentry's tracing features. You still need to start transactions and spans.
+    options.EnableTracing = true;
 });
 
-// The following unhandled exception will be captured and sent to Sentry.
-throw new Exception("test");
+// This starts a new transaction and attaches it to the scope.
+var transaction = SentrySdk.StartTransaction("Program Main", "function");
+SentrySdk.ConfigureScope(scope => scope.Transaction = transaction);
+
+// Do some work. (This is where you'd have your own application logic.)
+FirstFunction();
+SecondFunction();
+ThirdFunction();
+
+// Always try to finish the transaction successfully.
+// Unhandled exceptions will fail the transaction automatically.
+// Optionally, you can try/catch the exception, and call transaction.Finish(exception) on failure.
+transaction.Finish();
+
+void FirstFunction()
+{
+    // This shows how you might instrument a particular function.
+    var span = transaction.StartChild("function", nameof(FirstFunction));
+
+    // Simulate doing some work
+    Thread.Sleep(100);
+
+    // Finish the span successfully.
+    span.Finish();
+}
+
+void SecondFunction()
+{
+    var span = transaction.StartChild("function", nameof(SecondFunction));
+
+    try
+    {
+        throw new ApplicationException("Something happened!");
+    }
+    catch (Exception exception)
+    {
+        // This is an example of capturing a handled exception.
+        SentrySdk.CaptureException(exception);
+        span.Finish(exception);
+    }
+
+    span.Finish();
+}
+
+void ThirdFunction()
+{
+    var span = transaction.StartChild("function", nameof(ThirdFunction));
+
+    // This is an example of an unhandled exception.  It will be captured automatically.
+    throw new InvalidOperationException("Something happened that crashed the app!");
+
+    // In this case, we can't attempt to finish the span, due to the exception.
+    // span.Finish();
+}

--- a/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
+++ b/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
@@ -2,12 +2,36 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!--Version is detected by default as the application release and sent to sentry-->
-    <Version>9.8.7</Version>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+    We set the SentryOrg and SentryProject globally in our root Directory.Build.props.
+    In your own project, uncomment the following block and set the values for your Sentry configuration.
+    Also note, these options do nothing if you are not authenticated.
+    See https://docs.sentry.io/platforms/dotnet/configuration/msbuild/
+    -->
+    <!--
+    <SentryUrl>...your Sentry URL if self-hosted, or omit this line if using sentry.io...</SentryUrl>
+    <SentryOrg>...your org...</SentryOrg>
+    <SentryProject>...your project...</SentryProject>
+    -->
+
+    <!--
+    After the above properties are configured, you can use the following features.
+    Uploading sources to Sentry during the build will enable Source Context in the Sentry issue details page.
+    Uploading symbols to Sentry will enable server-side symbolication.  However, that is not necessary here
+    because the PDB file is present at runtime. Thus, .NET will symbolicate stack traces client-side.
+    -->
+    <SentryUploadSources>true</SentryUploadSources>
+    <SentryUploadSymbols>false</SentryUploadSymbols>
+  </PropertyGroup>
+
+
+  <!-- In your own project, this would be a PackageReference to the latest version of Sentry. -->
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>

--- a/samples/Sentry.Samples.Console.Customized/Program.cs
+++ b/samples/Sentry.Samples.Console.Customized/Program.cs
@@ -3,12 +3,6 @@ using System.Xml.Xsl;
 using Sentry;
 using Sentry.Extensibility;
 
-// Tracks the release which sent the event and enables more features: https://docs.sentry.io/learn/releases/
-// Much like the DSN above, this is only one of the ways to define the release.
-// If not set here, it can also be defined via appsettings.json, environment variable 'SENTRY_RELEASE' and AssemblyVersion
-// STANDARD_CI_SOURCE_REVISION_ID -> TeamCity: %build.vcs.number%, VSTS: BUILD_SOURCEVERSION, Travis-CI: TRAVIS_COMMIT, AppVeyor: APPVEYOR_REPO_COMMIT, CircleCI: CIRCLE_SHA1
-[assembly: AssemblyInformationalVersion("e386dfd")]
-
 internal static class Program
 {
     private static async Task Main()

--- a/samples/Sentry.Samples.Console.Customized/Program.cs
+++ b/samples/Sentry.Samples.Console.Customized/Program.cs
@@ -3,10 +3,6 @@ using System.Xml.Xsl;
 using Sentry;
 using Sentry.Extensibility;
 
-// One of the ways to set your DSN is via an attribute:
-// It could be set via AssemblyInfo.cs and patched via CI.
-// Other ways are via environment variable, configuration files and explicitly via parameter to Init
-[assembly: Dsn(Program.DefaultDsn)]
 // Tracks the release which sent the event and enables more features: https://docs.sentry.io/learn/releases/
 // Much like the DSN above, this is only one of the ways to define the release.
 // If not set here, it can also be defined via appsettings.json, environment variable 'SENTRY_RELEASE' and AssemblyVersion
@@ -15,10 +11,6 @@ using Sentry.Extensibility;
 
 internal static class Program
 {
-    public const string DefaultDsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
-    // A different DSN for a section of the app (i.e: admin)
-    public const string AdminDsn = "https://f670c444cca14cf2bb4bfc403525b6a3@sentry.io/259314";
-
     private static async Task Main()
     {
         // When the SDK is disabled, no callback is executed:
@@ -33,6 +25,11 @@ internal static class Program
         // Enable the SDK
         using (SentrySdk.Init(o =>
         {
+            // A Sentry Data Source Name (DSN) is required.
+            // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+            // You can set it in the SENTRY_DSN environment variable, or you can set it in code here.
+            // o.Dsn = "... Your DSN ...";
+
             // Send stack trace for events that were not created from an exception
             // e.g: CaptureMessage, log.LogDebug, log.LogInformation ...
             o.AttachStacktrace = true;
@@ -191,7 +188,8 @@ internal static class Program
             evt.Level = SentryLevel.Debug;
             SentrySdk.CaptureEvent(evt);
 
-            // Using a different DSN:
+            // Using a different DSN for a section of the app (i.e: admin)
+            const string AdminDsn = "https://f670c444cca14cf2bb4bfc403525b6a3@sentry.io/259314";
             using (var adminClient = new SentryClient(new SentryOptions { Dsn = AdminDsn }))
             {
                 // Make believe web framework middleware

--- a/samples/Sentry.Samples.Console.Customized/Sentry.Samples.Console.Customized.csproj
+++ b/samples/Sentry.Samples.Console.Customized/Sentry.Samples.Console.Customized.csproj
@@ -2,18 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <!--Set explicitly to demonstrate one way of defining the Sentry Release-->
-    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <Reference Include="System.Net.Http" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.Console.Profiling/Program.cs
+++ b/samples/Sentry.Samples.Console.Profiling/Program.cs
@@ -4,12 +4,6 @@ using Sentry;
 using Sentry.Extensibility;
 using Sentry.Profiling;
 
-// Tracks the release which sent the event and enables more features: https://docs.sentry.io/learn/releases/
-// Much like the DSN above, this is only one of the ways to define the release.
-// If not set here, it can also be defined via appsettings.json, environment variable 'SENTRY_RELEASE' and AssemblyVersion
-// STANDARD_CI_SOURCE_REVISION_ID -> TeamCity: %build.vcs.number%, VSTS: BUILD_SOURCEVERSION, Travis-CI: TRAVIS_COMMIT, AppVeyor: APPVEYOR_REPO_COMMIT, CircleCI: CIRCLE_SHA1
-[assembly: AssemblyInformationalVersion("e386dfd")]
-
 internal static class Program
 {
     private static async Task Main()

--- a/samples/Sentry.Samples.Console.Profiling/Program.cs
+++ b/samples/Sentry.Samples.Console.Profiling/Program.cs
@@ -4,10 +4,6 @@ using Sentry;
 using Sentry.Extensibility;
 using Sentry.Profiling;
 
-// One of the ways to set your DSN is via an attribute:
-// It could be set via AssemblyInfo.cs and patched via CI.
-// Other ways are via environment variable, configuration files and explicitly via parameter to Init
-[assembly: Dsn(Program.DefaultDsn)]
 // Tracks the release which sent the event and enables more features: https://docs.sentry.io/learn/releases/
 // Much like the DSN above, this is only one of the ways to define the release.
 // If not set here, it can also be defined via appsettings.json, environment variable 'SENTRY_RELEASE' and AssemblyVersion
@@ -16,10 +12,6 @@ using Sentry.Profiling;
 
 internal static class Program
 {
-    public const string DefaultDsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
-    // A different DSN for a section of the app (i.e: admin)
-    public const string AdminDsn = "https://f670c444cca14cf2bb4bfc403525b6a3@sentry.io/259314";
-
     private static async Task Main()
     {
         // When the SDK is disabled, no callback is executed:
@@ -34,6 +26,11 @@ internal static class Program
         // Enable the SDK
         using (SentrySdk.Init(o =>
         {
+            // A Sentry Data Source Name (DSN) is required.
+            // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+            // You can set it in the SENTRY_DSN environment variable, or you can set it in code here.
+            // o.Dsn = "... Your DSN ...";
+
             // Send stack trace for events that were not created from an exception
             // e.g: CaptureMessage, log.LogDebug, log.LogInformation ...
             o.AttachStacktrace = true;
@@ -200,7 +197,8 @@ internal static class Program
             evt.Level = SentryLevel.Debug;
             SentrySdk.CaptureEvent(evt);
 
-            // Using a different DSN:
+            // Using a different DSN for a section of the app (i.e: admin)
+            const string AdminDsn = "https://f670c444cca14cf2bb4bfc403525b6a3@sentry.io/259314";
             using (var adminClient = new SentryClient(new SentryOptions { Dsn = AdminDsn }))
             {
                 // Make believe web framework middleware

--- a/samples/Sentry.Samples.Console.Profiling/Sentry.Samples.Console.Profiling.csproj
+++ b/samples/Sentry.Samples.Console.Profiling/Sentry.Samples.Console.Profiling.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates the basic console sample to cover the key features we think most users will want to use.

Also uses an MSBuild-based approach to setting the default DSN for sample projects.  This allows a `SENTRY_DSN` environment variable to override the default without having to change any code.  We'll apply the same technique to the other samples as we clean them up one at a time.

See comments inline.

#skip-changelog