### PR TITLE
Capture open transactions on disabled hubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Buffer payloads asynchronously when appropriate ([#2297](https://github.com/getsentry/sentry-dotnet/pull/2297))
 - Restore `System.Reflection.Metadata` dependency for .NET Core 3 ([#2302](https://github.com/getsentry/sentry-dotnet/pull/2302))
+- Capture open transactions on disabled hubs ([#2319](https://github.com/getsentry/sentry-dotnet/pull/2319))
 
 ### Dependencies
 

--- a/src/Sentry/ISentryClient.cs
+++ b/src/Sentry/ISentryClient.cs
@@ -29,9 +29,10 @@ public interface ISentryClient
     /// </summary>
     /// <remarks>
     /// Note: this method is NOT meant to be called from user code!
-    /// Instead, call <see cref="ISpan.Finish(SpanStatus)"/> on the transaction.
+    /// Instead, call <see cref="ISpan.Finish()"/> on the transaction.
     /// </remarks>
     /// <param name="transaction">The transaction.</param>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     void CaptureTransaction(Transaction transaction);
 
     /// <summary>

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -496,7 +496,12 @@ public static partial class SentrySdk
     /// <summary>
     /// Captures a transaction.
     /// </summary>
+    /// <remarks>
+    /// Note: this method is NOT meant to be called from user code!
+    /// Instead, call <see cref="ISpan.Finish()"/> on the transaction.
+    /// </remarks>
     [DebuggerStepThrough]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static void CaptureTransaction(Transaction transaction)
         => CurrentHub.CaptureTransaction(transaction);
 

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -71,7 +71,17 @@ public static partial class SentrySdk
     /// <remarks>
     /// If the DSN is not found, the SDK will not change state.
     /// </remarks>
-    /// <returns>An object that should be disposed when the application terminates.</returns>
+    /// <returns>An object that can be disposed to disable the Sentry SDK, if desired.</returns>
+    /// <remarks>
+    /// Disposing the result will flush previously-captured events and disable the SDK.
+    /// In most cases there's no need to dispose the result.  There are only a few exceptions where it makes
+    /// sense to dispose:
+    /// <list type="bullet">
+    /// <item>You have additional work to perform that you don't want Sentry to monitor.</item>
+    /// <item>You have used <see cref="SentryOptionsExtensions.DisableAppDomainProcessExitFlush"/>.</item>
+    /// <item>You are integrating Sentry into an environment that has custom application lifetime events.</item>
+    /// </list>
+    /// </remarks>
     public static IDisposable Init() => Init((string?)null);
 
     /// <summary>
@@ -82,7 +92,17 @@ public static partial class SentrySdk
     /// </remarks>
     /// <seealso href="https://develop.sentry.dev/sdk/overview/#usage-for-end-users"/>
     /// <param name="dsn">The dsn.</param>
-    /// <returns>An object that should be disposed when the application terminates.</returns>
+    /// <returns>An object that can be disposed to disable the Sentry SDK, if desired.</returns>
+    /// <remarks>
+    /// Disposing the result will flush previously-captured events and disable the SDK.
+    /// In most cases there's no need to dispose the result.  There are only a few exceptions where it makes
+    /// sense to dispose:
+    /// <list type="bullet">
+    /// <item>You have additional work to perform that you don't want Sentry to monitor.</item>
+    /// <item>You have used <see cref="SentryOptionsExtensions.DisableAppDomainProcessExitFlush"/>.</item>
+    /// <item>You are integrating Sentry into an environment that has custom application lifetime events.</item>
+    /// </list>
+    /// </remarks>
     public static IDisposable Init(string? dsn) => !Dsn.IsDisabled(dsn)
         ? Init(c => c.Dsn = dsn)
         : DisabledHub.Instance;
@@ -91,7 +111,17 @@ public static partial class SentrySdk
     /// Initializes the SDK with an optional configuration options callback.
     /// </summary>
     /// <param name="configureOptions">The configuration options callback.</param>
-    /// <returns>An object that should be disposed when the application terminates.</returns>
+    /// <returns>An object that can be disposed to disable the Sentry SDK, if desired.</returns>
+    /// <remarks>
+    /// Disposing the result will flush previously-captured events and disable the SDK.
+    /// In most cases there's no need to dispose the result.  There are only a few exceptions where it makes
+    /// sense to dispose:
+    /// <list type="bullet">
+    /// <item>You have additional work to perform that you don't want Sentry to monitor.</item>
+    /// <item>You have used <see cref="SentryOptionsExtensions.DisableAppDomainProcessExitFlush"/>.</item>
+    /// <item>You are integrating Sentry into an environment that has custom application lifetime events.</item>
+    /// </list>
+    /// </remarks>
     public static IDisposable Init(Action<SentryOptions>? configureOptions)
     {
         var options = new SentryOptions();
@@ -107,7 +137,17 @@ public static partial class SentrySdk
     /// <remarks>
     /// Used by integrations which have their own delegates.
     /// </remarks>
-    /// <returns>An object that should be disposed when the application terminates.</returns>
+    /// <returns>An object that can be disposed to disable the Sentry SDK, if desired.</returns>
+    /// <remarks>
+    /// Disposing the result will flush previously-captured events and disable the SDK.
+    /// In most cases there's no need to dispose the result.  There are only a few exceptions where it makes
+    /// sense to dispose:
+    /// <list type="bullet">
+    /// <item>You have additional work to perform that you don't want Sentry to monitor.</item>
+    /// <item>You have used <see cref="SentryOptionsExtensions.DisableAppDomainProcessExitFlush"/>.</item>
+    /// <item>You are integrating Sentry into an environment that has custom application lifetime events.</item>
+    /// </list>
+    /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static IDisposable Init(SentryOptions options) => UseHub(InitHub(options));
 

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -23,6 +23,7 @@ public partial class HubTests
             Options = new SentryOptions
             {
                 Dsn = ValidDsn,
+                EnableTracing = true,
                 AutoSessionTracking = false
             };
 
@@ -1098,11 +1099,11 @@ public partial class HubTests
         }
 
         // Act
-        var t = hub.StartTransaction("test", "test");
-        t.Finish();
+        var transaction = hub.StartTransaction("test", "test");
+        transaction.Finish();
 
         // Assert
-        _fixture.Client.Received(enabled ? 1 : 0).CaptureTransaction(Arg.Any<Transaction>());
+        _fixture.Client.Received().CaptureTransaction(Arg.Is<Transaction>(t => t.IsSampled == enabled));
     }
 
 #if ANDROID && CI_BUILD


### PR DESCRIPTION
This is a subtle but important change to how transactions are managed with regard to disabled hubs.

Previously, if the hub was disabled (ie `SentrySdk.Init` was _disposed_) then no more transactions could be captured on that hub.  This is a problem in the case where an unhandled exception occurs in an `async Main` (or a top-level async main), because open transactions aren't marked as failed/aborted, but just not captured at all.  The corresponding error event then has a Trace ID that can't be correlated to any transaction.

With this change, we now prevent _new_ transactions from being started after a hub is disabled (by ensuring they're sampled out).  But we will go ahead and capture any that were already started _before_ the hub was disabled.

This ultimately has the side effect of resolving #321 - fully working correctly with async main.  The exception side of that was inadvertently resolved with #2103.  This PR takes care of the associated transaction.

We can also now change our position on disposing from `SentrySdk.Init`.  In most cases you no longer need to dispose it, because we will flush automatically in `AppDomainProcessExitIntegration`.  The reasons to still dispose are: if you have disabled that integration, or if you want to do unmonitored work after disabling Sentry, or if you are writing an integration that has its own lifetime events.  Otherwise, disposing doesn't _hurt_, but it is no longer required.  Comments are adjusted accordingly.

We also had some strong wording about users not calling `CaptureTransaction` directly, so I've hidden those with `[EditorBrowsable(EditorBrowsableState.Never)]` attributes.

