### PR TITLE
Removed legacy group

### DIFF
--- a/SentryNoMobile.slnf
+++ b/SentryNoMobile.slnf
@@ -26,6 +26,7 @@
       "samples\\Sentry.Samples.OpenTelemetry.AspNetCore\\Sentry.Samples.OpenTelemetry.AspNetCore.csproj",
       "samples\\Sentry.Samples.OpenTelemetry.Console\\Sentry.Samples.OpenTelemetry.Console.csproj",
       "samples\\Sentry.Samples.Serilog\\Sentry.Samples.Serilog.csproj",
+      "src\\Sentry.AspNet\\Sentry.AspNet.csproj",
       "src\\Sentry.AspNetCore.Grpc\\Sentry.AspNetCore.Grpc.csproj",
       "src\\Sentry.AspNetCore\\Sentry.AspNetCore.csproj",
       "src\\Sentry.Azure.Functions.Worker\\Sentry.Azure.Functions.Worker.csproj",

--- a/SentryNoSamples.slnf
+++ b/SentryNoSamples.slnf
@@ -4,6 +4,7 @@
     "projects": [
       "benchmarks\\Sentry.Benchmarks\\Sentry.Benchmarks.csproj",
       "src\\Sentry.Android.AssemblyReader\\Sentry.Android.AssemblyReader.csproj",
+      "src\\Sentry.AspNet\\Sentry.AspNet.csproj",
       "src\\Sentry.AspNetCore.Grpc\\Sentry.AspNetCore.Grpc.csproj",
       "src\\Sentry.AspNetCore\\Sentry.AspNetCore.csproj",
       "src\\Sentry.Azure.Functions.Worker\\Sentry.Azure.Functions.Worker.csproj",

--- a/scripts/generate-solution-filters-config.yaml
+++ b/scripts/generate-solution-filters-config.yaml
@@ -18,10 +18,6 @@ groupConfigs:
   windowsOnly:
     # .NET Framework projects
     - "**/*.AspNet.csproj"
-  legacy:
-    # In slnf files that we maintain purely for developer convenience,
-    # we typically exclude these projects
-    - "**/*.AspNet.csproj"
 
 filterConfigs:
 
@@ -152,8 +148,6 @@ filterConfigs:
       groups:
         - "allProjects"
     exclude:
-      groups:
-        - "legacy"
       patterns:
         - "**/*Bindings*.csproj"
         - "**/*Android*.csproj"
@@ -165,8 +159,6 @@ filterConfigs:
       groups:
         - "allProjects"
     exclude:
-      groups:
-        - "legacy"
       patterns:
         - "samples/**/*"
         - "**/*Bindings*"


### PR DESCRIPTION
#skip-changelog

Removed `legacy` group from the solution filters as both the `Mobile` and `NoMobile` `slnf` files (which use this) should include the `Sentry.AspNet.csproj` file.