### PR TITLE
ref: SpanId creation

### DIFF
--- a/benchmarks/Sentry.Benchmarks/SpanIdBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/SpanIdBenchmarks.cs
@@ -1,0 +1,12 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Sentry.Benchmarks;
+
+public class SpanIdBenchmarks
+{
+    [Benchmark(Description = "Creates a Span ID")]
+    public void CreateSpanId()
+    {
+        SpanId.Create();
+    }
+}

--- a/src/Sentry/Internal/RandomValuesFactory.cs
+++ b/src/Sentry/Internal/RandomValuesFactory.cs
@@ -7,7 +7,7 @@ internal abstract class RandomValuesFactory
     public abstract double NextDouble();
     public abstract void NextBytes(byte[] bytes);
 
-#if NET6_0_OR_GREATER
+#if !(NETSTANDARD2_0 || NET461)
     public abstract void NextBytes(Span<byte> bytes);
 #endif
 

--- a/src/Sentry/Internal/RandomValuesFactory.cs
+++ b/src/Sentry/Internal/RandomValuesFactory.cs
@@ -6,6 +6,7 @@ internal abstract class RandomValuesFactory
     public abstract int NextInt(int minValue, int maxValue);
     public abstract double NextDouble();
     public abstract void NextBytes(byte[] bytes);
+    public abstract void NextBytes(Span<byte> bytes);
 
     public bool NextBool(double rate) => rate switch
     {

--- a/src/Sentry/Internal/RandomValuesFactory.cs
+++ b/src/Sentry/Internal/RandomValuesFactory.cs
@@ -6,7 +6,10 @@ internal abstract class RandomValuesFactory
     public abstract int NextInt(int minValue, int maxValue);
     public abstract double NextDouble();
     public abstract void NextBytes(byte[] bytes);
+
+#if NET6_0_OR_GREATER
     public abstract void NextBytes(Span<byte> bytes);
+#endif
 
     public bool NextBool(double rate) => rate switch
     {

--- a/src/Sentry/Internal/SynchronizedRandomValuesFactory.cs
+++ b/src/Sentry/Internal/SynchronizedRandomValuesFactory.cs
@@ -16,10 +16,5 @@ internal class SynchronizedRandomValuesFactory : RandomValuesFactory
     public override int NextInt(int minValue, int maxValue) => Random.Next(minValue, maxValue);
     public override double NextDouble() => Random.NextDouble();
     public override void NextBytes(byte[] bytes) => Random.NextBytes(bytes);
-    public override void NextBytes(Span<byte> bytes) => Random.NextBytes(bytes
-#if NETSTANDARD2_0 || NET461
-            .ToArray()
-#endif
-    );
 #endif
 }

--- a/src/Sentry/Internal/SynchronizedRandomValuesFactory.cs
+++ b/src/Sentry/Internal/SynchronizedRandomValuesFactory.cs
@@ -7,6 +7,7 @@ internal class SynchronizedRandomValuesFactory : RandomValuesFactory
         public override int NextInt(int minValue, int maxValue) => Random.Shared.Next(minValue, maxValue);
         public override double NextDouble() => Random.Shared.NextDouble();
         public override void NextBytes(byte[] bytes) => Random.Shared.NextBytes(bytes);
+        public override void NextBytes(Span<byte> bytes) => Random.Shared.NextBytes(bytes);
 #else
     private static readonly AsyncLocal<Random> LocalRandom = new();
     private static Random Random => LocalRandom.Value ??= new Random();
@@ -15,5 +16,10 @@ internal class SynchronizedRandomValuesFactory : RandomValuesFactory
     public override int NextInt(int minValue, int maxValue) => Random.Next(minValue, maxValue);
     public override double NextDouble() => Random.NextDouble();
     public override void NextBytes(byte[] bytes) => Random.NextBytes(bytes);
+    public override void NextBytes(Span<byte> bytes) => Random.NextBytes(bytes
+#if NETSTANDARD2_0 || NET461
+            .ToArray()
+#endif
+    );
 #endif
 }

