### PR TITLE
Add tag filters to SentryLoggingOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add tag filters to SentryLoggingOptions ([#2360](https://github.com/getsentry/sentry-dotnet/pull/2360))
+
 ## 3.31.0
 
 ### Features

--- a/src/Sentry.Extensions.Logging/SentryLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryLogger.cs
@@ -82,7 +82,7 @@ internal sealed class SentryLogger : ILogger
         Exception? exception,
         string? message,
         string category,
-        SubstringOrRegexPattern[] tagFilters)
+        ICollection<SubstringOrRegexPattern> tagFilters)
     {
         var @event = new SentryEvent(exception)
         {

--- a/src/Sentry.Extensions.Logging/SentryLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryLogger.cs
@@ -106,7 +106,6 @@ internal sealed class SentryLogger : ILogger
                     continue;
                 }
 
-                // TODO: should the code ensure "{OriginalFormat}" is not specified by user and removed?
                 if (tagFilters.Any(x => x.IsMatch(property.Key)))
                 {
                     continue;

--- a/src/Sentry.Extensions.Logging/SentryLoggingOptions.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggingOptions.cs
@@ -48,4 +48,9 @@ public class SentryLoggingOptions : SentryOptions
     /// List of callbacks to be invoked when initializing the SDK
     /// </summary>
     internal Action<Scope>[] ConfigureScopeCallbacks { get; set; } = Array.Empty<Action<Scope>>();
+
+    /// <summary>
+    /// List of substrings or regular expression patterns to filter out tags
+    /// </summary>
+    public SubstringOrRegexPattern[] TagFilters { get; set; } = Array.Empty<SubstringOrRegexPattern>();
 }

--- a/src/Sentry.Extensions.Logging/SentryLoggingOptions.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggingOptions.cs
@@ -52,5 +52,5 @@ public class SentryLoggingOptions : SentryOptions
     /// <summary>
     /// List of substrings or regular expression patterns to filter out tags
     /// </summary>
-    public SubstringOrRegexPattern[] TagFilters { get; set; } = Array.Empty<SubstringOrRegexPattern>();
+    public ICollection<SubstringOrRegexPattern> TagFilters { get; set; } = new List<SubstringOrRegexPattern>();
 }

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -41,6 +41,7 @@ namespace Sentry.Extensions.Logging
         public bool InitializeSdk { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumBreadcrumbLevel { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumEventLevel { get; set; }
+        public System.Collections.Generic.ICollection<Sentry.SubstringOrRegexPattern> TagFilters { get; set; }
         public void ConfigureScope(System.Action<Sentry.Scope> action) { }
     }
     public static class SentryLoggingOptionsExtensions

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -41,6 +41,7 @@ namespace Sentry.Extensions.Logging
         public bool InitializeSdk { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumBreadcrumbLevel { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumEventLevel { get; set; }
+        public System.Collections.Generic.ICollection<Sentry.SubstringOrRegexPattern> TagFilters { get; set; }
         public void ConfigureScope(System.Action<Sentry.Scope> action) { }
     }
     public static class SentryLoggingOptionsExtensions

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -41,6 +41,7 @@ namespace Sentry.Extensions.Logging
         public bool InitializeSdk { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumBreadcrumbLevel { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumEventLevel { get; set; }
+        public System.Collections.Generic.ICollection<Sentry.SubstringOrRegexPattern> TagFilters { get; set; }
         public void ConfigureScope(System.Action<Sentry.Scope> action) { }
     }
     public static class SentryLoggingOptionsExtensions

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -41,6 +41,7 @@ namespace Sentry.Extensions.Logging
         public bool InitializeSdk { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumBreadcrumbLevel { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumEventLevel { get; set; }
+        public System.Collections.Generic.ICollection<Sentry.SubstringOrRegexPattern> TagFilters { get; set; }
         public void ConfigureScope(System.Action<Sentry.Scope> action) { }
     }
     public static class SentryLoggingOptionsExtensions

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
@@ -112,7 +112,7 @@ public class SentryLoggerTests
         try
         {
             Thread.CurrentThread.CurrentCulture = new("da-DK");
-            sentryEvent = SentryLogger.CreateEvent(LogLevel.Debug, default, props, null, null, "category");
+            sentryEvent = SentryLogger.CreateEvent(LogLevel.Debug, default, props, null, null, "category", Array.Empty<SubstringOrRegexPattern>());
         }
         finally
         {
@@ -530,5 +530,22 @@ public class SentryLoggerTests
         var actual = sut.BeginScope("state");
 
         Assert.Same(actual, expected);
+    }
+
+    [Fact]
+    public void Filtered_tags_are_not_on_event()
+    {
+        var props = new List<KeyValuePair<string, object>>
+        {
+            new("AzFunctions", "rule"),
+            new("AzureFunctions_FunctionName", "Func"),
+            new("AzureFunctions_InvocationId", "20a09c3b-e9dd-43fe-9a73-ebae1f90cab6"),
+        };
+
+        var tagFilters = new[] { new SubstringOrRegexPattern("AzureFunctions_") };
+
+        var sentryEvent = SentryLogger.CreateEvent(LogLevel.Debug, default, props, null, null, "category", tagFilters);
+
+        sentryEvent.Tags.Should().OnlyContain(pair => pair.Key == "AzFunctions" && pair.Value == "rule");
     }
 }


### PR DESCRIPTION
Allow specifying patterns or regular expressions to filter tags.