### PR TITLE
Move tags filtering from SentryLogger to Scope

### DIFF
--- a/src/Sentry.Extensions.Logging/SentryLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryLogger.cs
@@ -47,7 +47,7 @@ internal sealed class SentryLogger : ILogger
 
         if (ShouldCaptureEvent(logLevel, eventId, exception))
         {
-            var @event = CreateEvent(logLevel, eventId, state, exception, message, CategoryName, _options.TagFilters);
+            var @event = CreateEvent(logLevel, eventId, state, exception, message, CategoryName);
 
             _ = _hub.CaptureEvent(@event);
         }
@@ -81,8 +81,7 @@ internal sealed class SentryLogger : ILogger
         TState state,
         Exception? exception,
         string? message,
-        string category,
-        ICollection<SubstringOrRegexPattern> tagFilters)
+        string category)
     {
         var @event = new SentryEvent(exception)
         {
@@ -103,11 +102,6 @@ internal sealed class SentryLogger : ILogger
                         Formatted = message,
                         Message = template
                     };
-                    continue;
-                }
-
-                if (tagFilters.Any(x => x.IsMatch(property.Key)))
-                {
                     continue;
                 }
 

--- a/src/Sentry.Extensions.Logging/SentryLoggingOptions.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggingOptions.cs
@@ -48,9 +48,4 @@ public class SentryLoggingOptions : SentryOptions
     /// List of callbacks to be invoked when initializing the SDK
     /// </summary>
     internal Action<Scope>[] ConfigureScopeCallbacks { get; set; } = Array.Empty<Action<Scope>>();
