### PR TITLE
Added Sentry.AspNet.csproj back to Sentry-CI-Build-macOS.slnf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Added Sentry.AspNet.csproj back to Sentry-CI-Build-macOS.slnf ([#2612](https://github.com/getsentry/sentry-dotnet/pull/2612))
+
 ## 3.39.0
 
 ### Features

--- a/Sentry-CI-Build-macOS.slnf
+++ b/Sentry-CI-Build-macOS.slnf
@@ -31,6 +31,7 @@
       "samples\\Sentry.Samples.OpenTelemetry.Console\\Sentry.Samples.OpenTelemetry.Console.csproj",
       "samples\\Sentry.Samples.Serilog\\Sentry.Samples.Serilog.csproj",
       "src\\Sentry.Android.AssemblyReader\\Sentry.Android.AssemblyReader.csproj",
+      "src\\Sentry.AspNet\\Sentry.AspNet.csproj",
       "src\\Sentry.AspNetCore.Grpc\\Sentry.AspNetCore.Grpc.csproj",
       "src\\Sentry.AspNetCore\\Sentry.AspNetCore.csproj",
       "src\\Sentry.AzureFunctions.Worker\\Sentry.AzureFunctions.Worker.csproj",

--- a/scripts/generate-solution-filters-config.yaml
+++ b/scripts/generate-solution-filters-config.yaml
@@ -48,8 +48,6 @@ filterConfigs:
         - "modules/perfview/**/TraceEvent.csproj"
         - "modules/perfview/**/FastSerialization.csproj"
     exclude:
-      groups:
-        - "windowsOnly"
       patterns:
         - "**/*AndroidTestApp.csproj"
         - "**/*DeviceTests*.csproj"


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/2610