### PR TITLE
Allow setting the active span on the scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features
 
 - Add tag filters to SentryLoggingOptions ([#2360](https://github.com/getsentry/sentry-dotnet/pull/2360))
+- Allow setting the active span on the scope ([#2364](https://github.com/getsentry/sentry-dotnet/pull/2364))
+  - Note: Obsoletes the `Scope.GetSpan` method in favor of a `Scope.Span` property (which now has a setter as well).
 
 ### Dependencies
 

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -182,11 +182,7 @@ internal class Hub : IHubEx, IDisposable
         _ = ExceptionToSpanMap.GetValue(exception, _ => span);
     }
 
-    public ISpan? GetSpan()
-    {
-        var (currentScope, _) = ScopeManager.GetCurrent();
-        return currentScope.GetSpan();
-    }
+    public ISpan? GetSpan() => ScopeManager.GetCurrent().Key.Span;
 
     public SentryTraceHeader? GetTraceHeader() => GetSpan()?.GetTraceHeader();
 
@@ -286,7 +282,7 @@ internal class Hub : IHubEx, IDisposable
         }
 
         // Otherwise just get the currently active span on the scope (unless it's sampled out)
-        if (scope.GetSpan() is { IsSampled: not false } span)
+        if (scope.Span is { IsSampled: not false } span)
         {
             return span;
         }

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -516,10 +516,34 @@ public class Scope : IEventLike, IHasDistribution
     }
 
     /// <summary>
-    /// Gets the currently ongoing (not finished) span or <c>null</c> if none available.
-    /// This relies on the transactions being manually set on the scope via <see cref="Transaction"/>.
+    /// Obsolete.  Use the <see cref="Span"/> property instead.
     /// </summary>
-    public ISpan? GetSpan() => Transaction?.GetLastActiveSpan() ?? Transaction;
+    [Obsolete("Use the Span property instead.  This method will be removed in a future release.")]
+    public ISpan? GetSpan() => Span;
+
+    private ISpan? _span;
+
+    /// <summary>
+    /// Gets or sets the active span, or <c>null</c> if none available.
+    /// </summary>
+    /// <remarks>
+    /// If a span has been set on this property, it will become the active span until it is finished.
+    /// Otherwise, the active span is the latest unfinished span on the transaction, presuming a transaction
+    /// was set on the scope via the <see cref="Transaction"/> property.
+    /// </remarks>
+    public ISpan? Span
+    {
+        get
+        {
+            if (_span?.IsFinished is false)
+            {
+                return _span;
+            }
+
+            return Transaction?.GetLastActiveSpan() ?? Transaction;
+        }
+        set => _span = value;
+    }
 
     internal void ResetTransaction(ITransaction? expectedCurrentTransaction) =>
         Interlocked.CompareExchange(ref _transaction, null, expectedCurrentTransaction);

--- a/test/Sentry.DiagnosticSource.Tests/Integration/SQLite/SentryDiagnosticListenerTests.cs
+++ b/test/Sentry.DiagnosticSource.Tests/Integration/SQLite/SentryDiagnosticListenerTests.cs
@@ -38,11 +38,7 @@ public class SentryDiagnosticListenerTests
         }
         public ItemsContext NewContext() => new(_database.ContextOptions);
 