-
-    /// <summary>
-    /// List of substrings or regular expression patterns to filter out tags
-    /// </summary>
-    public ICollection<SubstringOrRegexPattern> TagFilters { get; set; } = new List<SubstringOrRegexPattern>();
 }

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -290,6 +290,11 @@ public class Scope : IEventLike, IHasDistribution
     /// <inheritdoc />
     public void SetTag(string key, string value)
     {
+        if (Options.TagFilters.Any(x => x.IsMatch(key)))
+        {
+            return;
+        }
+
         _tags[key] = value;
         if (Options.EnableScopeSync)
         {

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -132,6 +132,11 @@ public class SentryOptions
     internal List<IExceptionFilter>? ExceptionFilters { get; set; } = new();
 
     /// <summary>
+    /// List of substrings or regular expression patterns to filter out tags
+    /// </summary>
+    public ICollection<SubstringOrRegexPattern> TagFilters { get; set; } = new List<SubstringOrRegexPattern>();
+
+    /// <summary>
     /// The worker used by the client to pass envelopes.
     /// </summary>
     public IBackgroundWorker? BackgroundWorker { get; set; }

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -41,7 +41,6 @@ namespace Sentry.Extensions.Logging
         public bool InitializeSdk { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumBreadcrumbLevel { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumEventLevel { get; set; }
-        public System.Collections.Generic.ICollection<Sentry.SubstringOrRegexPattern> TagFilters { get; set; }
         public void ConfigureScope(System.Action<Sentry.Scope> action) { }
     }
     public static class SentryLoggingOptionsExtensions

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -41,7 +41,6 @@ namespace Sentry.Extensions.Logging
         public bool InitializeSdk { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumBreadcrumbLevel { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumEventLevel { get; set; }
-        public System.Collections.Generic.ICollection<Sentry.SubstringOrRegexPattern> TagFilters { get; set; }
         public void ConfigureScope(System.Action<Sentry.Scope> action) { }
     }
     public static class SentryLoggingOptionsExtensions

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -41,7 +41,6 @@ namespace Sentry.Extensions.Logging
         public bool InitializeSdk { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumBreadcrumbLevel { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumEventLevel { get; set; }
-        public System.Collections.Generic.ICollection<Sentry.SubstringOrRegexPattern> TagFilters { get; set; }
         public void ConfigureScope(System.Action<Sentry.Scope> action) { }
     }
     public static class SentryLoggingOptionsExtensions

--- a/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Extensions.Logging.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -41,7 +41,6 @@ namespace Sentry.Extensions.Logging
         public bool InitializeSdk { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumBreadcrumbLevel { get; set; }
         public Microsoft.Extensions.Logging.LogLevel MinimumEventLevel { get; set; }
-        public System.Collections.Generic.ICollection<Sentry.SubstringOrRegexPattern> TagFilters { get; set; }
         public void ConfigureScope(System.Action<Sentry.Scope> action) { }
     }
     public static class SentryLoggingOptionsExtensions

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
@@ -112,7 +112,7 @@ public class SentryLoggerTests
         try
         {
             Thread.CurrentThread.CurrentCulture = new("da-DK");
-            sentryEvent = SentryLogger.CreateEvent(LogLevel.Debug, default, props, null, null, "category", Array.Empty<SubstringOrRegexPattern>());
+            sentryEvent = SentryLogger.CreateEvent(LogLevel.Debug, default, props, null, null, "category");
         }
         finally
         {
@@ -530,22 +530,5 @@ public class SentryLoggerTests
         var actual = sut.BeginScope("state");
 
         Assert.Same(actual, expected);
-    }
-
-    [Fact]
-    public void Filtered_tags_are_not_on_event()
-    {
-        var props = new List<KeyValuePair<string, object>>
-        {
-            new("AzFunctions", "rule"),
-            new("AzureFunctions_FunctionName", "Func"),
-            new("AzureFunctions_InvocationId", "20a09c3b-e9dd-43fe-9a73-ebae1f90cab6"),
-        };
-
-        var tagFilters = new[] { new SubstringOrRegexPattern("AzureFunctions_") };
-
-        var sentryEvent = SentryLogger.CreateEvent(LogLevel.Debug, default, props, null, null, "category", tagFilters);
-
-        sentryEvent.Tags.Should().OnlyContain(pair => pair.Key == "AzFunctions" && pair.Value == "rule");
     }
 }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -613,6 +613,7 @@ namespace Sentry
         public string? ServerName { get; set; }
         public System.TimeSpan ShutdownTimeout { get; set; }
         public Sentry.StackTraceMode StackTraceMode { get; set; }
+        public System.Collections.Generic.ICollection<Sentry.SubstringOrRegexPattern> TagFilters { get; set; }
         public System.Collections.Generic.IList<Sentry.TracePropagationTarget> TracePropagationTargets { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -614,6 +614,7 @@ namespace Sentry
         public string? ServerName { get; set; }
         public System.TimeSpan ShutdownTimeout { get; set; }
         public Sentry.StackTraceMode StackTraceMode { get; set; }
+        public System.Collections.Generic.ICollection<Sentry.SubstringOrRegexPattern> TagFilters { get; set; }
         public System.Collections.Generic.IList<Sentry.TracePropagationTarget> TracePropagationTargets { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -614,6 +614,7 @@ namespace Sentry
         public string? ServerName { get; set; }
         public System.TimeSpan ShutdownTimeout { get; set; }
         public Sentry.StackTraceMode StackTraceMode { get; set; }
+        public System.Collections.Generic.ICollection<Sentry.SubstringOrRegexPattern> TagFilters { get; set; }
         public System.Collections.Generic.IList<Sentry.TracePropagationTarget> TracePropagationTargets { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -612,6 +612,7 @@ namespace Sentry
         public string? ServerName { get; set; }
         public System.TimeSpan ShutdownTimeout { get; set; }
         public Sentry.StackTraceMode StackTraceMode { get; set; }
+        public System.Collections.Generic.ICollection<Sentry.SubstringOrRegexPattern> TagFilters { get; set; }
         public System.Collections.Generic.IList<Sentry.TracePropagationTarget> TracePropagationTargets { get; set; }
         public double TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -462,6 +462,29 @@ public class ScopeTests
         // Assert
         observer.Received(expectedCount).AddBreadcrumb(Arg.Is(breadcrumb));
     }
+
+    [Fact]
+    public void Filtered_tags_are_not_set()
+    {
+        var tags = new List<KeyValuePair<string, string>>
+        {
+            new("AzFunctions", "rule"),
+            new("AzureFunctions_FunctionName", "Func"),
+            new("AzureFunctions_InvocationId", "20a09c3b-e9dd-43fe-9a73-ebae1f90cab6"),
+        };
+
+        var scope = new Scope(new SentryOptions
+        {
+            TagFilters = new[] { new SubstringOrRegexPattern("AzureFunctions_") }
+        });
+
+        foreach (var (key, value) in tags)
+        {
+            scope.SetTag(key, value);
+        }
+
+        scope.Tags.Should().OnlyContain(pair => pair.Key == "AzFunctions" && pair.Value == "rule");
+    }
 }
 
 public static class ScopeTestExtensions


### PR DESCRIPTION
Move tags filtering from SentryLogger to Scope.
By doing so, tags that are set via `Scope.SetTag(key, value)` can be filtered out.