### PR TITLE
fix: `Samples.iOS` on a device

### DIFF
--- a/samples/Sentry.Samples.Ios/Info.plist
+++ b/samples/Sentry.Samples.Ios/Info.plist
@@ -8,6 +8,8 @@
     <string>io.sentry.dotnet.samples.ios</string>
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
+    <key>MinimumOSVersion</key>
+    <string>10.0</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
     <key>LSRequiresIPhoneOS</key>

--- a/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
+++ b/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
@@ -24,7 +24,16 @@
   -->
   <PropertyGroup>
     <OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</OSArchitecture>
+    <!-- Switch to this when running on an actual device -->
+<!--    <RuntimeIdentifier Condition="'$(OSArchitecture)' == 'Arm64'">ios-arm64</RuntimeIdentifier>-->
     <RuntimeIdentifier Condition="'$(OSArchitecture)' == 'Arm64' And ('$(_iOSRuntimeIdentifier)' == 'iossimulator-x64' Or ('$(_iOSRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == ''))">iossimulator-arm64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <!--
+    To run on a device, you need to set the CodesignEntitlements property.
+  -->
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
 
   <!--
@@ -35,5 +44,4 @@
     <SentryUploadSources>true</SentryUploadSources>
     <SentryUploadSymbols>true</SentryUploadSymbols>
   </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
Because it would be a pain to figure out next time.

#skip-changelog