### PR TITLE
Remove session breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Buffer payloads asynchronously when appropriate ([#2297](https://github.com/getsentry/sentry-dotnet/pull/2297))
 - Restore `System.Reflection.Metadata` dependency for .NET Core 3 ([#2302](https://github.com/getsentry/sentry-dotnet/pull/2302))
 - Capture open transactions on disabled hubs ([#2319](https://github.com/getsentry/sentry-dotnet/pull/2319))
+- Remove session breadcrumbs ([#2333](https://github.com/getsentry/sentry-dotnet/pull/2333))
 
 ### Dependencies
 

--- a/src/Sentry/GlobalSessionManager.cs
+++ b/src/Sentry/GlobalSessionManager.cs
@@ -340,7 +340,6 @@ internal class GlobalSessionManager : ISessionManager
             EndSession(previousSession, _clock.GetUtcNow(), SessionEndStatus.Exited);
         }
 
-        AddSessionBreadcrumb("Starting Sentry Session");
         _options.LogInfo("Started new session (SID: {0}; DID: {1}).",
             session.Id, session.DistinctId);
 
@@ -360,7 +359,6 @@ internal class GlobalSessionManager : ISessionManager
             session.ReportError();
         }
 
-        AddSessionBreadcrumb("Ending Sentry Session");
         _options.LogInfo("Ended session (SID: {0}; DID: {1}) with status '{2}'.",
             session.Id, session.DistinctId, status);
 
@@ -390,8 +388,6 @@ internal class GlobalSessionManager : ISessionManager
     {
         if (_currentSession is { } session)
         {
-            AddSessionBreadcrumb("Pausing Sentry Session");
-
             var now = _clock.GetUtcNow();
             _lastPauseTimestamp = now;
             PersistSession(session.CreateUpdate(false, now), now);
@@ -408,8 +404,6 @@ internal class GlobalSessionManager : ISessionManager
 
             return Array.Empty<SessionUpdate>();
         }
-
-        AddSessionBreadcrumb("Resuming Sentry Session");
 
         // Reset the pause timestamp since the session is about to be resumed
         _lastPauseTimestamp = null;
@@ -472,7 +466,4 @@ internal class GlobalSessionManager : ISessionManager
 
         return null;
     }
-
-    private static void AddSessionBreadcrumb(string message)
-        => SentrySdk.AddBreadcrumb(message, "app.lifecycle", "session");
 }

--- a/src/Sentry/GlobalSessionManager.cs
+++ b/src/Sentry/GlobalSessionManager.cs
@@ -55,8 +55,7 @@ internal class GlobalSessionManager : ISessionManager
 
             Directory.CreateDirectory(directoryPath);
 
-            _options.LogDebug("Created directory for installation ID file ({0}).",
-                directoryPath);
+            _options.LogDebug("Created directory for installation ID file ({0}).", directoryPath);
 
             var filePath = Path.Combine(directoryPath, ".installation");
 
@@ -67,24 +66,19 @@ internal class GlobalSessionManager : ISessionManager
             }
             catch (FileNotFoundException)
             {
-                _options.LogDebug("File containing installation ID does not exist ({0}).",
-                    filePath);
+                _options.LogDebug("File containing installation ID does not exist ({0}).", filePath);
             }
             catch (DirectoryNotFoundException)
             {
                 // on PS4 we're seeing CreateDirectory work but ReadAllText throw DirectoryNotFoundException
-                _options.LogDebug(
-                    "Directory containing installation ID does not exist ({0}).",
-                    filePath);
+                _options.LogDebug("Directory containing installation ID does not exist ({0}).", filePath);
             }
 
             // Generate new installation ID and store it in a file
             var id = Guid.NewGuid().ToString();
             File.WriteAllText(filePath, id);
 
-            _options.LogDebug("Saved installation ID '{0}' to file '{1}'.",
-                id, filePath);
-
+            _options.LogDebug("Saved installation ID '{0}' to file '{1}'.", id, filePath);
             return id;
         }
         // If there's no write permission or the platform doesn't support this, we handle
@@ -92,7 +86,6 @@ internal class GlobalSessionManager : ISessionManager
         catch (Exception ex)
         {
             _options.LogError("Failed to resolve persistent installation ID.", ex);
-
             return null;
         }
     }
@@ -112,9 +105,7 @@ internal class GlobalSessionManager : ISessionManager
 
             if (string.IsNullOrWhiteSpace(installationId))
             {
-                _options.LogError(
-                    "Failed to find an appropriate network interface for installation ID.");
-
+                _options.LogError("Failed to find an appropriate network interface for installation ID.");
                 return null;
             }
 
@@ -123,7 +114,6 @@ internal class GlobalSessionManager : ISessionManager
         catch (Exception ex)
         {
             _options.LogError("Failed to resolve hardware installation ID.", ex);
-
             return null;
         }
     }
@@ -155,7 +145,7 @@ internal class GlobalSessionManager : ISessionManager
             var id =
                 TryGetPersistentInstallationId() ??
                 TryGetHardwareInstallationId() ??
-                GlobalSessionManager.GetMachineNameInstallationId();
+                GetMachineNameInstallationId();
 
             if (!string.IsNullOrWhiteSpace(id))
             {
@@ -186,9 +176,7 @@ internal class GlobalSessionManager : ISessionManager
         {
             Directory.CreateDirectory(_persistenceDirectoryPath);
 
-            _options.LogDebug(
-                "Created persistence directory for session file '{0}'.",
-                _persistenceDirectoryPath);
+            _options.LogDebug("Created persistence directory for session file '{0}'.", _persistenceDirectoryPath);
 
             var filePath = Path.Combine(_persistenceDirectoryPath, PersistedSessionFileName);
 
@@ -219,15 +207,12 @@ internal class GlobalSessionManager : ISessionManager
             {
                 try
                 {
-                    _options.LogDebug("Deleting persisted session file with contents: {0}",
-                        File.ReadAllText(filePath));
+                    var contents = File.ReadAllText(filePath);
+                    _options.LogDebug("Deleting persisted session file with contents: {0}", contents);
                 }
                 catch (Exception ex)
                 {
-                    _options.LogError(
-                        "Failed to read the contents of persisted session file '{0}'.",
-                        ex,
-                        filePath);
+                    _options.LogError("Failed to read the contents of persisted session file '{0}'.", ex, filePath);
                 }
             }
 
@@ -237,10 +222,7 @@ internal class GlobalSessionManager : ISessionManager
         }
         catch (Exception ex)
         {
-            _options.LogError(
-                "Failed to delete persisted session from the file system: '{0}'",
-                ex,
-                filePath);
+            _options.LogError("Failed to delete persisted session from the file system: '{0}'", ex, filePath);
         }
     }
 
@@ -316,8 +298,7 @@ internal class GlobalSessionManager : ISessionManager
         if (string.IsNullOrWhiteSpace(release))
         {
             // Release health without release is just health (useless)
-            _options.LogError(
-                "Failed to start a session because there is no release information.");
+            _options.LogError("Failed to start a session because there is no release information.");
 
             return null;
         }
@@ -333,15 +314,13 @@ internal class GlobalSessionManager : ISessionManager
         var previousSession = Interlocked.Exchange(ref _currentSession, session);
         if (previousSession is not null)
         {
-            _options.LogWarning(
-                "Starting a new session while an existing one is still active.");
+            _options.LogWarning("Starting a new session while an existing one is still active.");
 
             // End previous session
             EndSession(previousSession, _clock.GetUtcNow(), SessionEndStatus.Exited);
         }
 
-        _options.LogInfo("Started new session (SID: {0}; DID: {1}).",
-            session.Id, session.DistinctId);
+        _options.LogInfo("Started new session (SID: {0}; DID: {1}).", session.Id, session.DistinctId);
 
         var update = session.CreateUpdate(true, _clock.GetUtcNow());
 
@@ -374,7 +353,6 @@ internal class GlobalSessionManager : ISessionManager
         var session = Interlocked.Exchange(ref _currentSession, null);
         if (session is null)
         {
-
             _options.LogWarning("Failed to end session because there is none active.");
             return null;
         }
@@ -454,26 +432,21 @@ internal class GlobalSessionManager : ISessionManager
 
     public SessionUpdate? ReportError()
     {
-        if (_currentSession is { } session)
+        if (_currentSession is not { } session)
         {
-            session.ReportError();
-
-            // If we already have at least one error reported, the session update is pointless,
-            // so don't return anything.
-            if (session.ErrorCount > 1)
-            {
-                _options.LogDebug(
-                    "Reported an error on a session that already contains errors. Not creating an update.");
-
-                return null;
-            }
-
-            return session.CreateUpdate(false, _clock.GetUtcNow());
+            _options.LogDebug("Failed to report an error on a session because there is none active.");
+            return null;
         }
 
-        _options.LogDebug(
-            "Failed to report an error on a session because there is none active.");
+        session.ReportError();
 
-        return null;
+        // If we already have at least one error reported, the session update is pointless, so don't return anything.
+        if (session.ErrorCount > 1)
+        {
+            _options.LogDebug("Reported an error on a session that already contains errors. Not creating an update.");
+            return null;
+        }
+
+        return session.CreateUpdate(false, _clock.GetUtcNow());
     }
 }

