### PR TITLE
Re-enable HubTests.FlushOnDispose_SendsEnvelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fixes baggage propagation when an exception is thrown from middleware ([#2487](https://github.com/getsentry/sentry-dotnet/pull/2487))
+- Re-enable HubTests.FlushOnDispose_SendsEnvelope ([#2492](https://github.com/getsentry/sentry-dotnet/pull/2492))
 
 ### Dependencies
 

--- a/src/Sentry/Internal/BackgroundWorker.cs
+++ b/src/Sentry/Internal/BackgroundWorker.cs
@@ -202,7 +202,7 @@ internal class BackgroundWorker : IBackgroundWorker, IDisposable
     {
         if (_disposed)
         {
-            _options.LogDebug("BackgroundWorker disposed. Nothing to flush.");
+            _options.LogDebug("Worker disposed. Nothing to flush.");
             return;
         }
 
@@ -242,7 +242,6 @@ internal class BackgroundWorker : IBackgroundWorker, IDisposable
             _options.LogDebug("Timeout or shutdown already requested. Exiting.");
             return;
         }
-        _options.LogDebug("Flushing BackgroundWorker.");
 
         var completionSource = new TaskCompletionSource<bool>();
         cancellationToken.Register(() => completionSource.TrySetCanceled());

--- a/src/Sentry/Internal/BackgroundWorker.cs
+++ b/src/Sentry/Internal/BackgroundWorker.cs
@@ -202,7 +202,7 @@ internal class BackgroundWorker : IBackgroundWorker, IDisposable
     {
         if (_disposed)
         {
-            _options.LogDebug("Worker disposed. Nothing to flush.");
+            _options.LogDebug("BackgroundWorker disposed. Nothing to flush.");
             return;
         }
 
@@ -242,6 +242,7 @@ internal class BackgroundWorker : IBackgroundWorker, IDisposable
             _options.LogDebug("Timeout or shutdown already requested. Exiting.");
             return;
         }
+        _options.LogDebug("Flushing BackgroundWorker.");
 
         var completionSource = new TaskCompletionSource<bool>();
         cancellationToken.Register(() => completionSource.TrySetCanceled());

--- a/test/Sentry.Testing/RepeatAttribute.cs
+++ b/test/Sentry.Testing/RepeatAttribute.cs
@@ -1,0 +1,24 @@
+namespace Sentry.Testing;
+
+public class RepeatAttribute : Xunit.Sdk.DataAttribute
+{
+    private readonly int _count;
+    private readonly object[] _data;
+
+    public RepeatAttribute(int count, params object[] data)
+    {
+        if (count < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count),
+                "Repeat count must be greater than 0.");
+        }
+
+        _count = count;
+        _data = data;
+    }
+
+    public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+    {
+        return Enumerable.Repeat(_data, _count);
+    }
+}

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1293,7 +1293,7 @@ public partial class HubTests
     [Theory]
     [InlineData(false)]
     // [InlineData(true)]
-    [Repeat(100, true)]
+    [Repeat(20, true)]
     public async Task FlushOnDispose_SendsEnvelope(bool cachingEnabled)
     {
         // Arrange

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1292,8 +1292,7 @@ public partial class HubTests
 
     [Theory]
     [InlineData(false)]
-    // [InlineData(true)]
-    [Repeat(20, true)]
+    [InlineData(true)]
     public async Task FlushOnDispose_SendsEnvelope(bool cachingEnabled)
     {
         // Arrange

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1290,14 +1290,10 @@ public partial class HubTests
         hint.Attachments.Should().Contain(attachments);
     }
 
-#if ANDROID && CI_BUILD
-    // TODO: Test is flaky in CI
-    [SkippableTheory(typeof(NSubstitute.Exceptions.ReceivedCallsException))]
-#else
     [Theory]
-#endif
     [InlineData(false)]
-    [InlineData(true)]
+    // [InlineData(true)]
+    [Repeat(100, true)]
     public async Task FlushOnDispose_SendsEnvelope(bool cachingEnabled)
     {
         // Arrange


### PR DESCRIPTION
Fixes #2156 

### Summary
- I haven't been able to reproduce the original _flakiness_.
- I recommend we re-enable this test

### Investigation
I created a [`RepeatAttribute.cs`](https://github.com/getsentry/sentry-dotnet/blob/c0db8ca25bfd484b8244a9a2157977614d92018d/test/Sentry.Testing/RepeatAttribute.cs) for XUnit that allows a test to be run an arbitrary number of times. 

Initially I tried setting the number of repeats on this theory to 100, but the [Android CI servers fell over when I did that](https://github.com/getsentry/sentry-dotnet/actions/runs/5585579820/jobs/10208679170)... which is a pity. Worth noting that the other CI servers didn't have any problem with this, so there's definitely something **_special_** about the Android CI servers in this respect.  

When I dropped the number of test repeats to 20, the Android CI servers seemed to be able to cope again and all the tests passed. I reran the jobs for Android 4 times. Across 5 x different versions of Android then, including the original run, that's 500 tests and no failures. 

### Recommendation
I think we can re-enable this test. If we're happy with that, I'll uncomment [the InlineData attribute and delete the Repeat attribute that are currently sitting on the test](https://github.com/getsentry/sentry-dotnet/blob/c0db8ca25bfd484b8244a9a2157977614d92018d/test/Sentry.Tests/HubTests.cs#L1295C1-L1296C23). 
```csharp
    // [InlineData(true)]
    [Repeat(20, true)]
```