### PR TITLE
Require XML comments on public types for all build configurations

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,9 +6,6 @@
     <!--Generate xml docs for all projects under 'src'-->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <!-- CS1591: Missing XML comment for publicly visible type or member -->
-    <NoWarn Condition="'$(Configuration)' == 'Debug'">$(NoWarn);CS1591</NoWarn>
-
     <Authors>Sentry Team and Contributors</Authors>
     <Company>Sentry.io</Company>
     <Product>Sentry</Product>


### PR DESCRIPTION
We used to only require XML comments for public types be authored while in release configuration, but that makes it easy to miss them at development time.  Waiting for CI to fail is more friction than just requiring the docs in the first place, so restoring to default behavior.

#skip-changelog