### PR TITLE
Align SDK with docs regarding session update for dropped events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixes baggage propagation when an exception is thrown from middleware ([#2487](https://github.com/getsentry/sentry-dotnet/pull/2487))
 - Fix Durable Functions preventing orchestrators from completing ([#2491](https://github.com/getsentry/sentry-dotnet/pull/2491))
 - Re-enable HubTests.FlushOnDispose_SendsEnvelope ([#2492](https://github.com/getsentry/sentry-dotnet/pull/2492))
+- Align SDK with docs regarding session update for dropped events ([#2496](https://github.com/getsentry/sentry-dotnet/pull/2496))
 
 ### Dependencies
 

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -16,6 +16,7 @@ namespace Sentry;
 public class SentryClient : ISentryClient, IDisposable
 {
     private readonly SentryOptions _options;
+    private readonly ISessionManager _sessionManager;
     private readonly RandomValuesFactory _randomValuesFactory;
 
     internal IBackgroundWorker Worker { get; }
@@ -32,22 +33,17 @@ public class SentryClient : ISentryClient, IDisposable
     /// </summary>
     /// <param name="options">The configuration for this client.</param>
     public SentryClient(SentryOptions options)
-        : this(options, null, null) { }
+        : this(options, null, null, null) { }
 
     internal SentryClient(
         SentryOptions options,
-        RandomValuesFactory? randomValuesFactory)
-        : this(options, null, randomValuesFactory)
-    {
-    }
-
-    internal SentryClient(
-        SentryOptions options,
-        IBackgroundWorker? worker,
-        RandomValuesFactory? randomValuesFactory = null)
+        IBackgroundWorker? worker = null,
+        RandomValuesFactory? randomValuesFactory = null,
+        ISessionManager? sessionManager = null)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _randomValuesFactory = randomValuesFactory ?? new SynchronizedRandomValuesFactory();
+        _sessionManager = sessionManager ?? new GlobalSessionManager(options);
 
         options.SetupLogging(); // Only relevant if this client wasn't created as a result of calling Init
 
@@ -269,6 +265,20 @@ public class SentryClient : ISentryClient, IDisposable
             _options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Error);
             _options.LogInfo("Event dropped by BeforeSend callback.");
             return SentryId.Empty;
+        }
+
+        var hasTerminalException = processedEvent.HasTerminalException();
+        if (hasTerminalException)
+        {
+            // Event contains a terminal exception -> end session as crashed
+            _options.LogDebug("Ending session as Crashed, due to unhandled exception.");
+            scope.SessionUpdate = _sessionManager.EndSession(SessionEndStatus.Crashed);
+        }
+        else if (processedEvent.HasException())
+        {
+            // Event contains a non-terminal exception -> report error
+            // (this might return null if the session has already reported errors before)
+            scope.SessionUpdate = _sessionManager.ReportError();
         }
 
         if (_options.SampleRate != null)

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -10,7 +10,7 @@ public partial class HubTests
     {
         public SentryOptions Options { get; }
 
-        public ISentryClient Client { get; }
+        public ISentryClient Client { get; set;  }
 
         public ISessionManager SessionManager { get; set; }
 
@@ -387,23 +387,6 @@ public partial class HubTests
 #endif
 
     [Fact]
-    public void CaptureEvent_SessionActive_ExceptionReportsError()
-    {
-        // Arrange
-        _fixture.Options.Release = "release";
-        var hub = _fixture.GetSut();
-
-        hub.StartSession();
-
-        // Act
-        hub.CaptureEvent(new SentryEvent(new Exception()));
-        hub.EndSession();
-
-        // Assert
-        _fixture.Client.Received().CaptureSession(Arg.Is<SessionUpdate>(s => s.ErrorCount == 1));
-    }
-
-    [Fact]
     public void CaptureEvent_ActiveSession_UnhandledExceptionSessionEndedAsCrashed()
     {
         // Arrange
@@ -414,8 +397,9 @@ public partial class HubTests
             Dsn = ValidDsn,
             Release = "release"
         };
-        var client = new SentryClient(options, worker);
-        var hub = new Hub(options, client);
+        var sessionManager = new GlobalSessionManager(options);
+        var client = new SentryClient(options, worker, sessionManager: sessionManager);
+        var hub = new Hub(options, client, sessionManager);
 
         hub.StartSession();
 
@@ -477,8 +461,9 @@ public partial class HubTests
             Dsn = ValidDsn,
             Release = "release"
         };
-        var client = new SentryClient(options, worker);
-        var hub = new Hub(options, client);
+        var sessionManager = new GlobalSessionManager(options);
+        var client = new SentryClient(options, worker, sessionManager: sessionManager);
+        var hub = new Hub(options, client, sessionManager);
 
         var integration = new AppDomainUnhandledExceptionIntegration(Substitute.For<IAppDomain>());
         integration.Register(hub, options);

--- a/test/Sentry.Tests/HubTests.verify.cs
+++ b/test/Sentry.Tests/HubTests.verify.cs
@@ -15,8 +15,9 @@ public partial class HubTests
             Release = "release",
             TracesSampleRate = 1.0
         };
-        var client = new SentryClient(options, worker);
-        var hub = new Hub(options, client);
+        var sessionManager = new GlobalSessionManager(options);
+        var client = new SentryClient(options, worker, sessionManager: sessionManager);
+        var hub = new Hub(options, client, sessionManager);
 
         var transaction = hub.StartTransaction("my transaction", "my operation");
         hub.ConfigureScope(scope => scope.Transaction = transaction);

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -613,6 +613,65 @@ public partial class SentryClientTests
     }
 
     [Fact]
+    public void CaptureEvent_Processing_Order()
+    {
+        // Arrange
+        var @event = new SentryEvent(new Exception());
+        var processingOrder = new List<string>();
+
+        var exceptionFilter = Substitute.For<IExceptionFilter>();
+        exceptionFilter.Filter(Arg.Do<Exception>(_ =>
+            processingOrder.Add("exceptionFilter")
+            )).Returns(false);
+        _fixture.SentryOptions.ExceptionFilters.Add(exceptionFilter);
+
+        var exceptionProcessor = Substitute.For<ISentryEventExceptionProcessor>();
+        exceptionProcessor
+            .When(x => x.Process(Arg.Any<Exception>(), Arg.Any<SentryEvent>()))
+            .Do(_ => processingOrder.Add("exceptionProcessor"));
+        var scope = new Scope(_fixture.SentryOptions);
+        scope.ExceptionProcessors.Add(exceptionProcessor);
+
+        var eventProcessor = Substitute.For<ISentryEventProcessor>();
+        eventProcessor.Process(default).ReturnsForAnyArgs(_ =>
+        {
+            processingOrder.Add("eventProcessor");
+            return @event;
+        });
+        _fixture.SentryOptions.EventProcessors.Add((eventProcessor));
+
+        _fixture.SentryOptions.SetBeforeSend((e, _) =>
+        {
+            processingOrder.Add("SetBeforeSend");
+            return e;
+        });
+
+        var logger = Substitute.For<IDiagnosticLogger>();
+        logger.IsEnabled(Arg.Any<SentryLevel>()).Returns(true);
+        logger.When(x => x.Log(Arg.Any<SentryLevel>(), Arg.Is("Event not sampled.")))
+            .Do(_ => processingOrder.Add("SampleRate"));
+        _fixture.SentryOptions.DiagnosticLogger = logger;
+        _fixture.SentryOptions.Debug = true;
+
+        // Act
+        var client = _fixture.GetSut();
+        client.CaptureEvent(@event, scope);
+
+        // Assert
+        // See https://github.com/getsentry/sentry-dotnet/issues/1599
+        var expectedOrder = new List<string>()
+        {
+            "exceptionFilter",
+            "exceptionProcessor",
+            "eventProcessor",
+            "SetBeforeSend",
+            // TODO: work out what to do with session update
+            "SampleRate"
+        };
+        processingOrder.Should().Equal(expectedOrder);
+    }
+
+    [Fact]
     public void CaptureEvent_Release_SetFromOptions()
     {
         const string expectedRelease = "release number";


### PR DESCRIPTION
Completes [Align SDK with docs regarding session update for dropped events #1599](https://github.com/getsentry/sentry-dotnet/issues/1599).

All of this now happens in the `SentryClient.DoSendEvent` method in the .NET SDK. 

### Python
> 1. Check for ignored exception types (a.k.a `ignore_errors`)
> 3. Apply scoped `event_processor` (a.k.a `error_processor`)
> 4. Apply global `event_processor`
> 2. Apply `before_send`
> 5. Update the session if an event made it this far
> 6. Apply sampling rate

### .NET

The [CaptureEvent_Processing_Order](https://github.com/getsentry/sentry-dotnet/blob/46865c6919f8c54528b17aa36894203a929f6808/test/Sentry.Tests/SentryClientTests.cs#L617) ensures .NET SDK processing happens in the same order.