### PR TITLE
fix: 

### DIFF
--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -216,8 +216,7 @@ internal class Hub : IHubEx, IDisposable
         }
 
         var propagationContext = ScopeManager.GetCurrent().Key.PropagationContext;
-        propagationContext.DynamicSamplingContext ??= propagationContext.CreateDynamicSamplingContext(_options);
-        return propagationContext.DynamicSamplingContext.ToBaggageHeader();
+        return propagationContext.GetDynamicSamplingContext(_options).ToBaggageHeader();
     }
 
     public TransactionContext ContinueTrace(
@@ -352,9 +351,7 @@ internal class Hub : IHubEx, IDisposable
         evt.Contexts.Trace.TraceId = propagationContext.TraceId;
         evt.Contexts.Trace.SpanId = propagationContext.SpanId;
         evt.Contexts.Trace.ParentSpanId = propagationContext.ParentSpanId;
-
-        propagationContext.DynamicSamplingContext ??= propagationContext.CreateDynamicSamplingContext(_options);
-        evt.DynamicSamplingContext = propagationContext.DynamicSamplingContext;
+        evt.DynamicSamplingContext = propagationContext.GetDynamicSamplingContext(_options);
     }
 
     public SentryId CaptureEvent(SentryEvent evt, Action<Scope> configureScope) =>

--- a/src/Sentry/SentryPropagationContext.cs
+++ b/src/Sentry/SentryPropagationContext.cs
@@ -10,7 +10,16 @@ internal class SentryPropagationContext
 
     internal DynamicSamplingContext? _dynamicSamplingContext;
 
-    public DynamicSamplingContext GetDynamicSamplingContext(SentryOptions options) => _dynamicSamplingContext ??= this.CreateDynamicSamplingContext(options);
+    public DynamicSamplingContext GetDynamicSamplingContext(SentryOptions options)
+    {
+        if (_dynamicSamplingContext is null)
+        {
+            options.LogDebug("Creating the Dynamic Sampling Context from the Propagation Context");
+            _dynamicSamplingContext = this.CreateDynamicSamplingContext(options);
+        }
+
+        return _dynamicSamplingContext;
+    }
 
     internal SentryPropagationContext(
         SentryId traceId,

--- a/src/Sentry/SentryPropagationContext.cs
+++ b/src/Sentry/SentryPropagationContext.cs
@@ -8,22 +8,9 @@ internal class SentryPropagationContext
     public SpanId SpanId { get; }
     public SpanId? ParentSpanId { get; }
 
-    private DynamicSamplingContext? _dynamicSamplingContext;
-    public DynamicSamplingContext? DynamicSamplingContext
-    {
-        get => _dynamicSamplingContext;
-        set
-        {
-            if (_dynamicSamplingContext is null)
-            {
-                _dynamicSamplingContext = value;
-            }
-            else
-            {
-                throw new Exception("Attempted to set the DynamicSamplingContext but the context exists already.");
-            }
-        }
-    }
+    internal DynamicSamplingContext? _dynamicSamplingContext;
+
+    public DynamicSamplingContext GetDynamicSamplingContext(SentryOptions options) => _dynamicSamplingContext ??= this.CreateDynamicSamplingContext(options);
 
     internal SentryPropagationContext(
         SentryId traceId,
@@ -33,7 +20,7 @@ internal class SentryPropagationContext
         TraceId = traceId;
         SpanId = SpanId.Create();
         ParentSpanId = parentSpanId;
-        DynamicSamplingContext = dynamicSamplingContext;
+        _dynamicSamplingContext = dynamicSamplingContext;
     }
 
     public SentryPropagationContext()

--- a/test/Sentry.Tests/SentryPropagationContextTests.cs
+++ b/test/Sentry.Tests/SentryPropagationContextTests.cs
@@ -3,7 +3,7 @@ namespace Sentry.Tests;
 public class SentryPropagationContextTests
 {
     [Fact]
-    public void CreateFromHeaders_TraceHeaderNullButBaggageExists_CreatesPropagationContextWithoutDynamicSamplingContext()
+    public void CreateFromHeaders_TraceHeaderNullButBaggageExists_CreatesNewPropagationContext()
     {
         var baggageHeader = BaggageHeader.Create(new List<KeyValuePair<string, string>>
         {
@@ -15,7 +15,7 @@ public class SentryPropagationContextTests
 
         var propagationContext = SentryPropagationContext.CreateFromHeaders(null, null, baggageHeader);
 
-        Assert.Null(propagationContext.DynamicSamplingContext);
+        Assert.Null(propagationContext._dynamicSamplingContext);
     }
 
     [Fact]
@@ -32,7 +32,6 @@ public class SentryPropagationContextTests
 
         var propagationContext = SentryPropagationContext.CreateFromHeaders(null, traceHeader, baggageHeader);
 
-        Assert.NotNull(propagationContext.DynamicSamplingContext);
-        Assert.Equal(4, propagationContext.DynamicSamplingContext.Items.Count);
+        Assert.Equal(4, propagationContext.GetDynamicSamplingContext(new SentryOptions()).Items.Count);
     }
 }

--- a/test/Sentry.Tests/SentryPropagationContextTests.cs
+++ b/test/Sentry.Tests/SentryPropagationContextTests.cs
@@ -3,7 +3,7 @@ namespace Sentry.Tests;
 public class SentryPropagationContextTests
 {
     [Fact]
-    public void CreateFromHeaders_TraceHeaderNullButBaggageExists_CreatesNewPropagationContext()
+    public void CreateFromHeaders_TraceHeaderNullButBaggageExists_CreatesPropagationContextWithoutDynamicSamplingContext()
     {
         var baggageHeader = BaggageHeader.Create(new List<KeyValuePair<string, string>>
         {


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/2591

I don't understand how it even gets there. The property is guarded by null-coalescing operators. But the SDK should not just throw regardless.

So now we have a getter that just creates the context in case it's `null`.