### PR TITLE
feat: Enable `CaptureFailedRequests` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,6 @@ API Changes:
 - ISpanContext was removed. Use ITraceContext instead. ([#2668](https://github.com/getsentry/sentry-dotnet/pull/2668))
 - Removed IHasTransactionNameSource. Use ITransactionContext instead. ([#2654](https://github.com/getsentry/sentry-dotnet/pull/2654))
 - Adding `Distribution` to `IEventLike` ([#2660](https://github.com/getsentry/sentry-dotnet/pull/2660))
-
-
-### Features
-
 - Enable `CaptureFailedRequests`` by default ([2688](https://github.com/getsentry/sentry-dotnet/pull/2688))
 
 ## Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ API Changes:
 - Removed IHasTransactionNameSource. Use ITransactionContext instead. ([#2654](https://github.com/getsentry/sentry-dotnet/pull/2654))
 - Adding `Distribution` to `IEventLike` ([#2660](https://github.com/getsentry/sentry-dotnet/pull/2660))
 
+
+### Features
+
+- Enable `CaptureFailedRequests`` by default ([2688](https://github.com/getsentry/sentry-dotnet/pull/2688))
+
 ## Unreleased
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ API Changes:
 - ISpanContext was removed. Use ITraceContext instead. ([#2668](https://github.com/getsentry/sentry-dotnet/pull/2668))
 - Removed IHasTransactionNameSource. Use ITransactionContext instead. ([#2654](https://github.com/getsentry/sentry-dotnet/pull/2654))
 - Adding `Distribution` to `IEventLike` ([#2660](https://github.com/getsentry/sentry-dotnet/pull/2660))
-- Enable `CaptureFailedRequests`` by default ([2688](https://github.com/getsentry/sentry-dotnet/pull/2688))
+- Enable `CaptureFailedRequests` by default ([2688](https://github.com/getsentry/sentry-dotnet/pull/2688))
 
 ## Unreleased
 

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -664,7 +664,7 @@ public class SentryOptions
     /// <para>Also <see cref="FailedRequestTargets"/> can be used to filter to match only certain request URLs.</para>
     /// <para>Defaults to false due to PII reasons.</para>
     /// </summary>
-    public bool CaptureFailedRequests { get; set; }
+    public bool CaptureFailedRequests { get; set; } = true;
 
     /// <summary>
     /// <para>The SDK will only capture HTTP Client errors if the HTTP Response status code is within these defined ranges.</para>

--- a/test/Sentry.Tests/SentryOptionsTests.cs
+++ b/test/Sentry.Tests/SentryOptionsTests.cs
@@ -175,10 +175,10 @@ public class SentryOptionsTests
     }
 
     [Fact]
-    public void CaptureFailedRequests_ByDefault_IsFalse()
+    public void CaptureFailedRequests_ByDefault_IsTrue()
     {
         var sut = new SentryOptions();
-        Assert.False(sut.CaptureFailedRequests, "CaptureFailedRequests should be false by default to protect potentially PII (Privately Identifiable Information)");
+        Assert.True(sut.CaptureFailedRequests);
     }
 
     [Fact]


### PR DESCRIPTION
Resolves: https://github.com/getsentry/sentry-dotnet/issues/2448

Other SDKs have this already enabled.