### PR TITLE
Feat/upload proguard mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Added a MSBuild property `SentryUploadAndroidProguardMapping` to automatically upload the Proguard mapping file when targeting Android ([#2455](https://github.com/getsentry/sentry-dotnet/pull/2455))
 - Symbolication for Single File Apps ([#2425](https://github.com/getsentry/sentry-dotnet/pull/2425))
 - Add binding to `SwiftAsyncStacktraces` on iOS ([#2436](https://github.com/getsentry/sentry-dotnet/pull/2436))
 

--- a/samples/Sentry.Samples.Android/AndroidManifest.xml
+++ b/samples/Sentry.Samples.Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-  <application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true">
-  </application>
+  <application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
+++ b/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
@@ -16,7 +16,7 @@
     <!--
       The NuGet package the containing the binding comes with a .targets that sets the ProguardConfiguration
       Since we're referencing the project itself we're grabbing the ProguardConfiguration from project directly.
-    -->    
+    -->
     <ProguardConfiguration Include="..\..\src\Sentry.Bindings.Android\sentry-proguard.cfg" />
   </ItemGroup>
 
@@ -27,6 +27,7 @@
   <PropertyGroup>
     <SentryUploadSources>true</SentryUploadSources>
     <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadAndroidProguardMapping>true</SentryUploadAndroidProguardMapping>
   </PropertyGroup>
 
 </Project>

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -161,4 +161,14 @@
     <Warning Condition="'$(_SentryCLIExitCode)' != '0'" Text="Sentry CLI could not upload sources." />
 
   </Target>
+
+  <!-- Upload Android Proguard mapping file to Sentry after the build. -->
+  <Target Name="UploadAndroidProguardMappingFileToSentry" AfterTargets="Build;UploadSymbolsToSentry"
+          Condition="'$(SentryUploadAndroidProguardMapping)' == 'true' And '$(AndroidProguardMappingFile)' != ''">
+
+    <Message Importance="High" Text="Preparing to upload Android Proguard mapping to Sentry for '$(MSBuildProjectName)': $(AndroidProguardMappingFile))" />
+
+    <Exec Command="&quot;$(SentryCLI)&quot; upload-proguard $(AndroidProguardMappingFile)" IgnoreExitCode="true" ContinueOnError="WarnAndContinue" />
+
+  </Target>
 </Project>


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/2131

There is an MSBuild property `AndroidProguardMappingFile` for the mapping file path.