--- a/src/Sentry/Internal/SynchronizedRandomValuesFactory.cs
+++ b/src/Sentry/Internal/SynchronizedRandomValuesFactory.cs
@@ -16,5 +16,10 @@ internal class SynchronizedRandomValuesFactory : RandomValuesFactory
     public override int NextInt(int minValue, int maxValue) => Random.Next(minValue, maxValue);
     public override double NextDouble() => Random.NextDouble();
     public override void NextBytes(byte[] bytes) => Random.NextBytes(bytes);
+
+#if !(NETSTANDARD2_0 || NET461)
+    public override void NextBytes(Span<byte> bytes) => Random.NextBytes(bytes);
+#endif
+
 #endif
 }

--- a/src/Sentry/SpanId.cs
+++ b/src/Sentry/SpanId.cs
@@ -1,4 +1,5 @@
 using Sentry.Extensibility;
+using Sentry.Internal;
 
 namespace Sentry;
 
@@ -7,58 +8,60 @@ namespace Sentry;
 /// </summary>
 public readonly struct SpanId : IEquatable<SpanId>, IJsonSerializable
 {
-    private readonly string _value;
+    private static readonly RandomValuesFactory Random = new SynchronizedRandomValuesFactory();
 
-    private const string EmptyValue = "0000000000000000";
+    private readonly long _value;
+
+    private long GetValue() => _value;
 
     /// <summary>
     /// An empty Sentry span ID.
     /// </summary>
-    public static readonly SpanId Empty = new(EmptyValue);
+    public static readonly SpanId Empty = new(0);
 
     /// <summary>
     /// Creates a new instance of a Sentry span Id.
     /// </summary>
-    public SpanId(string value) => _value = value;
+    // TODO: mark as internal in version 4
+    public SpanId(string value) => long.TryParse(value, NumberStyles.HexNumber, null, out _value);
 
-    // This method is used to return a string with all zeroes in case
-    // the `_value` is equal to null.
-    // It can be equal to null because this is a struct and always has
-    // a parameterless constructor that evaluates to an instance with
-    // all fields initialized to default values.
-    // Effectively, using this method instead of just referencing `_value`
-    // makes the behavior more consistent, for example:
-    // default(SpanId).ToString() -> "0000000000000000"
-    // default(SpanId) == SpanId.Empty -> true
-    private string GetNormalizedValue() => !string.IsNullOrWhiteSpace(_value)
-        ? _value
-        : EmptyValue;
+    /// <summary>
+    /// Creates a new instance of a Sentry span Id.
+    /// </summary>
+    /// <param name="value"></param>
+    public SpanId(long value) => _value = value;
 
     /// <inheritdoc />
-    public bool Equals(SpanId other) => StringComparer.Ordinal.Equals(
-        GetNormalizedValue(),
-        other.GetNormalizedValue());
+    public bool Equals(SpanId other) => GetValue() == other.GetValue();
 
     /// <inheritdoc />
     public override bool Equals(object? obj) => obj is SpanId other && Equals(other);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(GetNormalizedValue());
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(_value);
 
     /// <inheritdoc />
-    public override string ToString() => GetNormalizedValue();
+    public override string ToString() => _value.ToString("x8");
 
-    // Note: spans are sentry IDs with only 16 characters, rest being truncated.
-    // This is obviously a bad idea as it invalidates GUID's uniqueness properties
-    // (https://devblogs.microsoft.com/oldnewthing/20080627-00/?p=21823)
-    // but all other SDKs do it this way, so we have no choice but to comply.
     /// <summary>
     /// Generates a new Sentry ID.
     /// </summary>
-    public static SpanId Create() => new(Guid.NewGuid().ToString("n")[..16]);
+    public static SpanId Create()
+    {
+        var buf = new byte[8];
+        long random;
+
+        do
+        {
+            Random.NextBytes(buf);
+            random = BitConverter.ToInt64(buf, 0);
+        } while (random == 0);
+
+        return new SpanId(random);
+    }
 
     /// <inheritdoc />
-    public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? _) => writer.WriteStringValue(GetNormalizedValue());
+    public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? _) => writer.WriteStringValue(ToString());
 
     /// <summary>
     /// Parses from string.
