### PR TITLE
Don't cancel previous runs on main or release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
+        if: github.ref_name != 'main' && !startsWith(github.ref_name, 'release/')
         uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # Tag: 0.11.0
 
       - name: Checkout

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,6 +23,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
+        if: github.ref_name != 'main' && !startsWith(github.ref_name, 'release/')
         uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # Tag: 0.11.0
 
       - name: Checkout repository

--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -15,6 +15,7 @@ jobs:
       DOTNET_NOLOGO: 1
     steps:
       - name: Cancel Previous Runs
+        if: github.ref_name != 'main' && !startsWith(github.ref_name, 'release/')
         uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # Tag: 0.11.0
 
       - name: Checkout

--- a/.github/workflows/device-tests-ios.yml
+++ b/.github/workflows/device-tests-ios.yml
@@ -17,6 +17,7 @@ jobs:
       NO_MACCATALYST: true
     steps:
       - name: Cancel Previous Runs
+        if: github.ref_name != 'main' && !startsWith(github.ref_name, 'release/')
         uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # Tag: 0.11.0
 
       - name: Checkout


### PR DESCRIPTION
We use the "cancel previous runs" action to avoid extraneous processing on PRs.  We should avoid doing this on `main` or `release/*` branches, so that the main commit log shows pass/fail correctly.  This also improves CI failure rate statistics, because previously, if we merged multiple PRs in succession, the only the last one would "succeed" because the others would end up being cancelled.

#skip-changelog