-        public ISpan GetSpan()
-        {
-            var (currentScope, _) = ScopeManager.GetCurrent();
-            return currentScope.GetSpan();
-        }
+        public ISpan GetSpan() => ScopeManager.GetCurrent().Key.Span;
 
         public ITransaction StartTransaction(IHub hub, ITransactionContext context)
         {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -404,6 +404,7 @@ namespace Sentry
         public string? Release { get; set; }
         public Sentry.Request Request { get; set; }
         public Sentry.SdkVersion Sdk { get; }
+        public Sentry.ISpan? Span { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
         public Sentry.ITransaction? Transaction { get; set; }
         public string? TransactionName { get; set; }
@@ -417,6 +418,7 @@ namespace Sentry
         public void ClearAttachments() { }
         public void ClearBreadcrumbs() { }
         public Sentry.Scope Clone() { }
+        [System.Obsolete("Use the Span property instead.  This method will be removed in a future release.")]
         public Sentry.ISpan? GetSpan() { }
         public void SetExtra(string key, object? value) { }
         public void SetTag(string key, string value) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -404,6 +404,7 @@ namespace Sentry
         public string? Release { get; set; }
         public Sentry.Request Request { get; set; }
         public Sentry.SdkVersion Sdk { get; }
+        public Sentry.ISpan? Span { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
         public Sentry.ITransaction? Transaction { get; set; }
         public string? TransactionName { get; set; }
@@ -417,6 +418,7 @@ namespace Sentry
         public void ClearAttachments() { }
         public void ClearBreadcrumbs() { }
         public Sentry.Scope Clone() { }
+        [System.Obsolete("Use the Span property instead.  This method will be removed in a future release.")]
         public Sentry.ISpan? GetSpan() { }
         public void SetExtra(string key, object? value) { }
         public void SetTag(string key, string value) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -404,6 +404,7 @@ namespace Sentry
         public string? Release { get; set; }
         public Sentry.Request Request { get; set; }
         public Sentry.SdkVersion Sdk { get; }
+        public Sentry.ISpan? Span { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
         public Sentry.ITransaction? Transaction { get; set; }
         public string? TransactionName { get; set; }
@@ -417,6 +418,7 @@ namespace Sentry
         public void ClearAttachments() { }
         public void ClearBreadcrumbs() { }
         public Sentry.Scope Clone() { }
+        [System.Obsolete("Use the Span property instead.  This method will be removed in a future release.")]
         public Sentry.ISpan? GetSpan() { }
         public void SetExtra(string key, object? value) { }
         public void SetTag(string key, string value) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -403,6 +403,7 @@ namespace Sentry
         public string? Release { get; set; }
         public Sentry.Request Request { get; set; }
         public Sentry.SdkVersion Sdk { get; }
+        public Sentry.ISpan? Span { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
         public Sentry.ITransaction? Transaction { get; set; }
         public string? TransactionName { get; set; }
@@ -416,6 +417,7 @@ namespace Sentry
         public void ClearAttachments() { }
         public void ClearBreadcrumbs() { }
         public Sentry.Scope Clone() { }
+        [System.Obsolete("Use the Span property instead.  This method will be removed in a future release.")]
         public Sentry.ISpan? GetSpan() { }
         public void SetExtra(string key, object? value) { }
         public void SetTag(string key, string value) { }

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -164,7 +164,7 @@ public class ScopeTests
     }
 
     [Fact]
-    public void GetSpan_NoSpans_ReturnsTransaction()
+    public void Span_NoSpans_ReturnsTransaction()
     {
         // Arrange
         var scope = new Scope();
@@ -179,7 +179,7 @@ public class ScopeTests
     }
 
     [Fact]
-    public void GetSpan_FinishedSpans_ReturnsTransaction()
+    public void Span_FinishedSpans_ReturnsTransaction()
     {
         // Arrange
         var scope = new Scope();
@@ -198,7 +198,7 @@ public class ScopeTests
     }
 
     [Fact]
-    public void GetSpan_ActiveSpans_ReturnsSpan()
+    public void Span_ActiveSpans_ReturnsSpan()
     {
         // Arrange
         var scope = new Scope();

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -172,7 +172,7 @@ public class ScopeTests
         scope.Transaction = transaction;
 
         // Act
-        var span = scope.GetSpan();
+        var span = scope.Span;
 
         // Assert
         span.Should().Be(transaction);
@@ -191,7 +191,7 @@ public class ScopeTests
         scope.Transaction = transaction;
 
         // Act
-        var span = scope.GetSpan();
+        var span = scope.Span;
 
         // Assert
         span.Should().Be(transaction);
@@ -210,7 +210,7 @@ public class ScopeTests
         scope.Transaction = transaction;
 
         // Act
-        var span = scope.GetSpan();
+        var span = scope.Span;
 
         // Assert
         span.Should().Be(activeSpan);

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -217,6 +217,67 @@ public class ScopeTests
     }
 
     [Fact]
+    public void Span_SetSpan_ReturnsValue()
+    {
+        // Arrange
+        var scope = new Scope();
+
+        var transaction = new TransactionTracer(DisabledHub.Instance, "foo", "_");
+        var firstSpan = transaction.StartChild("123");
+        var secondSpan = firstSpan.StartChild("456");
+
+        scope.Transaction = transaction;
+
+        // Assert Default
+        scope.Span.Should().Be(secondSpan);
+
+        // Act
+        scope.Span = firstSpan;
+
+        // Assert
+        scope.Span.Should().Be(firstSpan);
+    }
+
+    [Fact]
+    public void Span_SetSpanNull_ReturnsLatestOpen()
+    {
+        // Arrange
+        var scope = new Scope();
+
+        var transaction = new TransactionTracer(DisabledHub.Instance, "foo", "_");
+        var firstSpan = transaction.StartChild("123");
+        var secondSpan = firstSpan.StartChild("456");
+
+        scope.Transaction = transaction;
+
+        // Act
+        scope.Span = null;
+
+        // Assert
+        scope.Span.Should().Be(secondSpan);
+    }
+
+    [Fact]
+    public void Span_SetSpanThenCloseIt_ReturnsLatestOpen()
+    {
+        // Arrange
+        var scope = new Scope();
+
+        var transaction = new TransactionTracer(DisabledHub.Instance, "foo", "_");
+        var firstSpan = transaction.StartChild("123");
+        var secondSpan = firstSpan.StartChild("456");
+
+        scope.Transaction = transaction;
+
+        // Act
+        scope.Span = firstSpan;
+        firstSpan.Finish();
+
+        // Assert
+        scope.Span.Should().Be(secondSpan);
+    }
+
+    [Fact]
     public void AddAttachment_AddAttachments()
     {
         // Arrange


### PR DESCRIPTION
With this change,  the `GetSpan` method on the `Scope` class has been obsoleted, and replaced with a `Span` property that has both a getter and a setter.

Previous usage:

```csharp
SentrySdk.ConfigureScope(scope =>
{
    var span = scope.GetSpan();
});
```

New usage:

```csharp
SentrySdk.ConfigureScope(scope =>
{
    var span = scope.Span;
});
```

That's the boring part.  The new interesting part is that you can now _set_ the span if desired.  This can be used to pin an active span as the root span before starting complex tasks such as doing work in parallel.  This allows each subsequent child span to attach to the root, rather than to each other.

For example:

```csharp
var span = SentrySdk.GetSpan();
Parallel.ForEach(items, item =>
{
    SentrySdk.WithScope(scope =>
    {
        scope.Span = span;

        // Do some work that might generate new child spans, etc.
        // They'll all be created from the span set on the scope.
    });
});
```

Or asynchronously:

```csharp
var span = SentrySdk.GetSpan();
await Parallel.ForEachAsync(items, async (item, cancellationToken) =>
{
    await SentrySdk.WithScopeAsync(async scope =>
    {
        scope.Span = span;

        // Do some async work that might generate new child spans, etc.
        // They'll all be created from the span set on the scope.
    });
});
```

Or asynchronously with tasks:

```csharp
var span = SentrySdk.GetSpan();
await Task.WhenAll(items.Select(async item =>
{
    await SentrySdk.WithScopeAsync(async scope =>
    {
        scope.Span = span;

        // Do some async work that might generate new child spans, etc.
        // They'll all be created from the span set on the scope.
    });
}));
```

Resolves #1845
Resolves #1679 