### PR TITLE
fix(android): Fix internal Android SDK API changes break build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@
 
 ### Dependencies
 
-- Bump Java SDK from v6.25.1 to v6.25.2 ([#2484](https://github.com/getsentry/sentry-dotnet/pull/2484))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6252)
-  - [diff](https://github.com/getsentry/sentry-java/compare/6.25.1...6.25.2)
+- Bump Java SDK from v6.25.1 to v6.26.0 ([#2484](https://github.com/getsentry/sentry-dotnet/pull/2484), [#2498](https://github.com/getsentry/sentry-dotnet/pull/2498))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6260)
+  - [diff](https://github.com/getsentry/sentry-java/compare/6.25.1...6.26.0)
 - Bump CLI from v2.19.4 to v2.20.0 ([#2509](https://github.com/getsentry/sentry-dotnet/pull/2509))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2200)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.19.4...2.20.0)

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0-android</TargetFramework>
     <!-- BG8605 and BG8606 happen because there's a missing androidx.lifecycle dependency, but we don't need it here.  (The native Android Sentry SDK will use it if it exists.) -->
     <NoWarn>$(NoWarn);BG8605;BG8606</NoWarn>
-    <SentryAndroidSdkVersion>6.25.2</SentryAndroidSdkVersion>
+    <SentryAndroidSdkVersion>6.26.0</SentryAndroidSdkVersion>
     <SentryAndroidSdkDirectory>$(BaseIntermediateOutputPath)sdks\Sentry\Android\$(SentryAndroidSdkVersion)\</SentryAndroidSdkDirectory>
     <Description>.NET Bindings for the Sentry Android SDK</Description>
   </PropertyGroup>

--- a/src/Sentry.Bindings.Android/Transforms/Metadata.xml
+++ b/src/Sentry.Bindings.Android/Transforms/Metadata.xml
@@ -88,6 +88,16 @@
   <remove-node path="/api/package[@name='io.sentry']/interface[@name='BackfillingEventProcessor']" />
   <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='AnrV2EventProcessor']" />
 
+
+  <!--
+    SentryEvent.serialize() expects an parameter which implements ObjectWriter.
+    JsonObjectWriter implements ObjectWriter in Java, but somehow this is not reflected in the generated binding.
+    Here we force using JsonObjectWriter as otherwise we'd get the following error message:
+      Argument 1: cannot convert from 'Sentry.JavaSdk.JsonObjectWriter' to 'Sentry.JavaSdk.IObjectWriter'
+  -->
+  <attr path="/api/package[@name='io.sentry']/class[@name='SentryEvent']/method[@name='serialize']/parameter[1]"
+    name="managedType">Sentry.JavaSdk.JsonObjectWriter</attr>
+
   <!--
     The remaining APIS are removed to prevent various errors/warnings.
     TODO: Find other workarounds for each one, rather than removing the APIs.

--- a/src/Sentry/Platforms/Android/Extensions/SentryEventExtensions.cs
+++ b/src/Sentry/Platforms/Android/Extensions/SentryEventExtensions.cs
@@ -21,7 +21,8 @@ internal static class SentryEventExtensions
         using var streamWriter = new JavaOutputStreamWriter(stream);
         using var jsonWriter = new JavaSdk.JsonObjectWriter(streamWriter, javaOptions.MaxDepth);
         sentryEvent.Serialize(jsonWriter, javaOptions.Logger);
-        jsonWriter.Flush();
+
+        streamWriter.Flush();
         stream.Seek(0, SeekOrigin.Begin);
 
         using var json = JsonDocument.Parse(stream);


### PR DESCRIPTION
Starting with our Sentry Java/Android SDK `6.26.0` `SentryEvent.serialize()` expects a parameter which implements the `ObjectWriter` interface.
`JsonObjectWriter` implements this `ObjectWriter` interface in Java, but somehow this is not reflected in the generated binding.

This workaround replaces the interface with the `JsonObjectWriter` type in the `SentryEvent.serialize()`. Definitely not an elegant solution, if you have something better in mind or know how fix the binding generation itself please let me know 😊 