@@ -91,20 +94,4 @@ public readonly struct SpanId : IEquatable<SpanId>, IJsonSerializable
     /// The <see cref="Guid"/> from the <see cref="SentryId"/>.
     /// </summary>
     public static implicit operator string(SpanId id) => id.ToString();
-
-    // Note: no implicit conversion from `string` to `SpanId` as that leads to serious bugs.
-    // For example, given a method:
-    // transaction.StartChild(SpanId parentSpanId, string operation)
-    // And an *extension* method:
-    // transaction.StartChild(string operation, string description)
-    // The following code:
-    // transaction.StartChild("foo", "bar")
-    // Will resolve to the first method and not the second, which is incorrect.
-
-    /*
-    /// <summary>
-    /// A <see cref="SentryId"/> from a <see cref="Guid"/>.
-    /// </summary>
-    public static implicit operator SpanId(string value) => new(value);
-    */
 }

--- a/src/Sentry/SpanId.cs
+++ b/src/Sentry/SpanId.cs
@@ -23,7 +23,6 @@ public readonly struct SpanId : IEquatable<SpanId>, IJsonSerializable
     /// <summary>
     /// Creates a new instance of a Sentry span Id.
     /// </summary>
-    // TODO: mark as internal in version 4
     public SpanId(string value) => long.TryParse(value, NumberStyles.HexNumber, null, out _value);
 
     /// <summary>
@@ -33,7 +32,7 @@ public readonly struct SpanId : IEquatable<SpanId>, IJsonSerializable
     public SpanId(long value) => _value = value;
 
     /// <inheritdoc />
-    public bool Equals(SpanId other) => GetValue() == other.GetValue();
+    public bool Equals(SpanId other) => GetValue().Equals(other.GetValue());
 
     /// <inheritdoc />
     public override bool Equals(object? obj) => obj is SpanId other && Equals(other);

--- a/src/Sentry/SpanId.cs
+++ b/src/Sentry/SpanId.cs
@@ -48,13 +48,23 @@ public readonly struct SpanId : IEquatable<SpanId>, IJsonSerializable
     /// </summary>
     public static SpanId Create()
     {
-        var buf = new byte[8];
+        Span<byte> buf =
+#if NETSTANDARD2_0 || NET461
+            new byte[8];
+#else
+            stackalloc byte[8];
+#endif
         long random;
 
         do
         {
             Random.NextBytes(buf);
-            random = BitConverter.ToInt64(buf, 0);
+            random = BitConverter.ToInt64(
+#if NETSTANDARD2_0 || NET461
+                buf.ToArray(), 0);
+#else
+                buf);
+#endif
         } while (random == 0);
 
         return new SpanId(random);

--- a/src/Sentry/SpanId.cs
+++ b/src/Sentry/SpanId.cs
@@ -49,18 +49,19 @@ public readonly struct SpanId : IEquatable<SpanId>, IJsonSerializable
     /// </summary>
     public static SpanId Create()
     {
-        Span<byte> buf =
-#if NETSTANDARD2_0 || NET461
-            new byte[8];
+#if NET6_0_OR_GREATER
+        Span<byte> buf = stackalloc byte[8];
 #else
-            stackalloc byte[8];
+        byte[] buf = new byte[8];
 #endif
+
         Random.NextBytes(buf);
-        var random = BitConverter.ToInt64(
+
+        var random = BitConverter.ToInt64(buf
 #if NETSTANDARD2_0 || NET461
-            buf.ToArray(), 0);
+            , 0);
 #else
-            buf);
+            );
 #endif
 
         return new SpanId(random);

