### PR TITLE
sample: fix logging template

### DIFF
--- a/samples/Sentry.Samples.AspNetCore.Mvc/Controllers/HomeController.cs
+++ b/samples/Sentry.Samples.AspNetCore.Mvc/Controllers/HomeController.cs
@@ -30,7 +30,7 @@ public class HomeController : Controller
         {
             if (@params == null)
             {
-                _logger.LogWarning("Param is null!", @params);
+                _logger.LogWarning("Param {param} is null!", @params);
             }
 
             await _gameService.FetchNextPhaseDataAsync();


### PR DESCRIPTION
It warns in .NET 8 (#2617 )

> 50>HomeController.cs(33,36): Error CA2017 : Number of parameters supplied in the logging message template do not match the number of named placeholders (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017)



#skip-changelog