### PR TITLE
Ignore EOL warnings on workloads

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,9 @@
     <Features>strict</Features>
     <ImplicitUsings>true</ImplicitUsings>
 
+    <!-- Ignore EOL warnings... we need to support old stuff -->
+    <CheckEolWorkloads>false</CheckEolWorkloads>
+
     <!-- Allow references to unsigned assemblies (like MAUI) from signed projects -->
     <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Our builds are littered with warnings like:
![image](https://github.com/getsentry/sentry-dotnet/assets/728212/5d9ecff7-55af-43a1-aad8-480666911f09)

Those are probably good warnings to have if you're building an application. Building a framework, we need to support old stuff so it's just noise really. This PR adds a build property to disable these warnings. 

#skip-changelog