### PR TITLE
fix: SDK retrieves `IEventProcessors` added as transient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- The SDK retrieves `IEventProcessors` added as a transient service during initialization ([#2537](https://github.com/getsentry/sentry-dotnet/pull/2537))
+
 ## 3.35.0
 
 ### Features

--- a/src/Sentry.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/ApplicationBuilderExtensions.cs
@@ -44,6 +44,15 @@ internal static class ApplicationBuilderExtensions
                 o.UseStackTraceFactory(stackTraceFactory);
             }
 
+            if (app.ApplicationServices.GetService<IEnumerable<ISentryEventProcessor>>()?.Any() == true)
+            {
+                o.AddEventProcessorProvider(app.ApplicationServices.GetServices<ISentryEventProcessor>);
+            }
+
+            if (app.ApplicationServices.GetService<IEnumerable<ISentryEventExceptionProcessor>>()?.Any() == true)
+            {
+                o.AddExceptionProcessorProvider(app.ApplicationServices.GetServices<ISentryEventExceptionProcessor>);
+            }
         }
 
         var lifetime = app.ApplicationServices.GetService<IHostApplicationLifetime>();

--- a/test/Sentry.AspNetCore.Tests/ApplicationBuilderExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/ApplicationBuilderExtensionsTests.cs
@@ -59,6 +59,17 @@ public class ApplicationBuilderExtensionsTests
     }
 
     [Fact]
+    public void UseSentry_SentryEventProcessor_AccessibleThroughSentryOptions()
+    {
+        var sut = _fixture.GetSut();
+
+        _ = sut.UseSentry();
+
+        Assert.Contains(_fixture.SentryAspNetCoreOptions.GetAllEventProcessors(),
+            actual => actual == _fixture.SentryEventProcessor);
+    }
+
+    [Fact]
     public void UseSentry_OriginalEventProcessor_StillAvailable()
     {
         var originalProviders = _fixture.SentryAspNetCoreOptions.EventProcessorsProviders;
@@ -69,6 +80,17 @@ public class ApplicationBuilderExtensionsTests
 
         var missing = originalProviders.Except(_fixture.SentryAspNetCoreOptions.EventProcessorsProviders);
         Assert.Empty(missing);
+    }
+
+    [Fact]
+    public void UseSentry_SentryEventExceptionProcessor_AccessibleThroughSentryOptions()
+    {
+        var sut = _fixture.GetSut();
+
+        _ = sut.UseSentry();
+
+        Assert.Contains(_fixture.SentryAspNetCoreOptions.GetAllExceptionProcessors(),
+            actual => actual == _fixture.SentryEventExceptionProcessor);
     }
 
     [Fact]


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/2529

With the changes to the `SentryMiddleware` in https://github.com/getsentry/sentry-dotnet/pull/1979/files the SDK no longer retrieves processors from the service.
Adding a custom processor like `.AddTransient<ISentryEventProcessor, MyEventProcessor>();` currently does not work.