### PR TITLE
Add `RemoveExceptionFilter`, `RemoveEventProcessor` and `RemoveTransactionProcessor` extension methods on `SentryOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Initial work to support profiling in a future release. ([#2206](https://github.com/getsentry/sentry-dotnet/pull/2206))
 - Improve `WithScope` and add `WithScopeAsync` ([#2303](https://github.com/getsentry/sentry-dotnet/pull/2303)) ([#2309](https://github.com/getsentry/sentry-dotnet/pull/2309))
 - Build .NET Standard 2.1 for Unity ([#2328](https://github.com/getsentry/sentry-dotnet/pull/2328))
-- Added `SentryOptions.RemoveExceptionFilter` extension method ([#2331](https://github.com/getsentry/sentry-dotnet/pull/2331))
+- Add `RemoveExceptionFilter`, `RemoveEventProcessor` and `RemoveTransactionProcessor` extension methods on `SentryOptions` ([#2331](https://github.com/getsentry/sentry-dotnet/pull/2331))
 - Include Dynamic Sampling Context with error events, when there's a transaction ([#2332](https://github.com/getsentry/sentry-dotnet/pull/2332))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Initial work to support profiling in a future release. ([#2206](https://github.com/getsentry/sentry-dotnet/pull/2206))
 - Improve `WithScope` and add `WithScopeAsync` ([#2303](https://github.com/getsentry/sentry-dotnet/pull/2303)) ([#2309](https://github.com/getsentry/sentry-dotnet/pull/2309))
 - Build .NET Standard 2.1 for Unity ([#2328](https://github.com/getsentry/sentry-dotnet/pull/2328))
+- Added `SentryOptions.RemoveExceptionFilter` extension method ([#2331](https://github.com/getsentry/sentry-dotnet/pull/2331))
 - Include Dynamic Sampling Context with error events, when there's a transaction ([#2332](https://github.com/getsentry/sentry-dotnet/pull/2332))
 
 ### Fixes

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -1,5 +1,6 @@
 using Sentry.Extensibility;
 using Sentry.Infrastructure;
+using Sentry.Integrations;
 
 namespace Sentry.Internal;
 
@@ -58,14 +59,12 @@ internal class Hub : IHubEx, IDisposable
 
         _enricher = new Enricher(options);
 
-        var integrations = options.Integrations;
-        if (integrations?.Count > 0)
+        // An integration _can_ deregister itself, so make a copy of the list before iterating.
+        var integrations = options.Integrations?.ToList() ?? Enumerable.Empty<ISdkIntegration>();
+        foreach (var integration in integrations)
         {
-            foreach (var integration in integrations)
-            {
-                options.LogDebug("Registering integration: '{0}'.", integration.GetType().Name);
-                integration.Register(this, options);
-            }
+            options.LogDebug("Registering integration: '{0}'.", integration.GetType().Name);
+            integration.Register(this, options);
         }
     }
 

--- a/src/Sentry/SentryOptionsExtensions.cs
+++ b/src/Sentry/SentryOptionsExtensions.cs
@@ -129,6 +129,14 @@ public static class SentryOptionsExtensions
     }
 
     /// <summary>
+    /// Removes all filters of type <typeparamref name="TFilter"/>
+    /// </summary>
+    /// <typeparam name="TFilter">The type of filter(s) to remove.</typeparam>
+    /// <param name="options">The SentryOptions to remove the filter(s) from.</param>
+    public static void RemoveExceptionFilter<TFilter>(this SentryOptions options) where TFilter : IExceptionFilter
+        => options.ExceptionFilters = options.ExceptionFilters?.Where(p => p.GetType() != typeof(TFilter)).ToList();
+
+    /// <summary>
     /// Ignore exception of type <typeparamref name="TException"/> or derived.
     /// </summary>
     /// <typeparam name="TException">The type of the exception to ignore.</typeparam>

--- a/src/Sentry/SentryOptionsExtensions.cs
+++ b/src/Sentry/SentryOptionsExtensions.cs
@@ -263,6 +263,15 @@ public static class SentryOptionsExtensions
     }
 
     /// <summary>
+    /// Removes all event processors of type <typeparamref name="TProcessor"/>
+    /// </summary>
+    /// <typeparam name="TProcessor">The type of processor(s) to remove.</typeparam>
+    /// <param name="options">The SentryOptions to remove the processor(s) from.</param>
+    public static void RemoveEventProcessor<TProcessor>(this SentryOptions options)
+        where TProcessor : ISentryEventProcessor
+        => options.EventProcessors?.RemoveAll(processor => processor is TProcessor);
+
+    /// <summary>
     /// Adds an event processor provider which is invoked when creating a <see cref="SentryEvent"/>.
     /// </summary>
     /// <param name="options">The SentryOptions to hold the processor provider.</param>
@@ -312,6 +321,15 @@ public static class SentryOptionsExtensions
             options.TransactionProcessors.AddRange(processors);
         }
     }
+
+    /// <summary>
+    /// Removes all transaction processors of type <typeparamref name="TProcessor"/>
+    /// </summary>
+    /// <typeparam name="TProcessor">The type of processor(s) to remove.</typeparam>
+    /// <param name="options">The SentryOptions to remove the processor(s) from.</param>
+    public static void RemoveTransactionProcessor<TProcessor>(this SentryOptions options)
+        where TProcessor : ISentryTransactionProcessor
+        => options.TransactionProcessors?.RemoveAll(processor => processor is TProcessor);
 
     /// <summary>
     /// Adds an transaction processor provider which is invoked when creating a <see cref="Transaction"/>.

--- a/src/Sentry/SentryOptionsExtensions.cs
+++ b/src/Sentry/SentryOptionsExtensions.cs
@@ -30,8 +30,7 @@ public static class SentryOptionsExtensions
     /// </remarks>
     /// <param name="options">The SentryOptions to remove the processor from.</param>
     public static void DisableDuplicateEventDetection(this SentryOptions options)
-        => options.EventProcessors =
-            options.EventProcessors?.Where(p => p.GetType() != typeof(DuplicateEventDetectionEventProcessor)).ToList();
+        => options.RemoveEventProcessor<DuplicateEventDetectionEventProcessor>();
 
     /// <summary>
     /// Disables the capture of errors through <see cref="AppDomain.UnhandledException"/>.
@@ -46,8 +45,7 @@ public static class SentryOptionsExtensions
     /// </summary>
     /// <param name="options">The SentryOptions to remove the integration from.</param>
     public static void DisableDiagnosticSourceIntegration(this SentryOptions options)
-        => options.Integrations =
-            options.Integrations?.Where(p => p.GetType() != typeof(SentryDiagnosticListenerIntegration)).ToList();
+        => options.RemoveIntegration<SentryDiagnosticListenerIntegration>();
 #endif
 
     /// <summary>
@@ -72,8 +70,7 @@ public static class SentryOptionsExtensions
     /// <param name="options">The SentryOptions to remove the integration from.</param>
     public static void DisableNetFxInstallationsIntegration(this SentryOptions options)
     {
-        options.EventProcessors =
-            options.EventProcessors?.Where(p => p.GetType() != typeof(NetFxInstallationsEventProcessor)).ToList();
+        options.RemoveEventProcessor<NetFxInstallationsEventProcessor>();
         options.RemoveIntegration<NetFxInstallationsIntegration>();
     }
 #endif
@@ -108,8 +105,9 @@ public static class SentryOptionsExtensions
     /// </summary>
     /// <typeparam name="TIntegration">The type of the integration(s) to remove.</typeparam>
     /// <param name="options">The SentryOptions to remove the integration(s) from.</param>
-    public static void RemoveIntegration<TIntegration>(this SentryOptions options) where TIntegration : ISdkIntegration
-        => options.Integrations = options.Integrations?.Where(p => p.GetType() != typeof(TIntegration)).ToList();
+    public static void RemoveIntegration<TIntegration>(this SentryOptions options)
+        where TIntegration : ISdkIntegration
+        => options.Integrations?.RemoveAll(integration => integration is TIntegration);
 
     /// <summary>
     /// Add an exception filter.
@@ -133,15 +131,17 @@ public static class SentryOptionsExtensions
     /// </summary>
     /// <typeparam name="TFilter">The type of filter(s) to remove.</typeparam>
     /// <param name="options">The SentryOptions to remove the filter(s) from.</param>
-    public static void RemoveExceptionFilter<TFilter>(this SentryOptions options) where TFilter : IExceptionFilter
-        => options.ExceptionFilters = options.ExceptionFilters?.Where(p => p.GetType() != typeof(TFilter)).ToList();
+    public static void RemoveExceptionFilter<TFilter>(this SentryOptions options)
+        where TFilter : IExceptionFilter
+        => options.ExceptionFilters?.RemoveAll(filter => filter is TFilter);
 
     /// <summary>
     /// Ignore exception of type <typeparamref name="TException"/> or derived.
     /// </summary>
     /// <typeparam name="TException">The type of the exception to ignore.</typeparam>
     /// <param name="options">The SentryOptions to store the exceptions type ignore.</param>
-    public static void AddExceptionFilterForType<TException>(this SentryOptions options) where TException : Exception
+    public static void AddExceptionFilterForType<TException>(this SentryOptions options)
+        where TException : Exception
         => options.AddExceptionFilter(new ExceptionTypeFilter<TException>());
 
     /// <summary>

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -628,8 +628,14 @@ namespace Sentry
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventProcessor> GetAllEventProcessors(this Sentry.SentryOptions options) { }
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventExceptionProcessor> GetAllExceptionProcessors(this Sentry.SentryOptions options) { }
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryTransactionProcessor> GetAllTransactionProcessors(this Sentry.SentryOptions options) { }
+        public static void RemoveEventProcessor<TProcessor>(this Sentry.SentryOptions options)
+            where TProcessor : Sentry.Extensibility.ISentryEventProcessor { }
+        public static void RemoveExceptionFilter<TFilter>(this Sentry.SentryOptions options)
+            where TFilter : Sentry.Extensibility.IExceptionFilter { }
         public static void RemoveIntegration<TIntegration>(this Sentry.SentryOptions options)
             where TIntegration : Sentry.Integrations.ISdkIntegration { }
+        public static void RemoveTransactionProcessor<TProcessor>(this Sentry.SentryOptions options)
+            where TProcessor : Sentry.Extensibility.ISentryTransactionProcessor { }
         public static Sentry.SentryOptions UseStackTraceFactory(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryStackTraceFactory sentryStackTraceFactory) { }
     }
     public static class SentryScopeManagerExtensions

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -628,8 +628,14 @@ namespace Sentry
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventProcessor> GetAllEventProcessors(this Sentry.SentryOptions options) { }
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventExceptionProcessor> GetAllExceptionProcessors(this Sentry.SentryOptions options) { }
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryTransactionProcessor> GetAllTransactionProcessors(this Sentry.SentryOptions options) { }
+        public static void RemoveEventProcessor<TProcessor>(this Sentry.SentryOptions options)
+            where TProcessor : Sentry.Extensibility.ISentryEventProcessor { }
+        public static void RemoveExceptionFilter<TFilter>(this Sentry.SentryOptions options)
+            where TFilter : Sentry.Extensibility.IExceptionFilter { }
         public static void RemoveIntegration<TIntegration>(this Sentry.SentryOptions options)
             where TIntegration : Sentry.Integrations.ISdkIntegration { }
+        public static void RemoveTransactionProcessor<TProcessor>(this Sentry.SentryOptions options)
+            where TProcessor : Sentry.Extensibility.ISentryTransactionProcessor { }
         public static Sentry.SentryOptions UseStackTraceFactory(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryStackTraceFactory sentryStackTraceFactory) { }
     }
     public static class SentryScopeManagerExtensions

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -628,8 +628,14 @@ namespace Sentry
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventProcessor> GetAllEventProcessors(this Sentry.SentryOptions options) { }
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventExceptionProcessor> GetAllExceptionProcessors(this Sentry.SentryOptions options) { }
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryTransactionProcessor> GetAllTransactionProcessors(this Sentry.SentryOptions options) { }
+        public static void RemoveEventProcessor<TProcessor>(this Sentry.SentryOptions options)
+            where TProcessor : Sentry.Extensibility.ISentryEventProcessor { }
+        public static void RemoveExceptionFilter<TFilter>(this Sentry.SentryOptions options)
+            where TFilter : Sentry.Extensibility.IExceptionFilter { }
         public static void RemoveIntegration<TIntegration>(this Sentry.SentryOptions options)
             where TIntegration : Sentry.Integrations.ISdkIntegration { }
+        public static void RemoveTransactionProcessor<TProcessor>(this Sentry.SentryOptions options)
+            where TProcessor : Sentry.Extensibility.ISentryTransactionProcessor { }
         public static Sentry.SentryOptions UseStackTraceFactory(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryStackTraceFactory sentryStackTraceFactory) { }
     }
     public static class SentryScopeManagerExtensions

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -627,8 +627,14 @@ namespace Sentry
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventProcessor> GetAllEventProcessors(this Sentry.SentryOptions options) { }
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventExceptionProcessor> GetAllExceptionProcessors(this Sentry.SentryOptions options) { }
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryTransactionProcessor> GetAllTransactionProcessors(this Sentry.SentryOptions options) { }
+        public static void RemoveEventProcessor<TProcessor>(this Sentry.SentryOptions options)
+            where TProcessor : Sentry.Extensibility.ISentryEventProcessor { }
+        public static void RemoveExceptionFilter<TFilter>(this Sentry.SentryOptions options)
+            where TFilter : Sentry.Extensibility.IExceptionFilter { }
         public static void RemoveIntegration<TIntegration>(this Sentry.SentryOptions options)
             where TIntegration : Sentry.Integrations.ISdkIntegration { }
+        public static void RemoveTransactionProcessor<TProcessor>(this Sentry.SentryOptions options)
+            where TProcessor : Sentry.Extensibility.ISentryTransactionProcessor { }
         public static Sentry.SentryOptions UseStackTraceFactory(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryStackTraceFactory sentryStackTraceFactory) { }
     }
     public static class SentryScopeManagerExtensions


### PR DESCRIPTION
You can already remove `Integrations` and now also `Filters`! 🎉  