### PR TITLE
Fixed: Changelog prevents CI Builds in v4.0.0 branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,6 @@
 # Changelog
 
-## 4.0.0 Unreleased
-
-### Dependencies
-
-- Bump CLI from v2.20.7 to v2.21.1 ([#2645](https://github.com/getsentry/sentry-dotnet/pull/2645), [#2647](https://github.com/getsentry/sentry-dotnet/pull/2647))
-  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2211)
-  - [diff](https://github.com/getsentry/sentry-cli/compare/2.20.7...2.21.1)
-
-## 3.40.0-beta.0
+## Unreleased (version Four)
 
 ### Breaking changes
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/2678

#skip-changelog