--- a/test/Sentry.Tests/GlobalSessionManagerTests.cs
+++ b/test/Sentry.Tests/GlobalSessionManagerTests.cs
@@ -213,7 +213,7 @@ public class GlobalSessionManagerTests : IDisposable
 
         _fixture.Logger.Entries.Should().Contain(e =>
             e.Message == "Failed to end session because there is none active." &&
-            e.Level == SentryLevel.Debug);
+            e.Level == SentryLevel.Warning);
     }
 
     [Fact]


### PR DESCRIPTION
Session breadcrumbs were added in #1263 (released in 3.11.0).

Unfortunately, this creates some confusion such as seen in #2046.

- Ending a session typically occurs _after_ an event would be captured, so an end-of-session breadcrumb is usually absent.
- Starting a session while one was already active would create an end-of-session breadcrumb followed by a new start-of-session breadcrumb, which often is confusing because they look out-of-sequence.
- `AutoSessionTracking = true` missed the start-of-session breadcrumb due to a bug (the hub it added the breadcrumb to is still disabled at that time).
- Pausing/Resuming Sentry sessions added breadcrumbs correctly, but they're still categorized as `app.lifecycle` - which is incorrect.  The lifetime of the session does not necessarily correlate to the lifetime of the application.  If app lifecycle breadcrumbs are desired, they should be added directly with the application events - not tied to Sentry sessions.
- We currently don't send an `exited` session update when `AutoSessionTracking=true`.  The only benefit of adding that would be to enable session duration tracking, but that was removed from Sentry recently.  See https://github.com/getsentry/sentry/discussions/42716#discussioncomment-4676757

This PR removes session breadcrumbs.  It does not change the behavior of sessions themselves.

It also adds some more diagnostic logging, and sets an appropriate level for existing logging messages.

(There's some minor code cleanup in here as well.)

Closes #2046 