### PR TITLE
Fix Durable Functions preventing orchestrators from completing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fixes baggage propagation when an exception is thrown from middleware ([#2487](https://github.com/getsentry/sentry-dotnet/pull/2487))
+- Fix Durable Functions preventing orchestrators from completing ([#2491](https://github.com/getsentry/sentry-dotnet/pull/2491))
 
 ### Dependencies
 

--- a/src/Sentry.AzureFunctions.Worker/.editorconfig
+++ b/src/Sentry.AzureFunctions.Worker/.editorconfig
@@ -1,0 +1,5 @@
+[*.cs]
+
+# Reason: Azure Functions worker doesn't set SynchronizationContext but Durable Functions does and required affinity.
+# (https://github.com/Azure/azure-functions-dotnet-worker/issues/1520)
+dotnet_diagnostic.CA2007.severity = none

--- a/src/Sentry.AzureFunctions.Worker/SentryFunctionsWorkerMiddleware.cs
+++ b/src/Sentry.AzureFunctions.Worker/SentryFunctionsWorkerMiddleware.cs
@@ -15,7 +15,7 @@ internal class SentryFunctionsWorkerMiddleware : IFunctionsWorkerMiddleware
 
     public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
     {
-        var transactionName = await GetHttpTransactionNameAsync(context).ConfigureAwait(false) ?? context.FunctionDefinition.Name;
+        var transactionName = await GetHttpTransactionNameAsync(context) ?? context.FunctionDefinition.Name;
         var transaction = _hub.StartTransaction(transactionName, "function");
         Exception? unhandledException = null;
 
@@ -35,7 +35,7 @@ internal class SentryFunctionsWorkerMiddleware : IFunctionsWorkerMiddleware
 
             context.CancellationToken.ThrowIfCancellationRequested();
 
-            await next(context).ConfigureAwait(false);
+            await next(context);
         }
         catch (Exception exception)
         {
@@ -76,7 +76,7 @@ internal class SentryFunctionsWorkerMiddleware : IFunctionsWorkerMiddleware
     private static async Task<string?> GetHttpTransactionNameAsync(FunctionContext context)
     {
         // Get the HTTP request data
-        var requestData = await context.GetHttpRequestDataAsync().ConfigureAwait(false);
+        var requestData = await context.GetHttpRequestDataAsync();
         if (requestData is null)
         {
             // not an HTTP trigger


### PR DESCRIPTION
Fixes #2469

Durable Functions require middleware to be completed on the same `SynchronizationContext`.

Validation:

![image](https://github.com/getsentry/sentry-dotnet/assets/1309622/e1d505f8-59d5-4d4a-8f60-7d00e83ab26e)

![image](https://github.com/getsentry/sentry-dotnet/assets/1309622/56817e1d-d262-4be9-84ae-5112c26d6cfb)

![image](https://github.com/getsentry/sentry-dotnet/assets/1309622/31bf8de3-8235-42de-a1c1-0b0c6110182b)

![image](https://github.com/getsentry/sentry-dotnet/assets/1309622/c409b493-d2e5-4f31-aa1b-1f3e7dd898ba)

