### PR TITLE
Added OpenTelemetry MongoDB Sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The SDK now provides and overload of `ContinueTrace` that accepts headers as `string` ([#2601](https://github.com/getsentry/sentry-dotnet/pull/2601))
 - Sentry tracing middleware now gets configured automatically ([#2602](https://github.com/getsentry/sentry-dotnet/pull/2602))
+- Added OpenTelemetry MongoDB Sample ([#2634](https://github.com/getsentry/sentry-dotnet/pull/2634))
 
 ### Fixes
 

--- a/Sentry-CI-Build-Linux.slnf
+++ b/Sentry-CI-Build-Linux.slnf
@@ -26,6 +26,7 @@
       "samples\\Sentry.Samples.NLog\\Sentry.Samples.NLog.csproj",
       "samples\\Sentry.Samples.OpenTelemetry.AspNetCore\\Sentry.Samples.OpenTelemetry.AspNetCore.csproj",
       "samples\\Sentry.Samples.OpenTelemetry.Console\\Sentry.Samples.OpenTelemetry.Console.csproj",
+      "samples\\Sentry.Samples.OpenTelemetry.MongoDB\\Sentry.Samples.OpenTelemetry.MongoDB.csproj",
       "samples\\Sentry.Samples.Serilog\\Sentry.Samples.Serilog.csproj",
       "src\\Sentry.Android.AssemblyReader\\Sentry.Android.AssemblyReader.csproj",
       "src\\Sentry.AspNetCore.Grpc\\Sentry.AspNetCore.Grpc.csproj",

--- a/Sentry-CI-Build-Windows.slnf
+++ b/Sentry-CI-Build-Windows.slnf
@@ -25,6 +25,7 @@
       "samples\\Sentry.Samples.NLog\\Sentry.Samples.NLog.csproj",
       "samples\\Sentry.Samples.OpenTelemetry.AspNetCore\\Sentry.Samples.OpenTelemetry.AspNetCore.csproj",
       "samples\\Sentry.Samples.OpenTelemetry.Console\\Sentry.Samples.OpenTelemetry.Console.csproj",
+      "samples\\Sentry.Samples.OpenTelemetry.MongoDB\\Sentry.Samples.OpenTelemetry.MongoDB.csproj",
       "samples\\Sentry.Samples.Serilog\\Sentry.Samples.Serilog.csproj",
       "src\\Sentry.Android.AssemblyReader\\Sentry.Android.AssemblyReader.csproj",
       "src\\Sentry.AspNet\\Sentry.AspNet.csproj",

--- a/Sentry-CI-Build-macOS.slnf
+++ b/Sentry-CI-Build-macOS.slnf
@@ -29,6 +29,7 @@
       "samples\\Sentry.Samples.NLog\\Sentry.Samples.NLog.csproj",
       "samples\\Sentry.Samples.OpenTelemetry.AspNetCore\\Sentry.Samples.OpenTelemetry.AspNetCore.csproj",
       "samples\\Sentry.Samples.OpenTelemetry.Console\\Sentry.Samples.OpenTelemetry.Console.csproj",
+      "samples\\Sentry.Samples.OpenTelemetry.MongoDB\\Sentry.Samples.OpenTelemetry.MongoDB.csproj",
       "samples\\Sentry.Samples.Serilog\\Sentry.Samples.Serilog.csproj",
       "src\\Sentry.Android.AssemblyReader\\Sentry.Android.AssemblyReader.csproj",
       "src\\Sentry.AspNet\\Sentry.AspNet.csproj",

--- a/Sentry.sln
+++ b/Sentry.sln
@@ -161,6 +161,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TraceEvent", "modules\perfv
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastSerialization", "modules\perfview\src\FastSerialization\FastSerialization.csproj", "{8032310D-3C06-442C-A318-F365BCC4C804}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.OpenTelemetry.MongoDB", "samples\Sentry.Samples.OpenTelemetry.MongoDB\Sentry.Samples.OpenTelemetry.MongoDB.csproj", "{9759D497-457C-4141-80FA-7657E8F2FB11}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -462,6 +464,10 @@ Global
 		{8032310D-3C06-442C-A318-F365BCC4C804}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8032310D-3C06-442C-A318-F365BCC4C804}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8032310D-3C06-442C-A318-F365BCC4C804}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9759D497-457C-4141-80FA-7657E8F2FB11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9759D497-457C-4141-80FA-7657E8F2FB11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9759D497-457C-4141-80FA-7657E8F2FB11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9759D497-457C-4141-80FA-7657E8F2FB11}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{8328B70C-B808-4ED1-BB16-8555B2752CB6} = {7D4D7A6A-3F5C-4B4C-A198-AC51F9220231}
@@ -538,5 +544,6 @@ Global
 		{162A1CAE-ACEE-45CA-A6D0-7702ADE4D3DE} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
 		{67269916-C417-4CEE-BD7D-CA66C3830AEE} = {A3CCA27E-4DF8-479D-833C-CAA0950715AA}
 		{8032310D-3C06-442C-A318-F365BCC4C804} = {A3CCA27E-4DF8-479D-833C-CAA0950715AA}
+		{9759D497-457C-4141-80FA-7657E8F2FB11} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
 	EndGlobalSection
 EndGlobal

--- a/SentryNoMobile.slnf
+++ b/SentryNoMobile.slnf
@@ -25,6 +25,7 @@
       "samples\\Sentry.Samples.NLog\\Sentry.Samples.NLog.csproj",
       "samples\\Sentry.Samples.OpenTelemetry.AspNetCore\\Sentry.Samples.OpenTelemetry.AspNetCore.csproj",
       "samples\\Sentry.Samples.OpenTelemetry.Console\\Sentry.Samples.OpenTelemetry.Console.csproj",
+      "samples\\Sentry.Samples.OpenTelemetry.MongoDB\\Sentry.Samples.OpenTelemetry.MongoDB.csproj",
       "samples\\Sentry.Samples.Serilog\\Sentry.Samples.Serilog.csproj",
       "src\\Sentry.AspNetCore.Grpc\\Sentry.AspNetCore.Grpc.csproj",
       "src\\Sentry.AspNetCore\\Sentry.AspNetCore.csproj",

--- a/samples/Sentry.Samples.OpenTelemetry.MongoDB/Program.cs
+++ b/samples/Sentry.Samples.OpenTelemetry.MongoDB/Program.cs
@@ -1,0 +1,68 @@
+﻿using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.Driver.Core.Extensions.DiagnosticSources;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Sentry;
+using Sentry.OpenTelemetry;
+
+SentrySdk.Init(options =>
+{
+    // options.Dsn = "... Your DSN ...";
+    options.Debug = true;
+    options.TracesSampleRate = 1.0; // <-- Set the sample rate to 100% (in production you'd configure this to be lower)
+    options.UseOpenTelemetry(); // <-- Configure Sentry to use OpenTelemetry trace information
+});
+
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .ConfigureResource(resource => resource.AddService("sentry-mongo-sample"))
+    .AddMongoDBInstrumentation() // <-- Adds the MongoDB OTel datasource
+    .AddSentry() // <-- Configure OpenTelemetry to send traces to Sentry
+    .Build();
+
+/*
+ * The following configuration for the MongoClient ensures diagnostic information gets generated for OpenTelemetry.
+ */
+var connectionString = "mongodb://localhost:27017"; // <-- Replace with your connection string
+var clientSettings = MongoClientSettings.FromConnectionString(connectionString);
+var instrumentationOptions = new InstrumentationOptions
+{
+    ShouldStartActivity = @event => "fruit".Equals(@event.GetCollectionName()) // <-- Optionally filter diagnostic information by collection name
+};
+clientSettings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityEventSubscriber(instrumentationOptions));
+var mongoClient = new MongoClient(clientSettings);
+
+/*
+ * Start a sentry transaction... OTel diagnostics will be captured and sent to Sentry in this transaction
+ */
+// var transaction = SentrySdk.StartTransaction("Program Main", "function");
+// SentrySdk.ConfigureScope(scope => scope.Transaction = transaction);
+
+/*
+ * This is just some nonsense to demonstrate a few MongoDB operations... the main purpose of which is to generate
+ * diagnostic information that will be captured by OpenTelemetry and sent to Sentry.
+ */
+var db = mongoClient.GetDatabase("sentryMongoSample");
+var collection = db.GetCollection<BsonDocument>("fruit");
+
+var filter = Builders<BsonDocument>.Filter.Eq("_id", "1");
+
+var update = Builders<BsonDocument>.Update
+    .Set("name", "Red Apple")
+    .Set("color", "Red");
+
+var options = new FindOneAndUpdateOptions<BsonDocument>
+{
+    IsUpsert = true
+};
+
+collection.FindOneAndUpdate(filter, update, options);
+
+var document = collection.Find(filter).First();
+Console.WriteLine(document);
+
+/*
+ * Finally, finish the transaction and send it to Sentry
+ */
+// transaction.Finish();

--- a/samples/Sentry.Samples.OpenTelemetry.MongoDB/README.md
+++ b/samples/Sentry.Samples.OpenTelemetry.MongoDB/README.md
@@ -1,15 +1,10 @@
 # Overview
 
-This sample demonstrates how a MongoDB commands can be automatically instrumented using Sentry's OpenTelemetry package. 
+This sample demonstrates how a MongoDB commands can be automatically instrumented using Sentry's OpenTelemetry package.
 
-There are a few steps to get this working, but once it's configured it shouldn't require further attention:
-- Install relevant NuGet packages
-- Configure Sentry OpenTelemetry Tracing
-- Configure the OpenTelemetry Trace Provider to collect MongoDB diagnostic information
-- Configure the OpenTelemetry Trace Provider to send trace information to Sentry
-- Configure MongoDB Client to send diagnostic activity
+There are a few steps to get this working.
 
-## Install NuGet packages
+## 1. Install NuGet packages
 
 For this sample, we've used the following NuGet packages
 - `MongoDB.Driver`
@@ -18,7 +13,7 @@ For this sample, we've used the following NuGet packages
 - `Sentry`
 - `Sentry.OpenTelemetry`
 
-## Configure Sentry OpenTelemetry Tracing
+## 2. Configure Sentry OpenTelemetry Tracing
 
 In the SentryOptions builder:
 
@@ -27,7 +22,7 @@ In the SentryOptions builder:
     options.UseOpenTelemetry(); // <-- Configure Sentry to use OpenTelemetry trace information
 ```
 
-## Configure the OpenTelemetry Trace Provider to collect MongoDB diagnostic information
+## 3. Configure OpenTelemetry Trace to collect MongoDB diagnostics
 
 On the OpenTelemetry TraceProviderBuilder:
 
@@ -36,7 +31,7 @@ Sdk.CreateTracerProviderBuilder()
     .AddMongoDBInstrumentation() // <-- Adds the MongoDB OTel datasource
 ```
 
-## Configure the OpenTelemetry Trace Provider to send trace information to Sentry
+## 4. ConfigureOpenTelemetry to send traces to Sentry
 
 On the OpenTelemetry TraceProviderBuilder:
 
@@ -45,7 +40,7 @@ Sdk.CreateTracerProviderBuilder()
     .AddSentry() // <-- Configure OpenTelemetry to send traces to Sentry
 ```
 
-## Configure MongoDB to send diagnostic activity
+## 5. Enable MongoDB diagnostic activity
 
 Technically, this is all that's required:
 

--- a/samples/Sentry.Samples.OpenTelemetry.MongoDB/README.md
+++ b/samples/Sentry.Samples.OpenTelemetry.MongoDB/README.md
@@ -1,0 +1,59 @@
+# Overview
+
+This sample demonstrates how a MongoDB commands can be automatically instrumented using Sentry's OpenTelemetry package. 
+
+There are a few steps to get this working, but once it's configured it shouldn't require further attention:
+- Install relevant NuGet packages
+- Configure Sentry OpenTelemetry Tracing
+- Configure the OpenTelemetry Trace Provider to collect MongoDB diagnostic information
+- Configure the OpenTelemetry Trace Provider to send trace information to Sentry
+- Configure MongoDB Client to send diagnostic activity
+
+## Install NuGet packages
+
+For this sample, we've used the following NuGet packages
+- `MongoDB.Driver`
+- `MongoDB.Driver.Core.Extensions.OpenTelemetry`
+- `OpenTelemetry`
+- `Sentry`
+- `Sentry.OpenTelemetry`
+
+## Configure Sentry OpenTelemetry Tracing
+
+In the SentryOptions builder:
+
+```csharp
+    options.TracesSampleRate = 1.0; // <-- Set the sample rate to 100% (in production you'd configure this to be lower)
+    options.UseOpenTelemetry(); // <-- Configure Sentry to use OpenTelemetry trace information
+```
+
+## Configure the OpenTelemetry Trace Provider to collect MongoDB diagnostic information
+
+On the OpenTelemetry TraceProviderBuilder:
+
+```csharp
+Sdk.CreateTracerProviderBuilder()
+    .AddMongoDBInstrumentation() // <-- Adds the MongoDB OTel datasource
+```
+
+## Configure the OpenTelemetry Trace Provider to send trace information to Sentry
+
+On the OpenTelemetry TraceProviderBuilder:
+
+```csharp
+Sdk.CreateTracerProviderBuilder()
+    .AddSentry() // <-- Configure OpenTelemetry to send traces to Sentry
+```
+
+## Configure MongoDB to send diagnostic activity
+
+Technically, this is all that's required:
+
+```csharp
+var clientSettings = MongoClientSettings.FromConnectionString(connectionString);
+clientSettings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityEventSubscriber());
+var mongoClient = new MongoClient(clientSettings);
+```
+
+In the sample program, we've also added some options to the `DiagnosticsActivityEventSubscriber` to illustrate how you
+can configure the subscriber to only send certain events to OpenTelemetry.

--- a/samples/Sentry.Samples.OpenTelemetry.MongoDB/Sentry.Samples.OpenTelemetry.MongoDB.csproj
+++ b/samples/Sentry.Samples.OpenTelemetry.MongoDB/Sentry.Samples.OpenTelemetry.MongoDB.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+      <OutputType>Exe</OutputType>
+      <TargetFramework>net6.0</TargetFramework>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MongoDB.Driver" Version="2.21.0" />
+    <PackageReference Include="MongoDB.Driver.Core.Extensions.OpenTelemetry" Version="1.0.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.5.0" />
+  </ItemGroup>
+
+  <!-- In your own project, this would be a PackageReference to the latest version of Sentry. -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.OpenTelemetry\Sentry.OpenTelemetry.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
# Overview

The sample demonstrates how MongoDB commands can be automatically instrumented using Sentry's OpenTelemetry package. 

There are a few steps to get this working.

## 1. Install NuGet packages

For this sample, we've used the following NuGet packages
- `MongoDB.Driver`
- `MongoDB.Driver.Core.Extensions.OpenTelemetry`
- `OpenTelemetry`
- `Sentry`
- `Sentry.OpenTelemetry`

## 2. Configure Sentry OpenTelemetry Tracing

In the SentryOptions builder:

```csharp
    options.TracesSampleRate = 1.0; // <-- Set the sample rate to 100% (in production you'd configure this to be lower)
    options.UseOpenTelemetry(); // <-- Configure Sentry to use OpenTelemetry trace information
```

## 3. Configure OpenTelemetry Trace to collect MongoDB diagnostics

On the OpenTelemetry TraceProviderBuilder:

```csharp
Sdk.CreateTracerProviderBuilder()
    .AddMongoDBInstrumentation() // <-- Adds the MongoDB OTel datasource
```

## 4. ConfigureOpenTelemetry to send traces to Sentry

On the OpenTelemetry TraceProviderBuilder:

```csharp
Sdk.CreateTracerProviderBuilder()
    .AddSentry() // <-- Configure OpenTelemetry to send traces to Sentry
```

## 5. Enable MongoDB diagnostic activity

Technically, this is all that's required:

```csharp
var clientSettings = MongoClientSettings.FromConnectionString(connectionString);
clientSettings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityEventSubscriber());
var mongoClient = new MongoClient(clientSettings);
```

In the sample program, we've also added some options to the `DiagnosticsActivityEventSubscriber` to illustrate how you
can configure the subscriber to only send certain events to OpenTelemetry.
