### PR TITLE
feat: Public headers utility

### DIFF
--- a/src/Sentry/BaggageHeader.cs
+++ b/src/Sentry/BaggageHeader.cs
@@ -10,7 +10,11 @@ namespace Sentry;
 /// <seealso href="https://www.w3.org/TR/baggage"/>
 public class BaggageHeader
 {
-    internal const string HttpHeaderName = "baggage";
+    /// <summary>
+    /// The HTTP header name for baggage
+    /// </summary>
+    public const string HttpHeaderName = "baggage";
+
     internal const string SentryKeyPrefix = "sentry-";
 
     internal static IDiagnosticLogger? Logger { get; set; } = SentrySdk.CurrentOptions?.DiagnosticLogger;
@@ -47,6 +51,15 @@ public class BaggageHeader
         // Whitespace after delimiter is optional by the spec, but typical by convention.
         return string.Join(", ", members);
     }
+
+    /// <summary>
+    /// Parses a baggage header string
+    /// </summary>
+    /// <param name="baggage">The string to parse.</param>
+    /// <returns>
+    /// An object representing the sentry baggage header, or <c>null</c> if there are no members parsed.
+    /// </returns>
+    public static BaggageHeader? TryParse(string baggage) => TryParse(baggage, true);
 
     /// <summary>
     /// Parses a baggage header string.

--- a/src/Sentry/BaggageHeader.cs
+++ b/src/Sentry/BaggageHeader.cs
@@ -72,7 +72,7 @@ public class BaggageHeader
     /// <returns>
     /// An object representing the members baggage header, or <c>null</c> if there are no members parsed.
     /// </returns>
-    internal static BaggageHeader? TryParse(string baggage, bool onlySentry = false)
+    internal static BaggageHeader? TryParse(string baggage, bool onlySentry)
     {
         // Example from W3C baggage spec:
         // "key1=value1;property1;property2, key2 = value2, key3=value3; propertyKey=propertyValue"

--- a/src/Sentry/SentryMessageHandler.cs
+++ b/src/Sentry/SentryMessageHandler.cs
@@ -162,7 +162,7 @@ public abstract class SentryMessageHandler : DelegatingHandler
 
             // Merge existing baggage headers with ours.
             var allBaggage = headers
-                .Select(s => BaggageHeader.TryParse(s)).ExceptNulls()
+                .Select(s => BaggageHeader.TryParse(s, false)).ExceptNulls()
                 .Append(baggage);
             baggage = BaggageHeader.Merge(allBaggage);
 

--- a/src/Sentry/SentryTraceHeader.cs
+++ b/src/Sentry/SentryTraceHeader.cs
@@ -5,7 +5,10 @@ namespace Sentry;
 /// </summary>
 public class SentryTraceHeader
 {
-    internal const string HttpHeaderName = "sentry-trace";
+    /// <summary>
+    /// The HTTP header name for SentryTrace
+    /// </summary>
+    public const string HttpHeaderName = "sentry-trace";
 
     internal static readonly SentryTraceHeader Empty = new(SentryId.Empty, SpanId.Empty, null);
 

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -21,7 +21,9 @@ namespace Sentry
     }
     public class BaggageHeader
     {
+        public const string HttpHeaderName = "baggage";
         public override string ToString() { }
+        public static Sentry.BaggageHeader? TryParse(string baggage) { }
     }
     [System.Diagnostics.DebuggerDisplay("Message: {Message}, Type: {Type}")]
     public sealed class Breadcrumb : Sentry.IJsonSerializable
@@ -837,6 +839,7 @@ namespace Sentry
     }
     public class SentryTraceHeader
     {
+        public const string HttpHeaderName = "sentry-trace";
         public SentryTraceHeader(Sentry.SentryId traceId, Sentry.SpanId spanSpanId, bool? isSampled) { }
         public bool? IsSampled { get; }
         public Sentry.SpanId SpanId { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -21,7 +21,9 @@ namespace Sentry
     }
     public class BaggageHeader
     {
+        public const string HttpHeaderName = "baggage";
         public override string ToString() { }
+        public static Sentry.BaggageHeader? TryParse(string baggage) { }
     }
     [System.Diagnostics.DebuggerDisplay("Message: {Message}, Type: {Type}")]
     public sealed class Breadcrumb : Sentry.IJsonSerializable
@@ -838,6 +840,7 @@ namespace Sentry
     }
     public class SentryTraceHeader
     {
+        public const string HttpHeaderName = "sentry-trace";
         public SentryTraceHeader(Sentry.SentryId traceId, Sentry.SpanId spanSpanId, bool? isSampled) { }
         public bool? IsSampled { get; }
         public Sentry.SpanId SpanId { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -21,7 +21,9 @@ namespace Sentry
     }
     public class BaggageHeader
     {
+        public const string HttpHeaderName = "baggage";
         public override string ToString() { }
+        public static Sentry.BaggageHeader? TryParse(string baggage) { }
     }
     [System.Diagnostics.DebuggerDisplay("Message: {Message}, Type: {Type}")]
     public sealed class Breadcrumb : Sentry.IJsonSerializable
@@ -836,6 +838,7 @@ namespace Sentry
     }
     public class SentryTraceHeader
     {
+        public const string HttpHeaderName = "sentry-trace";
         public SentryTraceHeader(Sentry.SentryId traceId, Sentry.SpanId spanSpanId, bool? isSampled) { }
         public bool? IsSampled { get; }
         public Sentry.SpanId SpanId { get; }

--- a/test/Sentry.Tests/BaggageHeaderTests.verify.cs
+++ b/test/Sentry.Tests/BaggageHeaderTests.verify.cs
@@ -20,7 +20,8 @@ public partial class BaggageHeaderTests
             "other-vendor-value-1=foo," +
             "other-vendor-value-2=foo;bar;," +
             "dup-value=something, " +
-            "dup-value=something,");
+            "dup-value=something,"
+            , false);
 
         Assert.NotNull(header);
 
@@ -37,7 +38,8 @@ public partial class BaggageHeaderTests
             "sentry-public_key=49d0f7386ad645858ae85020e393bef3, " +
             "sentry-sample_rate=0.01337, " +
             "sentry-user_id=Am%C3%A9lie, " +
-            "other-vendor-value-2=foo;bar;");
+            "other-vendor-value-2=foo;bar;"
+            , false);
 
         return VerifyHeader(header);
     }


### PR DESCRIPTION
With the `ContinueTrace` now accepting the headers as `string` I think we should also provide the keys to them.
I added a public `TryParse` to the Baggage because
1. SentryTraceHeader has a public `TryParse`
2. `ContinueTrace` accepts a Baggage but there is no way for users to create a Baggage object.
Since the parsing part is not supposed to be a general tool but only deal with Sentry it defaults to `onlySentry = true`.

How it's supposed to be used:
```
// Grab the trace and baggage header i.e. from the context's request
var traceHeader = context.Request.Headers.GetValueOrDefault(SentryTraceHeader.HttpHeaderName);
var baggage = context.Request.Headers.GetValueOrDefault(BaggageHeader.HttpHeaderName);

var transactionContext = SentrySdk.ContinueTrace(sentryTraceHeader, baggageHeader);
var transaction = Sentry.startTransaction(transactionContext);
```