### PR TITLE
Update mobile samples

### DIFF
--- a/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
+++ b/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-android</TargetFramework>
+    <TargetFramework>net7.0-android</TargetFramework>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>

--- a/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
+++ b/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
@@ -13,4 +13,14 @@
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <Using Include="Android.App.Activity" Alias="Activity" />
   </ItemGroup>
+
+  <!--
+    For this demo app, let's upload sources and symbols to Sentry on every build, regardless of configuration.
+    In a real app, you probably only want to do this on Release builds.
+  -->
+  <PropertyGroup>
+    <SentryUploadSources>true</SentryUploadSources>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+  </PropertyGroup>
+
 </Project>

--- a/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
+++ b/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net7.0-ios</TargetFramework>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>

--- a/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
+++ b/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
@@ -27,4 +27,13 @@
     <RuntimeIdentifier Condition="'$(OSArchitecture)' == 'Arm64' And ('$(_iOSRuntimeIdentifier)' == 'iossimulator-x64' Or ('$(_iOSRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == ''))">iossimulator-arm64</RuntimeIdentifier>
   </PropertyGroup>
 
+  <!--
+    For this demo app, let's upload sources and symbols to Sentry on every build, regardless of configuration.
+    In a real app, you probably only want to do this on Release builds.
+  -->
+  <PropertyGroup>
+    <SentryUploadSources>true</SentryUploadSources>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+  </PropertyGroup>
+
 </Project>

--- a/samples/Sentry.Samples.MacCatalyst/Sentry.Samples.MacCatalyst.csproj
+++ b/samples/Sentry.Samples.MacCatalyst/Sentry.Samples.MacCatalyst.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net7.0-maccatalyst</TargetFramework>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>

--- a/samples/Sentry.Samples.MacCatalyst/Sentry.Samples.MacCatalyst.csproj
+++ b/samples/Sentry.Samples.MacCatalyst/Sentry.Samples.MacCatalyst.csproj
@@ -26,4 +26,13 @@
     <RuntimeIdentifier Condition="'$(OSArchitecture)' == 'Arm64' And ('$(_MacCatalystRuntimeIdentifier)' == 'maccatalyst-x64' Or ('$(_MacCatalystRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == ''))">maccatalyst-arm64</RuntimeIdentifier>
   </PropertyGroup>
 
+  <!--
+    For this demo app, let's upload sources and symbols to Sentry on every build, regardless of configuration.
+    In a real app, you probably only want to do this on Release builds.
+  -->
+  <PropertyGroup>
+    <SentryUploadSources>true</SentryUploadSources>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+  </PropertyGroup>
+
 </Project>

--- a/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
+++ b/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
@@ -38,6 +38,13 @@
     -->
     <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>
 
+    <!--
+      For this demo app, let's upload sources and symbols to Sentry on every build, regardless of configuration.
+      In a real app, you probably only want to do this on Release builds.
+    -->
+    <SentryUploadSources>true</SentryUploadSources>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+
   </PropertyGroup>
 
   <!--

--- a/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
+++ b/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
@@ -6,9 +6,9 @@
       On Mac, we'll also build for iOS and MacCatalyst.
       On Windows, we'll also build for Windows 10.
     -->
-    <TargetFrameworks>net6.0-android</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net7.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Sentry.Samples.Maui</RootNamespace>
     <UseMaui>true</UseMaui>


### PR DESCRIPTION
- Use .NET 7 for all mobile samples (in particular, note [MAUI 6 is already EOL](https://dotnet.microsoft.com/platform/support/policy/maui))
- Always upload symbols and sources from mobile samples - so we can demo line numbers and source context where available.

#skip-changelog