### PR TITLE
chore: Building Cocoa SDK wont change the module

### DIFF
--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -18,6 +18,11 @@ if [ ! -f $CARTHAGE ]; then
     cd ..
 fi
 
+rollbackSchemes() {
+    mv Sentry.xcodeproj/xcshareddata/xcschemes/SentryPrivate.xcscheme.bak Sentry.xcodeproj/xcshareddata/xcschemes/SentryPrivate.xcscheme
+    mv Sentry.xcodeproj/xcshareddata/xcschemes/SentrySwiftUI.xcscheme.bak Sentry.xcodeproj/xcshareddata/xcschemes/SentrySwiftUI.xcscheme
+}
+
 if [ $? -eq 0 ]
 then
     cd sentry-cocoa
@@ -40,6 +45,8 @@ then
         mv Sentry.xcodeproj/xcshareddata/xcschemes/SentryPrivate.xcscheme Sentry.xcodeproj/xcshareddata/xcschemes/SentryPrivate.xcscheme.bak
         mv Sentry.xcodeproj/xcshareddata/xcschemes/SentrySwiftUI.xcscheme Sentry.xcodeproj/xcshareddata/xcschemes/SentrySwiftUI.xcscheme.bak
 
+        trap 'rollbackSchemes; exit 1' SIGINT
+
         # Note - We keep the build output in separate directories so that .NET
         # bundles iOS with net6.0-ios and Mac Catalyst with net6.0-maccatalyst.
         # The lack of symlinks in the ios builds, means we should also be able
@@ -59,13 +66,12 @@ then
 
         echo $SHA > $SHAFILE
         echo ""
-
-        mv Sentry.xcodeproj/xcshareddata/xcschemes/SentryPrivate.xcscheme.bak Sentry.xcodeproj/xcshareddata/xcschemes/SentryPrivate.xcscheme
-        mv Sentry.xcodeproj/xcshareddata/xcschemes/SentrySwiftUI.xcscheme.bak Sentry.xcodeproj/xcshareddata/xcschemes/SentrySwiftUI.xcscheme
     fi
 
     # Remove anything we don't want to bundle in the nuget package.
     find Carthage/Build* \( -name Headers -o -name PrivateHeaders -o -name Modules \) -exec rm -rf {} +
+
+    rollbackSchemes
 fi
 
 popd > /dev/null

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -37,8 +37,8 @@ then
         # Delete SentryPrivate and SentrySwiftUI schemes
         # we dont want to build them
 
-        rm Sentry.xcodeproj/xcshareddata/xcschemes/SentryPrivate.xcscheme
-        rm Sentry.xcodeproj/xcshareddata/xcschemes/SentrySwiftUI.xcscheme
+        mv Sentry.xcodeproj/xcshareddata/xcschemes/SentryPrivate.xcscheme Sentry.xcodeproj/xcshareddata/xcschemes/SentryPrivate.xcscheme.bak
+        mv Sentry.xcodeproj/xcshareddata/xcschemes/SentrySwiftUI.xcscheme Sentry.xcodeproj/xcshareddata/xcschemes/SentrySwiftUI.xcscheme.bak
 
         # Note - We keep the build output in separate directories so that .NET
         # bundles iOS with net6.0-ios and Mac Catalyst with net6.0-maccatalyst.
@@ -59,6 +59,9 @@ then
 
         echo $SHA > $SHAFILE
         echo ""
+
+        mv Sentry.xcodeproj/xcshareddata/xcschemes/SentryPrivate.xcscheme.bak Sentry.xcodeproj/xcshareddata/xcschemes/SentryPrivate.xcscheme
+        mv Sentry.xcodeproj/xcshareddata/xcschemes/SentrySwiftUI.xcscheme.bak Sentry.xcodeproj/xcshareddata/xcschemes/SentrySwiftUI.xcscheme
     fi
 
     # Remove anything we don't want to bundle in the nuget package.


### PR DESCRIPTION
Updating the `build-sentry-cocoa.sh` so it does not leave sentry-cocoa sub module in a dirty state.

_#skip-changelog_