### PR TITLE
Various .NET MAUI fixes / improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - SentryHttpMessageHandler added when AddHttpClient is before UseSentry ([#2390](https://github.com/getsentry/sentry-dotnet/pull/2390))
 - Set the native sdk name for Android ([#2389](https://github.com/getsentry/sentry-dotnet/pull/2389))
+- Various .NET MAUI fixes / improvements ([#2403](https://github.com/getsentry/sentry-dotnet/pull/2403))
+  - The battery level was being reported incorrectly due to percentage multiplier.
+  - The device architecture (x64, arm64, etc.) is now reported
+  - On Windows, the OS type is now reported as "Windows" instead of "WinUI".  Additionally, the OS display version (ex, "22H2") is now included.
+  - `UIKit`, `ABI.Microsoft` and `WinRT`  frames are now marked "system" instead of "in app".
 
 ### Dependencies
 

--- a/src/Sentry.Maui/Internal/MauiDeviceData.cs
+++ b/src/Sentry.Maui/Internal/MauiDeviceData.cs
@@ -40,7 +40,7 @@ internal static class MauiDeviceData
             try
             {
                 var battery = Battery.Default;
-                device.BatteryLevel ??= battery.ChargeLevel < 0 ? null : (short)battery.ChargeLevel;
+                device.BatteryLevel ??= battery.ChargeLevel < 0 ? null : (short)(battery.ChargeLevel * 100.0);
                 device.BatteryStatus ??= battery.State.ToString();
                 device.IsCharging ??= battery.State switch
                 {

--- a/src/Sentry.Maui/Internal/MauiDeviceData.cs
+++ b/src/Sentry.Maui/Internal/MauiDeviceData.cs
@@ -32,7 +32,7 @@ internal static class MauiDeviceData
             // device.Brand ??= ?
             // device.Family ??= ?
             // device.ModelId ??= ?
-            // device.Architecture ??= ?
+            device.Architecture ??= RuntimeInformation.OSArchitecture.ToString();
             // ? = deviceInfo.Platform;
             // ? = deviceInfo.VersionString;
 

--- a/src/Sentry.Maui/Internal/MauiOsData.cs
+++ b/src/Sentry.Maui/Internal/MauiOsData.cs
@@ -1,3 +1,4 @@
+using Microsoft.Win32;
 using Sentry.Extensibility;
 using OperatingSystem = Sentry.Protocol.OperatingSystem;
 
@@ -17,13 +18,24 @@ internal static class MauiOsData
                 return;
             }
 
-            os.Name ??= deviceInfo.Platform.ToString();
-            os.Version ??= deviceInfo.VersionString;
+            os.Version = deviceInfo.VersionString;
 
-            // TODO: fill in these
-            // os.Build ??= ?
-            // os.KernelVersion ??= ?
-            // os.Rooted ??= ?
+#if WINDOWS
+            os.Name ??= "Windows";
+
+            using var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
+            if (key?.GetValue("DisplayVersion") is string displayVersion)
+            {
+                os.Build = displayVersion;
+            }
+            else if (key?.GetValue("ReleaseId") is string releaseId)
+            {
+                os.Build = releaseId;
+            }
+#else
+            os.Name = deviceInfo.Platform.ToString();
+#endif
+
         }
         catch (Exception ex)
         {

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -1056,6 +1056,7 @@ public class SentryOptions
                 "MS", // MS.Win32, MS.Internal, etc: Desktop apps
                 "ABI.Microsoft", // MAUI
                 "WinRT", // WinRT, UWP, WinUI
+                "UIKit", // iOS / MacCatalyst
                 "Newtonsoft.Json",
                 "FSharp",
                 "Serilog",

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -1054,6 +1054,8 @@ public class SentryOptions
                 "Sentry",
                 "Microsoft",
                 "MS", // MS.Win32, MS.Internal, etc: Desktop apps
+                "ABI.Microsoft", // MAUI
+                "WinRT", // WinRT, UWP, WinUI
                 "Newtonsoft.Json",
                 "FSharp",
                 "Serilog",


### PR DESCRIPTION
- The battery level was being reported incorrectly due to percentage multiplier.  For example, a fully charged battery was being reported as 1% instead of 100%.
- The device architecture (x64, arm64, etc.) is now reported
- On Windows, the OS type is now reported as "Windows" instead of "WinUI".  Additionally, the OS display version (ex, "22H2") is now included.
- `UIKit`, `ABI.Microsoft` and `WinRT`  frames are now marked "system" instead of "in app" - fixes #2393 and a similar issue on Windows.