### PR TITLE
Fixed Sentry.Samples.OpenTelemetry.Console

### DIFF
--- a/samples/Sentry.Samples.OpenTelemetry.Console/Program.cs
+++ b/samples/Sentry.Samples.OpenTelemetry.Console/Program.cs
@@ -14,6 +14,13 @@ using Sentry.OpenTelemetry;
 var serviceName = "Sentry.Samples.OpenTelemetry.Console";
 var serviceVersion = "1.0.0";
 
+SentrySdk.Init(options =>
+{
+    // options.Dsn = "... Your DSN ...";
+    options.TracesSampleRate = 1.0;
+    options.UseOpenTelemetry(); // <-- Configure Sentry to use OpenTelemetry trace information
+});
+
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddSource(serviceName)
     .ConfigureResource(resource =>
@@ -22,10 +29,3 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             serviceVersion: serviceVersion))
     .AddSentry() // <-- Configure OpenTelemetry to send traces to Sentry
     .Build();
-
-SentrySdk.Init(options =>
-{
-    // options.Dsn = "... Your DSN ...";
-    options.TracesSampleRate = 1.0;
-    options.UseOpenTelemetry(); // <-- Configure Sentry to use OpenTelemetry trace information
-});


### PR DESCRIPTION
#skip-changelog

For console applications, Sentry needs to be initialised before OpenTelemetry... otherwise the `SentryOptions` aren't available in and we get an exception from the following code:

https://github.com/getsentry/sentry-dotnet/blob/47922b264660c0272b87c4c899412d106f5f6d34/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs#L42-L47