### PR TITLE
Fix `EnableTracing` option conflict with `TracesSampleRate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - Add tag filters to SentryLoggingOptions ([#2360](https://github.com/getsentry/sentry-dotnet/pull/2360))
 
+### Fixes
+
+- Fix `EnableTracing` option conflict with `TracesSampleRate` ([#2368](https://github.com/getsentry/sentry-dotnet/pull/2368))
+ - NOTE: This is a potentially breaking change, as the `TracesSampleRate` property has been made nullable.
+   Though extremely uncommon, if you are _retrieving_ the `TracesSampleRate` property for some reason, you will need to account for nulls.
+   However, there is no change to the behavior or _typical_ usage of either of these properties.
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.6.0 to v8.7.0 ([#2359](https://github.com/getsentry/sentry-dotnet/pull/2359))

--- a/SentryMobile.slnf
+++ b/SentryMobile.slnf
@@ -17,7 +17,6 @@
       "test\\Sentry.Extensions.Logging.Tests\\Sentry.Extensions.Logging.Tests.csproj",
       "test\\Sentry.Maui.Device.TestApp\\Sentry.Maui.Device.TestApp.csproj",
       "test\\Sentry.Maui.Tests\\Sentry.Maui.Tests.csproj",
-      "test\\Sentry.Testing.CrashableApp\\Sentry.Testing.CrashableApp.csproj",
       "test\\Sentry.Testing\\Sentry.Testing.csproj",
       "test\\Sentry.Tests\\Sentry.Tests.csproj"
     ]

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -148,7 +148,7 @@ internal class Hub : IHubEx, IDisposable
             // Random sampling runs only if the sampling decision hasn't been made already.
             if (transaction.IsSampled == null)
             {
-                var sampleRate = _options.TracesSampleRate;
+                var sampleRate = _options.TracesSampleRate ?? (_options.EnableTracing is true ? 1.0 : 0.0);
                 transaction.IsSampled = _randomValuesFactory.NextBool(sampleRate);
                 transaction.SampleRate = sampleRate;
             }

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -4,7 +4,6 @@ using Sentry.Android;
 using Sentry.Android.Callbacks;
 using Sentry.Android.Extensions;
 using Sentry.JavaSdk.Android.Core;
-using Sentry.Protocol;
 
 // ReSharper disable once CheckNamespace
 namespace Sentry;
@@ -108,8 +107,9 @@ public static partial class SentrySdk
             }
 
             // These options we have behind feature flags
-            if (options.IsTracingEnabled && options.Android.EnableAndroidSdkTracing)
+            if (options is {IsTracingEnabled: true, Android.EnableAndroidSdkTracing: true})
             {
+                o.EnableTracing = (JavaBoolean?)options.EnableTracing;
                 o.TracesSampleRate = (JavaDouble?)options.TracesSampleRate;
 
                 if (options.TracesSampler is { } tracesSampler)

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -66,8 +66,13 @@ public static partial class SentrySdk
         }
 
         // These options we have behind feature flags
-        if (options.IsTracingEnabled && options.iOS.EnableCocoaSdkTracing)
+        if (options is {IsTracingEnabled: true, iOS.EnableCocoaSdkTracing: true})
         {
+            if (options.EnableTracing != null)
+            {
+                cocoaOptions.EnableTracing = options.EnableTracing.Value;
+            }
+
             cocoaOptions.TracesSampleRate = options.TracesSampleRate;
 
             if (options.TracesSampler is { } tracesSampler)

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -614,7 +614,7 @@ namespace Sentry
         public System.TimeSpan ShutdownTimeout { get; set; }
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public System.Collections.Generic.IList<Sentry.TracePropagationTarget> TracePropagationTargets { get; set; }
-        public double TracesSampleRate { get; set; }
+        public double? TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
         public Sentry.Extensibility.ITransport? Transport { get; set; }
         public bool UseAsyncFileIO { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -615,7 +615,7 @@ namespace Sentry
         public System.TimeSpan ShutdownTimeout { get; set; }
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public System.Collections.Generic.IList<Sentry.TracePropagationTarget> TracePropagationTargets { get; set; }
-        public double TracesSampleRate { get; set; }
+        public double? TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
         public Sentry.Extensibility.ITransport? Transport { get; set; }
         public bool UseAsyncFileIO { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -615,7 +615,7 @@ namespace Sentry
         public System.TimeSpan ShutdownTimeout { get; set; }
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public System.Collections.Generic.IList<Sentry.TracePropagationTarget> TracePropagationTargets { get; set; }
-        public double TracesSampleRate { get; set; }
+        public double? TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
         public Sentry.Extensibility.ITransport? Transport { get; set; }
         public bool UseAsyncFileIO { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -613,7 +613,7 @@ namespace Sentry
         public System.TimeSpan ShutdownTimeout { get; set; }
         public Sentry.StackTraceMode StackTraceMode { get; set; }
         public System.Collections.Generic.IList<Sentry.TracePropagationTarget> TracePropagationTargets { get; set; }
-        public double TracesSampleRate { get; set; }
+        public double? TracesSampleRate { get; set; }
         public System.Func<Sentry.TransactionSamplingContext, double?>? TracesSampler { get; set; }
         public Sentry.Extensibility.ITransport? Transport { get; set; }
         public bool UseAsyncFileIO { get; set; }

--- a/test/Sentry.Tests/SentryOptionsTests.cs
+++ b/test/Sentry.Tests/SentryOptionsTests.cs
@@ -1,8 +1,3 @@
-#if NETFRAMEWORK
-using Sentry.PlatformAbstractions;
-using Xunit.Sdk;
-#endif
-
 namespace Sentry.Tests;
 
 public class SentryOptionsTests
@@ -43,6 +38,20 @@ public class SentryOptionsTests
     }
 
     [Fact]
+    public void TracesSampleRate_Default_Null()
+    {
+        var sut = new SentryOptions();
+        Assert.Null(sut.TracesSampleRate);
+    }
+
+    [Fact]
+    public void TracesSampler_Default_Null()
+    {
+        var sut = new SentryOptions();
+        Assert.Null(sut.TracesSampler);
+    }
+
+    [Fact]
     public void IsTracingEnabled_Default_False()
     {
         var sut = new SentryOptions();
@@ -50,39 +59,119 @@ public class SentryOptionsTests
     }
 
     [Fact]
-    public void EnableTracing_WhenNull()
-    {
-        var sut = new SentryOptions
-        {
-            EnableTracing = null
-        };
-
-        Assert.Null(sut.EnableTracing);
-        Assert.Equal(0.0, sut.TracesSampleRate);
-    }
-
-    [Fact]
-    public void EnableTracing_WhenFalse()
-    {
-        var sut = new SentryOptions
-        {
-            EnableTracing = false
-        };
-
-        Assert.False(sut.EnableTracing);
-        Assert.Equal(0.0, sut.TracesSampleRate);
-    }
-
-    [Fact]
-    public void EnableTracing_WhenTrue()
+    public void IsTracingEnabled_EnableTracing_True()
     {
         var sut = new SentryOptions
         {
             EnableTracing = true
         };
 
-        Assert.True(sut.EnableTracing);
-        Assert.Equal(1.0, sut.TracesSampleRate);
+        Assert.True(sut.IsTracingEnabled);
+    }
+
+    [Fact]
+    public void IsTracingEnabled_EnableTracing_False()
+    {
+        var sut = new SentryOptions
+        {
+            EnableTracing = false
+        };
+
+        Assert.False(sut.IsTracingEnabled);
+    }
+
+    [Fact]
+    public void IsTracingEnabled_TracesSampleRate_Zero()
+    {
+        var sut = new SentryOptions
+        {
+            TracesSampleRate = 0.0
+        };
+
+        Assert.False(sut.IsTracingEnabled);
+    }
+
+    [Fact]
+    public void IsTracingEnabled_TracesSampleRate_GreaterThanZero()
+    {
+        var sut = new SentryOptions
+        {
+            TracesSampleRate = double.Epsilon
+        };
+
+        Assert.True(sut.IsTracingEnabled);
+    }
+
+    [Fact]
+    public void IsTracingEnabled_TracesSampleRate_LessThanZero()
+    {
+        var sut = new SentryOptions();
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            sut.TracesSampleRate = -double.Epsilon);
+    }
+
+    [Fact]
+    public void IsTracingEnabled_TracesSampleRate_GreaterThanOne()
+    {
+        var sut = new SentryOptions();
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            sut.TracesSampleRate = 1.0000000000000002);
+    }
+
+    [Fact]
+    public void IsTracingEnabled_TracesSampler_Provided()
+    {
+        var sut = new SentryOptions
+        {
+            TracesSampler = _ => null
+        };
+
+        Assert.True(sut.IsTracingEnabled);
+    }
+
+    [Fact]
+    public void IsTracingEnabled_EnableTracing_True_TracesSampleRate_Zero()
+    {
+        // Edge Case:
+        //   Tracing enabled, but sample rate set to zero, and no sampler function, should be treated as disabled.
+
+        var sut = new SentryOptions
+        {
+            EnableTracing = true,
+            TracesSampleRate = 0.0
+        };
+
+        Assert.False(sut.IsTracingEnabled);
+    }
+
+    [Fact]
+    public void IsTracingEnabled_EnableTracing_False_TracesSampleRate_One()
+    {
+        // Edge Case:
+        //   Tracing disabled should be treated as disabled regardless of sample rate set.
+
+        var sut = new SentryOptions
+        {
+            EnableTracing = false,
+            TracesSampleRate = 1.0
+        };
+
+        Assert.False(sut.IsTracingEnabled);
+    }
+
+    [Fact]
+    public void IsTracingEnabled_EnableTracing_False_TracesSampler_Provided()
+    {
+        // Edge Case:
+        //   Tracing disabled should be treated as disabled regardless of sampler function set.
+
+        var sut = new SentryOptions
+        {
+            EnableTracing = false,
+            TracesSampler = _ => null
+        };
+
+        Assert.False(sut.IsTracingEnabled);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #2366 by having `TracesSampleRate` and `EnableTracing` properties have simple get/set implementations (except for some existing validation).  This issue was mainly seen during configuration binding in ASP.NET Core applications, and then - only in the case where `EnableTracing` was set `true` and `TracesSampleRate` was unset.

Unfortunately, the only way to implement the correct fix was to make `TracesSampleRate` a nullable `double?`.  Previously, it was a non-nullable `double`.  (The default value is now `null` instead of `0.0`.)  Normally I'd consider that to be a breaking change that could not be done without a major version bump.  But in this case, it's unlikely to affect anyone, because this property is typical _set_, but never retrieved externally.

There are no behavioral changes.  Both values work as they were originally intended.

I also improved the xmldocs, and fixed the exception type thrown when an invalid sample rate is set. (`ArgumentOutOfRangeException`, is more appropriate than `InvalidOperationException` for that). 