### PR TITLE
Remove ios simulator resources when building in Hot Restart mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
     However, there is no change to the behavior or _typical_ usage of either of these properties.
 
 - CachedTransport gracefully handles malformed envelopes during processing  ([#2371](https://github.com/getsentry/sentry-dotnet/pull/2371))
+- Remove extraneous iOS simulator resources when building MAUI apps using Visual Studio "Hot Restart" mode, to avoid hitting Windows max path  ([#2384](https://github.com/getsentry/sentry-dotnet/pull/2384))
+
 
 ### Dependencies
 

--- a/src/Sentry.Bindings.Cocoa/buildTransitive/Sentry.Bindings.Cocoa.targets
+++ b/src/Sentry.Bindings.Cocoa/buildTransitive/Sentry.Bindings.Cocoa.targets
@@ -39,4 +39,14 @@
 
   </Target>
 
+  <!--
+    Remove simulator resources when building for Hot Restart.
+    Effectively works around https://github.com/getsentry/sentry-dotnet/issues/2363
+  -->
+  <Target Name="_SentryRemoveSimulatorResourcesForHotRestartBuilds" AfterTargets="_CopyLocalBindingResources" Condition="'$(IsHotRestartBuild)' == 'true'">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::new('%(Identity)').Contains('Sentry.xcframework\ios-arm64_x86_64-simulator'))" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
The native resources from our Sentry Cocoa SDK (`Sentry.xcframeworks`) do not need to include files that are for the iOS simulator, when we're building for "Hot Restart" mode in Visual Studio - since that is specifically for going direct to device.

The simulator files add a few extra layers of directories, which can easily exceed Windows max path.  Removing them avoids this, without affecting functionality.

Tested locally on Visual Studio 17.6.0 on Windows.

Fixes #2363 