### PR TITLE
feat: Added `AddAttachment` to the `Hint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- `Hints` now accept attachments provided as a file path via `AddAttachment` method ([#2585](https://github.com/getsentry/sentry-dotnet/pull/2585))
+
 ## 3.36.0
 
 ### Features

--- a/src/Sentry/Hint.cs
+++ b/src/Sentry/Hint.cs
@@ -6,14 +6,20 @@ namespace Sentry;
 /// </summary>
 public class Hint
 {
+    private readonly SentryOptions? _options;
     private readonly List<Attachment> _attachments = new();
     private readonly Dictionary<string, object?> _items = new();
 
     /// <summary>
     /// Creates a new instance of <see cref="Hint"/>.
     /// </summary>
-    public Hint()
+    public Hint() : this(SentrySdk.CurrentHub)
     {
+    }
+
+    internal Hint(IHub hub)
+    {
+        _options = hub.GetSentryOptions();
     }
 
     /// <summary>
@@ -26,13 +32,6 @@ public class Hint
     {
         _items[key] = value;
     }
-
-    /// <summary>
-    /// The Java SDK has some logic so that certain Hint types do not copy attachments from the Scope.
-    /// This provides a location that allows us to do the same in the .NET SDK in the future.
-    /// </summary>
-    /// <param name="scope">The <see cref="Scope"/> that the attachments should be copied from</param>
-    internal void AddAttachmentsFromScope(Scope scope) => _attachments.AddRange(scope.Attachments);
 
     /// <summary>
     /// Attachments added to the Hint.
@@ -51,6 +50,35 @@ public class Hint
     /// BeforeSend and others.
     /// </remarks>
     public IDictionary<string, object?> Items => _items;
+
+    /// <summary>
+    /// The Java SDK has some logic so that certain Hint types do not copy attachments from the Scope.
+    /// This provides a location that allows us to do the same in the .NET SDK in the future.
+    /// </summary>
+    /// <param name="scope">The <see cref="Scope"/> that the attachments should be copied from</param>
+    internal void AddAttachmentsFromScope(Scope scope) => _attachments.AddRange(scope.Attachments);
+
+    /// <summary>
+    /// Creates a new Hint with one or more attachments.
+    /// </summary>
+    /// <param name="filePath">The path to the file to attach.</param>
+    /// <param name="type">The type of attachment.</param>
+    /// <param name="contentType">The content type of the attachment.</param>
+    public void AddAttachment(
+        string filePath,
+        AttachmentType type = AttachmentType.Default,
+        string? contentType = null)
+    {
+        if (_options is not null)
+        {
+            _attachments.Add(
+                new Attachment(
+                    type,
+                    new FileAttachmentContent(filePath, _options.UseAsyncFileIO),
+                    Path.GetFileName(filePath),
+                    contentType));
+        }
+    }
 
     /// <summary>
     /// Creates a new Hint with one or more attachments.

--- a/src/Sentry/Hint.cs
+++ b/src/Sentry/Hint.cs
@@ -13,13 +13,13 @@ public class Hint
     /// <summary>
     /// Creates a new instance of <see cref="Hint"/>.
     /// </summary>
-    public Hint() : this(SentrySdk.CurrentHub)
+    public Hint() : this(SentrySdk.CurrentHub.GetSentryOptions())
     {
     }
 
-    internal Hint(IHub hub)
+    internal Hint(SentryOptions? options)
     {
-        _options = hub.GetSentryOptions();
+        _options = options;
     }
 
     /// <summary>

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -148,6 +148,7 @@ namespace Sentry
         public Hint(string key, object? value) { }
         public System.Collections.Generic.ICollection<Sentry.Attachment> Attachments { get; }
         public System.Collections.Generic.IDictionary<string, object?> Items { get; }
+        public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
         public static Sentry.Hint WithAttachments(params Sentry.Attachment[] attachments) { }
         public static Sentry.Hint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.Attachment> attachments) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -148,6 +148,7 @@ namespace Sentry
         public Hint(string key, object? value) { }
         public System.Collections.Generic.ICollection<Sentry.Attachment> Attachments { get; }
         public System.Collections.Generic.IDictionary<string, object?> Items { get; }
+        public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
         public static Sentry.Hint WithAttachments(params Sentry.Attachment[] attachments) { }
         public static Sentry.Hint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.Attachment> attachments) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -148,6 +148,7 @@ namespace Sentry
         public Hint(string key, object? value) { }
         public System.Collections.Generic.ICollection<Sentry.Attachment> Attachments { get; }
         public System.Collections.Generic.IDictionary<string, object?> Items { get; }
+        public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
         public static Sentry.Hint WithAttachments(params Sentry.Attachment[] attachments) { }
         public static Sentry.Hint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.Attachment> attachments) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -147,6 +147,7 @@ namespace Sentry
         public Hint(string key, object? value) { }
         public System.Collections.Generic.ICollection<Sentry.Attachment> Attachments { get; }
         public System.Collections.Generic.IDictionary<string, object?> Items { get; }
+        public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
         public static Sentry.Hint WithAttachments(params Sentry.Attachment[] attachments) { }
         public static Sentry.Hint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.Attachment> attachments) { }
     }

--- a/test/Sentry.Tests/HintTests.cs
+++ b/test/Sentry.Tests/HintTests.cs
@@ -19,7 +19,7 @@ public class HintTests : IDisposable
         File.Create(attachmentPath1);
         File.Create(attachmentPath2);
 
-        var hint = new Hint();
+        var hint = new Hint(new SentryOptions());
 
         // Act
         hint.AddAttachment(attachmentPath1);

--- a/test/Sentry.Tests/HintTests.cs
+++ b/test/Sentry.Tests/HintTests.cs
@@ -1,18 +1,29 @@
 namespace Sentry.Tests;
 
-public class HintTests
+public class HintTests : IDisposable
 {
+    private readonly string _testDirectory;
+
+    public HintTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_testDirectory);
+    }
+
     [Fact]
-    public void AddAttachments_WithAttachments_AddsToHint()
+    public void AddAttachment_AddsToHint()
     {
         // Arrange
+        var attachmentPath1 = Path.Combine(_testDirectory, Path.GetTempFileName());
+        var attachmentPath2 = Path.Combine(_testDirectory, Path.GetTempFileName());
+        File.Create(attachmentPath1);
+        File.Create(attachmentPath2);
+
         var hint = new Hint();
-        var attachment1 = AttachmentHelper.FakeAttachment("attachment1");
-        var attachment2 = AttachmentHelper.FakeAttachment("attachment2");
 
         // Act
-        hint.Attachments.Add(attachment1);
-        hint.Attachments.Add(attachment2);
+        hint.AddAttachment(attachmentPath1);
+        hint.AddAttachment(attachmentPath2);
 
         // Assert
         Assert.Equal(2, hint.Attachments.Count);
@@ -36,8 +47,8 @@ public class HintTests
     {
         // Arrange
         var hint = new Hint();
-        var attachment1 = AttachmentHelper.FakeAttachment("attachment1");
-        hint.Attachments.Add(attachment1);
+        var attachment1 = Path.Combine(_testDirectory, Path.GetTempFileName());
+        hint.AddAttachment(attachment1);
 
         // Act
         hint.Attachments.Clear();
@@ -145,4 +156,6 @@ public class HintTests
         hint.Attachments.Should().Contain(attachment1);
         hint.Attachments.Should().Contain(attachment2);
     }
+
+    public void Dispose() => Directory.Delete(_testDirectory, true);
 }


### PR DESCRIPTION
Resolves: https://github.com/getsentry/sentry-dotnet/issues/2549

Taken from the API we have on the scope to add an attachment. So instead of 
```
options.SetBeforeSend((@event, hint) =>
{
    hint.Attachments.Add(new Attachment(
        AttachmentType.Default,
        new FileAttachmentContent("<filepath>", true),
        Path.GetFileName("<filepath>"),
        null));
    return @event;
});
```

we can do 
```
options.SetBeforeSend((@event, hint) =>
{
    hint.AddAttachment("<filepath>");
    return @event;
});
```