### PR TITLE
Add MinimumEventLevel to Sentry.Log4Net and convert events below it to breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Added Sampling Decision to Trace Envelope Header ([#2495](https://github.com/getsentry/sentry-dotnet/pull/2495))
+- Add MinimumEventLevel to Sentry.Log4Net and convert events below it to breadcrumbs ([#2505](https://github.com/getsentry/sentry-dotnet/pull/2505))
 
 ### Fixes
 

--- a/samples/Sentry.Samples.Log4Net/Program.cs
+++ b/samples/Sentry.Samples.Log4Net/Program.cs
@@ -26,6 +26,10 @@ internal class Program
         // Does not result in an event in Sentry
         Log.Debug("Debug message which is not sent.");
 
+        // app.config sets MinimumEventLevel to ERROR, so every below that level is added as a breadcrumb.
+        Log.Info("Info message which is added as a breadcrumb.");
+        Log.Error("Error message which is sent as an event.");
+
         try
         {
             DoWork();

--- a/samples/Sentry.Samples.Log4Net/app.config
+++ b/samples/Sentry.Samples.Log4Net/app.config
@@ -18,6 +18,9 @@
       <!--Sends the log event Identity value as the user-->
       <SendIdentity value="true" />
       <Environment value="dev" />
+      <!--If MinimumEventLevel is specified, every event above threshold
+      and below MinimumEventLevel will be added as a breadcrumb.-->
+      <MinimumEventLevel value="ERROR" />
       <threshold value="INFO" />
     </appender>
     <root>

--- a/src/Sentry.Log4Net/LevelMapping.cs
+++ b/src/Sentry.Log4Net/LevelMapping.cs
@@ -16,7 +16,7 @@ internal static class LevelMapping
         };
     }
 
-    public static BreadcrumbLevel? ToBreadcrumbLevel(this LoggingEvent loggingLevel)
+    public static BreadcrumbLevel ToBreadcrumbLevel(this LoggingEvent loggingLevel)
     {
         return loggingLevel.Level switch
         {
@@ -26,7 +26,7 @@ internal static class LevelMapping
             var l when l == Level.Notice || l == Level.Info => BreadcrumbLevel.Info,
             var l when l == Level.Debug || l == Level.Verbose || l == Level.Trace || l == Level.Finer || l == Level.Finest ||
                        l == Level.Fine => BreadcrumbLevel.Debug,
-            _ => null
+            _ => BreadcrumbLevel.Info
         };
     }
 }

--- a/src/Sentry.Log4Net/LevelMapping.cs
+++ b/src/Sentry.Log4Net/LevelMapping.cs
@@ -16,7 +16,7 @@ internal static class LevelMapping
         };
     }
 
-    public static BreadcrumbLevel ToBreadcrumbLevel(this LoggingEvent loggingLevel)
+    public static BreadcrumbLevel? ToBreadcrumbLevel(this LoggingEvent loggingLevel)
     {
         return loggingLevel.Level switch
         {
@@ -26,7 +26,7 @@ internal static class LevelMapping
             var l when l == Level.Notice || l == Level.Info => BreadcrumbLevel.Info,
             var l when l == Level.Debug || l == Level.Verbose || l == Level.Trace || l == Level.Finer || l == Level.Finest ||
                        l == Level.Fine => BreadcrumbLevel.Debug,
-            _ => BreadcrumbLevel.Info
+            _ => null
         };
     }
 }

--- a/src/Sentry.Log4Net/LevelMapping.cs
+++ b/src/Sentry.Log4Net/LevelMapping.cs
@@ -15,4 +15,18 @@ internal static class LevelMapping
             _ => null
         };
     }
+
+    public static BreadcrumbLevel? ToBreadcrumbLevel(this LoggingEvent loggingLevel)
+    {
+        return loggingLevel.Level switch
+        {
+            var l when l == Level.Fatal || l == Level.Emergency || l == Level.All => BreadcrumbLevel.Critical,
+            var l when l == Level.Alert || l == Level.Critical || l == Level.Severe || l == Level.Error => BreadcrumbLevel.Error,
+            var l when l == Level.Warn => BreadcrumbLevel.Warning,
+            var l when l == Level.Notice || l == Level.Info => BreadcrumbLevel.Info,
+            var l when l == Level.Debug || l == Level.Verbose || l == Level.Trace || l == Level.Finer || l == Level.Finest ||
+                       l == Level.Fine => BreadcrumbLevel.Debug,
+            _ => null
+        };
+    }
 }

