### PR TITLE
Fallback to `AssemblyVersion` if `InformalVersion` is `NullOrEmpty`

### DIFF
--- a/src/Sentry/Reflection/AssemblyExtensions.cs
+++ b/src/Sentry/Reflection/AssemblyExtensions.cs
@@ -30,7 +30,7 @@ public static class AssemblyExtensions
         try
         {
             var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-            if (informationalVersion != null)
+            if (!string.IsNullOrEmpty(informationalVersion))
             {
                 return informationalVersion;
             }
@@ -41,10 +41,6 @@ public static class AssemblyExtensions
             // therefore this method uses a try/catch to make sure this method always returns a value
         }
 
-        // Note: even though the informational version could be "invalid" (e.g. string.Empty), it should
-        // be used for versioning and the software should not fallback to the assembly version string.
-        // See https://github.com/getsentry/sentry-dotnet/pull/1079#issuecomment-866992216
-        // TODO: Lets change this in a new major to return the Version as fallback
         return assembly.GetName().Version?.ToString();
     }
 }

--- a/test/Sentry.Tests/Internals/ApplicationVersionLocatorTests.cs
+++ b/test/Sentry.Tests/Internals/ApplicationVersionLocatorTests.cs
@@ -36,11 +36,11 @@ public class ApplicationVersionLocatorTests
 
     [Theory]
     [InlineData("")]
-    public void GetCurrent_InvalidCases_ReturnsNull(string version)
+    public void GetCurrent_InvalidCases_DoesNotReturnNull(string version)
     {
         var asm = AssemblyCreationHelper.CreateWithInformationalVersion(version);
         var actual = ApplicationVersionLocator.GetCurrent(asm);
-        Assert.Null(actual);
+        Assert.NotNull(actual);
     }
 
     [Fact]


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/2664
This removed the comments and todo.
Based on this comment: https://github.com/getsentry/sentry-dotnet/issues/1538#issuecomment-1105929550 the `AssemblyInformationalVersionAttribute` is automatically created and defaults to `<Version>`.
This can be disabled with the `GenerateAssemblyInformationalVersionAttribute` leading to the informal version returning `null`.
In that case, the SDK falls back to the assembly version.

#skip-changelog