--- a/test/Sentry.Testing/IsolatedRandomValuesFactory.cs
+++ b/test/Sentry.Testing/IsolatedRandomValuesFactory.cs
@@ -11,9 +11,8 @@ internal class IsolatedRandomValuesFactory : RandomValuesFactory
     public override double NextDouble() => _random.NextDouble();
 
     public override void NextBytes(byte[] bytes) => _random.NextBytes(bytes);
-    public override void NextBytes(Span<byte> bytes) => _random.NextBytes(bytes
-#if NETSTANDARD2_0 || NET48
-            .ToArray()
+#if NET6_0_OR_GREATER
+    public override void NextBytes(Span<byte> bytes) => _random.NextBytes(bytes);
 #endif
-    );
+
 }

--- a/test/Sentry.Testing/IsolatedRandomValuesFactory.cs
+++ b/test/Sentry.Testing/IsolatedRandomValuesFactory.cs
@@ -11,4 +11,9 @@ internal class IsolatedRandomValuesFactory : RandomValuesFactory
     public override double NextDouble() => _random.NextDouble();
 
     public override void NextBytes(byte[] bytes) => _random.NextBytes(bytes);
+    public override void NextBytes(Span<byte> bytes) => _random.NextBytes(bytes
+#if NETSTANDARD2_0 || NET48
+            .ToArray()
+#endif
+    );
 }

--- a/test/Sentry.Testing/IsolatedRandomValuesFactory.cs
+++ b/test/Sentry.Testing/IsolatedRandomValuesFactory.cs
@@ -11,7 +11,8 @@ internal class IsolatedRandomValuesFactory : RandomValuesFactory
     public override double NextDouble() => _random.NextDouble();
 
     public override void NextBytes(byte[] bytes) => _random.NextBytes(bytes);
-#if NET6_0_OR_GREATER
+
+#if !(NETSTANDARD2_0 || NET48)
     public override void NextBytes(Span<byte> bytes) => _random.NextBytes(bytes);
 #endif
 

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -932,6 +932,7 @@ namespace Sentry
     public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>
     {
         public static readonly Sentry.SpanId Empty;
+        public SpanId(long value) { }
         public SpanId(string value) { }
         public bool Equals(Sentry.SpanId other) { }
         public override bool Equals(object? obj) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -933,6 +933,7 @@ namespace Sentry
     public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>
     {
         public static readonly Sentry.SpanId Empty;
+        public SpanId(long value) { }
         public SpanId(string value) { }
         public bool Equals(Sentry.SpanId other) { }
         public override bool Equals(object? obj) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -933,6 +933,7 @@ namespace Sentry
     public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>
     {
         public static readonly Sentry.SpanId Empty;
+        public SpanId(long value) { }
         public SpanId(string value) { }
         public bool Equals(Sentry.SpanId other) { }
         public override bool Equals(object? obj) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -931,6 +931,7 @@ namespace Sentry
     public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>
     {
         public static readonly Sentry.SpanId Empty;
+        public SpanId(long value) { }
         public SpanId(string value) { }
         public bool Equals(Sentry.SpanId other) { }
         public override bool Equals(object? obj) { }


### PR DESCRIPTION
In an effort to improve the memory footprint: There is no technical reason to keep the Id value as `string`.
The spanId value of `0` will be treated as `empty`.

```
BenchmarkDotNet=v0.13.5, OS=macOS Ventura 13.4 (22F66) [Darwin 22.5.0]
Apple M1 Pro, 1 CPU, 10 logical and 10 physical cores

OLD:
|              Method |     Mean |    Error |  StdDev |   Gen0 | Allocated |
|-------------------- |---------:|---------:|--------:|-------:|----------:|
| 'Creates a Span ID' | 722.1 ns | 63.51 ns | 3.48 ns | 0.0687 |     144 B |

NEW:
|              Method |     Mean |     Error |    StdDev | Allocated |
|-------------------- |---------:|----------:|----------:|----------:|
| 'Creates a Span ID' | 7.924 ns | 0.3097 ns | 0.0170 ns |         - |
```

#skip-changelog