--- a/src/Sentry.Log4Net/LevelMapping.cs
+++ b/src/Sentry.Log4Net/LevelMapping.cs
@@ -20,12 +20,12 @@ internal static class LevelMapping
     {
         return loggingLevel.Level switch
         {
-            var l when l == Level.Fatal || l == Level.Emergency || l == Level.All => BreadcrumbLevel.Critical,
+            var l when l == Level.Fatal || l == Level.Emergency => BreadcrumbLevel.Critical,
             var l when l == Level.Alert || l == Level.Critical || l == Level.Severe || l == Level.Error => BreadcrumbLevel.Error,
             var l when l == Level.Warn => BreadcrumbLevel.Warning,
             var l when l == Level.Notice || l == Level.Info => BreadcrumbLevel.Info,
             var l when l == Level.Debug || l == Level.Verbose || l == Level.Trace || l == Level.Finer || l == Level.Finest ||
-                       l == Level.Fine => BreadcrumbLevel.Debug,
+                       l == Level.Fine || l == Level.All => BreadcrumbLevel.Debug,
             _ => null
         };
     }

--- a/src/Sentry.Log4Net/LevelMapping.cs
+++ b/src/Sentry.Log4Net/LevelMapping.cs
@@ -16,17 +16,13 @@ internal static class LevelMapping
         };
     }
 
-    public static BreadcrumbLevel? ToBreadcrumbLevel(this LoggingEvent loggingLevel)
+    public static BreadcrumbLevel? ToBreadcrumbLevel(this LoggingEvent loggingLevel) => loggingLevel.Level switch
     {
-        return loggingLevel.Level switch
-        {
-            var l when l == Level.Fatal || l == Level.Emergency => BreadcrumbLevel.Critical,
-            var l when l == Level.Alert || l == Level.Critical || l == Level.Severe || l == Level.Error => BreadcrumbLevel.Error,
-            var l when l == Level.Warn => BreadcrumbLevel.Warning,
-            var l when l == Level.Notice || l == Level.Info => BreadcrumbLevel.Info,
-            var l when l == Level.Debug || l == Level.Verbose || l == Level.Trace || l == Level.Finer || l == Level.Finest ||
-                       l == Level.Fine || l == Level.All => BreadcrumbLevel.Debug,
-            _ => null
-        };
-    }
+        Level.Fatal or Level.Emergency => BreadcrumbLevel.Critical,
+        Level.Alert or Level.Critical or Level.Severe or Level.Error => BreadcrumbLevel.Error,
+        Level.Warn => BreadcrumbLevel.Warning,
+        Level.Notice or Level.Info => BreadcrumbLevel.Info,
+        Level.Debug or Level.Verbose or Level.Trace or Level.Finer or Level.Finest or Level.Fine or Level.All => BreadcrumbLevel.Debug,
+        _ => null
+    };
 }

--- a/src/Sentry.Log4Net/LevelMapping.cs
+++ b/src/Sentry.Log4Net/LevelMapping.cs
@@ -16,13 +16,17 @@ internal static class LevelMapping
         };
     }
 
-    public static BreadcrumbLevel? ToBreadcrumbLevel(this LoggingEvent loggingLevel) => loggingLevel.Level switch
+    public static BreadcrumbLevel? ToBreadcrumbLevel(this LoggingEvent loggingLevel)
     {
-        Level.Fatal or Level.Emergency => BreadcrumbLevel.Critical,
-        Level.Alert or Level.Critical or Level.Severe or Level.Error => BreadcrumbLevel.Error,
-        Level.Warn => BreadcrumbLevel.Warning,
-        Level.Notice or Level.Info => BreadcrumbLevel.Info,
-        Level.Debug or Level.Verbose or Level.Trace or Level.Finer or Level.Finest or Level.Fine or Level.All => BreadcrumbLevel.Debug,
-        _ => null
-    };
+        return loggingLevel.Level switch
+        {
+            var l when l == Level.Fatal || l == Level.Emergency => BreadcrumbLevel.Critical,
+            var l when l == Level.Alert || l == Level.Critical || l == Level.Severe || l == Level.Error => BreadcrumbLevel.Error,
+            var l when l == Level.Warn => BreadcrumbLevel.Warning,
+            var l when l == Level.Notice || l == Level.Info => BreadcrumbLevel.Info,
+            var l when l == Level.Debug || l == Level.Verbose || l == Level.Trace || l == Level.Finer || l == Level.Finest ||
+                l == Level.Fine || l == Level.All => BreadcrumbLevel.Debug,
+            _ => null
+        };
+    }
 }

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -90,12 +90,19 @@ public class SentryAppender : AppenderSkeleton
         {
             var message = !string.IsNullOrWhiteSpace(loggingEvent.RenderedMessage) ? loggingEvent.RenderedMessage : string.Empty;
             var category = loggingEvent.LoggerName;
-            var level = loggingEvent.ToBreadcrumbLevel();
             IDictionary<string, string> data = GetLoggingEventProperties(loggingEvent)
                 .Where(kvp => kvp.Value != null)
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value!.ToString());
 
