### PR TITLE
fix: Adding proguard rules to `Sentry.Bindings.Android`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Builds targeting Android no longer crash during SDK init. The package now contains the required proguard rules ([#2450]https://github.com/getsentry/sentry-dotnet/pull/2450)
 - Fix Sentry logger options for MAUI and Azure Functions ([#2423](https://github.com/getsentry/sentry-dotnet/pull/2423))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- Builds targeting Android no longer crash during SDK init. The package now contains the required proguard rules ([#2450]https://github.com/getsentry/sentry-dotnet/pull/2450)
+- Builds targeting Android with `r8` enabled no longer crash during SDK init. The package now contains the required proguard rules ([#2450]https://github.com/getsentry/sentry-dotnet/pull/2450)
 - Fix Sentry logger options for MAUI and Azure Functions ([#2423](https://github.com/getsentry/sentry-dotnet/pull/2423))
 
 ### Dependencies

--- a/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
+++ b/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
@@ -12,14 +12,14 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <Using Include="Android.App.Activity" Alias="Activity" />
-    
+
     <!--
       The NuGet package the containing the binding comes with a .targets that sets the ProguardConfiguration
       Since we're referencing the project itself we're grabbing the ProguardConfiguration from project directly.
     -->    
     <ProguardConfiguration Include="..\..\src\Sentry.Bindings.Android\sentry-proguard.cfg" />
   </ItemGroup>
-  
+
   <!--
     For this demo app, let's upload sources and symbols to Sentry on every build, regardless of configuration.
     In a real app, you probably only want to do this on Release builds.

--- a/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
+++ b/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
@@ -12,8 +12,14 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <Using Include="Android.App.Activity" Alias="Activity" />
+    
+    <!--
+      The NuGet package the containing the binding comes with a .targets that sets the ProguardConfiguration
+      Since we're referencing the project itself we're grabbing the ProguardConfiguration from project directly.
+    -->    
+    <ProguardConfiguration Include="..\..\src\Sentry.Bindings.Android\sentry-proguard.cfg" />
   </ItemGroup>
-
+  
   <!--
     For this demo app, let's upload sources and symbols to Sentry on every build, regardless of configuration.
     In a real app, you probably only want to do this on Release builds.
@@ -22,5 +28,5 @@
     <SentryUploadSources>true</SentryUploadSources>
     <SentryUploadSymbols>true</SentryUploadSymbols>
   </PropertyGroup>
-
+  
 </Project>

--- a/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
+++ b/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
@@ -28,5 +28,5 @@
     <SentryUploadSources>true</SentryUploadSources>
     <SentryUploadSymbols>true</SentryUploadSymbols>
   </PropertyGroup>
-  
+
 </Project>

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\README.md" />
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="" />
+    <None Include="$(MSBuildThisFileDirectory)build/Sentry.Bindings.Android.targets" Pack="true" PackagePath="build/Sentry.Bindings.Android.targets" />
+    <None Include="$(MSBuildThisFileDirectory)sentry-proguard.cfg" Pack="true" PackagePath="" />
     <PackageReference Remove="SIL.ReleaseTasks" />
   </ItemGroup>
 

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\README.md" />
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="" />
-    <None Include="$(MSBuildThisFileDirectory)build/Sentry.Bindings.Android.targets" Pack="true" PackagePath="build/Sentry.Bindings.Android.targets" />
+    <None Include="$(MSBuildThisFileDirectory)build/Sentry.Bindings.Android.targets" Pack="true" PackagePath="build/$(TargetFramework)$(TargetPlatformVersion)/Sentry.Bindings.Android.targets" />
     <None Include="$(MSBuildThisFileDirectory)sentry-proguard.cfg" Pack="true" PackagePath="" />
     <PackageReference Remove="SIL.ReleaseTasks" />
   </ItemGroup>

--- a/src/Sentry.Bindings.Android/build/Sentry.Bindings.Android.targets
+++ b/src/Sentry.Bindings.Android/build/Sentry.Bindings.Android.targets
@@ -1,0 +1,5 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ProguardConfiguration Include="$(MSBuildThisFileDirectory)..\proguard.cfg" />
+  </ItemGroup>
+</Project>

--- a/src/Sentry.Bindings.Android/build/Sentry.Bindings.Android.targets
+++ b/src/Sentry.Bindings.Android/build/Sentry.Bindings.Android.targets
@@ -1,5 +1,5 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ProguardConfiguration Include="$(MSBuildThisFileDirectory)..\proguard.cfg" />
+    <ProguardConfiguration Include="$(MSBuildThisFileDirectory)..\..\proguard.cfg" />
   </ItemGroup>
 </Project>

--- a/src/Sentry.Bindings.Android/sentry-proguard.cfg
+++ b/src/Sentry.Bindings.Android/sentry-proguard.cfg
@@ -1,5 +1,8 @@
 # Because we use string-based lookups we need to keep names on selected sentry-java classes
+-keep class io.sentry.Sentry { *; }
 -keep class io.sentry.android.core.SentryAndroid { *; }
 -keep class io.sentry.android.core.SentryAndroidOptions { *; }
 -keep class io.sentry.android.core.SentryInitProvider { *; }
 -keep class io.sentry.android.core.SentryPerformanceProvider { *; }
+-keep class io.sentry.android.supplemental.* { *; }
+-keep class io.sentry.protocol.**

--- a/src/Sentry.Bindings.Android/sentry-proguard.cfg
+++ b/src/Sentry.Bindings.Android/sentry-proguard.cfg
@@ -1,4 +1,4 @@
-# Keep names on select sentry-java classes & their methods - we use string-based JNI lookup in our integration.
+# Because we use string-based lookups we need to keep names on selected sentry-java classes
 -keep class io.sentry.android.core.SentryAndroid { *; }
 -keep class io.sentry.android.core.SentryAndroidOptions { *; }
 -keep class io.sentry.android.core.SentryInitProvider { *; }

--- a/src/Sentry.Bindings.Android/sentry-proguard.cfg
+++ b/src/Sentry.Bindings.Android/sentry-proguard.cfg
@@ -1,0 +1,5 @@
+# Keep names on select sentry-java classes & their methods - we use string-based JNI lookup in our integration.
+-keep class io.sentry.android.core.SentryAndroid { *; }
+-keep class io.sentry.android.core.SentryAndroidOptions { *; }
+-keep class io.sentry.android.core.SentryInitProvider { *; }
+-keep class io.sentry.android.core.SentryPerformanceProvider { *; }

--- a/src/Sentry.Bindings.Android/sentry-proguard.cfg
+++ b/src/Sentry.Bindings.Android/sentry-proguard.cfg
@@ -5,4 +5,4 @@
 -keep class io.sentry.android.core.SentryInitProvider { *; }
 -keep class io.sentry.android.core.SentryPerformanceProvider { *; }
 -keep class io.sentry.android.supplemental.* { *; }
--keep class io.sentry.protocol.**
+-keep class io.sentry.protocol.** { *; }


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/2376
The SDK is looking up the native methods via `string`. Enabling `r8` causes the classes and methods to change.
We're adding the proper rules to the NuGet package to `-keep` those.
The package structure changes to
```
.
├── README.md
├── Sentry.Bindings.Android.nuspec
├── [Content_Types].xml
├── _rels
├── build
│   └── net6.0-android31.0
│       └── Sentry.Bindings.Android.targets
├── lib
│   └── net6.0-android31.0
│       ├── Sentry.Bindings.Android.aar
│       ├── Sentry.Bindings.Android.dll
│       ├── Sentry.Bindings.Android.xml
│       ├── sentry-android-core-6.23.0.aar
│       └── sentry-android-ndk-6.23.0.aar
├── package
│   └── services
│       └── metadata
│           └── core-properties
│               └── 27823db434b24f20860179712cee0d5d.psmdcp
├── sentry-nuget.png
└── sentry-proguard.cfg
```