### PR TITLE
4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bump CLI from v2.20.6 to v2.20.7 ([#2604](https://github.com/getsentry/sentry-dotnet/pull/2604))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2207)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.20.6...2.20.7)
+
 ## 3.39.1
 
 ### Fixes


### PR DESCRIPTION
.NET 8 is GA'ing in November. We can't just add it to the SDK (even run tests) without dropping net6 mobile targets (see: https://github.com/getsentry/sentry-dotnet/issues/2623). 

This branch will hold commits that will make it to the release 4.0.0 of the SDK.

Additional work that make it into this: https://github.com/getsentry/sentry-dotnet/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+milestone%3A4.0.0