### PR TITLE
fix: Setting `StartTime` in TransactionTracer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- The SDK no longer creates transactions with their start date set to `Jan 01, 001` ([#2544](https://github.com/getsentry/sentry-dotnet/pull/2544))
+
 ### Dependencies
 
 - Bump CLI from v2.20.4 to v2.20.5 ([#2539](https://github.com/getsentry/sentry-dotnet/pull/2539))

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -234,6 +234,7 @@ public class TransactionTracer : ITransaction, IHasDistribution, IHasTransaction
         Description = context.Description;
         Status = context.Status;
         IsSampled = context.IsSampled;
+        StartTimestamp = _stopwatch.StartDateTimeOffset;
 
 		if (context is TransactionContext transactionContext)
         {


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/2543
Setting the `StartTime` got lost in https://github.com/getsentry/sentry-dotnet/pull/2452/files