-            _hub.AddBreadcrumb(message, category, type: null, data, level);
+            var level = loggingEvent.ToBreadcrumbLevel();
+            if (level is null)
+            {
+                _hub.AddBreadcrumb(message, category, type: null, data);
+            }
+            else
+            {
+                _hub.AddBreadcrumb(message, category, type: null, data, level.Value);
+            }
             return;
         }
 

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -31,7 +31,7 @@ public class SentryAppender : AppenderSkeleton
     /// Environment to send in the event.
     /// </summary>
     public string? Environment { get; set; }
-    
+
     /// <summary>
     /// Lowest level required for a log message to become an event.
     /// Every level above threshold and below this level will become a breadcrumb.
@@ -88,8 +88,8 @@ public class SentryAppender : AppenderSkeleton
 
         if (loggingEvent.Level < MinimumEventLevel)
         {
-            string? message = !string.IsNullOrWhiteSpace(loggingEvent.RenderedMessage) ? loggingEvent.RenderedMessage : null;
-            string category = loggingEvent.LoggerName;
+            var message = !string.IsNullOrWhiteSpace(loggingEvent.RenderedMessage) ? loggingEvent.RenderedMessage : string.Empty;
+            var category = loggingEvent.LoggerName;
             BreadcrumbLevel level = loggingEvent.ToBreadcrumbLevel();
             IDictionary<string, string> data = GetLoggingEventProperties(loggingEvent).ToDictionary(x => x.Key, x => x.Value.ToString());
 

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -86,12 +86,14 @@ public class SentryAppender : AppenderSkeleton
 
         var exception = loggingEvent.ExceptionObject ?? loggingEvent.MessageObject as Exception;
 
-        if (loggingEvent.Level < MinimumEventLevel)
+        if (MinimumEventLevel is not null && loggingEvent.Level < MinimumEventLevel)
         {
             var message = !string.IsNullOrWhiteSpace(loggingEvent.RenderedMessage) ? loggingEvent.RenderedMessage : string.Empty;
             var category = loggingEvent.LoggerName;
-            BreadcrumbLevel level = loggingEvent.ToBreadcrumbLevel();
-            IDictionary<string, string> data = GetLoggingEventProperties(loggingEvent).ToDictionary(x => x.Key, x => x.Value.ToString());
+            var level = loggingEvent.ToBreadcrumbLevel();
+            IDictionary<string, string> data = GetLoggingEventProperties(loggingEvent)
+                .Where(kvp => kvp.Value != null)
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value!.ToString());
 
             _hub.AddBreadcrumb(message, category, type: null, data, level);
             return;

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -90,19 +90,12 @@ public class SentryAppender : AppenderSkeleton
         {
             var message = !string.IsNullOrWhiteSpace(loggingEvent.RenderedMessage) ? loggingEvent.RenderedMessage : string.Empty;
             var category = loggingEvent.LoggerName;
+            var level = loggingEvent.ToBreadcrumbLevel();
             IDictionary<string, string> data = GetLoggingEventProperties(loggingEvent)
                 .Where(kvp => kvp.Value != null)
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value!.ToString());
 
-            var level = loggingEvent.ToBreadcrumbLevel();
-            if (level is null)
-            {
-                _hub.AddBreadcrumb(message, category, type: null, data);
-            }
-            else
-            {
-                _hub.AddBreadcrumb(message, category, type: null, data, level.Value);
-            }
+            _hub.AddBreadcrumb(message, category, type: null, data, level ?? default);
             return;
         }
 

