### PR TITLE
Fix NLog tests

### DIFF
--- a/test/Sentry.NLog.Tests/SentryTargetTests.cs
+++ b/test/Sentry.NLog.Tests/SentryTargetTests.cs
@@ -140,7 +140,7 @@ public class SentryTargetTests
     {
         _fixture.Options.InitializeSdk = false;
         var target = _fixture.GetTarget();
-        SimpleConfigurator.ConfigureForTargetLogging(target);
+        LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(target));
 
         var sut = LogManager.GetCurrentClassLogger();
 


### PR DESCRIPTION
Fix failing build due to NLog 5.2 API obsoletion.

Fixes:
```
/Users/matt/Code/getsentry/sentry-dotnet/test/Sentry.NLog.Tests/SentryTargetTests.cs(143,9): error CS0618: 'SimpleConfigurator' is obsolete: 'Use LogManager.Setup().LoadConfiguration() instead. Marked obsolete on NLog 5.2' [/Users/matt/Code/getsentry/sentry-dotnet/test/Sentry.NLog.Tests/Sentry.NLog.Tests.csproj::TargetFramework=net7.0]
/Users/matt/Code/getsentry/sentry-dotnet/test/Sentry.NLog.Tests/SentryTargetTests.cs(143,9): error CS0618: 'SimpleConfigurator.ConfigureForTargetLogging(Target)' is obsolete: 'Use LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(target)) instead. Marked obsolete on NLog 5.2' [/Users/matt/Code/getsentry/sentry-dotnet/test/Sentry.NLog.Tests/Sentry.NLog.Tests.csproj::TargetFramework=net7.0]
```
etc...

Aligns with NLog docs at: https://nlog-project.org/2023/05/30/nlog-5-2-trim-warnings.html


#skip-changelog