### PR TITLE
Apply Scope to exceptions captured via Activity.RecordException

### DIFF
--- a/src/Sentry.AspNetCore/ScopeExtensions.cs
+++ b/src/Sentry.AspNetCore/ScopeExtensions.cs
@@ -169,7 +169,9 @@ public static class ScopeExtensions
 
     private static void SetBody(Scope scope, HttpContext context, SentryAspNetCoreOptions options)
     {
-        var extractors = context.RequestServices.GetService<IEnumerable<IRequestPayloadExtractor>>();
+        // Resharper says this can't be null, but actually it can if SetBody is called multiple times in a single request
+        // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
+        var extractors = context.RequestServices?.GetService<IEnumerable<IRequestPayloadExtractor>>();
         if (extractors == null)
         {
             return;

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -157,12 +157,6 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
 
             // Transactions set otel attributes (and resource attributes) as context.
             transaction.Contexts["otel"] = GetOtelContext(attributes);
-            // Events are received/processed in a different AsyncLocal context. Restoring the scope that started it.
-            var activityScope = data.GetFused<Scope>();
-            if (activityScope is { } savedScope && _hub is Hub hub)
-            {
-                hub.RestoreScope(savedScope);
-            }
         }
         else
         {
@@ -175,6 +169,12 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
             span.SetExtra("otel.kind", data.Kind);
         }
 
+        // Events are received/processed in a different AsyncLocal context. Restoring the scope that started it.
+        var activityScope = data.GetFused<Scope>();
+        if (activityScope is { } savedScope && _hub is Hub hub)
+        {
+            hub.RestoreScope(savedScope);
+        }
         GenerateSentryErrorsFromOtelSpan(data, attributes);
 
         var status = GetSpanStatus(data.Status, attributes);


### PR DESCRIPTION
#skip-changelog

Fixes https://github.com/getsentry/sentry-dotnet/issues/2711
