### PR TITLE
Improve debug file upload handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Remove session breadcrumbs ([#2333](https://github.com/getsentry/sentry-dotnet/pull/2333))
 - Support synchronous `HttpClient.Send` in `SentryHttpMessageHandler` ([#2336](https://github.com/getsentry/sentry-dotnet/pull/2336))
 - Fix ASP.NET Core issue with missing context when using capture methods that configure scope ([#2339](https://github.com/getsentry/sentry-dotnet/pull/2339))
+- Improve debug file upload handling ([#2349](https://github.com/getsentry/sentry-dotnet/pull/2349))
 
 ### Dependencies
 

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -127,7 +127,7 @@
     <Message Importance="High" Condition="'$(SentryUploadSources)' == 'true'"
       Text="Preparing to upload debug symbols and sources to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
 
-    <Exec Command="$(SentryCLIUploadCommand) $(IntermediateOutputPath)" IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
+    <Exec Command="$(SentryCLIUploadCommand) $(OutputPath)" IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
     </Exec>
 

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -85,7 +85,6 @@
 
       <SentryCLIUploadOptions Condition="'$(SentryOrg)' != ''">$(SentryCLIUploadOptions) --org $(SentryOrg)</SentryCLIUploadOptions>
       <SentryCLIUploadOptions Condition="'$(SentryProject)' != ''">$(SentryCLIUploadOptions) --project $(SentryProject)</SentryCLIUploadOptions>
-      <SentryCLIUploadOptions Condition="'$(SentryUploadSources)' == 'true'">$(SentryCLIUploadOptions) --include-sources</SentryCLIUploadOptions>
       <SentryCLIUploadCommand>$(SentryCLIBaseCommand) debug-files upload</SentryCLIUploadCommand>
       <SentryCLIUploadCommand Condition="'$(SentryCLIUploadOptions.Trim())' != ''">$(SentryCLIUploadCommand) $(SentryCLIUploadOptions.Trim())</SentryCLIUploadCommand>
     </PropertyGroup>
@@ -110,11 +109,6 @@
     <PropertyGroup Condition="'$(_SentryCLIExitCode)' != '0'">
       <SentryCLI />
     </PropertyGroup>
-  </Target>
-
-  <!-- Upload symbols (and possibly sources) to Sentry after the build. -->
-  <Target Name="UploadSymbolsToSentry" AfterTargets="Build;Publish" DependsOnTargets="PrepareSentryCLI"
-    Condition="'$(SentryUploadSymbols)' == 'true' And '$(SentryCLI)' != ''">
 
     <Warning Condition="'$(SentryUploadSources)' == 'true' And '$(EmbedAllSources)' == 'true'"
       Text="Both SentryUploadSources and EmbedAllSources are enabled.  Disabling SentryUploadSources." />
@@ -122,29 +116,26 @@
       <SentryUploadSources>false</SentryUploadSources>
     </PropertyGroup>
 
-    <Message Importance="High" Condition="'$(SentryUploadSources)' != 'true'"
+  </Target>
+
+  <!-- Upload symbols to Sentry after the build. -->
+  <Target Name="UploadSymbolsToSentry" AfterTargets="Build;Publish" DependsOnTargets="PrepareSentryCLI"
+    Condition="'$(SentryUploadSymbols)' == 'true' And '$(SentryCLI)' != ''">
+
+    <Message Importance="High"
       Text="Preparing to upload debug symbols to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
-    <Message Importance="High" Condition="'$(SentryUploadSources)' == 'true'"
-      Text="Preparing to upload debug symbols and sources to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
 
     <Exec Command="$(SentryCLIUploadCommand) $(OutputPath)" IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
     </Exec>
 
-    <Warning Condition="'$(_SentryCLIExitCode)' != '0' And '$(SentryUploadSources)' != 'true'"
-      Text="Sentry CLI could not upload debug files." />
-    <Warning Condition="'$(_SentryCLIExitCode)' != '0' And '$(SentryUploadSources)' == 'true'"
-      Text="Sentry CLI could not upload debug files with sources.  Will retry without sources." />
-
-    <MSBuild Condition="'$(_SentryCLIExitCode)' != '0' And '$(SentryUploadSources)' == 'true'"
-      Projects="$(MSBuildProjectFile)" Targets="UploadSymbolsToSentry"
-      Properties="SentryUploadSymbols=true;SentryCLI=$(SentryCLI);SentryCLIBaseOptions=$(SentryCLIBaseOptions);SentryCLIUploadOptions=$(SentryCLIUploadOptions)" />
+    <Warning Condition="'$(_SentryCLIExitCode)' != '0'" Text="Sentry CLI could not upload debug files." />
 
   </Target>
 
-  <!-- Upload sources to Sentry after the build, if we didn't upload them with the symbols. -->
+  <!-- Upload sources to Sentry after the build. -->
   <Target Name="UploadSourcesToSentry" AfterTargets="Build;UploadSymbolsToSentry" DependsOnTargets="PrepareSentryCLI"
-    Condition="'$(SentryUploadSources)' == 'true' And '$(SentryUploadSymbols)' != 'true' And '$(SentryCLI)' != ''">
+    Condition="'$(SentryUploadSources)' == 'true' And '$(SentryCLI)' != ''">
 
     <Message Importance="High" Condition="'$(SentryUploadSources)' == 'true'"
       Text="Preparing to upload sources to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -50,9 +50,9 @@ BeforeAll {
     }
 }
 
-Describe 'CLI-integration' {
+$exe = ([RuntimeInformation]::IsOSPlatform([OSPlatform]::Windows) ? '.exe' : '')
 
-    $exe = [RuntimeInformation]::IsOSPlatform([OSPlatform]::Windows) ? '.exe' : '';
+Describe 'CLI-integration' {
 
     It "uploads symbols and sources for a console app build" {
         $result = DotnetBuild 'Sentry.Samples.Console.Basic' $True $True

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -52,13 +52,15 @@ BeforeAll {
 
 Describe 'CLI-integration' {
 
+    $exe = [RuntimeInformation]::IsOSPlatform([OSPlatform]::Windows) ? '.exe' : '';
+
     It "uploads symbols and sources for a console app build" {
         $result = DotnetBuild 'Sentry.Samples.Console.Basic' $True $True
         $result.ScriptOutput | Should -Contain 'Build succeeded.'
         $result.HasErrors() | Should -BeFalse
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
             'Sentry.pdb',
-            'Sentry.Samples.Console.Basic',
+            'Sentry.Samples.Console.Basic' + $exe,
             'Sentry.Samples.Console.Basic.pdb',
             'Sentry.Samples.Console.Basic.src.zip')
     }
@@ -69,7 +71,7 @@ Describe 'CLI-integration' {
         $result.HasErrors() | Should -BeFalse
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
             'Sentry.pdb',
-            'Sentry.Samples.Console.Basic',
+            'Sentry.Samples.Console.Basic' + $exe,
             'Sentry.Samples.Console.Basic.pdb')
     }
 

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -50,11 +50,10 @@ BeforeAll {
     }
 }
 
-$exe = ([RuntimeInformation]::IsOSPlatform([OSPlatform]::Windows) ? '.exe' : '')
-
 Describe 'CLI-integration' {
 
     It "uploads symbols and sources for a console app build" {
+        $exe = [RuntimeInformation]::IsOSPlatform([OSPlatform]::Windows) ? '.exe' : ''
         $result = DotnetBuild 'Sentry.Samples.Console.Basic' $True $True
         $result.ScriptOutput | Should -Contain 'Build succeeded.'
         $result.HasErrors() | Should -BeFalse
@@ -66,6 +65,7 @@ Describe 'CLI-integration' {
     }
 
     It "uploads symbols for a console app build" {
+        $exe = [RuntimeInformation]::IsOSPlatform([OSPlatform]::Windows) ? '.exe' : ''
         $result = DotnetBuild 'Sentry.Samples.Console.Basic' $True $False
         $result.ScriptOutput | Should -Contain 'Build succeeded.'
         $result.HasErrors() | Should -BeFalse

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -108,7 +108,7 @@ Describe 'CLI-integration' {
         )
     }
 
-    if ([RuntimeInformation]::IsOSPlatform([OSPlatform]::OSX)) {
+    if (![RuntimeInformation]::IsOSPlatform([OSPlatform]::OSX)) {
         # Remaining tests run on macOS only
         return
     }

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -13,12 +13,7 @@ BeforeAll {
     function DotnetBuild([string]$Sample, [bool]$Symbols, [bool]$Sources, [string]$TargetFramework = '')
     {
         $rootDir = "$(Get-Item $PSScriptRoot/../../)"
-
-        if ($TargetFramework -ne '') {
-            $framework = @('-f', $TargetFramework)
-        } else {
-            $framework = ''
-        }
+        $framework = $TargetFramework -eq '' ? '' : @('-f', $TargetFramework)
 
         Invoke-SentryServer {
             Param([string]$url)

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -60,7 +60,7 @@ Describe 'CLI-integration' {
         $result.HasErrors() | Should -BeFalse
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
             'Sentry.pdb',
-            'Sentry.Samples.Console.Basic' + $exe,
+            "Sentry.Samples.Console.Basic$exe",
             'Sentry.Samples.Console.Basic.pdb',
             'Sentry.Samples.Console.Basic.src.zip')
     }
@@ -71,7 +71,7 @@ Describe 'CLI-integration' {
         $result.HasErrors() | Should -BeFalse
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
             'Sentry.pdb',
-            'Sentry.Samples.Console.Basic' + $exe,
+            "Sentry.Samples.Console.Basic$exe",
             'Sentry.Samples.Console.Basic.pdb')
     }
 

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -1,3 +1,5 @@
+using namespace System.Runtime.InteropServices
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
@@ -8,15 +10,23 @@ if (!(Test-Path env:CI ))
 }
 
 BeforeAll {
-    function DotnetBuild([string]$Sample)
+    function DotnetBuild([string]$Sample, [bool]$Symbols, [bool]$Sources, [string]$TargetFramework = '')
     {
         $rootDir = "$(Get-Item $PSScriptRoot/../../)"
+
+        if ($TargetFramework -ne '') {
+            $framework = @('-f', $TargetFramework)
+        } else {
+            $framework = ''
+        }
 
         Invoke-SentryServer {
             Param([string]$url)
             Write-Host "Building $Sample"
-            dotnet build "samples/$sample/$sample.csproj" -c Release --no-restore --nologo `
+            dotnet build "samples/$sample/$sample.csproj" -c Release $framework --no-restore --nologo `
                 /p:UseSentryCLI=true `
+                /p:SentryUploadSymbols=$Symbols `
+                /p:SentryUploadSources=$Sources `
                 /p:SentryOrg=org `
                 /p:SentryProject=project `
                 /p:SentryUrl=$url `
@@ -46,141 +56,86 @@ BeforeAll {
 }
 
 Describe 'CLI-integration' {
-    It "uploads symbols for a console app build" {
-        $result = DotnetBuild 'Sentry.Samples.Console.Basic'
+
+    It "uploads symbols and sources for a console app build" {
+        $result = DotnetBuild 'Sentry.Samples.Console.Basic' $True $True
         $result.ScriptOutput | Should -Contain 'Build succeeded.'
         $result.HasErrors() | Should -BeFalse
-        return; # TODO enable actual test, see https://github.com/getsentry/sentry-dotnet/issues/2260
-        $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @('apphost.exe', 'Sentry.pdb', 'Sentry.Samples.Console.Basic.pdb')
+        $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
+            'Sentry.pdb',
+            'Sentry.Samples.Console.Basic',
+            'Sentry.Samples.Console.Basic.pdb',
+            'Sentry.Samples.Console.Basic.src.zip')
     }
 
-    It "uploads symbols for a MAUI app build" {
-        $result = DotnetBuild 'Sentry.Samples.Maui'
+    It "uploads symbols for a console app build" {
+        $result = DotnetBuild 'Sentry.Samples.Console.Basic' $True $False
         $result.ScriptOutput | Should -Contain 'Build succeeded.'
         $result.HasErrors() | Should -BeFalse
-        return; # TODO enable actual test, see https://github.com/getsentry/sentry-dotnet/issues/2260
-        $actual = $result.UploadedDebugFiles() | Sort-Object -Unique
-        $expected = @(
-            'apphost.exe', `
-                'Java.Interop.dll.so', `
-                'K4os.Compression.LZ4.dll.so', `
-                'libmonodroid.so', `
-                'libmonosgen-2.0.so', `
-                'libsentry-android.so', `
-                'libsentry.so', `
-                'libsentrysupplemental.so', `
-                'libSystem.IO.Compression.Native.so', `
-                'libSystem.Native.so', `
-                'libSystem.Security.Cryptography.Native.Android.so', `
-                'libxamarin-app.so', `
-                'Microsoft.Extensions.Configuration.Abstractions.dll.so', `
-                'Microsoft.Extensions.Configuration.Binder.dll.so', `
-                'Microsoft.Extensions.Configuration.dll.so', `
-                'Microsoft.Extensions.DependencyInjection.Abstractions.dll.so', `
-                'Microsoft.Extensions.DependencyInjection.dll.so', `
-                'Microsoft.Extensions.Http.dll.so', `
-                'Microsoft.Extensions.Logging.Abstractions.dll.so', `
-                'Microsoft.Extensions.Logging.Configuration.dll.so', `
-                'Microsoft.Extensions.Logging.dll.so', `
-                'Microsoft.Extensions.Options.ConfigurationExtensions.dll.so', `
-                'Microsoft.Extensions.Options.dll.so', `
-                'Microsoft.Extensions.Primitives.dll.so', `
-                'Microsoft.Maui.Controls.Compatibility.dll.so', `
-                'Microsoft.Maui.Controls.dll.so', `
-                'Microsoft.Maui.Controls.Xaml.dll.so', `
-                'Microsoft.Maui.dll.so', `
-                'Microsoft.Maui.Essentials.dll.so', `
-                'Microsoft.Maui.Graphics.dll.so', `
-                'Microsoft.Win32.Primitives.dll.so', `
-                'Mono.Android.dll.so', `
-                'Sentry.Android.AssemblyReader.dll.so', `
-                'Sentry.Android.AssemblyReader.pdb', `
-                'Sentry.Bindings.Android.dll.so', `
-                'Sentry.Bindings.Android.pdb', `
-                'Sentry.dll.so', `
-                'Sentry.Extensions.Logging.dll.so', `
-                'Sentry.Extensions.Logging.pdb', `
-                'Sentry.Maui.dll.so', `
-                'Sentry.Maui.pdb', `
-                'Sentry.pdb', `
-                'Sentry.Samples.Maui.dll.so', `
-                'Sentry.Samples.Maui.pdb', `
-                'System.Collections.Concurrent.dll.so', `
-                'System.Collections.dll.so', `
-                'System.Collections.Immutable.dll.so', `
-                'System.Collections.NonGeneric.dll.so', `
-                'System.Collections.Specialized.dll.so', `
-                'System.ComponentModel.dll.so', `
-                'System.ComponentModel.Primitives.dll.so', `
-                'System.ComponentModel.TypeConverter.dll.so', `
-                'System.Console.dll.so', `
-                'System.Diagnostics.DiagnosticSource.dll.so', `
-                'System.Diagnostics.StackTrace.dll.so', `
-                'System.Diagnostics.TraceSource.dll.so', `
-                'System.dll.so', `
-                'System.IO.Compression.dll.so', `
-                'System.IO.Compression.ZipFile.dll.so', `
-                'System.IO.FileSystem.DriveInfo.dll.so', `
-                'System.IO.MemoryMappedFiles.dll.so', `
-                'System.Linq.dll.so', `
-                'System.Linq.Expressions.dll.so', `
-                'System.Memory.dll.so', `
-                'System.Net.Http.dll.so', `
-                'System.Net.NetworkInformation.dll.so', `
-                'System.Net.Primitives.dll.so', `
-                'System.Net.Requests.dll.so', `
-                'System.Net.Security.dll.so', `
-                'System.Net.WebProxy.dll.so', `
-                'System.Numerics.Vectors.dll.so', `
-                'System.ObjectModel.dll.so', `
-                'System.Private.CoreLib.dll.so', `
-                'System.Private.Uri.dll.so', `
-                'System.Private.Xml.dll.so', `
-                'System.Reflection.Metadata.dll.so', `
-                'System.Reflection.Primitives.dll.so', `
-                'System.Runtime.CompilerServices.Unsafe.dll.so', `
-                'System.Runtime.dll.so', `
-                'System.Runtime.InteropServices.dll.so', `
-                'System.Runtime.InteropServices.RuntimeInformation.dll.so', `
-                'System.Runtime.Serialization.Primitives.dll.so', `
-                'System.Security.Cryptography.Algorithms.dll.so', `
-                'System.Security.Cryptography.Primitives.dll.so', `
-                'System.Text.Encodings.Web.dll.so', `
-                'System.Text.Json.dll.so', `
-                'System.Text.RegularExpressions.dll.so', `
-                'System.Threading.dll.so', `
-                'System.Threading.Thread.dll.so', `
-                'System.Threading.ThreadPool.dll.so', `
-                'System.Xml.ReaderWriter.dll.so', `
-                'Xamarin.AndroidX.Activity.dll.so', `
-                'Xamarin.AndroidX.AppCompat.AppCompatResources.dll.so', `
-                'Xamarin.AndroidX.AppCompat.dll.so', `
-                'Xamarin.AndroidX.CardView.dll.so', `
-                'Xamarin.AndroidX.Collection.dll.so', `
-                'Xamarin.AndroidX.CoordinatorLayout.dll.so', `
-                'Xamarin.AndroidX.Core.dll.so', `
-                'Xamarin.AndroidX.CursorAdapter.dll.so', `
-                'Xamarin.AndroidX.CustomView.dll.so', `
-                'Xamarin.AndroidX.DrawerLayout.dll.so', `
-                'Xamarin.AndroidX.Fragment.dll.so', `
-                'Xamarin.AndroidX.Lifecycle.Common.dll.so', `
-                'Xamarin.AndroidX.Lifecycle.LiveData.Core.dll.so', `
-                'Xamarin.AndroidX.Lifecycle.ViewModel.dll.so', `
-                'Xamarin.AndroidX.Lifecycle.ViewModelSavedState.dll.so', `
-                'Xamarin.AndroidX.Loader.dll.so', `
-                'Xamarin.AndroidX.Navigation.Common.dll.so', `
-                'Xamarin.AndroidX.Navigation.Fragment.dll.so', `
-                'Xamarin.AndroidX.Navigation.Runtime.dll.so', `
-                'Xamarin.AndroidX.Navigation.UI.dll.so', `
-                'Xamarin.AndroidX.RecyclerView.dll.so', `
-                'Xamarin.AndroidX.SavedState.dll.so', `
-                'Xamarin.AndroidX.SwipeRefreshLayout.dll.so', `
-                'Xamarin.AndroidX.ViewPager.dll.so', `
-                'Xamarin.AndroidX.ViewPager2.dll.so', `
-                'Xamarin.Google.Android.Material.dll.so', `
-                'Xamarin.Kotlin.StdLib.dll.so', `
-                'Xamarin.KotlinX.Coroutines.Core.Jvm.dll.so' `
+        $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
+            'Sentry.pdb',
+            'Sentry.Samples.Console.Basic',
+            'Sentry.Samples.Console.Basic.pdb')
+    }
+
+    It "uploads sources for a console app build" {
+        $result = DotnetBuild 'Sentry.Samples.Console.Basic' $False $True
+        $result.ScriptOutput | Should -Contain 'Build succeeded.'
+        $result.HasErrors() | Should -BeFalse
+        $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
+            'Sentry.Samples.Console.Basic.src.zip')
+    }
+
+    It "uploads nothing for a console app build when disabled" {
+        $result = DotnetBuild 'Sentry.Samples.Console.Basic' $False $False
+        $result.ScriptOutput | Should -Contain 'Build succeeded.'
+        $result.HasErrors() | Should -BeFalse
+        $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @()
+    }
+
+    It "uploads symbols and sources for a MAUI Android app build" {
+        $result = DotnetBuild 'Sentry.Samples.Maui' $True $True 'net6.0-android'
+        $result.ScriptOutput | Should -Contain 'Build succeeded.'
+        $result.HasErrors() | Should -BeFalse
+        $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
+            'Sentry.Android.AssemblyReader.pdb',
+            'Sentry.Bindings.Android.pdb',
+            'Sentry.Extensions.Logging.pdb',
+            'Sentry.Maui.pdb',
+            'Sentry.pdb',
+            'Sentry.Samples.Maui.pdb',
+            'Sentry.Samples.Maui.src.zip'
         )
-        @(Compare-Object -ReferenceObject $expected -DifferenceObject $actual -PassThru) | Should -Be @()
+    }
+
+    if ([RuntimeInformation]::IsOSPlatform([OSPlatform]::OSX)) {
+        # Remaining tests run on macOS only
+        return
+    }
+
+    It "uploads symbols and sources for a MAUI iOS app build" {
+        $result = DotnetBuild 'Sentry.Samples.Maui' $True $True 'net6.0-ios'
+        $result.ScriptOutput | Should -Contain 'Build succeeded.'
+        $result.HasErrors() | Should -BeFalse
+        $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
+            'libmono-component-debugger.dylib',
+            'libmono-component-diagnostics_tracing.dylib',
+            'libmono-component-hot_reload.dylib',
+            'libmonosgen-2.0.dylib',
+            'libSystem.IO.Compression.Native.dylib',
+            'libSystem.Native.dylib',
+            'libSystem.Net.Security.Native.dylib',
+            'libSystem.Security.Cryptography.Native.Apple.dylib',
+            'libxamarin-dotnet-debug.dylib',
+            'libxamarin-dotnet.dylib',
+            'Sentry',
+            'Sentry.Bindings.Cocoa.pdb',
+            'Sentry.Extensions.Logging.pdb',
+            'Sentry.Maui.pdb',
+            'Sentry.pdb',
+            'Sentry.Samples.Maui',
+            'Sentry.Samples.Maui.pdb',
+            'Sentry.Samples.Maui.src.zip'
+        )
     }
 }


### PR DESCRIPTION
- Upload from `bin` folder rather than `obj`.  This uploads fewer unnecessary files, and also ensures that symbols from dependencies are uploaded.  Fixes #2260.
- Complete the integration tests started in #2191 - they actually check the list of upload files now.
- Expand the tests to cover various combination of input flags and project types
- Upload source bundles separately from symbols so we can always see the source bundle being uploaded in the tests.  It also simplifies the implementation.
