### PR TITLE
ref: SDK internal Tag handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- The SDK now provides and overload of `ContinueTrace` that accepts headers as `string` ([#2601](https://github.com/getsentry/sentry-dotnet/pull/2601))
 - Sentry tracing middleware now gets configured automatically ([#2602](https://github.com/getsentry/sentry-dotnet/pull/2602))
 
 ### Dependencies
@@ -11,6 +12,7 @@
 - Bump CLI from v2.20.6 to v2.20.7 ([#2604](https://github.com/getsentry/sentry-dotnet/pull/2604))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2207)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.20.6...2.20.7)
+
 ## 3.39.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Added distributed tracing without performance for Azure Function Workers ([#2630](https://github.com/getsentry/sentry-dotnet/pull/2630))
 - The SDK now provides and overload of `ContinueTrace` that accepts headers as `string` ([#2601](https://github.com/getsentry/sentry-dotnet/pull/2601))
 - Sentry tracing middleware now gets configured automatically ([#2602](https://github.com/getsentry/sentry-dotnet/pull/2602))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - The SDK now provides and overload of `ContinueTrace` that accepts headers as `string` ([#2601](https://github.com/getsentry/sentry-dotnet/pull/2601))
 - Sentry tracing middleware now gets configured automatically ([#2602](https://github.com/getsentry/sentry-dotnet/pull/2602))
 
+### Fixes
+
+- Resolved issue identifying users with OpenTelemetry ([#2618](https://github.com/getsentry/sentry-dotnet/pull/2618))
+
 ### Dependencies
 
 - Bump CLI from v2.20.6 to v2.20.7 ([#2604](https://github.com/getsentry/sentry-dotnet/pull/2604))

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -43,7 +43,7 @@
 
   <Target Name="OnlyTargetInstalledWorkloads" BeforeTargets="BeforeBuild" Condition="'$(WorkloadList)' == ''">
 
-    <Exec Command="dotnet workload list" ConsoleToMSBuild="true" StandardOutputImportance="Low">
+    <Exec Command="dotnet workload list" ConsoleToMSBuild="true" StandardOutputImportance="Low" EchoOff="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="WorkloadList"/>
     </Exec>
 

--- a/Sentry.sln.DotSettings
+++ b/Sentry.sln.DotSettings
@@ -1,2 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=enrichers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=instrumenter/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/benchmarks/Sentry.Benchmarks/SpanIdBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/SpanIdBenchmarks.cs
@@ -1,0 +1,12 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Sentry.Benchmarks;
+
+public class SpanIdBenchmarks
+{
+    [Benchmark(Description = "Creates a Span ID")]
+    public void CreateSpanId()
+    {
+        SpanId.Create();
+    }
+}

--- a/benchmarks/Sentry.Benchmarks/TransactionBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/TransactionBenchmarks.cs
@@ -1,0 +1,34 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Sentry.Benchmarks;
+
+public class TransactionBenchmarks
+{
+    private const string Operation = "Operation";
+    private const string Name = "Name";
+
+    [Params(1, 10, 100, 1000)]
+    public int SpanCount;
+
+    private IDisposable _sdk;
+
+    [GlobalSetup(Target = nameof(CreateTransaction))]
+    public void EnabledSdk() => _sdk = SentrySdk.Init(Constants.ValidDsn);
+
+    [GlobalCleanup(Target = nameof(CreateTransaction))]
+    public void DisableDsk() => _sdk.Dispose();
+
+    [Benchmark(Description = "Creates a Transaction")]
+    public void CreateTransaction()
+    {
+        var transaction = SentrySdk.StartTransaction(Name, Operation);
+
+        for (var i = 0; i < SpanCount; i++)
+        {
+            var span = transaction.StartChild(Operation);
+            span.Finish();
+        }
+
+        transaction.Finish();
+    }
+}

--- a/samples/Sentry.Samples.AspNetCore.Mvc/Controllers/HomeController.cs
+++ b/samples/Sentry.Samples.AspNetCore.Mvc/Controllers/HomeController.cs
@@ -30,7 +30,7 @@ public class HomeController : Controller
         {
             if (@params == null)
             {
-                _logger.LogWarning("Param is null!", @params);
+                _logger.LogWarning("Param {param} is null!", @params);
             }
 
             await _gameService.FetchNextPhaseDataAsync();

--- a/samples/Sentry.Samples.OpenTelemetry.AspNetCore/FakeAuthHandler.cs
+++ b/samples/Sentry.Samples.OpenTelemetry.AspNetCore/FakeAuthHandler.cs
@@ -1,0 +1,38 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace Sentry.Samples.OpenTelemetry.AspNetCore;
+
+public class FakeAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string UserId = "UserId";
+
+    public const string AuthenticationScheme = "Test";
+
+    public FakeAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        ISystemClock clock) : base(options, logger, encoder, clock)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.Name, "Fake user"),
+            new(ClaimTypes.NameIdentifier, "fake-user")
+        };
+
+        var identity = new ClaimsIdentity(claims, AuthenticationScheme);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, AuthenticationScheme);
+
+        var result = AuthenticateResult.Success(ticket);
+
+        return Task.FromResult(result);
+    }
+}

--- a/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Properties/launchSettings.json
+++ b/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Properties/launchSettings.json
@@ -1,11 +1,11 @@
 ﻿{
   "profiles": {
-    "http": {
+    "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "hello",
-      "applicationUrl": "http://localhost:5092",
+      "applicationUrl": "https://localhost:5092",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Sentry.AspNetCore/DefaultUserFactory.cs
+++ b/src/Sentry.AspNetCore/DefaultUserFactory.cs
@@ -2,8 +2,23 @@ using Microsoft.AspNetCore.Http;
 
 namespace Sentry.AspNetCore;
 
-internal class DefaultUserFactory : IUserFactory
+#pragma warning disable CS0618
+internal class DefaultUserFactory : IUserFactory, ISentryUserFactory
+#pragma warning restore CS0618
 {
+    private readonly IHttpContextAccessor? _httpContextAccessor;
+
+    public DefaultUserFactory()
+    {
+    }
+
+    public DefaultUserFactory(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public User? Create() => _httpContextAccessor?.HttpContext is {} httpContext ? Create(httpContext) : null;
+
     public User? Create(HttpContext context)
     {
         var principal = context.User;

--- a/src/Sentry.AspNetCore/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Sentry;
 using Sentry.AspNetCore;
 using Sentry.Extensibility;
 using Sentry.Extensions.Logging.Extensions.DependencyInjection;
@@ -20,7 +21,12 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton<ISentryEventProcessor, AspNetCoreEventProcessor>();
         services.AddSingleton<ISentryEventExceptionProcessor, AspNetCoreExceptionProcessor>();
+
+        services.AddHttpContextAccessor();
+#pragma warning disable CS0618
         services.TryAddSingleton<IUserFactory, DefaultUserFactory>();
+#pragma warning restore CS0618
+        services.TryAddSingleton<ISentryUserFactory, DefaultUserFactory>();
 
         services
             .AddSingleton<IRequestPayloadExtractor, FormRequestPayloadExtractor>()

--- a/src/Sentry.AspNetCore/IUserFactory.cs
+++ b/src/Sentry.AspNetCore/IUserFactory.cs
@@ -5,6 +5,7 @@ namespace Sentry.AspNetCore;
 /// <summary>
 /// Sentry User Factory
 /// </summary>
+[Obsolete("This interface is tightly coupled to AspNetCore and will be removed in version 4.0.0. Please consider using ISentryUserFactory with IHttpContextAccessor instead.")]
 public interface IUserFactory
 {
     /// <summary>

--- a/src/Sentry.AspNetCore/ScopeExtensions.cs
+++ b/src/Sentry.AspNetCore/ScopeExtensions.cs
@@ -38,8 +38,10 @@ public static class ScopeExtensions
 
         if (options.SendDefaultPii && !scope.HasUser())
         {
+#pragma warning disable CS0618
             var userFactory = context.RequestServices.GetService<IUserFactory>();
             var user = userFactory?.Create(context);
+#pragma warning restore CS0618
 
             if (user != null)
             {

--- a/src/Sentry.AzureFunctions.Worker/HttpRequestDataExtensions.cs
+++ b/src/Sentry.AzureFunctions.Worker/HttpRequestDataExtensions.cs
@@ -1,0 +1,60 @@
+using Microsoft.Azure.Functions.Worker.Http;
+using Sentry.Extensibility;
+
+namespace Sentry.AzureFunctions.Worker;
+
+internal static class HttpRequestDataExtensions
+{
+    public static SentryTraceHeader? TryGetSentryTraceHeader(this HttpRequestData context, IDiagnosticLogger? logger)
+    {
+        var traceHeaderValue = context.Headers.TryGetValues(SentryTraceHeader.HttpHeaderName, out var values)
+            ? values.FirstOrDefault()
+            : null;
+
+        if (traceHeaderValue is null)
+        {
+            logger?.LogDebug("Did not receive a Sentry trace header.");
+            return null;
+        }
+
+        logger?.LogDebug("Received Sentry trace header '{0}'.", traceHeaderValue);
+
+        try
+        {
+            return SentryTraceHeader.Parse(traceHeaderValue);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError("Invalid Sentry trace header '{0}'.", ex, traceHeaderValue);
+            return null;
+        }
+    }
+
+    public static BaggageHeader? TryGetBaggageHeader(this HttpRequestData context, IDiagnosticLogger? logger)
+    {
+        var baggageValue = context.Headers.TryGetValues(BaggageHeader.HttpHeaderName, out var value)
+            ? value.FirstOrDefault()
+            : null;
+
+        if (baggageValue is null)
+        {
+            logger?.LogDebug("Did not receive a Sentry baggage header.");
+            return null;
+        }
+
+        // Note: If there are multiple baggage headers, they will be joined with comma delimiters,
+        // and can thus be treated as a single baggage header.
+
+        logger?.LogDebug("Received baggage header '{0}'.", baggageValue);
+
+        try
+        {
+            return BaggageHeader.TryParse(baggageValue, onlySentry: true);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError("Invalid baggage header '{0}'.", ex, baggageValue);
+            return null;
+        }
+    }
+}

--- a/src/Sentry.AzureFunctions.Worker/SentryFunctionsWorkerMiddleware.cs
+++ b/src/Sentry.AzureFunctions.Worker/SentryFunctionsWorkerMiddleware.cs
@@ -1,22 +1,28 @@
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.Middleware;
+using Sentry.Extensibility;
 
 namespace Sentry.AzureFunctions.Worker;
 
 internal class SentryFunctionsWorkerMiddleware : IFunctionsWorkerMiddleware
 {
+    private const string Operation = "function";
+
     private readonly IHub _hub;
+    private readonly IDiagnosticLogger? _logger;
     private static readonly ConcurrentDictionary<string, string> TransactionNameCache = new();
 
     public SentryFunctionsWorkerMiddleware(IHub hub)
     {
         _hub = hub;
+        _logger = hub.GetSentryOptions()?.DiagnosticLogger;
     }
 
     public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
     {
-        var transactionName = await GetHttpTransactionNameAsync(context) ?? context.FunctionDefinition.Name;
-        var transaction = _hub.StartTransaction(transactionName, "function");
+        var transactionContext = await StartOrContinueTraceAsync(context);
+        var transaction = _hub.StartTransaction(transactionContext);
         Exception? unhandledException = null;
 
         try
@@ -73,42 +79,45 @@ internal class SentryFunctionsWorkerMiddleware : IFunctionsWorkerMiddleware
         }
     }
 
-    private static async Task<string?> GetHttpTransactionNameAsync(FunctionContext context)
+    private async Task<TransactionContext> StartOrContinueTraceAsync(FunctionContext context)
     {
+        var transactionName = context.FunctionDefinition.Name;
+
         // Get the HTTP request data
         var requestData = await context.GetHttpRequestDataAsync();
         if (requestData is null)
         {
             // not an HTTP trigger
-            return null;
+            return SentrySdk.ContinueTrace((SentryTraceHeader?)null, (BaggageHeader?)null, transactionName, Operation);
         }
 
         var httpMethod = requestData.Method.ToUpperInvariant();
-
         var transactionNameKey = $"{context.FunctionDefinition.EntryPoint}-{httpMethod}";
-        if (TransactionNameCache.TryGetValue(transactionNameKey, out var value))
+
+        if (!TransactionNameCache.TryGetValue(transactionNameKey, out transactionName))
         {
-            return value;
+            // Find the HTTP Trigger attribute via reflection
+            var assembly = Assembly.LoadFrom(context.FunctionDefinition.PathToAssembly);
+            var entryPointName = context.FunctionDefinition.EntryPoint;
+
+            var typeName = entryPointName[..entryPointName.LastIndexOf('.')];
+            var methodName = entryPointName[(typeName.Length + 1)..];
+            var attribute = assembly.GetType(typeName)?.GetMethod(methodName)?.GetParameters()
+                .Select(p => p.GetCustomAttribute<HttpTriggerAttribute>())
+                .FirstOrDefault(a => a is not null);
+
+            transactionName = attribute?.Route is { } route
+                // Compose the transaction name from the method and route
+                ? $"{httpMethod} /{route.TrimStart('/')}"
+                // There's no route provided, so use the absolute path of the URL
+                : $"{httpMethod} {requestData.Url.AbsolutePath}";
+
+            TransactionNameCache.TryAdd(transactionNameKey, transactionName);
         }
 
-        // Find the HTTP Trigger attribute via reflection
-        var assembly = Assembly.LoadFrom(context.FunctionDefinition.PathToAssembly);
-        var entryPointName = context.FunctionDefinition.EntryPoint;
+        var traceHeader = requestData.TryGetSentryTraceHeader(_logger);
+        var baggageHeader = requestData.TryGetBaggageHeader(_logger);
 
-        var typeName = entryPointName[..entryPointName.LastIndexOf('.')];
-        var methodName = entryPointName[(typeName.Length + 1)..];
-        var attribute = assembly.GetType(typeName)?.GetMethod(methodName)?.GetParameters()
-            .Select(p => p.GetCustomAttribute<HttpTriggerAttribute>())
-            .FirstOrDefault(a => a is not null);
-
-        var transactionName = attribute?.Route is { } route
-            // Compose the transaction name from the method and route
-            ? $"{httpMethod} /{route.TrimStart('/')}"
-            // There's no route provided, so use the absolute path of the URL
-            : $"{httpMethod} {requestData.Url.AbsolutePath}";
-
-        TransactionNameCache.TryAdd(transactionNameKey, transactionName);
-
-        return transactionName;
+        return SentrySdk.ContinueTrace(traceHeader, baggageHeader, transactionName, Operation);
     }
 }

--- a/src/Sentry.OpenTelemetry/AspNetCoreEnricher.cs
+++ b/src/Sentry.OpenTelemetry/AspNetCoreEnricher.cs
@@ -1,0 +1,22 @@
+﻿namespace Sentry.OpenTelemetry;
+
+internal class AspNetCoreEnricher : IOpenTelemetryEnricher
+{
+    private readonly ISentryUserFactory _userFactory;
+
+    internal AspNetCoreEnricher(ISentryUserFactory userFactory) => _userFactory = userFactory;
+
+    public void Enrich(ISpan span, Activity activity, IHub hub, SentryOptions? options)
+    {
+        if (options?.SendDefaultPii is true)
+        {
+            hub.ConfigureScope(scope =>
+            {
+                if (!scope.HasUser() && _userFactory.Create() is {} user)
+                {
+                    scope.User = user;
+                }
+            });
+        }
+    }
+}

--- a/src/Sentry.OpenTelemetry/IOpenTelemetryEnricher.cs
+++ b/src/Sentry.OpenTelemetry/IOpenTelemetryEnricher.cs
@@ -1,0 +1,6 @@
+namespace Sentry.OpenTelemetry;
+
+internal interface IOpenTelemetryEnricher
+{
+    void Enrich(ISpan span, Activity activity, IHub hub, SentryOptions? options);
+}

--- a/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
@@ -29,6 +30,18 @@ public static class TracerProviderBuilderExtensions
     {
         defaultTextMapPropagator ??= new SentryPropagator();
         Sdk.SetDefaultTextMapPropagator(defaultTextMapPropagator);
-        return tracerProviderBuilder.AddProcessor<SentrySpanProcessor>();
+        return tracerProviderBuilder.AddProcessor(services =>
+        {
+            List<IOpenTelemetryEnricher> enrichers = new();
+
+            // AspNetCoreEnricher
+            var userFactory = services.GetService<ISentryUserFactory>();
+            if (userFactory is not null)
+            {
+                enrichers.Add(new AspNetCoreEnricher(userFactory));
+            }
+
+            return new SentrySpanProcessor(SentrySdk.CurrentHub, enrichers);
+        });
     }
 }

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -80,7 +80,20 @@ public class DisabledHub : IHub, IDisposable
     public BaggageHeader? GetBaggage() => null;
 
     /// <summary>
-    /// Returns null.
+    /// Returns sampled out transaction context.
+    /// </summary>
+    public TransactionContext ContinueTrace(
+        string? traceHeader,
+        string? baggageHeader,
+        string? name = null,
+        string? operation = null)
+    {
+        // Transactions from DisabledHub are always sampled out
+        return new TransactionContext( name ?? string.Empty, operation ?? string.Empty, false);
+    }
+
+    /// <summary>
+    /// Returns sampled out transaction context.
     /// </summary>
     public TransactionContext ContinueTrace(
         SentryTraceHeader? traceHeader,

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -118,6 +118,17 @@ public sealed class HubAdapter : IHub, IHubEx
     /// </summary>
     [DebuggerStepThrough]
     public TransactionContext ContinueTrace(
+        string? traceHeader,
+        string? baggageHeader,
+        string? name = null,
+        string? operation = null)
+        => SentrySdk.ContinueTrace(traceHeader, baggageHeader, name, operation);
+
+    /// <summary>
+    /// Forwards the call to <see cref="SentrySdk"/>.
+    /// </summary>
+    [DebuggerStepThrough]
+    public TransactionContext ContinueTrace(
         SentryTraceHeader? traceHeader,
         BaggageHeader? baggageHeader,
         string? name = null,

--- a/src/Sentry/Hint.cs
+++ b/src/Sentry/Hint.cs
@@ -8,7 +8,7 @@ public class Hint
 {
     private readonly SentryOptions? _options;
     private readonly List<Attachment> _attachments = new();
-    private readonly Dictionary<string, object?> _items = new();
+    private Dictionary<string, object?>? _items;
 
     /// <summary>
     /// Creates a new instance of <see cref="Hint"/>.
@@ -30,7 +30,7 @@ public class Hint
     public Hint(string key, object? value)
         : this()
     {
-        _items[key] = value;
+        Items[key] = value;
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public class Hint
     /// These are not sent to Sentry, but rather they are available during processing, such as when using
     /// BeforeSend and others.
     /// </remarks>
-    public IDictionary<string, object?> Items => _items;
+    public IDictionary<string, object?> Items => _items ??= new Dictionary<string, object?>();
 
     /// <summary>
     /// The Java SDK has some logic so that certain Hint types do not copy attachments from the Scope.

--- a/src/Sentry/IHasTags.cs
+++ b/src/Sentry/IHasTags.cs
@@ -43,7 +43,7 @@ public static class HasTagsExtensions
     /// </summary>
     /// <param name="hasTags"></param>
     /// <returns></returns>
-    public static IReadOnlyDictionary<string, string>? GetTagsOrNull(this IHasTags hasTags)
+    internal static IReadOnlyDictionary<string, string>? GetTagsOrNull(this IHasTags hasTags)
     {
         if (hasTags is SpanTracer s)
         {

--- a/src/Sentry/IHasTags.cs
+++ b/src/Sentry/IHasTags.cs
@@ -37,4 +37,19 @@ public static class HasTagsExtensions
             hasTags.SetTag(key, value);
         }
     }
+
+    /// <summary>
+    /// Get tags or null.
+    /// </summary>
+    /// <param name="hasTags"></param>
+    /// <returns></returns>
+    public static IReadOnlyDictionary<string, string>? GetTagsOrNull(this IHasTags hasTags)
+    {
+        if (hasTags is SpanTracer s)
+        {
+            return s.InternalTags;
+        }
+
+        return hasTags.Tags;
+    }
 }

--- a/src/Sentry/IHub.cs
+++ b/src/Sentry/IHub.cs
@@ -50,6 +50,18 @@ public interface IHub :
     BaggageHeader? GetBaggage();
 
     /// <summary>
+    /// Continues a trace based on HTTP header values provided as strings.
+    /// </summary>
+    /// <remarks>
+    /// If no "sentry-trace" header is provided a random trace ID and span ID is created.
+    /// </remarks>
+    TransactionContext ContinueTrace(
+        string? traceHeader,
+        string? baggageHeader,
+        string? name = null,
+        string? operation = null);
+
+    /// <summary>
     /// Continues a trace based on HTTP header values.
     /// </summary>
     /// <remarks>

--- a/src/Sentry/ISentryUserFactory.cs
+++ b/src/Sentry/ISentryUserFactory.cs
@@ -1,0 +1,6 @@
+namespace Sentry;
+
+internal interface ISentryUserFactory
+{
+    public User? Create();
+}

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -220,6 +220,27 @@ internal class Hub : IHubEx, IDisposable
     }
 
     public TransactionContext ContinueTrace(
+        string? traceHeader,
+        string? baggageHeader,
+        string? name = null,
+        string? operation = null)
+    {
+        SentryTraceHeader? sentryTraceHeader = null;
+        if (traceHeader is not null)
+        {
+            sentryTraceHeader = SentryTraceHeader.Parse(traceHeader);
+        }
+
+        BaggageHeader? sentryBaggageHeader = null;
+        if (baggageHeader is not null)
+        {
+            sentryBaggageHeader = BaggageHeader.TryParse(baggageHeader, onlySentry: true);
+        }
+
+        return ContinueTrace(sentryTraceHeader, sentryBaggageHeader, name, operation);
+    }
+
+    public TransactionContext ContinueTrace(
         SentryTraceHeader? traceHeader,
         BaggageHeader? baggageHeader,
         string? name = null,

--- a/src/Sentry/Internal/RandomValuesFactory.cs
+++ b/src/Sentry/Internal/RandomValuesFactory.cs
@@ -6,6 +6,7 @@ internal abstract class RandomValuesFactory
     public abstract int NextInt(int minValue, int maxValue);
     public abstract double NextDouble();
     public abstract void NextBytes(byte[] bytes);
+    public abstract void NextBytes(Span<byte> bytes);
 
     public bool NextBool(double rate) => rate switch
     {

--- a/src/Sentry/Internal/SynchronizedRandomValuesFactory.cs
+++ b/src/Sentry/Internal/SynchronizedRandomValuesFactory.cs
@@ -7,6 +7,7 @@ internal class SynchronizedRandomValuesFactory : RandomValuesFactory
         public override int NextInt(int minValue, int maxValue) => Random.Shared.Next(minValue, maxValue);
         public override double NextDouble() => Random.Shared.NextDouble();
         public override void NextBytes(byte[] bytes) => Random.Shared.NextBytes(bytes);
+        public override void NextBytes(Span<byte> bytes) => Random.Shared.NextBytes(bytes);
 #else
     private static readonly AsyncLocal<Random> LocalRandom = new();
     private static Random Random => LocalRandom.Value ??= new Random();
@@ -15,5 +16,10 @@ internal class SynchronizedRandomValuesFactory : RandomValuesFactory
     public override int NextInt(int minValue, int maxValue) => Random.Next(minValue, maxValue);
     public override double NextDouble() => Random.NextDouble();
     public override void NextBytes(byte[] bytes) => Random.NextBytes(bytes);
+    public override void NextBytes(Span<byte> bytes) => Random.NextBytes(bytes
+#if NETSTANDARD2_0 || NET461
+            .ToArray()
+#endif
+    );
 #endif
 }

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -421,9 +421,9 @@ public class Scope : IEventLike, IHasDistribution
             }
         }
 
-        foreach (var (key, value) in Tags)
+        foreach (var (key, value) in _tags)
         {
-            if (!other.Tags.ContainsKey(key))
+            if(other.GetTagsOrNull()?.ContainsKey(key) is true)
             {
                 other.SetTag(key, value);
             }

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -152,7 +152,6 @@
     <InternalsVisibleTo Include="Sentry.NLog" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.NLog.Tests" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.OpenTelemetry" PublicKey="$(SentryPublicKey)" />
-    <InternalsVisibleTo Include="Sentry.OpenTelemetry.AspNetCore" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.OpenTelemetry.Tests" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.Profiling" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.Profiling.Tests" PublicKey="$(SentryPublicKey)" />

--- a/src/Sentry/SentryOptionsExtensions.cs
+++ b/src/Sentry/SentryOptionsExtensions.cs
@@ -400,7 +400,7 @@ public static class SentryOptionsExtensions
     public static void ApplyDefaultTags(this SentryOptions options, IHasTags hasTags)
     {
         foreach (var defaultTag in options.DefaultTags
-            .Where(t => !hasTags.Tags.TryGetValue(t.Key, out _)))
+            .Where(t => hasTags.GetTagsOrNull()?.TryGetValue(t.Key, out _) is not true))
         {
             hasTags.SetTag(defaultTag.Key, defaultTag.Value);
         }

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -625,6 +625,20 @@ public static partial class SentrySdk
         => CurrentHub.GetBaggage();
 
     /// <summary>
+    /// Continues a trace based on HTTP header values provided as strings.
+    /// </summary>
+    /// <remarks>
+    /// If no "sentry-trace" header is provided a random trace ID and span ID is created.
+    /// </remarks>
+    [DebuggerStepThrough]
+    public static TransactionContext ContinueTrace(
+        string? traceHeader,
+        string? baggageHeader,
+        string? name = null,
+        string? operation = null)
+        => CurrentHub.ContinueTrace(traceHeader, baggageHeader, name, operation);
+
+    /// <summary>
     /// Continues a trace based on HTTP header values.
     /// </summary>
     /// <remarks>

--- a/src/Sentry/Span.cs
+++ b/src/Sentry/Span.cs
@@ -88,7 +88,7 @@ public class Span : ISpanData, IJsonSerializable
         Status = tracer.Status;
         IsSampled = tracer.IsSampled;
         _extra = tracer.Extra.ToDictionary();
-        _tags = tracer.Tags.ToDictionary();
+        _tags = tracer.GetTagsOrNull()?.ToDictionary();
     }
 
     /// <inheritdoc />

--- a/src/Sentry/SpanId.cs
+++ b/src/Sentry/SpanId.cs
@@ -1,4 +1,5 @@
 using Sentry.Extensibility;
+using Sentry.Internal;
 
 namespace Sentry;
 
@@ -7,58 +8,60 @@ namespace Sentry;
 /// </summary>
 public readonly struct SpanId : IEquatable<SpanId>, IJsonSerializable
 {
-    private readonly string _value;
+    private static readonly RandomValuesFactory Random = new SynchronizedRandomValuesFactory();
 
-    private const string EmptyValue = "0000000000000000";
+    private readonly long _value;
+
+    private long GetValue() => _value;
 
     /// <summary>
     /// An empty Sentry span ID.
     /// </summary>
-    public static readonly SpanId Empty = new(EmptyValue);
+    public static readonly SpanId Empty = new(0);
 
     /// <summary>
     /// Creates a new instance of a Sentry span Id.
     /// </summary>
-    public SpanId(string value) => _value = value;
+    // TODO: mark as internal in version 4
+    public SpanId(string value) => long.TryParse(value, NumberStyles.HexNumber, null, out _value);
 
-    // This method is used to return a string with all zeroes in case
-    // the `_value` is equal to null.
-    // It can be equal to null because this is a struct and always has
-    // a parameterless constructor that evaluates to an instance with
-    // all fields initialized to default values.
-    // Effectively, using this method instead of just referencing `_value`
-    // makes the behavior more consistent, for example:
-    // default(SpanId).ToString() -> "0000000000000000"
-    // default(SpanId) == SpanId.Empty -> true
-    private string GetNormalizedValue() => !string.IsNullOrWhiteSpace(_value)
-        ? _value
-        : EmptyValue;
+    /// <summary>
+    /// Creates a new instance of a Sentry span Id.
+    /// </summary>
+    /// <param name="value"></param>
+    public SpanId(long value) => _value = value;
 
     /// <inheritdoc />
-    public bool Equals(SpanId other) => StringComparer.Ordinal.Equals(
-        GetNormalizedValue(),
-        other.GetNormalizedValue());
+    public bool Equals(SpanId other) => GetValue() == other.GetValue();
 
     /// <inheritdoc />
     public override bool Equals(object? obj) => obj is SpanId other && Equals(other);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(GetNormalizedValue());
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(_value);
 
     /// <inheritdoc />
-    public override string ToString() => GetNormalizedValue();
+    public override string ToString() => _value.ToString("x8");
 
-    // Note: spans are sentry IDs with only 16 characters, rest being truncated.
-    // This is obviously a bad idea as it invalidates GUID's uniqueness properties
-    // (https://devblogs.microsoft.com/oldnewthing/20080627-00/?p=21823)
-    // but all other SDKs do it this way, so we have no choice but to comply.
     /// <summary>
     /// Generates a new Sentry ID.
     /// </summary>
-    public static SpanId Create() => new(Guid.NewGuid().ToString("n")[..16]);
+    public static SpanId Create()
+    {
+        var buf = new byte[8];
+        long random;
+
+        do
+        {
+            Random.NextBytes(buf);
+            random = BitConverter.ToInt64(buf, 0);
+        } while (random == 0);
+
+        return new SpanId(random);
+    }
 
     /// <inheritdoc />
-    public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? _) => writer.WriteStringValue(GetNormalizedValue());
+    public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? _) => writer.WriteStringValue(ToString());
 
     /// <summary>
     /// Parses from string.
@@ -91,20 +94,4 @@ public readonly struct SpanId : IEquatable<SpanId>, IJsonSerializable
     /// The <see cref="Guid"/> from the <see cref="SentryId"/>.
     /// </summary>
     public static implicit operator string(SpanId id) => id.ToString();
-
-    // Note: no implicit conversion from `string` to `SpanId` as that leads to serious bugs.
-    // For example, given a method:
-    // transaction.StartChild(SpanId parentSpanId, string operation)
-    // And an *extension* method:
-    // transaction.StartChild(string operation, string description)
-    // The following code:
-    // transaction.StartChild("foo", "bar")
-    // Will resolve to the first method and not the second, which is incorrect.
-
-    /*
-    /// <summary>
-    /// A <see cref="SentryId"/> from a <see cref="Guid"/>.
-    /// </summary>
-    public static implicit operator SpanId(string value) => new(value);
-    */
 }

--- a/src/Sentry/SpanId.cs
+++ b/src/Sentry/SpanId.cs
@@ -48,13 +48,23 @@ public readonly struct SpanId : IEquatable<SpanId>, IJsonSerializable
     /// </summary>
     public static SpanId Create()
     {
-        var buf = new byte[8];
+        Span<byte> buf =
+#if NETSTANDARD2_0 || NET461
+            new byte[8];
+#else
+            stackalloc byte[8];
+#endif
         long random;
 
         do
         {
             Random.NextBytes(buf);
-            random = BitConverter.ToInt64(buf, 0);
+            random = BitConverter.ToInt64(
+#if NETSTANDARD2_0 || NET461
+                buf.ToArray(), 0);
+#else
+                buf);
+#endif
         } while (random == 0);
 
         return new SpanId(random);

--- a/src/Sentry/SpanTracer.cs
+++ b/src/Sentry/SpanTracer.cs
@@ -52,6 +52,8 @@ public class SpanTracer : ISpan
 
     private ConcurrentDictionary<string, string>? _tags;
 
+    internal ConcurrentDictionary<string, string>? InternalTags => _tags;
+
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string> Tags => _tags ??= new ConcurrentDictionary<string, string>();
 

--- a/src/Sentry/Transaction.cs
+++ b/src/Sentry/Transaction.cs
@@ -258,7 +258,7 @@ public class Transaction : ITransactionData, IJsonSerializable, IHasDistribution
         Fingerprint = tracer.Fingerprint;
         _breadcrumbs = tracer.Breadcrumbs.ToList();
         _extra = tracer.Extra.ToDictionary();
-        _tags = tracer.Tags.ToDictionary();
+        _tags = tracer.GetTagsOrNull()?.ToDictionary() ?? new Dictionary<string, string>();
         _spans = tracer.Spans
             .Where(s => s is not SpanTracer { IsSentryRequest: true }) // Filter sentry requests created by Sentry.OpenTelemetry.SentrySpanProcessor
             .Select(s => new Span(s)).ToArray();

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -32,6 +32,9 @@ namespace Sentry.AspNetCore
     {
         Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
     }
+    [System.Obsolete("This interface is tightly coupled to AspNetCore and will be removed in version 4." +
+        "0.0. Please consider using ISentryUserFactory with IHttpContextAccessor instead." +
+        "")]
     public interface IUserFactory
     {
         Sentry.User? Create(Microsoft.AspNetCore.Http.HttpContext context);

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -32,6 +32,9 @@ namespace Sentry.AspNetCore
     {
         Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
     }
+    [System.Obsolete("This interface is tightly coupled to AspNetCore and will be removed in version 4." +
+        "0.0. Please consider using ISentryUserFactory with IHttpContextAccessor instead." +
+        "")]
     public interface IUserFactory
     {
         Sentry.User? Create(Microsoft.AspNetCore.Http.HttpContext context);

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -32,6 +32,9 @@ namespace Sentry.AspNetCore
     {
         Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
     }
+    [System.Obsolete("This interface is tightly coupled to AspNetCore and will be removed in version 4." +
+        "0.0. Please consider using ISentryUserFactory with IHttpContextAccessor instead." +
+        "")]
     public interface IUserFactory
     {
         Sentry.User? Create(Microsoft.AspNetCore.Http.HttpContext context);

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -32,6 +32,9 @@ namespace Sentry.AspNetCore
     {
         Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
     }
+    [System.Obsolete("This interface is tightly coupled to AspNetCore and will be removed in version 4." +
+        "0.0. Please consider using ISentryUserFactory with IHttpContextAccessor instead." +
+        "")]
     public interface IUserFactory
     {
         Sentry.User? Create(Microsoft.AspNetCore.Http.HttpContext context);

--- a/test/Sentry.AspNetCore.Tests/DefaultUserFactoryTests.cs
+++ b/test/Sentry.AspNetCore.Tests/DefaultUserFactoryTests.cs
@@ -86,6 +86,16 @@ public class DefaultUserFactoryTests
     }
 
     [Fact]
+    public void Create_ContextAccessorNoClaims_IpAddress()
+    {
+        _ = HttpContext.User.Claims.Returns(Enumerable.Empty<Claim>());
+        var contextAccessor = Substitute.For<IHttpContextAccessor>();
+        contextAccessor.HttpContext.Returns(HttpContext);
+        var actual = new DefaultUserFactory(contextAccessor).Create();
+        Assert.Equal(IPAddress.IPv6Loopback.ToString(), actual?.IpAddress);
+    }
+
+    [Fact]
     public void Create_ClaimNameAndIdentityDontMatch_UsernameFromIdentity()
     {
         const string expected = "App configured to read it from a different claim";

--- a/test/Sentry.AspNetCore.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/ServiceCollectionExtensionsTests.cs
@@ -68,6 +68,7 @@ public class ServiceCollectionExtensionsTests
         Assert.Same(typeof(DefaultRequestPayloadExtractor), last.ImplementationType);
     }
 
+#pragma warning disable CS0618
     [Fact]
     public void AddSentry_DefaultUserFactory_Registered()
     {
@@ -75,4 +76,5 @@ public class ServiceCollectionExtensionsTests
         _sut.Received().Add(Arg.Is<ServiceDescriptor>(d => d.ServiceType == typeof(IUserFactory)
                                                            && d.ImplementationType == typeof(DefaultUserFactory)));
     }
+#pragma warning restore CS0618
 }

--- a/test/Sentry.OpenTelemetry.Tests/AspNetCoreEnricherTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/AspNetCoreEnricherTests.cs
@@ -1,0 +1,48 @@
+namespace Sentry.OpenTelemetry.Tests;
+
+public class AspNetCoreEnricherTests
+{
+    [Fact]
+    public void Enrich_SendDefaultPii_UserOnScope()
+    {
+        // Arrange
+        var scope = new Scope();
+        var options = new SentryOptions { SendDefaultPii = true };
+        var hub = Substitute.For<IHub>();
+        hub.ConfigureScope(Arg.Do<Action<Scope>>(action => action(scope)));
+
+        var user = new User{ Id = "foo" };
+        var userFactory = Substitute.For<ISentryUserFactory>();
+        userFactory.Create().Returns(user);
+
+        var enricher = new AspNetCoreEnricher(userFactory);
+
+        // Act
+        enricher.Enrich(null!, null!, hub, options);
+
+        // Assert
+        scope.HasUser().Should().BeTrue();
+        scope.User.Should().Be(user);
+    }
+
+    [Fact]
+    public void Enrich_SendDefaultPiiFalse_NoUserOnScope()
+    {
+        // Arrange
+        var scope = new Scope();
+        var originalUser = scope.User;
+        var options = new SentryOptions { SendDefaultPii = false };
+        var hub = Substitute.For<IHub>();
+        hub.ConfigureScope(Arg.Do<Action<Scope>>(action => action(scope)));
+
+        var userFactory = Substitute.For<ISentryUserFactory>();
+        var enricher = new AspNetCoreEnricher(userFactory);
+
+        // Act
+        enricher.Enrich(null!, null!, hub, options);
+
+        // Assert
+        scope.HasUser().Should().BeFalse();
+        scope.User.Should().Be(originalUser);
+    }
+}

--- a/test/Sentry.OpenTelemetry.Tests/Sentry.OpenTelemetry.Tests.csproj
+++ b/test/Sentry.OpenTelemetry.Tests/Sentry.OpenTelemetry.Tests.csproj
@@ -11,14 +11,12 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <!-- Use the netcoreapp3.1 target to test netstandard2.0 -->
-    <ProjectReference Include="..\..\src\Sentry.OpenTelemetry\Sentry.OpenTelemetry.csproj"
-                      AdditionalProperties="TargetFramework=netstandard2.0" />
+    <ProjectReference Include="..\..\src\Sentry.OpenTelemetry\Sentry.OpenTelemetry.csproj" AdditionalProperties="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <!-- Use the net6.0 target to test netstandard2.1 -->
-    <ProjectReference Include="..\..\src\Sentry.OpenTelemetry\Sentry.OpenTelemetry.csproj"
-                      AdditionalProperties="TargetFramework=netstandard2.1" />
+    <ProjectReference Include="..\..\src\Sentry.OpenTelemetry\Sentry.OpenTelemetry.csproj" AdditionalProperties="TargetFramework=netstandard2.1" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' and '$(TargetFramework)' != 'net6.0'">

--- a/test/Sentry.Testing/IsolatedRandomValuesFactory.cs
+++ b/test/Sentry.Testing/IsolatedRandomValuesFactory.cs
@@ -11,4 +11,9 @@ internal class IsolatedRandomValuesFactory : RandomValuesFactory
     public override double NextDouble() => _random.NextDouble();
 
     public override void NextBytes(byte[] bytes) => _random.NextBytes(bytes);
+    public override void NextBytes(Span<byte> bytes) => _random.NextBytes(bytes
+#if NETSTANDARD2_0 || NET48
+            .ToArray()
+#endif
+    );
 }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -934,6 +934,7 @@ namespace Sentry
     public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>
     {
         public static readonly Sentry.SpanId Empty;
+        public SpanId(long value) { }
         public SpanId(string value) { }
         public bool Equals(Sentry.SpanId other) { }
         public override bool Equals(object? obj) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -231,6 +231,7 @@ namespace Sentry
         void BindException(System.Exception exception, Sentry.ISpan span);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope);
         Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null);
+        Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null);
         void EndSession(Sentry.SessionEndStatus status = 0);
         Sentry.BaggageHeader? GetBaggage();
         Sentry.ISpan? GetSpan();
@@ -760,6 +761,7 @@ namespace Sentry
         public static void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public static System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public static Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
+        public static Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
         public static void EndSession(Sentry.SessionEndStatus status = 0) { }
         public static void Flush() { }
         public static void Flush(System.TimeSpan timeout) { }
@@ -1236,6 +1238,7 @@ namespace Sentry.Extensibility
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
+        public Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
         public void Dispose() { }
         public void EndSession(Sentry.SessionEndStatus status = 0) { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
@@ -1277,6 +1280,7 @@ namespace Sentry.Extensibility
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
+        public Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
         public void EndSession(Sentry.SessionEndStatus status = 0) { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
         public Sentry.BaggageHeader? GetBaggage() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -231,6 +231,7 @@ namespace Sentry
         void BindException(System.Exception exception, Sentry.ISpan span);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope);
         Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null);
+        Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null);
         void EndSession(Sentry.SessionEndStatus status = 0);
         Sentry.BaggageHeader? GetBaggage();
         Sentry.ISpan? GetSpan();
@@ -761,6 +762,7 @@ namespace Sentry
         public static void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public static System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public static Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
+        public static Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
         public static void EndSession(Sentry.SessionEndStatus status = 0) { }
         public static void Flush() { }
         public static void Flush(System.TimeSpan timeout) { }
@@ -1237,6 +1239,7 @@ namespace Sentry.Extensibility
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
+        public Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
         public void Dispose() { }
         public void EndSession(Sentry.SessionEndStatus status = 0) { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
@@ -1278,6 +1281,7 @@ namespace Sentry.Extensibility
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
+        public Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
         public void EndSession(Sentry.SessionEndStatus status = 0) { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
         public Sentry.BaggageHeader? GetBaggage() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -935,6 +935,7 @@ namespace Sentry
     public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>
     {
         public static readonly Sentry.SpanId Empty;
+        public SpanId(long value) { }
         public SpanId(string value) { }
         public bool Equals(Sentry.SpanId other) { }
         public override bool Equals(object? obj) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -231,6 +231,7 @@ namespace Sentry
         void BindException(System.Exception exception, Sentry.ISpan span);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope);
         Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null);
+        Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null);
         void EndSession(Sentry.SessionEndStatus status = 0);
         Sentry.BaggageHeader? GetBaggage();
         Sentry.ISpan? GetSpan();
@@ -761,6 +762,7 @@ namespace Sentry
         public static void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public static System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public static Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
+        public static Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
         public static void EndSession(Sentry.SessionEndStatus status = 0) { }
         public static void Flush() { }
         public static void Flush(System.TimeSpan timeout) { }
@@ -1237,6 +1239,7 @@ namespace Sentry.Extensibility
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
+        public Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
         public void Dispose() { }
         public void EndSession(Sentry.SessionEndStatus status = 0) { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
@@ -1278,6 +1281,7 @@ namespace Sentry.Extensibility
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
+        public Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
         public void EndSession(Sentry.SessionEndStatus status = 0) { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
         public Sentry.BaggageHeader? GetBaggage() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -935,6 +935,7 @@ namespace Sentry
     public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>
     {
         public static readonly Sentry.SpanId Empty;
+        public SpanId(long value) { }
         public SpanId(string value) { }
         public bool Equals(Sentry.SpanId other) { }
         public override bool Equals(object? obj) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -230,6 +230,7 @@ namespace Sentry
         void BindException(System.Exception exception, Sentry.ISpan span);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope);
         Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null);
+        Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null);
         void EndSession(Sentry.SessionEndStatus status = 0);
         Sentry.BaggageHeader? GetBaggage();
         Sentry.ISpan? GetSpan();
@@ -759,6 +760,7 @@ namespace Sentry
         public static void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public static System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public static Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
+        public static Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
         public static void EndSession(Sentry.SessionEndStatus status = 0) { }
         public static void Flush() { }
         public static void Flush(System.TimeSpan timeout) { }
@@ -1235,6 +1237,7 @@ namespace Sentry.Extensibility
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
+        public Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
         public void Dispose() { }
         public void EndSession(Sentry.SessionEndStatus status = 0) { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
@@ -1276,6 +1279,7 @@ namespace Sentry.Extensibility
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
+        public Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
         public void EndSession(Sentry.SessionEndStatus status = 0) { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
         public Sentry.BaggageHeader? GetBaggage() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -933,6 +933,7 @@ namespace Sentry
     public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>
     {
         public static readonly Sentry.SpanId Empty;
+        public SpanId(long value) { }
         public SpanId(string value) { }
         public bool Equals(Sentry.SpanId other) { }
         public override bool Equals(object? obj) { }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -915,11 +915,14 @@ public partial class HubTests
         var propagationContext = new SentryPropagationContext(
             SentryId.Parse("43365712692146d08ee11a729dfbcaca"), SpanId.Parse("1000000000000000"));
         hub.ConfigureScope(scope => scope.PropagationContext = propagationContext);
+
         var traceHeader = new SentryTraceHeader(SentryId.Parse("5bd5f6d346b442dd9177dce9302fd737"),
             SpanId.Parse("2000000000000000"), null);
         var baggageHeader = BaggageHeader.Create(new List<KeyValuePair<string, string>>
         {
-            {"sentry-public_key", "49d0f7386ad645858ae85020e393bef3"}
+            {"sentry-trace_id", "5bd5f6d346b442dd9177dce9302fd737"},
+            {"sentry-public_key", "49d0f7386ad645858ae85020e393bef3"},
+            {"sentry-sample_rate", "1.0"}
         });
 
         hub.ConfigureScope(scope => scope.PropagationContext.TraceId.Should().Be("43365712692146d08ee11a729dfbcaca")); // Sanity check
@@ -932,6 +935,35 @@ public partial class HubTests
         {
             scope.PropagationContext.TraceId.Should().Be(SentryId.Parse("5bd5f6d346b442dd9177dce9302fd737"));
             scope.PropagationContext.ParentSpanId.Should().Be(SpanId.Parse("2000000000000000"));
+            Assert.NotNull(scope.PropagationContext._dynamicSamplingContext);
+        });
+
+        transactionContext.TraceId.Should().Be(SentryId.Parse("5bd5f6d346b442dd9177dce9302fd737"));
+        transactionContext.ParentSpanId.Should().Be(SpanId.Parse("2000000000000000"));
+    }
+
+    [Fact]
+    public void ContinueTrace_ReceivesHeadersAsStrings_SetsPropagationContextAndReturnsTransactionContext()
+    {
+        // Arrange
+        var hub = _fixture.GetSut();
+        var propagationContext = new SentryPropagationContext(
+            SentryId.Parse("43365712692146d08ee11a729dfbcaca"), SpanId.Parse("1000000000000000"));
+        hub.ConfigureScope(scope => scope.PropagationContext = propagationContext);
+        var traceHeader = "5bd5f6d346b442dd9177dce9302fd737-2000000000000000";
+        var baggageHeader ="sentry-trace_id=5bd5f6d346b442dd9177dce9302fd737, sentry-public_key=49d0f7386ad645858ae85020e393bef3, sentry-sample_rate=1.0";
+
+        hub.ConfigureScope(scope => scope.PropagationContext.TraceId.Should().Be("43365712692146d08ee11a729dfbcaca")); // Sanity check
+
+        // Act
+        var transactionContext = hub.ContinueTrace(traceHeader, baggageHeader, "test-name");
+
+        // Assert
+        hub.ConfigureScope(scope =>
+        {
+            scope.PropagationContext.TraceId.Should().Be(SentryId.Parse("5bd5f6d346b442dd9177dce9302fd737"));
+            scope.PropagationContext.ParentSpanId.Should().Be(SpanId.Parse("2000000000000000"));
+            Assert.NotNull(scope.PropagationContext._dynamicSamplingContext);
         });
 
         transactionContext.TraceId.Should().Be(SentryId.Parse("5bd5f6d346b442dd9177dce9302fd737"));


### PR DESCRIPTION
First iteration
```
OLD:
|                  Method | SpanCount |        Mean |        Error |    StdDev |     Gen0 |     Gen1 |  Allocated |
|------------------------ |---------- |------------:|-------------:|----------:|---------:|---------:|-----------:|
| 'Creates a Transaction' |         1 |    18.74 us |     9.389 us |  0.515 us |   1.9531 |   0.7324 |   11.45 KB |
| 'Creates a Transaction' |        10 |    46.50 us |    10.036 us |  0.550 us |   5.1270 |   1.8921 |   29.41 KB |
| 'Creates a Transaction' |       100 |   328.92 us |   391.109 us | 21.438 us |  36.6211 |  13.1836 |  209.87 KB |
| 'Creates a Transaction' |      1000 | 3,126.71 us | 1,627.935 us | 89.233 us | 343.7500 | 121.0938 | 2010.25 KB |

NEW:
|                  Method | SpanCount |        Mean |        Error |     StdDev |     Gen0 |    Gen1 |  Allocated |
|------------------------ |---------- |------------:|-------------:|-----------:|---------:|--------:|-----------:|
| 'Creates a Transaction' |         1 |    16.71 us |     5.680 us |   0.311 us |   2.9907 |  0.9766 |   10.64 KB |
| 'Creates a Transaction' |        10 |    40.69 us |    49.539 us |   2.715 us |   3.7231 |  1.4038 |   21.28 KB |
| 'Creates a Transaction' |       100 |   233.04 us |   140.121 us |   7.680 us |  28.3203 |  8.7891 |  128.62 KB |
| 'Creates a Transaction' |      1000 | 2,260.93 us | 2,510.363 us | 137.601 us | 253.9063 | 82.0313 | 1197.68 KB |
```