### PR TITLE
Configure Sentry tracing middleware automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added additional `DB` attributes to automatically generated spans like `name` and `provider` ([#2583](https://github.com/getsentry/sentry-dotnet/pull/2583))
 - `Hints` now accept attachments provided as a file path via `AddAttachment` method ([#2585](https://github.com/getsentry/sentry-dotnet/pull/2585))
+- Sentry tracing middleware now gets configured automatically ([#2602](https://github.com/getsentry/sentry-dotnet/pull/2602))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Sentry tracing middleware now gets configured automatically ([#2602](https://github.com/getsentry/sentry-dotnet/pull/2602))
+
 ### Dependencies
 
 - Bump CLI from v2.20.6 to v2.20.7 ([#2604](https://github.com/getsentry/sentry-dotnet/pull/2604))
@@ -14,7 +18,6 @@
 
 - Added additional `DB` attributes to automatically generated spans like `name` and `provider` ([#2583](https://github.com/getsentry/sentry-dotnet/pull/2583))
 - `Hints` now accept attachments provided as a file path via `AddAttachment` method ([#2585](https://github.com/getsentry/sentry-dotnet/pull/2585))
-- Sentry tracing middleware now gets configured automatically ([#2602](https://github.com/getsentry/sentry-dotnet/pull/2602))
 
 ### Fixes
 

--- a/Sentry.sln.DotSettings
+++ b/Sentry.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=instrumenter/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/samples/Sentry.Samples.AspNetCore.Basic/Program.cs
+++ b/samples/Sentry.Samples.AspNetCore.Basic/Program.cs
@@ -31,9 +31,6 @@ public class Program
             {
                 app.UseRouting();
 
-                // Enable Sentry performance monitoring
-                app.UseSentryTracing();
-
                 // An example ASP.NET Core middleware that throws an
                 // exception when serving a request to path: /throw
                 app.UseEndpoints(endpoints =>

--- a/samples/Sentry.Samples.AspNetCore.Blazor.Server/Program.cs
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Server/Program.cs
@@ -13,9 +13,6 @@ builder.WebHost.UseSentry(options =>
 
 var app = builder.Build();
 
-// Enable Sentry performance monitoring
-app.UseSentryTracing();
-
 app.UseHttpsRedirection();
 
 app.UseStaticFiles();

--- a/samples/Sentry.Samples.AspNetCore.Grpc/Startup.cs
+++ b/samples/Sentry.Samples.AspNetCore.Grpc/Startup.cs
@@ -19,7 +19,6 @@ public class Startup
         }
 
         app.UseRouting();
-        app.UseSentryTracing();
 
         app.UseEndpoints(endpoints =>
         {

--- a/samples/Sentry.Samples.AspNetCore.Mvc/Startup.cs
+++ b/samples/Sentry.Samples.AspNetCore.Mvc/Startup.cs
@@ -45,7 +45,6 @@ public class Startup
         app.UseStaticFiles();
 
         app.UseRouting();
-        app.UseSentryTracing();
 
         app.UseSentryTunneling();
 

--- a/src/Sentry.AspNetCore/SentryTracingBuilder.cs
+++ b/src/Sentry.AspNetCore/SentryTracingBuilder.cs
@@ -41,8 +41,8 @@ internal class SentryTracingBuilder : IApplicationBuilder
     {
         var builder = InnerBuilder.Use(middleware);
         return (Properties.ContainsKey(EndpointRouteBuilder) && !this.IsSentryTracingRegistered())
-            // UseRouting sets a property on the builder that we can to detect when UseRouting has been added... we then
-            // register SentryTracing immediately afterwards (the best place for it)
+            // UseRouting sets a property on the builder that we use to detect when UseRouting has been added and we
+            // register SentryTracing immediately afterwards
             // https://github.com/dotnet/aspnetcore/blob/8eaf4b51f73ae2b0ed079e4f8253afb53e96b703/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs#L58-L62
             ? builder.UseSentryTracing()
             : builder;

--- a/src/Sentry.AspNetCore/SentryTracingBuilder.cs
+++ b/src/Sentry.AspNetCore/SentryTracingBuilder.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Sentry.AspNetCore;
+
+/// <summary>
+/// Delegates/wraps the inner builder, so that we can intercept calls to <see cref="Use"/> and add our middleware
+/// </summary>
+internal class SentryTracingBuilder : IApplicationBuilder
+{
+    private const string EndpointRouteBuilder = "__EndpointRouteBuilder";
+    public SentryTracingBuilder(IApplicationBuilder inner)
+    {
+        InnerBuilder = inner;
+    }
+
+    private IApplicationBuilder InnerBuilder { get; }
+
+    /// <inheritdoc />
+    public IServiceProvider ApplicationServices
+    {
+        get => InnerBuilder.ApplicationServices;
+        set => InnerBuilder.ApplicationServices = value;
+    }
+
+    /// <inheritdoc />
+    public IDictionary<string, object?> Properties => InnerBuilder.Properties;
+
+    /// <inheritdoc />
+    public IFeatureCollection ServerFeatures => InnerBuilder.ServerFeatures;
+
+    /// <inheritdoc />
+    public RequestDelegate Build() => InnerBuilder.Build();
+
+    /// <inheritdoc />
+    public IApplicationBuilder New() => new SentryTracingBuilder(InnerBuilder.New());
+
+    /// <inheritdoc />
+    public IApplicationBuilder Use(Func<RequestDelegate, RequestDelegate> middleware)
+    {
+        var builder = InnerBuilder.Use(middleware);
+        return (Properties.ContainsKey(EndpointRouteBuilder) && !this.IsSentryTracingRegistered())
+            // UseRouting sets a property on the builder that we can to detect when UseRouting has been added... we then
+            // register SentryTracing immediately afterwards (the best place for it)
+            // https://github.com/dotnet/aspnetcore/blob/8eaf4b51f73ae2b0ed079e4f8253afb53e96b703/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs#L58-L62
+            ? builder.UseSentryTracing()
+            : builder;
+    }
+}

--- a/src/Sentry.AspNetCore/SentryTracingBuilder.cs
+++ b/src/Sentry.AspNetCore/SentryTracingBuilder.cs
@@ -1,6 +1,9 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Sentry.AspNetCore;
 
@@ -39,12 +42,20 @@ internal class SentryTracingBuilder : IApplicationBuilder
     /// <inheritdoc />
     public IApplicationBuilder Use(Func<RequestDelegate, RequestDelegate> middleware)
     {
-        var builder = InnerBuilder.Use(middleware);
-        return (Properties.ContainsKey(EndpointRouteBuilder) && !this.IsSentryTracingRegistered())
-            // UseRouting sets a property on the builder that we use to detect when UseRouting has been added and we
-            // register SentryTracing immediately afterwards
-            // https://github.com/dotnet/aspnetcore/blob/8eaf4b51f73ae2b0ed079e4f8253afb53e96b703/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs#L58-L62
-            ? builder.UseSentryTracing()
-            : builder;
+        // UseRouting sets a property on the builder that we use to detect when UseRouting has been added and we
+        // register SentryTracing immediately afterwards
+        // https://github.com/dotnet/aspnetcore/blob/8eaf4b51f73ae2b0ed079e4f8253afb53e96b703/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs#L58-L62
+        if (Properties.ContainsKey(EndpointRouteBuilder) && this.ShouldRegisterSentryTracing())
+        {
+            var options = InnerBuilder.ApplicationServices.GetService<IOptions<SentryAspNetCoreOptions>>();
+            var instrumenter = options?.Value.Instrumenter ?? Instrumenter.Sentry;
+            if (instrumenter == Instrumenter.Sentry)
+            {
+                return InnerBuilder.Use(middleware).UseSentryTracing();
+            }
+            this.StoreInstrumenter(instrumenter); // Saves us from having to resolve the options to make this check again
+        }
+
+        return InnerBuilder.Use(middleware);
     }
 }

--- a/src/Sentry.AspNetCore/SentryTracingMiddlewareExtensions.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddlewareExtensions.cs
@@ -9,12 +9,24 @@ namespace Microsoft.AspNetCore.Builder;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class SentryTracingMiddlewareExtensions
 {
+    private const string UseSentryTracingKey = "__UseSentryTracing";
+
+    internal static bool IsSentryTracingRegistered(this IApplicationBuilder builder)
+        => builder.Properties.ContainsKey(UseSentryTracingKey);
+
     /// <summary>
     /// Adds Sentry's tracing middleware to the pipeline.
     /// Make sure to place this middleware after <c>UseRouting(...)</c>.
     /// </summary>
     public static IApplicationBuilder UseSentryTracing(this IApplicationBuilder builder)
     {
+        // Don't register twice
+        if (builder.IsSentryTracingRegistered())
+        {
+            return builder;
+        }
+
+        builder.Properties[UseSentryTracingKey] = true;
         builder.UseMiddleware<SentryTracingMiddleware>();
         return builder;
     }

--- a/src/Sentry.AspNetCore/SentryTracingStartupFilter.cs
+++ b/src/Sentry.AspNetCore/SentryTracingStartupFilter.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Sentry.AspNetCore;
+
+internal class SentryTracingStartupFilter: IStartupFilter
+{
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+    {
+        return builder =>
+        {
+            var wrappedBuilder = new SentryTracingBuilder(builder);
+            next(wrappedBuilder);
+        };
+    }
+}

--- a/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
@@ -99,6 +99,7 @@ public static class SentryWebHostBuilderExtensions
 
         _ = builder.ConfigureServices(c => _ =
             c.AddTransient<IStartupFilter, SentryStartupFilter>()
+             .AddTransient<IStartupFilter, SentryTracingStartupFilter>()
              .AddTransient<SentryMiddleware>()
         );
 

--- a/test/Sentry.AspNetCore.Tests/SentryHttpMessageHandlerBuilderFilterTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryHttpMessageHandlerBuilderFilterTests.cs
@@ -57,7 +57,6 @@ public class SentryHttpMessageHandlerBuilderFilterTests
             .Configure(app =>
             {
                 app.UseRouting();
-                app.UseSentryTracing();
 
                 app.UseEndpoints(routes =>
                 {

--- a/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
@@ -33,7 +33,6 @@ public class SentryTracingMiddlewareTests
             .Configure(app =>
             {
                 app.UseRouting();
-                app.UseSentryTracing();
 
                 app.UseEndpoints(routes =>
                 {
@@ -83,7 +82,6 @@ public class SentryTracingMiddlewareTests
             .Configure(app =>
             {
                 app.UseRouting();
-                app.UseSentryTracing();
 
                 app.UseEndpoints(routes =>
                 {
@@ -127,7 +125,6 @@ public class SentryTracingMiddlewareTests
             .Configure(app =>
             {
                 app.UseRouting();
-                app.UseSentryTracing();
 
                 app.UseEndpoints(routes => routes.Map("/person/{id}", _ => Task.CompletedTask));
             }));
@@ -193,7 +190,6 @@ public class SentryTracingMiddlewareTests
             .Configure(app =>
             {
                 app.UseRouting();
-                app.UseSentryTracing();
 
                 app.UseEndpoints(routes => routes.Map("/person/{id}", async _ =>
                 {
@@ -299,7 +295,6 @@ public class SentryTracingMiddlewareTests
             .Configure(app =>
             {
                 app.UseRouting();
-                app.UseSentryTracing();
 
                 app.UseEndpoints(routes => routes.Map("/person/{id}", async _ =>
                 {
@@ -363,7 +358,6 @@ public class SentryTracingMiddlewareTests
             .Configure(app =>
             {
                 app.UseRouting();
-                app.UseSentryTracing();
 
                 app.UseEndpoints(routes =>
                 {
@@ -417,7 +411,6 @@ public class SentryTracingMiddlewareTests
             .Configure(app =>
             {
                 app.UseRouting();
-                app.UseSentryTracing();
 
                 app.UseEndpoints(routes =>
                 {
@@ -475,7 +468,6 @@ public class SentryTracingMiddlewareTests
             .Configure(app =>
             {
                 app.UseRouting();
-                app.UseSentryTracing();
 
                 app.UseEndpoints(routes => routes.Map("/person/{id}", context =>
                 {
@@ -522,7 +514,8 @@ public class SentryTracingMiddlewareTests
             })
             .Configure(app =>
             {
-                app.UseRouting();
+                // We have to do this before routing, otherwise it won't wrap our SentryTracingMiddleware, which is what
+                // binds the ExceptionToSpanMap
                 app.Use(async (_, c) =>
                 {
                     try
@@ -534,7 +527,7 @@ public class SentryTracingMiddlewareTests
                         // We just want to know if it got into Sentry's Hub
                     }
                 });
-                app.UseSentryTracing();
+                app.UseRouting();
 
                 app.UseEndpoints(routes => routes.Map("/person/{id}", _ => throw exception));
             }));

--- a/test/Sentry.AspNetCore.Tests/WebIntegrationTests.verify.cs
+++ b/test/Sentry.AspNetCore.Tests/WebIntegrationTests.verify.cs
@@ -52,7 +52,6 @@ public class WebIntegrationTests
                 .Configure(app =>
                 {
                     app.UseRouting();
-                    app.UseSentryTracing();
                     app.UseEndpoints(routeBuilder => routeBuilder.MapControllers());
                 }));
 
@@ -119,7 +118,6 @@ public class WebIntegrationTests
                 .Configure(app =>
                 {
                     app.UseRouting();
-                    app.UseSentryTracing();
                     app.UseCors();
                     app.UseEndpoints(_ => _.MapControllers());
                 }));


### PR DESCRIPTION
Addresses [Sentry tracing middleware should be added automatically #2202](https://github.com/getsentry/sentry-dotnet/issues/2202).

With this PR, it's almost never necessary for SDK users to call `UseSentryTracing` anymore, which will hopefully make it way easier for SDK users to get started with Sentry Tracing.

## Approach

We've used a much simpler variant of Andrew Lock's solution:
- We register `SentryTracingStartupFilter` as a `IStartupFilter`
  - That filter wraps the `IApplicationBuilder` in a `SentryTracingBuilder` so that we can intercept all of the calls to `builder.Use<T>`
- On each call to `Use<T>` our custom builder checks to see if the `__EndpointRouteBuilder` property has been set on the builder... which is a marker for `UseRouting`. As soon as that property is set, we know `UseRouting` has been called and we can then register our tracing middleware
- One other thing we do, before registering the middleware, is check that `SentryAspNetCoreOptions.Instrumenter == Instrumeter.Sentry`. If not, we don't register the tracing middleware... this would happen if folks were using OpenTelemetry rather than Sentry to auto-instrument their AspNET Core applications. 

## Caveats

[Sentry.Google.Cloud.Functions](https://github.com/getsentry/sentry-dotnet/blob/3554dabf6f9b0cc79ac6b8f0f5984c057de7a80d/src/Sentry.Google.Cloud.Functions/SentryStartup.cs#L85) is one of the few places I saw where I think users would still need to make the call to UseSentryTracing. There might be some other outlier scenarios like that but for the bulk of users, using vanilla ASP.NET Core, the developer experience should be way less complicated. 