### PR TITLE
more details on contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,10 @@ For big feature it's advised to raise an issue to discuss it first.
 ## TLDR
 
 * Install the .NET SDKs
-* To quickly get up and running, you can just run `dotnet build`
-* To run a full build and test locally before pushing, run `./build.sh` or `./buld.ps1`
+* Install PowerShell
+* Restore workloads with `dotnet workload restore` (needs `sudo` on a Mac)
+* To quickly get up and running, you can just run `dotnet build Sentry.sln`
+* To run a full build in Release mode and test, before pushing, run `./build.sh` or `./buld.cmd`
 
 ## Dependencies
 
@@ -29,9 +31,9 @@ For big feature it's advised to raise an issue to discuss it first.
 To build any of `Sentry.Maui`, `Sentry.Maui.Tests`, or `Sentry.Samples.Maui`, you'll need to have .NET SDK 6.0.400 or greater installed, and have installed the MAUI workloads installed, either through Visual Studio setup, or by running `dotnet workload restore` (or `dotnet workload install maui`) from the Sentry source code root directory.
 You may also need other platform dependencies.  See https://docs.microsoft.com/dotnet/maui/ for details.  Basically, if you can build and run the "MyMauiApp" example you should also be able to build and run the Sentry MAUI sample app.
 
-### Targeting Android, iOS and macCatalyst
+### Targeting Android, iOS and Mac Catalyst
 
-Although the files in `/src/Sentry/Platforms/` are part of the `Sentry` project, they are [conditionally targeted](https://github.com/getsentry/sentry-dotnet/blob/b1bfe1efc04eb4c911a85f1cf4cd2e5a176d7c8a/src/Sentry/Sentry.csproj#L19-L21) when the platform is Android, iOS or macCatalyst.  We build for Android on all platforms, but currently compile iOS and macCatalyst _only when building on a Mac_.
+Although the files in `/src/Sentry/Platforms/` are part of the `Sentry` project, they are [conditionally targeted](https://github.com/getsentry/sentry-dotnet/blob/b1bfe1efc04eb4c911a85f1cf4cd2e5a176d7c8a/src/Sentry/Sentry.csproj#L19-L21) when the platform is Android, iOS or Mac Catalyst.  We build for Android on all platforms, but currently compile iOS and Mac Catalyst _only when building on a Mac_.
 
 ```xml
 <!-- Platform-specific props included here -->
@@ -49,7 +51,7 @@ This repository uses [Verify](https://github.com/VerifyTests/Verify) to store th
 When a change involves modifying the public API area (by for example adding a public method),
 that change will need to be approved, otherwise the CI process will fail.
 
-To do that, run the build locally (i.e: `./build.sh` or `pwsh .\build.ps1`)
+To do that, run the build locally (i.e: `./build.sh` or `build.cmd`)
 and commit the `verify` files that were changed.
 
 
@@ -61,7 +63,7 @@ Apple Silicon processors (such as the "M1") are arm64 processosr. While .NET 6 a
 - Always install the x64 release of .NET Core 3.1 (it is not avaialable for arm64).
   - If prompted, you will need to allow Apple's [Rosetta](https://support.apple.com/HT211861) to be installed.  If you have previously done this for another app, you won't be prompted again.
 
-If you are only running `dotnet test` on the command line, you don't need to do anything else.
+If you are only running `dotnet test Sentry.sln` on the command line, you don't need to do anything else.
 
 If you are using JetBrains Rider as your IDE, you should install the arm64 version of Rider.  Within Rider, the .NET SDK used for build and tests is selected under `Preferences` -> `Build, Execution, Deployment` -> `Toolset and Build`.
 


### PR DESCRIPTION
`dotnet build` doesn't work anymore because there's more than 1 `sln` now
also we depend on powershell now (to build the native libs for native crash demo)


#skip-changelog