### PR TITLE
chore: obsolete StackFrame.InstructionOffset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Obsoletion
 
 - `WithScope` and `WithScopeAsync` have been proven to not work correctly in desktop contexts when using a global scope. They are now deprecated in favor of the overloads of `CaptureEvent`, `CaptureMessage`, and `CaptureException`. Those methods provide a callback to a configurable scope. ([#2677](https://github.com/getsentry/sentry-dotnet/pull/2677))
+- `StackFrame.InstructionOffset` has not been used in the SDK and has been ignored on the server for years. ([#2689](https://github.com/getsentry/sentry-dotnet/pull/2689))
 
 ### Features
 

--- a/src/Sentry/SentryStackFrame.cs
+++ b/src/Sentry/SentryStackFrame.cs
@@ -128,6 +128,7 @@ public sealed class SentryStackFrame : IJsonSerializable
     /// The official docs refer to it as 'The difference between instruction address and symbol address in bytes.'
     /// In .NET this means the IL Offset within the assembly.
     /// </remarks>
+    [Obsolete("This property is unused and will be removed in the future.")]
     public long? InstructionOffset { get; set; }
 
     /// <summary>
@@ -168,7 +169,9 @@ public sealed class SentryStackFrame : IJsonSerializable
         writer.WriteStringIfNotWhiteSpace("image_addr", ImageAddress.NullIfDefault()?.ToHexString());
         writer.WriteStringIfNotWhiteSpace("symbol_addr", SymbolAddress?.ToHexString());
         writer.WriteStringIfNotWhiteSpace("instruction_addr", InstructionAddress);
+#pragma warning disable 0618
         writer.WriteNumberIfNotNull("instruction_offset", InstructionOffset);
+#pragma warning restore 0618
         writer.WriteStringIfNotWhiteSpace("addr_mode", AddressMode);
         writer.WriteStringIfNotWhiteSpace("function_id", FunctionId);
 
@@ -263,7 +266,9 @@ public sealed class SentryStackFrame : IJsonSerializable
             ImageAddress = imageAddress,
             SymbolAddress = symbolAddress,
             InstructionAddress = instructionAddress,
+#pragma warning disable 0618
             InstructionOffset = instructionOffset,
+#pragma warning restore 0618
             AddressMode = addressMode,
             FunctionId = functionId,
         };

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -813,6 +813,7 @@ namespace Sentry
         public long ImageAddress { get; set; }
         public bool? InApp { get; set; }
         public string? InstructionAddress { get; set; }
+        [System.Obsolete("This property is unused and will be removed in the future.")]
         public long? InstructionOffset { get; set; }
         public int? LineNumber { get; set; }
         public string? Module { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -814,6 +814,7 @@ namespace Sentry
         public long ImageAddress { get; set; }
         public bool? InApp { get; set; }
         public string? InstructionAddress { get; set; }
+        [System.Obsolete("This property is unused and will be removed in the future.")]
         public long? InstructionOffset { get; set; }
         public int? LineNumber { get; set; }
         public string? Module { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -814,6 +814,7 @@ namespace Sentry
         public long ImageAddress { get; set; }
         public bool? InApp { get; set; }
         public string? InstructionAddress { get; set; }
+        [System.Obsolete("This property is unused and will be removed in the future.")]
         public long? InstructionOffset { get; set; }
         public int? LineNumber { get; set; }
         public string? Module { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -812,6 +812,7 @@ namespace Sentry
         public long ImageAddress { get; set; }
         public bool? InApp { get; set; }
         public string? InstructionAddress { get; set; }
+        [System.Obsolete("This property is unused and will be removed in the future.")]
         public long? InstructionOffset { get; set; }
         public int? LineNumber { get; set; }
         public string? Module { get; set; }

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
@@ -30,7 +30,9 @@ public class SentryStackFrameTests
             Platform = "Platform",
             ImageAddress = 3,
             SymbolAddress = 4,
+#pragma warning disable 0618
             InstructionOffset = 5,
+#pragma warning restore 0618
             InstructionAddress = "0xffffffff",
             AddressMode = "rel:0"
         };


### PR DESCRIPTION
This has been removed from Sentry 7 years ago: https://github.com/getsentry/sentry/blob/ee1ffefa293f3970737c3f206dcc5536daaa5177/CHANGES#L1645