### PR TITLE
Fix - Failing to report issues via Blazor WebAssembly 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed baggage propagation when an exception is thrown from middleware ([#2487](https://github.com/getsentry/sentry-dotnet/pull/2487))
 - Fix Durable Functions preventing orchestrators from completing ([#2491](https://github.com/getsentry/sentry-dotnet/pull/2491))
 - Re-enable HubTests.FlushOnDispose_SendsEnvelope ([#2492](https://github.com/getsentry/sentry-dotnet/pull/2492))
+- Fixed reporting issues via Blazor WebAssembly ([#2506](https://github.com/getsentry/sentry-dotnet/pull/2506))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Fixed baggage propagation when an exception is thrown from middleware ([#2487](https://github.com/getsentry/sentry-dotnet/pull/2487))
 - Fix Durable Functions preventing orchestrators from completing ([#2491](https://github.com/getsentry/sentry-dotnet/pull/2491))
 - Re-enable HubTests.FlushOnDispose_SendsEnvelope ([#2492](https://github.com/getsentry/sentry-dotnet/pull/2492))
-- Fixed reporting issues via Blazor WebAssembly ([#2506](https://github.com/getsentry/sentry-dotnet/pull/2506))
+- Fixed the SDK failing to report issues via Blazor WebAssembly due to a `PlatformNotSupportedException` ([#2506](https://github.com/getsentry/sentry-dotnet/pull/2506))
 
 ### Dependencies
 

--- a/src/Sentry/Internal/DebugStackTrace.cs
+++ b/src/Sentry/Internal/DebugStackTrace.cs
@@ -440,16 +440,23 @@ internal class DebugStackTrace : SentryStackTrace
 #if NET5_0_OR_GREATER && PLATFORM_NEUTRAL
         // Maybe we're dealing with a single file assembly
         // https://github.com/getsentry/sentry-dotnet/issues/2362
-        if (SingleFileApp.MainModule.IsBundle())
+        try
         {
-            if (SingleFileApp.MainModule?.GetDebugImage(module) is not { } embeddedDebugImage)
+            if (SingleFileApp.MainModule.IsBundle())
             {
-                options.LogInfo("Skipping embedded debug image for module '{0}' because the Debug ID couldn't be determined", moduleName);
-                return null;
-            }
+                if (SingleFileApp.MainModule?.GetDebugImage(module) is not { } embeddedDebugImage)
+                {
+                    options.LogInfo("Skipping embedded debug image for module '{0}' because the Debug ID couldn't be determined", moduleName);
+                    return null;
+                }
 
-            options.LogDebug("Got embedded debug image for '{0}' having Debug ID: {1}", moduleName, embeddedDebugImage.DebugId);
-            return embeddedDebugImage;
+                options.LogDebug("Got embedded debug image for '{0}' having Debug ID: {1}", moduleName, embeddedDebugImage.DebugId);
+                return embeddedDebugImage;
+            }
+        }
+        catch (PlatformNotSupportedException)
+        {
+            // Thrown by Blazor WASM (and possibly other platforms).
         }
 #endif
 


### PR DESCRIPTION
Fixes [#2499](https://github.com/getsentry/sentry-dotnet/issues/2499) Failing to report issues via Blazor WebAssembly 