### PR TITLE
Fix ASP.NET Core issue with missing context when using capture methods that configure scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Restore `System.Reflection.Metadata` dependency for .NET Core 3 ([#2302](https://github.com/getsentry/sentry-dotnet/pull/2302))
 - Capture open transactions on disabled hubs ([#2319](https://github.com/getsentry/sentry-dotnet/pull/2319))
 - Remove session breadcrumbs ([#2333](https://github.com/getsentry/sentry-dotnet/pull/2333))
+- Fix ASP.NET Core issue with missing context when using capture methods that configure scope ([#2339](https://github.com/getsentry/sentry-dotnet/pull/2339))
 
 ### Dependencies
 

--- a/src/Sentry.AspNetCore.Grpc/SentryGrpcInterceptor.cs
+++ b/src/Sentry.AspNetCore.Grpc/SentryGrpcInterceptor.cs
@@ -59,7 +59,7 @@ public class SentryGrpcInterceptor : Interceptor
         {
             hub.ConfigureScope(scope =>
             {
-                scope.OnEvaluating += (_, _) => scope.Populate(context, request, _options);
+                scope.OnEvaluating += (_, activeScope) => activeScope.Populate(context, request, _options);
             });
 
             try
@@ -102,7 +102,7 @@ public class SentryGrpcInterceptor : Interceptor
         {
             hub.ConfigureScope(scope =>
             {
-                scope.OnEvaluating += (_, _) => scope.Populate(context, request, _options);
+                scope.OnEvaluating += (_, activeScope) => activeScope.Populate(context, request, _options);
             });
 
             try
@@ -140,7 +140,7 @@ public class SentryGrpcInterceptor : Interceptor
         {
             hub.ConfigureScope(scope =>
             {
-                scope.OnEvaluating += (_, _) => scope.Populate<TRequest>(context, null, _options);
+                scope.OnEvaluating += (_, activeScope) => activeScope.Populate<TRequest>(context, null, _options);
             });
 
             try
@@ -183,7 +183,7 @@ public class SentryGrpcInterceptor : Interceptor
         {
             hub.ConfigureScope(scope =>
             {
-                scope.OnEvaluating += (_, _) => scope.Populate<TRequest>(context, null, _options);
+                scope.OnEvaluating += (_, activeScope) => activeScope.Populate<TRequest>(context, null, _options);
             });
 
             try

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -81,7 +81,7 @@ public class Scope : IEventLike, IHasDistribution
     /// but execution at a later time, when more data is available.
     /// </remarks>
     /// <see cref="Evaluate"/>
-    internal event EventHandler? OnEvaluating;
+    internal event EventHandler<Scope>? OnEvaluating;
 
     /// <inheritdoc />
     public SentryLevel? Level { get; set; }
@@ -464,6 +464,8 @@ public class Scope : IEventLike, IHasDistribution
     public Scope Clone()
     {
         var clone = new Scope(Options);
+        clone.OnEvaluating = OnEvaluating;
+
         Apply(clone);
 
         foreach (var processor in EventProcessors)
@@ -500,7 +502,7 @@ public class Scope : IEventLike, IHasDistribution
 
             try
             {
-                OnEvaluating?.Invoke(this, EventArgs.Empty);
+                OnEvaluating?.Invoke(this, this);
             }
             catch (Exception ex)
             {

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -119,7 +119,10 @@ public class Scope : IEventLike, IHasDistribution
     /// <inheritdoc />
     public User User
     {
-        get => _user ??= new User { PropertyChanged = UserChanged };
+        get => _user ??= new User
+        {
+            PropertyChanged = UserChanged
+        };
         set
         {
             _user = value;
@@ -127,6 +130,7 @@ public class Scope : IEventLike, IHasDistribution
             {
                 _user.PropertyChanged = UserChanged;
             }
+
             UserChanged.Invoke(_user);
         }
     }
@@ -196,7 +200,7 @@ public class Scope : IEventLike, IHasDistribution
     public IReadOnlyList<string> Fingerprint { get; set; } = Array.Empty<string>();
 
 #if NETSTANDARD2_0 || NETFRAMEWORK
-    private ConcurrentQueue<Breadcrumb> _breadcrumbs = new(); 
+    private ConcurrentQueue<Breadcrumb> _breadcrumbs = new();
 #else
     private readonly ConcurrentQueue<Breadcrumb> _breadcrumbs = new();
 #endif
@@ -215,10 +219,9 @@ public class Scope : IEventLike, IHasDistribution
     public IReadOnlyDictionary<string, string> Tags => _tags;
 
 #if NETSTANDARD2_0 || NETFRAMEWORK
-        private ConcurrentBag<Attachment> _attachments = new();
+    private ConcurrentBag<Attachment> _attachments = new();
 #else
     private readonly ConcurrentBag<Attachment> _attachments = new();
-
 #endif
 
     /// <summary>
@@ -310,7 +313,7 @@ public class Scope : IEventLike, IHasDistribution
     public void AddAttachment(Attachment attachment) => _attachments.Add(attachment);
 
     /// <summary>
-    /// Resets all the properties and collections within the scope to their default values. 
+    /// Resets all the properties and collections within the scope to their default values.
     /// </summary>
     public void Clear()
     {
@@ -337,7 +340,7 @@ public class Scope : IEventLike, IHasDistribution
     public void ClearAttachments()
     {
 #if NETSTANDARD2_0 || NETFRAMEWORK
-            Interlocked.Exchange(ref _attachments, new());
+        Interlocked.Exchange(ref _attachments, new());
 #else
         _attachments.Clear();
 #endif
@@ -353,7 +356,7 @@ public class Scope : IEventLike, IHasDistribution
         Interlocked.Exchange(ref _breadcrumbs, new());
 #else
         _breadcrumbs.Clear();
-#endif        
+#endif
     }
 
 
@@ -501,9 +504,7 @@ public class Scope : IEventLike, IHasDistribution
             }
             catch (Exception ex)
             {
-                Options.DiagnosticLogger?.LogError(
-                    "Failed invoking event handler.",
-                    ex);
+                Options.DiagnosticLogger?.LogError("Failed invoking event handler.", ex);
             }
             finally
             {

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -217,9 +217,11 @@ public partial class SentryClientTests
 
         var evaluated = false;
         object actualSender = null;
-        scope.OnEvaluating += (sender, _) =>
+        object actualScope = null;
+        scope.OnEvaluating += (sender, activeScope) =>
         {
             actualSender = sender;
+            actualScope = activeScope;
             evaluated = true;
         };
 
@@ -227,6 +229,7 @@ public partial class SentryClientTests
 
         Assert.True(evaluated);
         Assert.Same(scope, actualSender);
+        Assert.Same(scope, actualScope);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #2337