### PR TITLE
fix: binding missing method

### DIFF
--- a/scripts/dirty-check.ps1
+++ b/scripts/dirty-check.ps1
@@ -1,13 +1,16 @@
 Set-StrictMode -Version Latest
 
+$pathToCheck = $args[0]
+
 $ErrorActionPreference = 'Stop'
 
 # Any value will be truthy in PS so if our check returns something, we've got tracked changes
-$changes = git status --untracked-files=no --porcelain
-Write-Output $changes
+$changes = git diff --name-only $pathToCheck
 if($changes){
-    Write-Error 'Git working directory is dirty' `
-    -CategoryActivity Error -ErrorAction Stop
+    Write-Output "Path: $pathToCheck"
+    Write-Output "Changes:`n$changes"
+    Write-Error 'Dirty files detected.' `
+        -CategoryActivity Error -ErrorAction Stop
 }
 else
 {

--- a/scripts/dirty-check.ps1
+++ b/scripts/dirty-check.ps1
@@ -1,0 +1,16 @@
+Set-StrictMode -Version Latest
+
+$ErrorActionPreference = 'Stop'
+
+# Any value will be truthy in PS so if our check returns something, we've got tracked changes
+$changes = git status --untracked-files=no --porcelain
+Write-Output $changes
+if($changes){
+    Write-Error 'Git working directory is dirty' `
+    -CategoryActivity Error -ErrorAction Stop
+}
+else
+{
+    Write-Output 'Working directory clean excluding untracked files'
+}
+

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -560,10 +560,6 @@ interface SentryFrame : SentrySerializable
     [NullAllowed, Export ("instructionAddress")]
     string InstructionAddress { get; set; }
 
-    // @property (nonatomic) NSUInteger instruction;
-    [Export ("instruction")]
-    nuint Instruction { get; set; }
-
     // @property (copy, nonatomic) NSNumber * _Nullable lineNumber;
     [NullAllowed, Export ("lineNumber", ArgumentSemantic.Copy)]
     NSNumber LineNumber { get; set; }
@@ -875,9 +871,9 @@ interface SentryOptions
     [Export ("enableMetricKit")]
     bool EnableMetricKit { get; set; }
 
-    // @property (nonatomic) BOOL enableTimeToFullDisplayTracing;
-    [Export ("enableTimeToFullDisplayTracing")]
-    bool EnableTimeToFullDisplayTracing { get; set; }
+    // @property (nonatomic) BOOL enableTimeToFullDisplay;
+    [Export ("enableTimeToFullDisplay")]
+    bool EnableTimeToFullDisplay { get; set; }
 
     // @property (assign, nonatomic) BOOL swiftAsyncStacktraces;
     [Export ("swiftAsyncStacktraces")]
@@ -2298,7 +2294,7 @@ interface SentryEnvelope
     SentryEnvelopeItem[] Items { get; }
 }
 
-// @interface SentryScreenFrames : NSObject <NSCopying>
+// @interface SentryScreenFrames : NSObject
 [BaseType (typeof(NSObject))]
 [DisableDefaultCtor]
 [Internal]
@@ -2396,17 +2392,6 @@ interface PrivateSentrySDKOnly
     [Static]
     [Export ("getExtraContext")]
     NSDictionary ExtraContext { get; }
-
-    // +(uint64_t)startProfilingForTrace:(SentryId * _Nonnull)traceId;
-    [Static]
-    [Export ("startProfilingForTrace:")]
-    ulong StartProfilingForTrace (SentryId traceId);
-
-    // +(NSDictionary<NSString *,id> * _Nullable)collectProfileForTrace:(SentryId * _Nonnull)traceId since:(uint64_t)startSystemTime;
-    [Static]
-    [Export ("collectProfileForTrace:since:")]
-    [return: NullAllowed]
-    NSDictionary<NSString, NSObject> CollectProfileForTrace (SentryId traceId, ulong startSystemTime);
 
     // @property (copy, nonatomic, class) SentryOnAppStartMeasurementAvailable _Nullable onAppStartMeasurementAvailable;
     [Static]

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -560,6 +560,10 @@ interface SentryFrame : SentrySerializable
     [NullAllowed, Export ("instructionAddress")]
     string InstructionAddress { get; set; }
 
+    // @property (nonatomic) NSUInteger instruction;
+    [Export ("instruction")]
+    nuint Instruction { get; set; }
+
     // @property (copy, nonatomic) NSNumber * _Nullable lineNumber;
     [NullAllowed, Export ("lineNumber", ArgumentSemantic.Copy)]
     NSNumber LineNumber { get; set; }
@@ -871,9 +875,9 @@ interface SentryOptions
     [Export ("enableMetricKit")]
     bool EnableMetricKit { get; set; }
 
