### PR TITLE
fix: skip intermediate source files

### DIFF
--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -30,6 +30,7 @@
     <Compile Include="..\..\modules\Ben.Demystifier\src\**\*.cs">
       <Link>%(RecursiveDir)\%(Filename)%(Extension)</Link>
     </Compile>
+    <Compile Remove="..\..\modules\Ben.Demystifier\**\obj\**" />
   </ItemGroup>
 
   <!-- Ben.Demystifier also needs System.Reflection.Metadata 5.0.0 or higher on all platforms. -->


### PR DESCRIPTION
Building the submodules result in those projects having `/obj/AssemblyInfo.cs` generated. The glob patterns in Sentry.csproj includes all sources, resulting in a broken build.

This ignores the `obj` folder so loading an IDE or simply directly projects in submodules won't break development

#skip-changelog