### PR TITLE
Calls to SentryTracingBuilder can now be chained correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fixed chaining on the IApplicationBuilder for methods like UseRouting and UseEndpoints ([#2726](https://github.com/getsentry/sentry-dotnet/pull/2726))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.13.0 to v8.13.1 ([#2722](https://github.com/getsentry/sentry-dotnet/pull/2722))

--- a/src/Sentry.AspNetCore/SentryTracingBuilder.cs
+++ b/src/Sentry.AspNetCore/SentryTracingBuilder.cs
@@ -51,11 +51,13 @@ internal class SentryTracingBuilder : IApplicationBuilder
             var instrumenter = options?.Value.Instrumenter ?? Instrumenter.Sentry;
             if (instrumenter == Instrumenter.Sentry)
             {
-                return InnerBuilder.Use(middleware).UseSentryTracing();
+                InnerBuilder.Use(middleware).UseSentryTracing();
+                return this; // Make sure we return the same builder (not the inner builder), for chaining
             }
             this.StoreInstrumenter(instrumenter); // Saves us from having to resolve the options to make this check again
         }
 
-        return InnerBuilder.Use(middleware);
+        InnerBuilder.Use(middleware);
+        return this; // Make sure we return the same builder (not the inner builder), for chaining
     }
 }


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/2721

# Problem

The dotnet `UseRouting` and `UseEndpoints` methods are just extensions on the builder... they set properties etc. on the builder before adding middleware. The only part of what they do that gets passed to the `SentryTracingBuilder.InnerBuilder` then is the delegate that they return on the last line of their implementation (e.g. [this](https://github.com/dotnet/aspnetcore/blob/8eaf4b51f73ae2b0ed079e4f8253afb53e96b703/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs#L113)).

Previously we were calling that delegate against the InnerBuilder and returning the result directly (which implicitly returns a reference to the InnerBuilder). Chained calls would then be against the InnerBuilder rather than the SentryTracingBuilder. 

This caused issues since `UseRouting` sets properties on the `SentryTracingBuilder` and then (in the chained call) `UserEndpoints` tries to follow up with some matching logic... only it's not using the same builder! It's using the InnerBuilder at this stage 😢 

# Solution

We've separated using the InnerBuilder to call the delegate from the return value in our SentryTracingBuilder so that for chained calls, the same builder will always be used.