### PR TITLE
Fix Sentry logger options for MAUI and Azure Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix Sentry logger options for MAUI and Azure Functions ([#2423](https://github.com/getsentry/sentry-dotnet/pull/2423))
+
 ## 3.33.1
 
 ### Fixes

--- a/src/Sentry.AzureFunctions.Worker/SentryAzureFunctionsLoggerProvider.cs
+++ b/src/Sentry.AzureFunctions.Worker/SentryAzureFunctionsLoggerProvider.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Sentry.Extensions.Logging;
+
+namespace Sentry.AzureFunctions.Worker;
+
+[ProviderAlias("Sentry")]
+internal class SentryAzureFunctionsLoggerProvider : SentryLoggerProvider
+{
+    public SentryAzureFunctionsLoggerProvider(IOptions<SentryAzureFunctionsOptions> options, IHub hub)
+        : base(options, hub)
+    {
+    }
+}

--- a/src/Sentry.AzureFunctions.Worker/SentryFunctionsWorkerApplicationBuilderExtensions.cs
+++ b/src/Sentry.AzureFunctions.Worker/SentryFunctionsWorkerApplicationBuilderExtensions.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Sentry.Extensions.Logging;
 using Sentry.Extensions.Logging.Extensions.DependencyInjection;
 
 namespace Sentry.AzureFunctions.Worker;
@@ -47,7 +46,7 @@ public static class SentryFunctionsWorkerApplicationBuilderExtensions
         }
 
         services.AddLogging();
-        services.AddSingleton<ILoggerProvider, SentryLoggerProvider>();
+        services.AddSingleton<ILoggerProvider, SentryAzureFunctionsLoggerProvider>();
         services.AddSingleton<IConfigureOptions<SentryAzureFunctionsOptions>, SentryAzureFunctionsOptionsSetup>();
 
         services.AddSentry<SentryAzureFunctionsOptions>();

--- a/src/Sentry.Maui/Internal/SentryMauiLoggerProvider.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiLoggerProvider.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Sentry.Extensions.Logging;
+
+namespace Sentry.Maui.Internal;
+
+[ProviderAlias("Sentry")]
+internal class SentryMauiLoggerProvider : SentryLoggerProvider
+{
+    public SentryMauiLoggerProvider(IOptions<SentryMauiOptions> options, IHub hub)
+        : base(options, hub)
+    {
+    }
+}

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Maui.LifecycleEvents;
 using Sentry.Extensibility;
-using Sentry.Extensions.Logging;
 using Sentry.Extensions.Logging.Extensions.DependencyInjection;
 using Sentry.Maui;
 using Sentry.Maui.Internal;
@@ -54,7 +53,7 @@ public static class SentryMauiAppBuilderExtensions
         }
 
         services.AddLogging();
-        services.AddSingleton<ILoggerProvider, SentryLoggerProvider>();
+        services.AddSingleton<ILoggerProvider, SentryMauiLoggerProvider>();
         services.AddSingleton<IMauiInitializeService, SentryMauiInitializer>();
         services.AddSingleton<IConfigureOptions<SentryMauiOptions>, SentryMauiOptionsSetup>();
         services.AddSingleton<Disposer>();


### PR DESCRIPTION
Whenever we extend an options class from `SentryLoggerOptions`, we also need to extend a logger provider from `SentryLoggerProvider` to use for DI registration.  Otherwise, the options passed to the logger will be a new instance of `SentryLoggingOptions` with the default values, rather than the ones that may have been set on the extended options class.

We were already doing this for ASP.NET Core, but also need to do it for MAUI and Azure Functions.

Fixes #2422