### PR TITLE
Workaround Tizen build issue

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -33,7 +33,12 @@ runs:
     - name: Install .NET 7 SDK
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.x.x
+        dotnet-version: 7.0.203   # switch back to 7.x.x after resolving the below Tizen issue.
+
+    # Workaround for Tizen issue
+    # See https://github.com/dotnet/sdk/issues/33192
+    - name: Pin to .NET SDK 7.0.203
+      run: dotnet new globaljson --sdk-version 7.0.203 --force
 
     - name: Dependency Caching
       uses: actions/cache@v3

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -39,6 +39,7 @@ runs:
     # See https://github.com/dotnet/sdk/issues/33192
     - name: Pin to .NET SDK 7.0.203
       run: dotnet new globaljson --sdk-version 7.0.203 --force
+      shell: bash
 
     - name: Dependency Caching
       uses: actions/cache@v3


### PR DESCRIPTION
CI builds for `Sentry.Maui` are currently failing with:

```
Error:
/Users/runner/.dotnet/sdk/7.0.302/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(376,5):
error NETSDK1073: The FrameworkReference 'Samsung.Tizen' was not recognized [/Users/runner/work/sentry-dotnet/sentry-dotnet/src/Sentry.Maui/Sentry.Maui.csproj::TargetFramework=net6.0-tizen]
```

Example: https://github.com/getsentry/sentry-dotnet/actions/runs/5245925863/jobs/9474055956#step:9:150

Reproduced and reported to Microsoft: https://github.com/dotnet/sdk/issues/33192

This workaround pins CI to the prior SDK version until we have resolution.


#skip-changelog