### PR TITLE
fix: idle transaction misleading diagnostic

### DIFF
--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -12,7 +12,7 @@ public class TransactionTracer : ITransaction, IHasDistribution, IHasTransaction
     private readonly IHub _hub;
     private readonly SentryOptions? _options;
     private readonly Timer? _idleTimer;
-    private long _idleTimerStopped;
+    private long _cancelIdleTimeout;
     private readonly SentryStopwatch _stopwatch = SentryStopwatch.StartNew();
     private readonly Instrumenter _instrumenter = Instrumenter.Sentry;
 
@@ -247,6 +247,7 @@ public class TransactionTracer : ITransaction, IHasDistribution, IHasTransaction
         // Set idle timer only if an idle timeout has been provided directly
         if (idleTimeout.HasValue)
         {
+            _cancelIdleTimeout = 1;  // Timer will be cancelled once, atomically setting this back to 0
             _idleTimer = new Timer(state =>
             {
                 if (state is not TransactionTracer transactionTracer)
@@ -288,8 +289,8 @@ public class TransactionTracer : ITransaction, IHasDistribution, IHasTransaction
         if (instrumenter != _instrumenter)
         {
             _options?.LogWarning(
-                $"Attempted to create a span via {instrumenter} instrumentation to a span or transaction" +
-                $" originating from {_instrumenter} instrumentation. The span will not be created.");
+                "Attempted to create a span via {0} instrumentation to a span or transaction" +
+                " originating from {1} instrumentation. The span will not be created.", instrumenter, _instrumenter);
             return NoOpSpan.Instance;
         }
 
@@ -318,10 +319,10 @@ public class TransactionTracer : ITransaction, IHasDistribution, IHasTransaction
     /// <inheritdoc />
     public void Finish()
     {
-        _options?.LogDebug($"Attempting to finish Transaction {SpanId}.");
-        if (Interlocked.Exchange(ref _idleTimerStopped, 1) == 0)
+        _options?.LogDebug("Attempting to finish Transaction {0}.", SpanId);
+        if (Interlocked.Exchange(ref _cancelIdleTimeout, 0) == 1)
         {
-            _options?.LogDebug($"Disposing of idle timer for Transaction {SpanId}.");
+            _options?.LogDebug("Disposing of idle timer for Transaction {0}.", SpanId);
             _idleTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
             _idleTimer?.Dispose();
         }
@@ -331,20 +332,20 @@ public class TransactionTracer : ITransaction, IHasDistribution, IHasTransaction
             // Normally we wouldn't start transactions for Sentry requests but when instrumenting with OpenTelemetry
             // we are only able to determine whether it's a sentry request or not when closing a span... we leave these
             // to be garbage collected and we don't want idle timers triggering on them
-            _options?.LogDebug($"Transaction {SpanId} is a Sentry Request. Don't complete.");
+            _options?.LogDebug("Transaction {0} is a Sentry Request. Don't complete.", SpanId);
             return;
         }
 
         TransactionProfiler?.Finish();
         Status ??= SpanStatus.Ok;
         EndTimestamp ??= _stopwatch.CurrentDateTimeOffset;
-        _options?.LogDebug($"Finished Transaction {SpanId}.");
+        _options?.LogDebug("Finished Transaction {0}.", SpanId);
 
         foreach (var span in _spans)
         {
             if (!span.IsFinished)
             {
-                _options?.LogDebug($"Deadline exceeded for Transaction {SpanId} -> Span {span.SpanId}.");
+                _options?.LogDebug("Deadline exceeded for Transaction {0} -> Span {1}.", SpanId, span.SpanId);
                 span.Finish(SpanStatus.DeadlineExceeded);
             }
         }


### PR DESCRIPTION
Running code without the use of idle transactions resulted in:

```
  Debug: De-queueing event
  Debug: Attempting to finish Transaction c085ab9d7b3e45a9.
  Debug: Disposing of idle timer for Transaction c085ab9d7b3e45a9.
  Debug: Profiling stopped on transaction finish.
  Debug: Finished Transaction c085ab9d7b3e45a9.
  Debug: Enqueuing envelope 3b14a5f4404f4dae9dce66893b6b6db3

```

It was confusing to see **idle timer** in the logs. Turns out no idle timer was used, but we're logging nonetheless. This fixes that.

Additionally, removes the use of interpolation on diagnostic logging in favor of the generic API and template to avoid boxing

#skip-changelog