--- a/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1,4 +1,4 @@
-[assembly: System.CLSCompliant(true)]
+﻿[assembly: System.CLSCompliant(true)]
 namespace Sentry.Log4Net
 {
     public class SentryAppender : log4net.Appender.AppenderSkeleton
@@ -6,6 +6,7 @@ namespace Sentry.Log4Net
         public SentryAppender() { }
         public string? Dsn { get; set; }
         public string? Environment { get; set; }
+        public log4net.Core.Level? MinimumEventLevel { get; set; }
         public bool SendIdentity { get; set; }
         protected override void Append(log4net.Core.LoggingEvent loggingEvent) { }
         protected override void OnClose() { }

--- a/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -6,6 +6,7 @@ namespace Sentry.Log4Net
         public SentryAppender() { }
         public string? Dsn { get; set; }
         public string? Environment { get; set; }
+        public log4net.Core.Level? MinimumEventLevel { get; set; }
         public bool SendIdentity { get; set; }
         protected override void Append(log4net.Core.LoggingEvent loggingEvent) { }
         protected override void OnClose() { }

--- a/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -6,6 +6,7 @@ namespace Sentry.Log4Net
         public SentryAppender() { }
         public string? Dsn { get; set; }
         public string? Environment { get; set; }
+        public log4net.Core.Level? MinimumEventLevel { get; set; }
         public bool SendIdentity { get; set; }
         protected override void Append(log4net.Core.LoggingEvent loggingEvent) { }
         protected override void OnClose() { }

--- a/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Log4Net.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -6,6 +6,7 @@ namespace Sentry.Log4Net
         public SentryAppender() { }
         public string? Dsn { get; set; }
         public string? Environment { get; set; }
+        public log4net.Core.Level? MinimumEventLevel { get; set; }
         public bool SendIdentity { get; set; }
         protected override void Append(log4net.Core.LoggingEvent loggingEvent) { }
         protected override void OnClose() { }

--- a/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
+++ b/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
@@ -15,7 +15,6 @@ public class SentryAppenderTests
 
         public Fixture()
         {
-            Hub.IsEnabled.Returns(true);
             HubAccessor = () => Hub;
             Hub.ConfigureScope(Arg.Invoke(Scope));
             InitAction = s =>

--- a/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
+++ b/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
@@ -318,7 +318,7 @@ public class SentryAppenderTests
     }
 
     [Fact]
-    public void MinimumEventLevel_ConvertsEventsBelowToBreadcrumbs()
+    public void DoAppend_BelowMinimumEventLevel_AddsBreadcrumb()
     {
         var sut = _fixture.GetSut();
         sut.Threshold = Level.Debug;

--- a/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
+++ b/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
@@ -331,13 +331,6 @@ public class SentryAppenderTests
         });
         sut.DoAppend(warnEvt);
 
-        var errorEvent = new LoggingEvent(new LoggingEventData
-        {
-            Level = Level.Error,
-            Message = "log4net event"
-        });
-        sut.DoAppend(errorEvent);
-
         var breadcrumb = _fixture.Scope.Breadcrumbs.First();
         Assert.Equal(expectedBreadcrumbMsg, breadcrumb.Message);
     }

--- a/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
+++ b/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
@@ -131,7 +131,7 @@ public class SentryAppenderTests
     }
 
     [Fact]
-    public void Append_BelowThreshold_NoOp()
+    public void Append_BelowThreshold_DoesNotSendEvent()
     {
         var sut = _fixture.GetSut();
         sut.Threshold = Level.Warn;
@@ -141,6 +141,7 @@ public class SentryAppenderTests
         });
 
         sut.DoAppend(evt);
+        _fixture.Hub.DidNotReceiveWithAnyArgs().CaptureEvent(Arg.Any<SentryEvent>());
     }
 
     [Fact]


### PR DESCRIPTION
Both NLog and Serilog integrations already feature `MinimumEventLevel`. I attempted to also add it for log4net, hope its implementation is acceptable to you.

If `MinimumEventLevel` is specified, every log4net LoggingEvent above `threshold` and below `MinimumEventLevel` will be converted to a breadcrumb.

Heavily inspired by this solution from SO:
https://stackoverflow.com/a/62923187/10249243