### PR TITLE
Fixed Error status of OpenTelemetry Spans when using Activity.RecordException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fixed SDK not sending exceptions via Blazor WebAssembly due to a `PlatformNotSupportedException` ([#2506](https://github.com/getsentry/sentry-dotnet/pull/2506))
 - Align SDK with docs regarding session update for dropped events ([#2496](https://github.com/getsentry/sentry-dotnet/pull/2496))
 - Introduced `HttpMessageHandler` in favor of the now deprecated `HttpClientHandler` on the options. This allows the SDK to support NSUrlSessionHandler on iOS ([#2503](https://github.com/getsentry/sentry-dotnet/pull/2503))
-- Fixed Error status of OpenTelemetry Spans when using Activity.RecordException ([#2515](https://github.com/getsentry/sentry-dotnet/pull/2515))
+- Using `Activity.RecordException` now correctly updates the error status of OpenTelemetry Spans ([#2515](https://github.com/getsentry/sentry-dotnet/pull/2515))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed SDK not sending exceptions via Blazor WebAssembly due to a `PlatformNotSupportedException` ([#2506](https://github.com/getsentry/sentry-dotnet/pull/2506))
 - Align SDK with docs regarding session update for dropped events ([#2496](https://github.com/getsentry/sentry-dotnet/pull/2496))
 - Introduced `HttpMessageHandler` in favor of the now deprecated `HttpClientHandler` on the options. This allows the SDK to support NSUrlSessionHandler on iOS ([#2503](https://github.com/getsentry/sentry-dotnet/pull/2503))
+- Span Status is now set correctly for spans with an ERROR status in OpenTelemetry ([#2515](https://github.com/getsentry/sentry-dotnet/pull/2515))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fixed SDK not sending exceptions via Blazor WebAssembly due to a `PlatformNotSupportedException` ([#2506](https://github.com/getsentry/sentry-dotnet/pull/2506))
 - Align SDK with docs regarding session update for dropped events ([#2496](https://github.com/getsentry/sentry-dotnet/pull/2496))
 - Introduced `HttpMessageHandler` in favor of the now deprecated `HttpClientHandler` on the options. This allows the SDK to support NSUrlSessionHandler on iOS ([#2503](https://github.com/getsentry/sentry-dotnet/pull/2503))
-- Span Status is now set correctly for spans with an ERROR status in OpenTelemetry ([#2515](https://github.com/getsentry/sentry-dotnet/pull/2515))
+- Fixed Error status of OpenTelemetry Spans when using Activity.RecordException ([#2515](https://github.com/getsentry/sentry-dotnet/pull/2515))
 
 ### Dependencies
 

--- a/src/Sentry.OpenTelemetry/OpenTelemetry/ATTRIBUTION.txt
+++ b/src/Sentry.OpenTelemetry/OpenTelemetry/ATTRIBUTION.txt
@@ -1,0 +1,18 @@
+Parts of the code in this subdirectory have been adapted from
+https://github.com/open-telemetry/opentelemetry-dotnet/
+
+The original license is as follows:
+
+Copyright The OpenTelemetry Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/Sentry.OpenTelemetry/OpenTelemetry/SemanticConventions.cs
+++ b/src/Sentry.OpenTelemetry/OpenTelemetry/SemanticConventions.cs
@@ -1,0 +1,114 @@
+// Modified from:
+// https://github.com/open-telemetry/opentelemetry-dotnet/blob/dacc532d51ca0f3775160b84fa6d7d9403a8ccde/src/Shared/SemanticConventions.cs
+
+// <copyright file="SemanticConventions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace Sentry.OpenTelemetry;
+
+/// <summary>
+/// Constants for semantic attribute names outlined by the OpenTelemetry specifications.
+/// <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/README.md"/> and
+/// <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/README.md"/>.
+/// </summary>
+internal static class SemanticConventions
+{
+    // The set of constants matches the specification as of this commit.
+    // https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions
+    // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md
+    public const string AttributeNetTransport = "net.transport";
+    public const string AttributeNetPeerIp = "net.peer.ip";
+    public const string AttributeNetPeerPort = "net.peer.port";
+    public const string AttributeNetPeerName = "net.peer.name";
+    public const string AttributeNetHostIp = "net.host.ip";
+    public const string AttributeNetHostPort = "net.host.port";
+    public const string AttributeNetHostName = "net.host.name";
+
+    public const string AttributeEnduserId = "enduser.id";
+    public const string AttributeEnduserRole = "enduser.role";
+    public const string AttributeEnduserScope = "enduser.scope";
+
+    public const string AttributePeerService = "peer.service";
+
+    public const string AttributeHttpMethod = "http.method";
+    public const string AttributeHttpUrl = "http.url";
+    public const string AttributeHttpTarget = "http.target";
+    public const string AttributeHttpHost = "http.host";
+    public const string AttributeHttpScheme = "http.scheme";
+    public const string AttributeHttpStatusCode = "http.status_code";
+    public const string AttributeHttpStatusText = "http.status_text";
+    public const string AttributeHttpFlavor = "http.flavor";
+    public const string AttributeHttpServerName = "http.server_name";
+    public const string AttributeHttpRoute = "http.route";
+    public const string AttributeHttpClientIP = "http.client_ip";
+    public const string AttributeHttpUserAgent = "http.user_agent";
+    public const string AttributeHttpRequestContentLength = "http.request_content_length";
+    public const string AttributeHttpRequestContentLengthUncompressed = "http.request_content_length_uncompressed";
+    public const string AttributeHttpResponseContentLength = "http.response_content_length";
+    public const string AttributeHttpResponseContentLengthUncompressed = "http.response_content_length_uncompressed";
+
+    public const string AttributeDbSystem = "db.system";
+    public const string AttributeDbConnectionString = "db.connection_string";
+    public const string AttributeDbUser = "db.user";
+    public const string AttributeDbMsSqlInstanceName = "db.mssql.instance_name";
+    public const string AttributeDbJdbcDriverClassName = "db.jdbc.driver_classname";
+    public const string AttributeDbName = "db.name";
+    public const string AttributeDbStatement = "db.statement";
+    public const string AttributeDbOperation = "db.operation";
+    public const string AttributeDbInstance = "db.instance";
+    public const string AttributeDbUrl = "db.url";
+    public const string AttributeDbCassandraKeyspace = "db.cassandra.keyspace";
+    public const string AttributeDbHBaseNamespace = "db.hbase.namespace";
+    public const string AttributeDbRedisDatabaseIndex = "db.redis.database_index";
+    public const string AttributeDbMongoDbCollection = "db.mongodb.collection";
+
+    public const string AttributeRpcSystem = "rpc.system";
+    public const string AttributeRpcService = "rpc.service";
+    public const string AttributeRpcMethod = "rpc.method";
+    public const string AttributeRpcGrpcStatusCode = "rpc.grpc.status_code";
+
+    public const string AttributeMessageType = "message.type";
+    public const string AttributeMessageId = "message.id";
+    public const string AttributeMessageCompressedSize = "message.compressed_size";
+    public const string AttributeMessageUncompressedSize = "message.uncompressed_size";
+
+    public const string AttributeFaasTrigger = "faas.trigger";
+    public const string AttributeFaasExecution = "faas.execution";
+    public const string AttributeFaasDocumentCollection = "faas.document.collection";
+    public const string AttributeFaasDocumentOperation = "faas.document.operation";
+    public const string AttributeFaasDocumentTime = "faas.document.time";
+    public const string AttributeFaasDocumentName = "faas.document.name";
+    public const string AttributeFaasTime = "faas.time";
+    public const string AttributeFaasCron = "faas.cron";
+
+    public const string AttributeMessagingSystem = "messaging.system";
+    public const string AttributeMessagingDestination = "messaging.destination";
+    public const string AttributeMessagingDestinationKind = "messaging.destination_kind";
+    public const string AttributeMessagingTempDestination = "messaging.temp_destination";
+    public const string AttributeMessagingProtocol = "messaging.protocol";
+    public const string AttributeMessagingProtocolVersion = "messaging.protocol_version";
+    public const string AttributeMessagingUrl = "messaging.url";
+    public const string AttributeMessagingMessageId = "messaging.message_id";
+    public const string AttributeMessagingConversationId = "messaging.conversation_id";
+    public const string AttributeMessagingPayloadSize = "messaging.message_payload_size_bytes";
+    public const string AttributeMessagingPayloadCompressedSize = "messaging.message_payload_compressed_size_bytes";
+    public const string AttributeMessagingOperation = "messaging.operation";
+
+    public const string AttributeExceptionEventName = "exception";
+    public const string AttributeExceptionType = "exception.type";
+    public const string AttributeExceptionMessage = "exception.message";
+    public const string AttributeExceptionStacktrace = "exception.stacktrace";
+}

--- a/src/Sentry.OpenTelemetry/OpenTelemetry/SemanticConventions.cs
+++ b/src/Sentry.OpenTelemetry/OpenTelemetry/SemanticConventions.cs
@@ -17,6 +17,7 @@
 // limitations under the License.
 // </copyright>
 
+// ReSharper disable once CheckNamespace
 namespace Sentry.OpenTelemetry;
 
 /// <summary>

--- a/src/Sentry.OpenTelemetry/OpenTelemetry/SpanAttributeConstants.cs
+++ b/src/Sentry.OpenTelemetry/OpenTelemetry/SpanAttributeConstants.cs
@@ -1,0 +1,30 @@
+// Modified from:
+// https://github.com/open-telemetry/opentelemetry-dotnet/blob/dacc532d51ca0f3775160b84fa6d7d9403a8ccde/src/Shared/SpanAttributeConstants.cs
+
+// <copyright file="SpanAttributeConstants.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace Sentry.OpenTelemetry;
+
+/// <summary>
+/// Defines well-known span attribute keys.
+/// </summary>
+internal static class SpanAttributeConstants
+{
+    public const string StatusCodeKey = "otel.status_code";
+    public const string StatusDescriptionKey = "otel.status_description";
+    public const string DatabaseStatementTypeKey = "db.statement_type";
+}

--- a/src/Sentry.OpenTelemetry/OpenTelemetry/SpanAttributeConstants.cs
+++ b/src/Sentry.OpenTelemetry/OpenTelemetry/SpanAttributeConstants.cs
@@ -17,6 +17,7 @@
 // limitations under the License.
 // </copyright>
 
+// ReSharper disable once CheckNamespace
 namespace Sentry.OpenTelemetry;
 
 /// <summary>

--- a/src/Sentry.OpenTelemetry/OpenTelemetry/StatusTags.cs
+++ b/src/Sentry.OpenTelemetry/OpenTelemetry/StatusTags.cs
@@ -1,3 +1,4 @@
+// ReSharper disable once CheckNamespace
 namespace Sentry.OpenTelemetry;
 
 internal static class StatusTags

--- a/src/Sentry.OpenTelemetry/OpenTelemetry/StatusTags.cs
+++ b/src/Sentry.OpenTelemetry/OpenTelemetry/StatusTags.cs
@@ -1,0 +1,9 @@
+namespace Sentry.OpenTelemetry;
+
+internal static class StatusTags
+{
+    // See https://github.com/open-telemetry/opentelemetry-dotnet/blob/dacc532d51ca0f3775160b84fa6d7d9403a8ccde/src/Shared/StatusHelper.cs#L26
+    public const string UnsetStatusCodeTagValue = "UNSET";
+    public const string OkStatusCodeTagValue = "OK";
+    public const string ErrorStatusCodeTagValue = "ERROR";
+}

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -1,4 +1,5 @@
 using OpenTelemetry;
+using OpenTelemetry.Trace;
 using Sentry.Extensibility;
 using Sentry.Internal.Extensions;
 
@@ -169,14 +170,22 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
         _map.TryRemove(data.SpanId, out _);
     }
 
-    internal static SpanStatus GetSpanStatus(ActivityStatusCode status, IDictionary<string, object?> attributes) =>
-        status switch
+    internal static SpanStatus GetSpanStatus(ActivityStatusCode status, IDictionary<string, object?> attributes)
+    {
+        // See https://github.com/open-telemetry/opentelemetry-dotnet/discussions/4703
+        if (attributes.TryGetValue(SpanAttributeConstants.StatusCodeKey, out var statusCode)
+            && statusCode is StatusTags.ErrorStatusCodeTagValue
+           )
         {
+            return GetErrorSpanStatus(attributes);
+        }
+        return status switch {
             ActivityStatusCode.Unset => SpanStatus.Ok,
             ActivityStatusCode.Ok => SpanStatus.Ok,
             ActivityStatusCode.Error => GetErrorSpanStatus(attributes),
             _ => SpanStatus.UnknownError
         };
+    }
 
     private static SpanStatus GetErrorSpanStatus(IDictionary<string, object?> attributes)
     {
@@ -203,7 +212,7 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
 
         // HTTP span
         // https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/http/
-        if (attributes.TryGetTypedValue("http.method", out string httpMethod))
+        if (attributes.TryGetTypedValue(SemanticConventions.AttributeHttpMethod, out string httpMethod))
         {
             if (activity.Kind == ActivityKind.Client)
             {
@@ -211,13 +220,13 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
                 return ("http.client", httpMethod, TransactionNameSource.Custom);
             }
 
-            if (attributes.TryGetTypedValue("http.route", out string httpRoute))
+            if (attributes.TryGetTypedValue(SemanticConventions.AttributeHttpRoute, out string httpRoute))
             {
                 // A route exists.  Use the method and route.
                 return ("http.server", $"{httpMethod} {httpRoute}", TransactionNameSource.Route);
             }
 
-            if (attributes.TryGetTypedValue("http.target", out string httpTarget))
+            if (attributes.TryGetTypedValue(SemanticConventions.AttributeHttpTarget, out string httpTarget))
             {
                 // A target exists.  Use the method and target.  If the target is "/" we can treat it like a route.
                 var source = httpTarget == "/" ? TransactionNameSource.Route : TransactionNameSource.Url;
@@ -230,9 +239,9 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
 
         // DB span
         // https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/database/
-        if (attributes.ContainsKey("db.system"))
+        if (attributes.ContainsKey(SemanticConventions.AttributeDbSystem))
         {
-            if (attributes.TryGetTypedValue("db.statement", out string dbStatement))
+            if (attributes.TryGetTypedValue(SemanticConventions.AttributeDbStatement, out string dbStatement))
             {
                 // We have a database statement.  Use it.
                 return ("db", dbStatement, TransactionNameSource.Task);
@@ -244,21 +253,21 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
 
         // RPC span
         // https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/rpc/
-        if (attributes.ContainsKey("rpc.service"))
+        if (attributes.ContainsKey(SemanticConventions.AttributeRpcService))
         {
             return ("rpc", activity.DisplayName, TransactionNameSource.Route);
         }
 
         // Messaging span
         // https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/messaging/
-        if (attributes.ContainsKey("messaging.system"))
+        if (attributes.ContainsKey(SemanticConventions.AttributeMessagingSystem))
         {
             return ("message", activity.DisplayName, TransactionNameSource.Route);
         }
 
         // FaaS (Functions/Lambda) span
         // https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/faas/
-        if (attributes.TryGetTypedValue("faas.trigger", out string faasTrigger))
+        if (attributes.TryGetTypedValue(SemanticConventions.AttributeFaasTrigger, out string faasTrigger))
         {
             return (faasTrigger, activity.DisplayName, TransactionNameSource.Route);
         }

--- a/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
@@ -95,6 +95,10 @@ public class SentrySpanProcessorTests : ActivitySourceTests
             var grpcAttributes = new Dictionary<string, object> { ["rpc.grpc.status_code"] = 7 };
             SentrySpanProcessor.GetSpanStatus(ActivityStatusCode.Error, grpcAttributes)
                 .Should().Be(SpanStatus.PermissionDenied);
+
+            var errorAttributes = new Dictionary<string, object> { [SpanAttributeConstants.StatusCodeKey] = StatusTags.ErrorStatusCodeTagValue };
+            SentrySpanProcessor.GetSpanStatus(ActivityStatusCode.Ok, errorAttributes).Should().Be(SpanStatus.UnknownError);
+            SentrySpanProcessor.GetSpanStatus(ActivityStatusCode.Unset, errorAttributes).Should().Be(SpanStatus.UnknownError);
         }
     }
 


### PR DESCRIPTION
Fixes [#2514](https://github.com/getsentry/sentry-dotnet/issues/2514)

It's not perfect, as we don't have the full exception details available to us via the OpenTelemetry API... all we have is exception type, message and "stack trace"... although it's not really a stack trace - it's actually just `Exception.ToString()`. 

That might look something like this:
```csharp
Program+MyException: Attempted to divide by zero.
    ---> System.DivideByZeroException: Attempted to divide by zero.
    at Program.Main()
    --- End of inner exception stack trace ---
    at Program.Main()   
```

It could be more complicated in the case of an `AggregateException`. It might be possible to parse this into an exception graph that could be then be used in our `MainExceptionProcessor` to create one or more SentryExceptions. There would be no Debug info.

That all sounds like a lot of work though and it probably makes more sense to push to get the underlying [issue in the Otel codebase](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2439#issuecomment-1577314568) resolved instead. 

For the time being, we're just putting the **_stack trace_** provided by OpenTelemetry in an `otel.stack_trace` attribute that gets sent with the event for the exception. So people can see the stack trace provided by OpenTelemetry if they want. 