### PR TITLE
Ignore Checkmarx warning in Rider about AspNetCore 2.1.7

### DIFF
--- a/Sentry.sln.DotSettings
+++ b/Sentry.sln.DotSettings
@@ -1,3 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=F2486CC8_002DFAB7_002D4775_002D976F_002DC5A4CF97867F_002Fdl_003ABen_002EDemystifier_003A_002E_002E_003F_002E_002E_003Fmodules_003FBen_002EDemystifier_003Fsrc_003FBen_002EDemystifier/@EntryIndexedValue">ExplicitlyExcluded</s:String>
-	<s:Boolean x:Key="/Default/Housekeeping/ExcludedProjects/ProjectMasksToIgnore/=Ben_002EDemystifier/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/Housekeeping/ExcludedProjects/ProjectMasksToIgnore/=Ben_002EDemystifier/@EntryIndexedValue">True</s:Boolean>
+    <s:String x:Key="/Default/Environment/PackageChecker/IgnoredPackage/=Microsoft_002EAspNetCore/@EntryIndexedValue">2.1.7</s:String>
+</wpf:ResourceDictionary>


### PR DESCRIPTION
Open `SentryAspNetCore.slnf` in rider and you'll see:

<img width="387" alt="image" src="https://github.com/getsentry/sentry-dotnet/assets/1396388/e2800297-09bf-4c5d-a73a-99e36a158d86">

<img width="498" alt="image" src="https://github.com/getsentry/sentry-dotnet/assets/1396388/b8d3add9-e125-4fa0-a282-213df8b8118b">

These are safe to ignore, but ignoring them in Rider doesn't persist to the solution, and you still see the popup every time you open the project anyway.  That problem is being addressed here: https://youtrack.jetbrains.com/issue/RIDER-87242. 
 However, that issue provides a partial workaround that we can apply in this PR to reduce the noise.


The vulnerability itself is safe to ignore.  It's not related to any library used by any of the Sentry .NET SDKs, but rather to where we _test_ `Sentry.AspNetCore` for ASP.NET Core 2.1 on .NET Framework.  And yes - believe it or not - that is still supported by Microsoft, and likely will be indefinitely.  See existing comments in the source repo for further details:

https://github.com/getsentry/sentry-dotnet/blob/d53cf8de97a43f6aa084588d949d9f72757ef09d/test/Sentry.AspNetCore.TestUtils/Sentry.AspNetCore.TestUtils.csproj#L13-L35

#skip-changelog