### PR TITLE
Set the native sdk name for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+## Fixes
+
+- Set the native sdk name for Android ([#2389](https://github.com/getsentry/sentry-dotnet/pull/2389))
+
 ## 3.33.0
 
 ### Features

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -163,6 +163,7 @@ public static partial class SentrySdk
             o.EnableExternalConfiguration = false;
             o.EnableDeduplication = false;
             o.AttachServerName = false;
+            o.NativeSdkName = "sentry.native.dotnet";
 
             // These options are intentionally not expose or modified
             //o.MaxRequestBodySize   // N/A for Android apps


### PR DESCRIPTION
Per https://github.com/getsentry/team-mobile/issues/48#issuecomment-1559160186, setting the sdk name reported by the Sentry Native SDK that Android uses to `"sentry.native.dotnet"`.

The Java parts of the Android SDK will still use `"sentry.java.android.dotnet"`.

There is no change to iOS, which uses `"sentry.cocoa.dotnet"`.