### PR TITLE
Construct hint items lazily

### DIFF
--- a/src/Sentry/Hint.cs
+++ b/src/Sentry/Hint.cs
@@ -8,7 +8,7 @@ public class Hint
 {
     private readonly SentryOptions? _options;
     private readonly List<Attachment> _attachments = new();
-    private readonly Dictionary<string, object?> _items = new();
+    private Dictionary<string, object?>? _items;
 
     /// <summary>
     /// Creates a new instance of <see cref="Hint"/>.
@@ -30,7 +30,7 @@ public class Hint
     public Hint(string key, object? value)
         : this()
     {
-        _items[key] = value;
+        Items[key] = value;
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public class Hint
     /// These are not sent to Sentry, but rather they are available during processing, such as when using
     /// BeforeSend and others.
     /// </remarks>
-    public IDictionary<string, object?> Items => _items;
+    public IDictionary<string, object?> Items => _items ??= new Dictionary<string, object?>();
 
     /// <summary>
     /// The Java SDK has some logic so that certain Hint types do not copy attachments from the Scope.


### PR DESCRIPTION
#skip-changelog

Related to https://github.com/getsentry/sentry-dotnet/issues/2607#event-10342342475

In applications that use breadcrumbs heavily, the biggest memory hog is `Dictionary<string,object?>`. The following is a snapshot from a memory profile of an app that's creating lots of breadcrumbs:
![image](https://github.com/getsentry/sentry-dotnet/assets/728212/86d32cc2-217f-4d5b-96f8-adf2fa7cdef9)

All of those are unnecessarily created by the Hint constructor. By delaying instatiation of `Hint.Items` until they're actually used, we can avoid the unnecessary allocations for all these dictionaries. 

# Results

Saves about (752B - 672B) / 752B = **10.64%** of memory allocated for breadcrumbs. 

Note: The savings scale linearly from individual breadcrumbs to hundreds of breadcrumbs (although savings for breadcrumbs in particular will be capped per Transaction by `SentryOptions.MaxBreadcrumbs`.

## Before

![image](https://github.com/getsentry/sentry-dotnet/assets/728212/a0bda902-6d6e-45f9-80d5-f479590fc435)

## After

![image](https://github.com/getsentry/sentry-dotnet/assets/728212/e99ac8c3-5210-41ac-8ad1-7bea7315a0a5)
