### PR TITLE
ref: Instantiating `_tags` for Spans lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Reduced the memory footprint of `SpanTracer` by initializing the tags lazily ([2636](https://github.com/getsentry/sentry-dotnet/pull/2636))
 - Added distributed tracing without performance for Azure Function Workers ([#2630](https://github.com/getsentry/sentry-dotnet/pull/2630))
 - The SDK now provides and overload of `ContinueTrace` that accepts headers as `string` ([#2601](https://github.com/getsentry/sentry-dotnet/pull/2601))
 - Sentry tracing middleware now gets configured automatically ([#2602](https://github.com/getsentry/sentry-dotnet/pull/2602))

--- a/benchmarks/Sentry.Benchmarks/TransactionBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/TransactionBenchmarks.cs
@@ -1,0 +1,34 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Sentry.Benchmarks;
+
+public class TransactionBenchmarks
+{
+    private const string Operation = "Operation";
+    private const string Name = "Name";
+
+    [Params(1, 10, 100, 1000)]
+    public int SpanCount;
+
+    private IDisposable _sdk;
+
+    [GlobalSetup(Target = nameof(CreateTransaction))]
+    public void EnabledSdk() => _sdk = SentrySdk.Init(Constants.ValidDsn);
+
+    [GlobalCleanup(Target = nameof(CreateTransaction))]
+    public void DisableDsk() => _sdk.Dispose();
+
+    [Benchmark(Description = "Creates a Transaction")]
+    public void CreateTransaction()
+    {
+        var transaction = SentrySdk.StartTransaction(Name, Operation);
+
+        for (var i = 0; i < SpanCount; i++)
+        {
+            var span = transaction.StartChild(Operation);
+            span.Finish();
+        }
+
+        transaction.Finish();
+    }
+}

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -421,9 +421,9 @@ public class Scope : IEventLike, IHasDistribution
             }
         }
 
-        foreach (var (key, value) in _tags)
+        foreach (var (key, value) in Tags)
         {
-            if(!other.Tags.ContainsKey(key))
+            if (!other.Tags.ContainsKey(key))
             {
                 other.SetTag(key, value);
             }

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -421,9 +421,9 @@ public class Scope : IEventLike, IHasDistribution
             }
         }
 
-        foreach (var (key, value) in Tags)
+        foreach (var (key, value) in _tags)
         {
-            if (!other.Tags.ContainsKey(key))
+            if(!other.Tags.ContainsKey(key))
             {
                 other.SetTag(key, value);
             }

--- a/src/Sentry/Span.cs
+++ b/src/Sentry/Span.cs
@@ -88,7 +88,7 @@ public class Span : ISpanData, IJsonSerializable
         Status = tracer.Status;
         IsSampled = tracer.IsSampled;
         _extra = tracer.Extra.ToDictionary();
-        _tags = tracer.Tags.ToDictionary();
+        _tags = tracer is SpanTracer s ? s.InternalTags?.ToDictionary() : tracer.Tags.ToDictionary();
     }
 
     /// <inheritdoc />

--- a/src/Sentry/SpanTracer.cs
+++ b/src/Sentry/SpanTracer.cs
@@ -52,6 +52,8 @@ public class SpanTracer : ISpan
 
     private ConcurrentDictionary<string, string>? _tags;
 
+    internal ConcurrentDictionary<string, string>? InternalTags => _tags;
+
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string> Tags => _tags ??= new ConcurrentDictionary<string, string>();
 


### PR DESCRIPTION
Lazy tag creation for spans.

```
OLD:
|                  Method | SpanCount |        Mean |        Error |     StdDev |     Gen0 |     Gen1 |  Allocated |
|------------------------ |---------- |------------:|-------------:|-----------:|---------:|---------:|-----------:|
| 'Creates a Transaction' |         1 |    19.95 us |     8.426 us |   0.462 us |   2.2278 |   0.8545 |   11.79 KB |
| 'Creates a Transaction' |        10 |    60.71 us |    28.927 us |   1.586 us |   5.6152 |   2.0752 |   32.29 KB |
| 'Creates a Transaction' |       100 |   485.11 us |    24.521 us |   1.344 us |  40.0391 |  13.6719 |  238.07 KB |
| 'Creates a Transaction' |      1000 | 4,790.64 us | 2,046.437 us | 112.172 us | 390.6250 | 140.6250 | 2291.61 KB |

NEW:
|                  Method | SpanCount |        Mean |       Error |     StdDev |     Gen0 |    Gen1 |  Allocated |
|------------------------ |---------- |------------:|------------:|-----------:|---------:|--------:|-----------:|
| 'Creates a Transaction' |         1 |    19.34 us |    12.07 us |   0.662 us |   1.8616 |  0.6714 |   10.98 KB |
| 'Creates a Transaction' |        10 |    56.41 us |    36.59 us |   2.006 us |   4.5166 |  1.4648 |   24.16 KB |
| 'Creates a Transaction' |       100 |   398.66 us |    27.15 us |   1.488 us |  37.5977 |  9.7656 |  156.81 KB |
| 'Creates a Transaction' |      1000 | 3,723.91 us | 3,241.45 us | 177.675 us | 343.7500 | 85.9375 | 1479.07 KB |
```
#skip-changelog