### PR TITLE
ref: Internal `IsTracingEnabled` to `IsPerformanceMonitoringEnabled`

### DIFF
--- a/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentryDiagnosticListenerIntegration.cs
+++ b/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentryDiagnosticListenerIntegration.cs
@@ -7,7 +7,7 @@ internal class SentryDiagnosticListenerIntegration : ISdkIntegration
 {
     public void Register(IHub hub, SentryOptions options)
     {
-        if (!options.IsTracingEnabled)
+        if (!options.IsPerformanceMonitoringEnabled)
         {
             options.Log(SentryLevel.Info, "DiagnosticSource Integration is disabled because tracing is disabled.");
             options.DisableDiagnosticSourceIntegration();

--- a/src/Sentry.EntityFramework/DbInterceptionIntegration.cs
+++ b/src/Sentry.EntityFramework/DbInterceptionIntegration.cs
@@ -9,7 +9,7 @@ internal class DbInterceptionIntegration : ISdkIntegration
 
     public void Register(IHub hub, SentryOptions options)
     {
-        if (!options.IsTracingEnabled)
+        if (!options.IsPerformanceMonitoringEnabled)
         {
             options.DiagnosticLogger?.LogInfo(SampleRateDisabledMessage);
         }

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -115,7 +115,7 @@ public static partial class SentrySdk
             }
 
             // These options we have behind feature flags
-            if (options is {IsTracingEnabled: true, Android.EnableAndroidSdkTracing: true})
+            if (options is {IsPerformanceMonitoringEnabled: true, Android.EnableAndroidSdkTracing: true})
             {
                 o.EnableTracing = (JavaBoolean?)options.EnableTracing;
                 o.TracesSampleRate = (JavaDouble?)options.TracesSampleRate;

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -69,7 +69,7 @@ public static partial class SentrySdk
         }
 
         // These options we have behind feature flags
-        if (options is {IsTracingEnabled: true, iOS.EnableCocoaSdkTracing: true})
+        if (options is {IsPerformanceMonitoringEnabled: true, iOS.EnableCocoaSdkTracing: true})
         {
             if (options.EnableTracing != null)
             {

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -716,7 +716,7 @@ public class SentryOptions
     public Dictionary<string, string> DefaultTags => _defaultTags ??= new Dictionary<string, string>();
 
     /// <summary>
-    /// Indicates whether tracing is enabled, via any combination of
+    /// Indicates whether the performance feature is enabled, via any combination of
     /// <see cref="EnableTracing"/>, <see cref="TracesSampleRate"/>, or <see cref="TracesSampler"/>.
     /// </summary>
     internal bool IsPerformanceMonitoringEnabled => EnableTracing switch

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -719,7 +719,7 @@ public class SentryOptions
     /// Indicates whether tracing is enabled, via any combination of
     /// <see cref="EnableTracing"/>, <see cref="TracesSampleRate"/>, or <see cref="TracesSampler"/>.
     /// </summary>
-    internal bool IsTracingEnabled => EnableTracing switch
+    internal bool IsPerformanceMonitoringEnabled => EnableTracing switch
     {
         false => false,
         null => TracesSampler is not null || TracesSampleRate is > 0.0,

--- a/test/Sentry.Tests/SentryOptionsTests.cs
+++ b/test/Sentry.Tests/SentryOptionsTests.cs
@@ -55,7 +55,7 @@ public class SentryOptionsTests
     public void IsTracingEnabled_Default_False()
     {
         var sut = new SentryOptions();
-        Assert.False(sut.IsTracingEnabled);
+        Assert.False(sut.IsPerformanceMonitoringEnabled);
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class SentryOptionsTests
             EnableTracing = true
         };
 
-        Assert.True(sut.IsTracingEnabled);
+        Assert.True(sut.IsPerformanceMonitoringEnabled);
     }
 
     [Fact]
@@ -77,7 +77,7 @@ public class SentryOptionsTests
             EnableTracing = false
         };
 
-        Assert.False(sut.IsTracingEnabled);
+        Assert.False(sut.IsPerformanceMonitoringEnabled);
     }
 
     [Fact]
@@ -88,7 +88,7 @@ public class SentryOptionsTests
             TracesSampleRate = 0.0
         };
 
-        Assert.False(sut.IsTracingEnabled);
+        Assert.False(sut.IsPerformanceMonitoringEnabled);
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public class SentryOptionsTests
             TracesSampleRate = double.Epsilon
         };
 
-        Assert.True(sut.IsTracingEnabled);
+        Assert.True(sut.IsPerformanceMonitoringEnabled);
     }
 
     [Fact]
@@ -126,7 +126,7 @@ public class SentryOptionsTests
             TracesSampler = _ => null
         };
 
-        Assert.True(sut.IsTracingEnabled);
+        Assert.True(sut.IsPerformanceMonitoringEnabled);
     }
 
     [Fact]
