### PR TITLE
Reduce debug files uploaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - SentryHttpMessageHandler added when AddHttpClient is before UseSentry ([#2390](https://github.com/getsentry/sentry-dotnet/pull/2390))
 - Set the native sdk name for Android ([#2389](https://github.com/getsentry/sentry-dotnet/pull/2389))
+- Reduce debug files uploaded ([#2404](https://github.com/getsentry/sentry-dotnet/pull/2404))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@
 
 - SentryHttpMessageHandler added when AddHttpClient is before UseSentry ([#2390](https://github.com/getsentry/sentry-dotnet/pull/2390))
 - Set the native sdk name for Android ([#2389](https://github.com/getsentry/sentry-dotnet/pull/2389))
-- Reduce debug files uploaded ([#2404](https://github.com/getsentry/sentry-dotnet/pull/2404))
 - Various .NET MAUI fixes / improvements ([#2403](https://github.com/getsentry/sentry-dotnet/pull/2403))
   - The battery level was being reported incorrectly due to percentage multiplier.
   - The device architecture (x64, arm64, etc.) is now reported
   - On Windows, the OS type is now reported as "Windows" instead of "WinUI".  Additionally, the OS display version (ex, "22H2") is now included.
   - `UIKit`, `ABI.Microsoft` and `WinRT`  frames are now marked "system" instead of "in app".
+- Reduce debug files uploaded ([#2404](https://github.com/getsentry/sentry-dotnet/pull/2404))
 
 ### Dependencies
 

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -125,7 +125,14 @@
     <Message Importance="High"
       Text="Preparing to upload debug symbols to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
 
-    <Exec Command="$(SentryCLIUploadCommand) $(OutputPath)" IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
+    <ItemGroup>
+      <SentryCLIUploadSymbolType Include="pdb" />
+      <SentryCLIUploadSymbolType Include="portablepdb" />
+      <SentryCLIUploadSymbolType Include="dsym" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'" />
+      <SentryCLIUploadSymbolType Include="dsym" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'" />
+    </ItemGroup>
+
+    <Exec Command="$(SentryCLIUploadCommand) @(SentryCLIUploadSymbolType -> '-t %(Identity)', ' ') $(OutputPath)" IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
     </Exec>
 

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -111,6 +111,17 @@ Describe 'CLI-integration' {
         $result.ScriptOutput | Should -Contain 'Build succeeded.'
         $result.HasErrors() | Should -BeFalse
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
+            'libmono-component-debugger.dylib',
+            'libmono-component-diagnostics_tracing.dylib',
+            'libmono-component-hot_reload.dylib',
+            'libmonosgen-2.0.dylib',
+            'libSystem.IO.Compression.Native.dylib',
+            'libSystem.Native.dylib',
+            'libSystem.Net.Security.Native.dylib',
+            'libSystem.Security.Cryptography.Native.Apple.dylib',
+            'libxamarin-dotnet-debug.dylib',
+            'libxamarin-dotnet.dylib',
+            'Sentry',
             'Sentry.Bindings.Cocoa.pdb',
             'Sentry.Extensions.Logging.pdb',
             'Sentry.Maui.pdb',

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -53,25 +53,21 @@ BeforeAll {
 Describe 'CLI-integration' {
 
     It "uploads symbols and sources for a console app build" {
-        $exe = [RuntimeInformation]::IsOSPlatform([OSPlatform]::Windows) ? '.exe' : ''
         $result = DotnetBuild 'Sentry.Samples.Console.Basic' $True $True
         $result.ScriptOutput | Should -Contain 'Build succeeded.'
         $result.HasErrors() | Should -BeFalse
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
             'Sentry.pdb',
-            "Sentry.Samples.Console.Basic$exe",
             'Sentry.Samples.Console.Basic.pdb',
             'Sentry.Samples.Console.Basic.src.zip')
     }
 
     It "uploads symbols for a console app build" {
-        $exe = [RuntimeInformation]::IsOSPlatform([OSPlatform]::Windows) ? '.exe' : ''
         $result = DotnetBuild 'Sentry.Samples.Console.Basic' $True $False
         $result.ScriptOutput | Should -Contain 'Build succeeded.'
         $result.HasErrors() | Should -BeFalse
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
             'Sentry.pdb',
-            "Sentry.Samples.Console.Basic$exe",
             'Sentry.Samples.Console.Basic.pdb')
     }
 
@@ -115,22 +111,10 @@ Describe 'CLI-integration' {
         $result.ScriptOutput | Should -Contain 'Build succeeded.'
         $result.HasErrors() | Should -BeFalse
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
-            'libmono-component-debugger.dylib',
-            'libmono-component-diagnostics_tracing.dylib',
-            'libmono-component-hot_reload.dylib',
-            'libmonosgen-2.0.dylib',
-            'libSystem.IO.Compression.Native.dylib',
-            'libSystem.Native.dylib',
-            'libSystem.Net.Security.Native.dylib',
-            'libSystem.Security.Cryptography.Native.Apple.dylib',
-            'libxamarin-dotnet-debug.dylib',
-            'libxamarin-dotnet.dylib',
-            'Sentry',
             'Sentry.Bindings.Cocoa.pdb',
             'Sentry.Extensions.Logging.pdb',
             'Sentry.Maui.pdb',
             'Sentry.pdb',
-            'Sentry.Samples.Maui',
             'Sentry.Samples.Maui.pdb',
             'Sentry.Samples.Maui.src.zip'
         )

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -126,6 +126,7 @@ Describe 'CLI-integration' {
             'Sentry.Extensions.Logging.pdb',
             'Sentry.Maui.pdb',
             'Sentry.pdb',
+            'Sentry.Samples.Maui',
             'Sentry.Samples.Maui.pdb',
             'Sentry.Samples.Maui.src.zip'
         )


### PR DESCRIPTION
When `<SentryUploadSymbols>` is `true`, we use `sentry-cli` to upload _any_ valid debug info file from the output directory.  Unfortunately, that also picks up every `.so`, `.dll` and `.exe` because they can contain native stack unwind details and symbol tables.  For most .NET projects, we only need the `.pdb` files.  We also need the `dsym` files (`.dylib`, etc.) on iOS/MacCatalyst.

This PR updates our msbuild target to only include the symbol files that are needed per platform.