-    // @property (nonatomic) BOOL enableTimeToFullDisplay;
-    [Export ("enableTimeToFullDisplay")]
-    bool EnableTimeToFullDisplay { get; set; }
+    // @property (nonatomic) BOOL enableTimeToFullDisplayTracing;
+    [Export ("enableTimeToFullDisplayTracing")]
+    bool EnableTimeToFullDisplayTracing { get; set; }
 
     // @property (assign, nonatomic) BOOL swiftAsyncStacktraces;
     [Export ("swiftAsyncStacktraces")]
@@ -2294,7 +2298,7 @@ interface SentryEnvelope
     SentryEnvelopeItem[] Items { get; }
 }
 
-// @interface SentryScreenFrames : NSObject
+// @interface SentryScreenFrames : NSObject <NSCopying>
 [BaseType (typeof(NSObject))]
 [DisableDefaultCtor]
 [Internal]
@@ -2392,6 +2396,17 @@ interface PrivateSentrySDKOnly
     [Static]
     [Export ("getExtraContext")]
     NSDictionary ExtraContext { get; }
+
+    // +(uint64_t)startProfilingForTrace:(SentryId * _Nonnull)traceId;
+    [Static]
+    [Export ("startProfilingForTrace:")]
+    ulong StartProfilingForTrace (SentryId traceId);
+
+    // +(NSDictionary<NSString *,id> * _Nullable)collectProfileForTrace:(SentryId * _Nonnull)traceId since:(uint64_t)startSystemTime;
+    [Static]
+    [Export ("collectProfileForTrace:since:")]
+    [return: NullAllowed]
+    NSDictionary<NSString, NSObject> CollectProfileForTrace (SentryId traceId, ulong startSystemTime);
 
     // @property (copy, nonatomic, class) SentryOnAppStartMeasurementAvailable _Nullable onAppStartMeasurementAvailable;
     [Static]

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -60,7 +60,7 @@
   </Target>
   <Target Name="_InnerGenerateSentryCocoaBindings">
     <Exec Command="pwsh ../../scripts/generate-cocoa-bindings.ps1" />
-    <Exec Command="pwsh ../../scripts/dirty-check.ps1" />
+    <Exec Condition="'$(GITHUB_ACTIONS)' == 'true'" Command="pwsh ../../scripts/dirty-check.ps1" />
   </Target>
 
   <!-- Workaround for https://github.com/xamarin/xamarin-macios/issues/15299 -->

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -54,12 +54,12 @@
   </Target>
 
   <!-- Generate bindings -->
-  <Target Name="_GenerateSentryCocoaBindings" AfterTargets="_BuildSentryCocoaSDK" Condition="$([MSBuild]::IsOSPlatform('OSX'))"
-    Inputs="..\..\modules\sentry-cocoa\Carthage\.built-from-sha" Outputs="ApiDefinitions.cs;StructsAndEnums.cs">
+  <Target Name="_GenerateSentryCocoaBindings" AfterTargets="_BuildSentryCocoaSDK" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="_InnerGenerateSentryCocoaBindings" Properties="TargetFramework=once" />
   </Target>
   <Target Name="_InnerGenerateSentryCocoaBindings">
     <Exec Command="pwsh ../../scripts/generate-cocoa-bindings.ps1" />
+    <!-- See https://github.com/getsentry/sentry-dotnet/pull/2558 -->
     <Exec Condition="'$(GITHUB_ACTIONS)' == 'true'" Command="pwsh ../../scripts/dirty-check.ps1" />
   </Target>
 

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -60,7 +60,7 @@
   <Target Name="_InnerGenerateSentryCocoaBindings">
     <Exec Command="pwsh ../../scripts/generate-cocoa-bindings.ps1" />
     <!-- See https://github.com/getsentry/sentry-dotnet/pull/2558 -->
-    <Exec Condition="'$(GITHUB_ACTIONS)' == 'true'" Command="pwsh ../../scripts/dirty-check.ps1" />
+    <Exec Condition="'$(GITHUB_ACTIONS)' == 'true'" Command="pwsh ../../scripts/dirty-check.ps1 $(MSBuildThisFileDirectory)" />
   </Target>
 
   <!-- Workaround for https://github.com/xamarin/xamarin-macios/issues/15299 -->

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -60,6 +60,7 @@
   </Target>
   <Target Name="_InnerGenerateSentryCocoaBindings">
     <Exec Command="pwsh ../../scripts/generate-cocoa-bindings.ps1" />
+    <Exec Command="pwsh ../../scripts/dirty-check.ps1" />
   </Target>
 
   <!-- Workaround for https://github.com/xamarin/xamarin-macios/issues/15299 -->


### PR DESCRIPTION
Latest release of the cocoa SDK has some API changes: https://github.com/getsentry/sentry-cocoa/pull/3194

It seems that our CI builds a new binding, but doesn't break if the world changes.

We need to pin the cocoa SDK version and make sure we re-run the binding generation code in the bump PR. And if building the binding project results in a dirty repository, we need to break the build.

#skip-changelog