@@ -141,7 +141,7 @@ public class SentryOptionsTests
             TracesSampleRate = 0.0
         };
 
-        Assert.False(sut.IsTracingEnabled);
+        Assert.False(sut.IsPerformanceMonitoringEnabled);
     }
 
     [Fact]
@@ -156,7 +156,7 @@ public class SentryOptionsTests
             TracesSampleRate = 1.0
         };
 
-        Assert.False(sut.IsTracingEnabled);
+        Assert.False(sut.IsPerformanceMonitoringEnabled);
     }
 
     [Fact]
@@ -171,7 +171,7 @@ public class SentryOptionsTests
             TracesSampler = _ => null
         };
 
-        Assert.False(sut.IsTracingEnabled);
+        Assert.False(sut.IsPerformanceMonitoringEnabled);
     }
 
     [Fact]

--- a/test/Sentry.Tests/SentryOptionsTests.cs
+++ b/test/Sentry.Tests/SentryOptionsTests.cs
@@ -52,14 +52,14 @@ public class SentryOptionsTests
     }
 
     [Fact]
-    public void IsTracingEnabled_Default_False()
+    public void IsPerformanceMonitoringEnabled_Default_False()
     {
         var sut = new SentryOptions();
         Assert.False(sut.IsPerformanceMonitoringEnabled);
     }
 
     [Fact]
-    public void IsTracingEnabled_EnableTracing_True()
+    public void IsPerformanceMonitoringEnabled_EnableTracing_True()
     {
         var sut = new SentryOptions
         {
@@ -70,7 +70,7 @@ public class SentryOptionsTests
     }
 
     [Fact]
-    public void IsTracingEnabled_EnableTracing_False()
+    public void IsPerformanceMonitoringEnabled_EnableTracing_False()
     {
         var sut = new SentryOptions
         {
@@ -81,7 +81,7 @@ public class SentryOptionsTests
     }
 
     [Fact]
-    public void IsTracingEnabled_TracesSampleRate_Zero()
+    public void IsPerformanceMonitoringEnabled_TracesSampleRate_Zero()
     {
         var sut = new SentryOptions
         {
@@ -92,7 +92,7 @@ public class SentryOptionsTests
     }
 
     [Fact]
-    public void IsTracingEnabled_TracesSampleRate_GreaterThanZero()
+    public void IsPerformanceMonitoringEnabled_TracesSampleRate_GreaterThanZero()
     {
         var sut = new SentryOptions
         {
@@ -103,7 +103,7 @@ public class SentryOptionsTests
     }
 
     [Fact]
-    public void IsTracingEnabled_TracesSampleRate_LessThanZero()
+    public void IsPerformanceMonitoringEnabled_TracesSampleRate_LessThanZero()
     {
         var sut = new SentryOptions();
         Assert.Throws<ArgumentOutOfRangeException>(() =>
@@ -111,7 +111,7 @@ public class SentryOptionsTests
     }
 
     [Fact]
-    public void IsTracingEnabled_TracesSampleRate_GreaterThanOne()
+    public void IsPerformanceMonitoringEnabled_TracesSampleRate_GreaterThanOne()
     {
         var sut = new SentryOptions();
         Assert.Throws<ArgumentOutOfRangeException>(() =>
@@ -119,7 +119,7 @@ public class SentryOptionsTests
     }
 
     [Fact]
-    public void IsTracingEnabled_TracesSampler_Provided()
+    public void IsPerformanceMonitoringEnabled_TracesSampler_Provided()
     {
         var sut = new SentryOptions
         {
@@ -130,7 +130,7 @@ public class SentryOptionsTests
     }
 
     [Fact]
-    public void IsTracingEnabled_EnableTracing_True_TracesSampleRate_Zero()
+    public void IsPerformanceMonitoringEnabled_EnableTracing_True_TracesSampleRate_Zero()
     {
         // Edge Case:
         //   Tracing enabled, but sample rate set to zero, and no sampler function, should be treated as disabled.
@@ -145,7 +145,7 @@ public class SentryOptionsTests
     }
 
     [Fact]
-    public void IsTracingEnabled_EnableTracing_False_TracesSampleRate_One()
+    public void IsPerformanceMonitoringEnabled_EnableTracing_False_TracesSampleRate_One()
     {
         // Edge Case:
         //   Tracing disabled should be treated as disabled regardless of sample rate set.
@@ -160,7 +160,7 @@ public class SentryOptionsTests
     }
 
     [Fact]
-    public void IsTracingEnabled_EnableTracing_False_TracesSampler_Provided()
+    public void IsPerformanceMonitoringEnabled_EnableTracing_False_TracesSampler_Provided()
     {
         // Edge Case:
         //   Tracing disabled should be treated as disabled regardless of sampler function set.


### PR DESCRIPTION
With tracing without performance in the SDK this should start separating intentions.
#skip-changelog