### PR TITLE
Execute `dotnet workload list` task silently in builds

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -43,7 +43,7 @@
 
   <Target Name="OnlyTargetInstalledWorkloads" BeforeTargets="BeforeBuild" Condition="'$(WorkloadList)' == ''">
 
-    <Exec Command="dotnet workload list" ConsoleToMSBuild="true" StandardOutputImportance="Low">
+    <Exec Command="dotnet workload list" ConsoleToMSBuild="true" StandardOutputImportance="Low" EchoOff="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="WorkloadList"/>
     </Exec>
 


### PR DESCRIPTION
#skip-changelog

Added `EchoOff`:
https://github.com/getsentry/sentry-dotnet/blob/421b242ad2a2bad771cd37db0dd7da8e70bf0aa2/Directory.Build.targets#L46