### PR TITLE
Chore: Update Target Frameworks for Sentry.OpenTelemetry

### DIFF
--- a/src/Sentry.OpenTelemetry/Sentry.OpenTelemetry.csproj
+++ b/src/Sentry.OpenTelemetry/Sentry.OpenTelemetry.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net462;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -4,8 +4,6 @@ using Sentry.Internal.Extensions;
 
 namespace Sentry.OpenTelemetry;
 
-// https://develop.sentry.dev/sdk/performance/opentelemetry
-
 /// <summary>
 /// Sentry span processor for Open Telemetry.
 /// </summary>

--- a/test/Sentry.OpenTelemetry.Tests/Sentry.OpenTelemetry.Tests.csproj
+++ b/test/Sentry.OpenTelemetry.Tests/Sentry.OpenTelemetry.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
@@ -135,15 +135,6 @@ public class SentrySpanProcessorTests : ActivitySourceTests
         }
     }
 
-#if NET5_0_OR_GREATER
-    /*
-     * Don't run on .NET Framework until we get a resolution to:
-     *   https://github.com/open-telemetry/opentelemetry-dotnet/issues/4623
-     *
-     * netcoreapp3.1 on macOS 12 fails for the same reason so we've just gone with NET5_0_OR_GREATER
-     */
-
-
     [Fact]
     public void OnStart_WithParentSpanId_StartsChildSpan()
     {
@@ -306,5 +297,4 @@ public class SentrySpanProcessorTests : ActivitySourceTests
             }
         }
     }
-#endif
 }


### PR DESCRIPTION
`Sentry.OpenTelemetry` won't work on anything under `net5.0` due to a [bug/limitation of the OpenTelemetry .NET SDK](https://github.com/getsentry/sentry-dotnet/blob/e49c3c78202b5e43e4bca662f75a92b0f1b11360/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs#L138-L144). See https://github.com/getsentry/sentry-dotnet/pull/2453#discussion_r1249881487 for details. 

Also, we'd need [`OpenTelemetry 1.3.2`](https://www.nuget.org/packages/OpenTelemetry/1.3.2#supportedframeworks-body-tab) to support anything below `net6.0`. I wasn't able to get our package compiling against `OpenTelemetry 1.3.2` so  currently we're targeting `net6.0` and above. 

This Pull Request updates the target frameworks for `Sentry.OpenTelemetry.csproj` and `Sentry.OpenTelemetry.Tests.csproj` accordingly.

#skip-changelog