### PR TITLE
fix: Pinning dependency versions in tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 2
+
+- package-ecosystem: nuget
+  directory: "/test"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 2 
   
 - package-ecosystem: "github-actions"
   directory: "/"

--- a/test/Sentry.AspNetCore.Grpc.Tests/Sentry.AspNetCore.Grpc.Tests.csproj
+++ b/test/Sentry.AspNetCore.Grpc.Tests/Sentry.AspNetCore.Grpc.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.*" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.*" />
-    <PackageReference Include="Grpc.Tools" Version="2.*" PrivateAssets="All" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.54.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.54.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.54.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.AspNetCore.TestUtils/Sentry.AspNetCore.TestUtils.csproj
+++ b/test/Sentry.AspNetCore.TestUtils/Sentry.AspNetCore.TestUtils.csproj
@@ -26,30 +26,30 @@
     See https://github.com/dotnet/aspnetcore/issues/15423
   -->
   <ItemGroup Condition="$(TargetFramework) == 'net48'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
 
     <!-- This is needed because the version that is brought in transitively also has a vulnerability warning -->
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.25" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.*" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.32" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.*" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.*" />
-    <PackageReference Include="Verify.AspNetCore" Version="2.*" />
-    <PackageReference Include="Verify.Http" Version="4.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.19" />
+    <PackageReference Include="Verify.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Verify.Http" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.*" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.*" />
-    <PackageReference Include="Verify.AspNetCore" Version="3.*" />
-    <PackageReference Include="Verify.Http" Version="4.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.8" />
+    <PackageReference Include="Verify.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="Verify.Http" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
@@ -11,29 +11,29 @@
 
   <!-- Test EF Core 7 on .NET 7 -->
   <!-- <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Verify.EntityFramework" Version="8.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.*" />
+    <PackageReference Include="Verify.EntityFramework" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.8" />
   </ItemGroup> -->
 
   <!-- Test EF Core 6 on .NET 6 and 7 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Verify.EntityFramework" Version="7.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.*" />
+    <PackageReference Include="Verify.EntityFramework" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.19" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.19" />
   </ItemGroup>
 
   <!-- Test EF Core 5 on .NET Core 3.1 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.17" />
   </ItemGroup>
 
   <!-- Test EF Core 3.1 on .NET Framework -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48' ">
     <ProjectReference Include="..\..\src\Sentry.DiagnosticSource\Sentry.DiagnosticSource.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.32" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.32" />
   </ItemGroup>
 
   <!--
@@ -44,12 +44,12 @@
     <PackageReference Include="LocalDb" Version="14.2.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <PackageReference Include="LocalDb" Version="14.*" />
+    <PackageReference Include="LocalDb" Version="14.2.1" />
   </ItemGroup>
 
   <ItemGroup>
     <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
-    <PackageReference Include="System.Drawing.Common" Version="6.*" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
 
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />

--- a/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
+++ b/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
@@ -7,22 +7,22 @@
   <!-- Test EF Core 7 on .NET 7 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.8" />
   </ItemGroup>
 
   <!-- Test EF Core 6 on .NET 6 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.19" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.19" />
   </ItemGroup>
 
   <!-- Test EF Core 5 on .NET Core 3.1 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.17" />
 
     <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
@@ -32,8 +32,8 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <ProjectReference Include="..\..\src\Sentry.DiagnosticSource\Sentry.DiagnosticSource.csproj" />
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.32" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.32" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.EntityFramework.Tests/Sentry.EntityFramework.Tests.csproj
+++ b/test/Sentry.EntityFramework.Tests/Sentry.EntityFramework.Tests.csproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.*" />
-    <PackageReference Include="Effort.EF6" Version="2.*" />
-    <PackageReference Include="EfClassicLocalDb" Version="14.*" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
+    <PackageReference Include="Effort.EF6" Version="2.2.16" />
+    <PackageReference Include="EfClassicLocalDb" Version="14.5.2" />
 
     <!-- this is needed because the version that is brought in transitively has a vulnerability warning -->
-    <PackageReference Include="System.Drawing.Common" Version="6.*" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
 
     <ProjectReference Include="..\..\src\Sentry.EntityFramework\Sentry.EntityFramework.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />

--- a/test/Sentry.Extensions.Logging.Tests/Sentry.Extensions.Logging.Tests.csproj
+++ b/test/Sentry.Extensions.Logging.Tests/Sentry.Extensions.Logging.Tests.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == ''">

--- a/test/Sentry.Serilog.Tests/Sentry.Serilog.Tests.csproj
+++ b/test/Sentry.Serilog.Tests/Sentry.Serilog.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.*" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.*" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
 
     <ProjectReference Include="..\..\src\Sentry.Serilog\Sentry.Serilog.csproj" />
     <ProjectReference Include="..\Sentry.AspNetCore.TestUtils\Sentry.AspNetCore.TestUtils.csproj" />


### PR DESCRIPTION
Based on the most frustrating of all development experiences. New versions of packages were released but could not be downloaded. This resulted in the greatest of confusions and broke my local environment. (not for the first time)
I don't see a good reason, especially for tests, why versions of dependencies cannot be pinned.

I'd rather have them pinned and add a bumping mechanism instead of getting surprised.

#skip-changelog