### PR TITLE
Fixes: Identifying Users with OpenTelemetry doesn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- Identifying Users with OpenTelemetry doesn't work ([#2618](https://github.com/getsentry/sentry-dotnet/pull/2618))
+- Resolved issue identifying users with OpenTelemetry ([#2618](https://github.com/getsentry/sentry-dotnet/pull/2618))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@
 
 - Sentry tracing middleware now gets configured automatically ([#2602](https://github.com/getsentry/sentry-dotnet/pull/2602))
 
+### Fixes
+
+- Identifying Users with OpenTelemetry doesn't work ([#2618](https://github.com/getsentry/sentry-dotnet/pull/2618))
+
 ### Dependencies
 
 - Bump CLI from v2.20.6 to v2.20.7 ([#2604](https://github.com/getsentry/sentry-dotnet/pull/2604))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2207)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.20.6...2.20.7)
+
 ## 3.39.1
 
 ### Fixes

--- a/Sentry.sln.DotSettings
+++ b/Sentry.sln.DotSettings
@@ -1,2 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=enrichers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=instrumenter/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/samples/Sentry.Samples.OpenTelemetry.AspNetCore/FakeAuthHandler.cs
+++ b/samples/Sentry.Samples.OpenTelemetry.AspNetCore/FakeAuthHandler.cs
@@ -1,0 +1,38 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace Sentry.Samples.OpenTelemetry.AspNetCore;
+
+public class FakeAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string UserId = "UserId";
+
+    public const string AuthenticationScheme = "Test";
+
+    public FakeAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        ISystemClock clock) : base(options, logger, encoder, clock)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.Name, "Fake user"),
+            new(ClaimTypes.NameIdentifier, "fake-user")
+        };
+
+        var identity = new ClaimsIdentity(claims, AuthenticationScheme);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, AuthenticationScheme);
+
+        var result = AuthenticateResult.Success(ticket);
+
+        return Task.FromResult(result);
+    }
+}

