### PR TITLE
Fix UWP GateKeeper errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Reduce debug files uploaded ([#2404](https://github.com/getsentry/sentry-dotnet/pull/2404))
 - Fix system frames being marked as "in-app" ([#2408](https://github.com/getsentry/sentry-dotnet/pull/2408))
   - NOTE: This important fix corrects a value that is used during issue grouping, so you may receive new alerts for existing issues after deploying this update.
+- Fix UWP GateKeeper errors ([#2415](https://github.com/getsentry/sentry-dotnet/pull/2415))
 
 ### Dependencies
 

--- a/src/Sentry/Internal/FastSerialization/GrowableArray.cs
+++ b/src/Sentry/Internal/FastSerialization/GrowableArray.cs
@@ -10,11 +10,6 @@ internal struct HashableGrowableArray<T> : IReadOnlyList<T>, IEquatable<Hashable
     private int _hashCode = 0;
     private bool _sealed = false;
 
-    public HashableGrowableArray()
-    {
-        _items = new GrowableArray<T>();
-    }
-
     public HashableGrowableArray(int capacity)
     {
         _items = new GrowableArray<T>(capacity);
@@ -95,13 +90,7 @@ internal struct HashableGrowableArray<T> : IReadOnlyList<T>, IEquatable<Hashable
 internal struct GrowableArray<T> : IReadOnlyList<T>
 {
     /// <summary>
-    /// Create an empty growable array.
-    /// </summary>
-    public GrowableArray() : this(0) { }
-
-    /// <summary>
-    /// Create a growable array with the given initial size it will grow as needed.  There is also the
-    /// default constructor that assumes initialSize of 0 (and does not actually allocate the array.
+    /// Create a growable array with the given initial size it will grow as needed.
     /// </summary>
     /// <param name="initialSize"></param>
     public GrowableArray(int initialSize)

--- a/src/Sentry/Internal/SparseArray.cs
+++ b/src/Sentry/Internal/SparseArray.cs
@@ -9,13 +9,7 @@ internal sealed class SparseScalarArray<T> where T : IEquatable<T>
     private GrowableArray<T> _items;
     private T _uninitializedValue;
 
-    public SparseScalarArray(T uninitializedValue)
-    {
-        _items = new GrowableArray<T>();
-        _uninitializedValue = uninitializedValue;
-    }
-
-    public SparseScalarArray(T uninitializedValue, int capacity)
+    public SparseScalarArray(T uninitializedValue, int capacity = 0)
     {
         _items = new GrowableArray<T>(capacity);
         _uninitializedValue = uninitializedValue;

--- a/test/Sentry.Tests/Protocol/ProfilerTests.verify.cs
+++ b/test/Sentry.Tests/Protocol/ProfilerTests.verify.cs
@@ -12,7 +12,7 @@ public class ProfilerTests
 
     private static void AddStack(SampleProfile sut, List<int> frames)
     {
-        var stack = new HashableGrowableArray<int>();
+        var stack = new HashableGrowableArray<int>(0);
         foreach (var frame in frames)
         {
             stack.Add(frame);


### PR DESCRIPTION
Reported from UWP customer through Sentry Support.

Using .NET Native and "Enable static analysis for .NET Native" enabled, UWP's GateKeeper errors with:

```
Sentry : Gatekeeper error GK0018 : GK0018 Value type 'Sentry.Internal.GrowableArray' has an explicit default constructor which is unsupported. Use an initialization function instead.

Sentry : Gatekeeper error GK0018 : GK0018 Value type 'Sentry.Internal.HashableGrowableArray' has an explicit default constructor which is unsupported. Use an initialization function instead.
```

I was able to reproduce this, and resolve with the changes in this PR.