### PR TITLE
fix: Use '.' as decimal separator

### DIFF
--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -180,7 +180,7 @@ internal static class JsonExtensions
 
         // Otherwise, let's get the value as a string and parse it ourselves.
         // Note that we already know this will succeed due to JsonValueKind.Number
-        return double.Parse(json.ToString()!);
+        return double.Parse(json.ToString()!, CultureInfo.InvariantCulture);
     }
 
     public static long? GetAddressAsLong(this JsonElement json)

--- a/src/Sentry/Internal/Http/RetryAfterHandler.cs
+++ b/src/Sentry/Internal/Http/RetryAfterHandler.cs
@@ -85,7 +85,7 @@ internal class RetryAfterHandler : DelegatingHandler
         // Sentry was sending floating point numbers which are not handled by RetryConditionHeaderValue
         // To be compatible with older versions of sentry on premise: https://github.com/getsentry/sentry/issues/7919
         if (response.Headers.TryGetValues("Retry-After", out var values)
-            && double.TryParse(values.FirstOrDefault(), out var retryAfterSeconds))
+            && double.TryParse(values.FirstOrDefault(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var retryAfterSeconds))
         {
             return _clock.GetUtcNow().AddTicks((long)(retryAfterSeconds * TimeSpan.TicksPerSecond));
         }


### PR DESCRIPTION
These two tests were failing for me
`SendAsync_TooManyRequestsWithRetryAfterHeaderFloat_RetryAfterSet`
`SendAsync_TooManyRequestsWithRetryAfterHeaderFloat_SecondRequestIsThrottled`
with

```
System.ArgumentOutOfRangeException : The added or subtracted value results in an un-representable DateTime.
Parameter name: value

Stack Trace: 
DateTime.AddTicks(Int64 value)
DateTimeOffset.AddTicks(Int64 ticks)
RetryAfterHandler.GetRetryAfterTimestamp(HttpResponseMessage response) line 90
<SendAsync>d__8.MoveNext() line 63
--- End of stack trace from previous location where exception was thrown ---
ExceptionDispatchInfo.Throw()
TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
TaskAwaiter`1.GetResult()
<SendAsync_TooManyRequestsWithRetryAfterHeaderFloat_SecondRequestIsThrottled>d__8.MoveNext() line 117
--- End of stack trace from previous location where exception was thrown ---
ExceptionDispatchInfo.Throw()
TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
ExceptionDispatchInfo.Throw()
TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
ExceptionDispatchInfo.Throw()
TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
```

The culprit was that the retry-after value was parsed with the current culture, which is on my Danish system use `,` as the decimal separator.
I did a quick search for other places that could suffer from a similar problem and found the one in `JsonExtensions`.