### PR TITLE
ios: missing binding method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+
+- Symbolication for Single File Apps ([#2425](https://github.com/getsentry/sentry-dotnet/pull/2425))
+- Add binding to `SwiftAsyncStacktraces` on iOS ([#2436](https://github.com/getsentry/sentry-dotnet/pull/2436))
+
 ### Fixes
 
 - Fix Sentry logger options for MAUI and Azure Functions ([#2423](https://github.com/getsentry/sentry-dotnet/pull/2423))
@@ -17,10 +22,6 @@
 - Bump Java SDK from v6.22.0 to v6.23.0 ([#2429](https://github.com/getsentry/sentry-dotnet/pull/2429))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6230)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.22.0...6.23.0)
-
-### Features
-
-- Symbolication for Single File Apps ([#2425](https://github.com/getsentry/sentry-dotnet/pull/2425))
 
 ## 3.33.1
 

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -874,6 +874,10 @@ interface SentryOptions
     // @property (nonatomic) BOOL enableTimeToFullDisplay;
     [Export ("enableTimeToFullDisplay")]
     bool EnableTimeToFullDisplay { get; set; }
+
+    // @property (assign, nonatomic) BOOL swiftAsyncStacktraces;
+    [Export ("swiftAsyncStacktraces")]
+    bool SwiftAsyncStacktraces { get; set; }
 }
 
 // @protocol SentryIntegrationProtocol <NSObject>


### PR DESCRIPTION
Building a new checkout of `main` reruns the script to create bindings and makes a change.

In CI, do we break if we end up with a dirty workspace? It's probably a good idea to catch cases such as this.

Additionally, `modules/sentry-cocoa` was dirty, with 2 files deleted:

```
-Subproject commit d277532e1c8af813981ba01f591b15bbdd735615
+Subproject commit d277532e1c8af813981ba01f591b15bbdd735615-dirty
..
        modified:   modules/sentry-cocoa (modified content)
..
        deleted:    Sentry.xcodeproj/xcshareddata/xcschemes/SentryPrivate.xcscheme
        deleted:    Sentry.xcodeproj/xcshareddata/xcschemes/SentrySwiftUI.xcscheme
```

`d277532e1c8af813981ba01f591b15bbdd735615` is 8.8.0 so nothing wrong on the .NET end, @brustolin were these deleted after the release? Or is it something with the way we build things with Carthage?