--- a/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Properties/launchSettings.json
+++ b/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Properties/launchSettings.json
@@ -1,11 +1,11 @@
 ﻿{
   "profiles": {
-    "http": {
+    "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "hello",
-      "applicationUrl": "http://localhost:5092",
+      "applicationUrl": "https://localhost:5092",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Sentry.AspNetCore/DefaultUserFactory.cs
+++ b/src/Sentry.AspNetCore/DefaultUserFactory.cs
@@ -2,7 +2,9 @@ using Microsoft.AspNetCore.Http;
 
 namespace Sentry.AspNetCore;
 
+#pragma warning disable CS0618
 internal class DefaultUserFactory : IUserFactory, ISentryUserFactory
+#pragma warning restore CS0618
 {
     private readonly IHttpContextAccessor? _httpContextAccessor;
 

--- a/src/Sentry.AspNetCore/DefaultUserFactory.cs
+++ b/src/Sentry.AspNetCore/DefaultUserFactory.cs
@@ -2,8 +2,21 @@ using Microsoft.AspNetCore.Http;
 
 namespace Sentry.AspNetCore;
 
-internal class DefaultUserFactory : IUserFactory
+internal class DefaultUserFactory : IUserFactory, ISentryUserFactory
 {
+    private readonly IHttpContextAccessor? _httpContextAccessor;
+
+    public DefaultUserFactory()
+    {
+    }
+
+    public DefaultUserFactory(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public User? Create() => _httpContextAccessor?.HttpContext is {} httpContext ? Create(httpContext) : null;
+
     public User? Create(HttpContext context)
     {
         var principal = context.User;

--- a/src/Sentry.AspNetCore/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
@@ -23,7 +23,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISentryEventExceptionProcessor, AspNetCoreExceptionProcessor>();
 
         services.AddHttpContextAccessor();
+#pragma warning disable CS0618
         services.TryAddSingleton<IUserFactory, DefaultUserFactory>();
+#pragma warning restore CS0618
         services.TryAddSingleton<ISentryUserFactory, DefaultUserFactory>();
 
         services

--- a/src/Sentry.AspNetCore/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Sentry;
 using Sentry.AspNetCore;
 using Sentry.Extensibility;
 using Sentry.Extensions.Logging.Extensions.DependencyInjection;
@@ -20,7 +21,10 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton<ISentryEventProcessor, AspNetCoreEventProcessor>();
         services.AddSingleton<ISentryEventExceptionProcessor, AspNetCoreExceptionProcessor>();
+
+        services.AddHttpContextAccessor();
         services.TryAddSingleton<IUserFactory, DefaultUserFactory>();
+        services.TryAddSingleton<ISentryUserFactory, DefaultUserFactory>();
 
         services
             .AddSingleton<IRequestPayloadExtractor, FormRequestPayloadExtractor>()

--- a/src/Sentry.AspNetCore/IUserFactory.cs
+++ b/src/Sentry.AspNetCore/IUserFactory.cs
@@ -3,7 +3,13 @@ using Microsoft.AspNetCore.Http;
 namespace Sentry.AspNetCore;
 
 /// <summary>
+/// <para>
 /// Sentry User Factory
+/// </para>
+/// <para>
+/// Note: This interface is tightly coupled to AspNetCore and Will be removed in version 4.0.0. Please consider using
+/// <see cref="ISentryUserFactory"/> with <see cref="IHttpContextAccessor"/> instead.
+/// </para>
 /// </summary>
 public interface IUserFactory
 {

--- a/src/Sentry.AspNetCore/IUserFactory.cs
+++ b/src/Sentry.AspNetCore/IUserFactory.cs
@@ -3,14 +3,9 @@ using Microsoft.AspNetCore.Http;
 namespace Sentry.AspNetCore;
 
 /// <summary>
-/// <para>
 /// Sentry User Factory
-/// </para>
-/// <para>
-/// Note: This interface is tightly coupled to AspNetCore and Will be removed in version 4.0.0. Please consider using
-/// <see cref="ISentryUserFactory"/> with <see cref="IHttpContextAccessor"/> instead.
-/// </para>
 /// </summary>
+[Obsolete("This interface is tightly coupled to AspNetCore and will be removed in version 4.0.0. Please consider using ISentryUserFactory with IHttpContextAccessor instead.")]
 public interface IUserFactory
 {
     /// <summary>

--- a/src/Sentry.AspNetCore/ScopeExtensions.cs
+++ b/src/Sentry.AspNetCore/ScopeExtensions.cs
@@ -38,8 +38,10 @@ public static class ScopeExtensions
 
         if (options.SendDefaultPii && !scope.HasUser())
         {
+#pragma warning disable CS0618
             var userFactory = context.RequestServices.GetService<IUserFactory>();
             var user = userFactory?.Create(context);
+#pragma warning restore CS0618
 
             if (user != null)
             {

--- a/src/Sentry.OpenTelemetry/AspNetCoreEnricher.cs
+++ b/src/Sentry.OpenTelemetry/AspNetCoreEnricher.cs
@@ -1,0 +1,26 @@
+﻿namespace Sentry.OpenTelemetry;
+
+internal class AspNetCoreEnricher : IOpenTelemetryEnricher
+{
+    private readonly ISentryUserFactory _userFactory;
+
+    internal AspNetCoreEnricher(ISentryUserFactory userFactory)
+    {
+        _userFactory = userFactory;
+    }
+
+    public void Enrich(ISpan span, Activity activity, IHub hub, SentryOptions? options)
+    {
+        var sendPii = options?.SendDefaultPii ?? false;
+        if (sendPii)
+        {
+            hub.ConfigureScope(scope =>
+            {
+                if (!scope.HasUser() && _userFactory.Create() is {} user)
+                {
+                    scope.User = user;
+                }
+            });
+        }
+    }
+}

--- a/src/Sentry.OpenTelemetry/AspNetCoreEnricher.cs
+++ b/src/Sentry.OpenTelemetry/AspNetCoreEnricher.cs
@@ -11,8 +11,7 @@ internal class AspNetCoreEnricher : IOpenTelemetryEnricher
 
     public void Enrich(ISpan span, Activity activity, IHub hub, SentryOptions? options)
     {
-        var sendPii = options?.SendDefaultPii ?? false;
-        if (sendPii)
+        if (options?.SendDefaultPii is true)
         {
             hub.ConfigureScope(scope =>
             {

--- a/src/Sentry.OpenTelemetry/AspNetCoreEnricher.cs
+++ b/src/Sentry.OpenTelemetry/AspNetCoreEnricher.cs
@@ -4,10 +4,7 @@ internal class AspNetCoreEnricher : IOpenTelemetryEnricher
 {
     private readonly ISentryUserFactory _userFactory;
 
-    internal AspNetCoreEnricher(ISentryUserFactory userFactory)
-    {
-        _userFactory = userFactory;
-    }
+    internal AspNetCoreEnricher(ISentryUserFactory userFactory) => _userFactory = userFactory;
 
     public void Enrich(ISpan span, Activity activity, IHub hub, SentryOptions? options)
     {

--- a/src/Sentry.OpenTelemetry/IOpenTelemetryEnricher.cs
+++ b/src/Sentry.OpenTelemetry/IOpenTelemetryEnricher.cs
@@ -1,0 +1,6 @@
+namespace Sentry.OpenTelemetry;
+
+internal interface IOpenTelemetryEnricher
+{
+    void Enrich(ISpan span, Activity activity, IHub hub, SentryOptions? options);
+}

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -1,6 +1,7 @@
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 using Sentry.Extensibility;
+using Sentry.Internal;
 using Sentry.Internal.Extensions;
 
 namespace Sentry.OpenTelemetry;
@@ -11,6 +12,7 @@ namespace Sentry.OpenTelemetry;
 public class SentrySpanProcessor : BaseProcessor<Activity>
 {
     private readonly IHub _hub;
+    private readonly IEnumerable<IOpenTelemetryEnricher> _enrichers;
 
     // ReSharper disable once MemberCanBePrivate.Global - Used by tests
     internal readonly ConcurrentDictionary<ActivitySpanId, ISpan> _map = new();
@@ -27,9 +29,14 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
     /// <summary>
     /// Constructs a <see cref="SentrySpanProcessor"/>.
     /// </summary>
-    public SentrySpanProcessor(IHub hub)
+    public SentrySpanProcessor(IHub hub) : this(hub, null)
+    {
+    }
+
+    internal SentrySpanProcessor(IHub hub, List<IOpenTelemetryEnricher>? enrichers)
     {
         _hub = hub;
+        _enrichers = enrichers ?? Enumerable.Empty<IOpenTelemetryEnricher>();
         _options = hub.GetSentryOptions();
 
         if (_options is not { })
@@ -165,6 +172,10 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
         GenerateSentryErrorsFromOtelSpan(data, attributes);
 
         var status = GetSpanStatus(data.Status, attributes);
+        foreach (var enricher in _enrichers)
+        {
+            enricher.Enrich(span, data, _hub, _options);
+        }
         span.Finish(status);
 
         _map.TryRemove(data.SpanId, out _);

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -33,7 +33,7 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
     {
     }
 
-    internal SentrySpanProcessor(IHub hub, List<IOpenTelemetryEnricher>? enrichers)
+    internal SentrySpanProcessor(IHub hub, IEnumerable<IOpenTelemetryEnricher>? enrichers)
     {
         _hub = hub;
         _enrichers = enrichers ?? Enumerable.Empty<IOpenTelemetryEnricher>();

--- a/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -36,7 +36,7 @@ public static class TracerProviderBuilderExtensions
 
             // AspNetCoreEnricher
             var userFactory = services.GetService<ISentryUserFactory>();
-            if (userFactory != null)
+            if (userFactory is not null)
             {
                 enrichers.Add(new AspNetCoreEnricher(userFactory));
             }

--- a/src/Sentry/ISentryUserFactory.cs
+++ b/src/Sentry/ISentryUserFactory.cs
@@ -1,0 +1,6 @@
+namespace Sentry;
+
+internal interface ISentryUserFactory
+{
+    public User? Create();
+}

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -152,7 +152,6 @@
     <InternalsVisibleTo Include="Sentry.NLog" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.NLog.Tests" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.OpenTelemetry" PublicKey="$(SentryPublicKey)" />
-    <InternalsVisibleTo Include="Sentry.OpenTelemetry.AspNetCore" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.OpenTelemetry.Tests" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.Profiling" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.Profiling.Tests" PublicKey="$(SentryPublicKey)" />

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -32,6 +32,9 @@ namespace Sentry.AspNetCore
     {
         Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
     }
+    [System.Obsolete("This interface is tightly coupled to AspNetCore and will be removed in version 4." +
+        "0.0. Please consider using ISentryUserFactory with IHttpContextAccessor instead." +
+        "")]
     public interface IUserFactory
     {
         Sentry.User? Create(Microsoft.AspNetCore.Http.HttpContext context);

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -32,6 +32,9 @@ namespace Sentry.AspNetCore
     {
         Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
     }
+    [System.Obsolete("This interface is tightly coupled to AspNetCore and will be removed in version 4." +
+        "0.0. Please consider using ISentryUserFactory with IHttpContextAccessor instead." +
+        "")]
     public interface IUserFactory
     {
         Sentry.User? Create(Microsoft.AspNetCore.Http.HttpContext context);

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -32,6 +32,9 @@ namespace Sentry.AspNetCore
     {
         Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
     }
+    [System.Obsolete("This interface is tightly coupled to AspNetCore and will be removed in version 4." +
+        "0.0. Please consider using ISentryUserFactory with IHttpContextAccessor instead." +
+        "")]
     public interface IUserFactory
     {
         Sentry.User? Create(Microsoft.AspNetCore.Http.HttpContext context);

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -32,6 +32,9 @@ namespace Sentry.AspNetCore
     {
         Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
     }
+    [System.Obsolete("This interface is tightly coupled to AspNetCore and will be removed in version 4." +
+        "0.0. Please consider using ISentryUserFactory with IHttpContextAccessor instead." +
+        "")]
     public interface IUserFactory
     {
         Sentry.User? Create(Microsoft.AspNetCore.Http.HttpContext context);

--- a/test/Sentry.AspNetCore.Tests/DefaultUserFactoryTests.cs
+++ b/test/Sentry.AspNetCore.Tests/DefaultUserFactoryTests.cs
@@ -86,6 +86,16 @@ public class DefaultUserFactoryTests
     }
 
     [Fact]
+    public void Create_ContextAccessorNoClaims_IpAddress()
+    {
+        _ = HttpContext.User.Claims.Returns(Enumerable.Empty<Claim>());
+        var contextAccessor = Substitute.For<IHttpContextAccessor>();
+        contextAccessor.HttpContext.Returns(HttpContext);
+        var actual = new DefaultUserFactory(contextAccessor).Create();
+        Assert.Equal(IPAddress.IPv6Loopback.ToString(), actual?.IpAddress);
+    }
+
+    [Fact]
     public void Create_ClaimNameAndIdentityDontMatch_UsernameFromIdentity()
     {
         const string expected = "App configured to read it from a different claim";

--- a/test/Sentry.AspNetCore.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/ServiceCollectionExtensionsTests.cs
@@ -68,6 +68,7 @@ public class ServiceCollectionExtensionsTests
         Assert.Same(typeof(DefaultRequestPayloadExtractor), last.ImplementationType);
     }
 
+#pragma warning disable CS0618
     [Fact]
     public void AddSentry_DefaultUserFactory_Registered()
     {
@@ -75,4 +76,5 @@ public class ServiceCollectionExtensionsTests
         _sut.Received().Add(Arg.Is<ServiceDescriptor>(d => d.ServiceType == typeof(IUserFactory)
                                                            && d.ImplementationType == typeof(DefaultUserFactory)));
     }
+#pragma warning restore CS0618
 }

--- a/test/Sentry.OpenTelemetry.Tests/AspNetCoreEnricherTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/AspNetCoreEnricherTests.cs
@@ -1,0 +1,48 @@
+namespace Sentry.OpenTelemetry.Tests;
+
+public class AspNetCoreEnricherTests
+{
+    [Fact]
+    public void Enrich_SendDefaultPii_UserOnScope()
+    {
+        // Arrange
+        var scope = new Scope();
+        var options = new SentryOptions { SendDefaultPii = true };
+        var hub = Substitute.For<IHub>();
+        hub.ConfigureScope(Arg.Do<Action<Scope>>(action => action(scope)));
+
+        var user = new User{ Id = "foo" };
+        var userFactory = Substitute.For<ISentryUserFactory>();
+        userFactory.Create().Returns(user);
+
+        var enricher = new AspNetCoreEnricher(userFactory);
+
+        // Act
+        enricher.Enrich(null!, null!, hub, options);
+
+        // Assert
+        scope.HasUser().Should().BeTrue();
+        scope.User.Should().Be(user);
+    }
+
+    [Fact]
+    public void Enrich_SendDefaultPiiFalse_NoUserOnScope()
+    {
+        // Arrange
+        var scope = new Scope();
+        var originalUser = scope.User;
+        var options = new SentryOptions { SendDefaultPii = false };
+        var hub = Substitute.For<IHub>();
+        hub.ConfigureScope(Arg.Do<Action<Scope>>(action => action(scope)));
+
+        var userFactory = Substitute.For<ISentryUserFactory>();
+        var enricher = new AspNetCoreEnricher(userFactory);
+
+        // Act
+        enricher.Enrich(null!, null!, hub, options);
+
+        // Assert
+        scope.HasUser().Should().BeFalse();
+        scope.User.Should().Be(originalUser);
+    }
+}

--- a/test/Sentry.OpenTelemetry.Tests/Sentry.OpenTelemetry.Tests.csproj
+++ b/test/Sentry.OpenTelemetry.Tests/Sentry.OpenTelemetry.Tests.csproj
@@ -11,14 +11,12 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <!-- Use the netcoreapp3.1 target to test netstandard2.0 -->
-    <ProjectReference Include="..\..\src\Sentry.OpenTelemetry\Sentry.OpenTelemetry.csproj"
-                      AdditionalProperties="TargetFramework=netstandard2.0" />
+    <ProjectReference Include="..\..\src\Sentry.OpenTelemetry\Sentry.OpenTelemetry.csproj" AdditionalProperties="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <!-- Use the net6.0 target to test netstandard2.1 -->
-    <ProjectReference Include="..\..\src\Sentry.OpenTelemetry\Sentry.OpenTelemetry.csproj"
-                      AdditionalProperties="TargetFramework=netstandard2.1" />
+    <ProjectReference Include="..\..\src\Sentry.OpenTelemetry\Sentry.OpenTelemetry.csproj" AdditionalProperties="TargetFramework=netstandard2.1" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' and '$(TargetFramework)' != 'net6.0'">


### PR DESCRIPTION
Fixes [Identifying Users with OpenTelemetry doesn't work #2616](https://github.com/getsentry/sentry-dotnet/issues/2616).

### Key implementation details
- The addition of: https://github.com/getsentry/sentry-dotnet/blob/ad6968c04ecdc2775692dddf48852da7090aef2b/src/Sentry.AspNetCore/Extensions/DependencyInjection/ServiceCollectionExtensions.cs#L25
- Added `ISentryUserFactory` to the `DefaultUserFactory` (eventually this should replace `IUserFactory`). This enables us to get the user data _without having to add any dependencies_ to the `Sentry.OpenTelemetry` package. See: https://github.com/getsentry/sentry-dotnet/blob/ad6968c04ecdc2775692dddf48852da7090aef2b/src/Sentry.AspNetCore/IUserFactory.cs#L10-L11
- Introduced an `AspNetCoreEnricher`: https://github.com/getsentry/sentry-dotnet/blob/ad6968c04ecdc2775692dddf48852da7090aef2b/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs#L37-L42