### PR TITLE
CI cleanup

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -17,14 +17,17 @@ runs:
         distribution: 'temurin'
         java-version: '11'
 
+    # https://github.com/actions/runner-images/issues/7667
+    # .NET 3.1 has been removed from all OS due to EOL
+    # .NET 6 and .NET 8 are not built-in with macos-13
     - name: Install .NET SDK
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
           3.1.x
-          6.0.x
+          6.0.x 
           7.0.x
-          8.0.100-rc.2.23502.2
+          8.0.x
         
     - name: Dependency Caching
       uses: actions/cache@v3
@@ -44,17 +47,14 @@ runs:
           maui-android \
           ${{ runner.os == 'macOS' && 'maui-ios maui-maccatalyst maui-windows' || '' }} \
           ${{ runner.os == 'Windows' && 'maui-windows' || '' }} \
-          --temp-dir "${{ runner.temp }}" --from-rollback-file rollback.json
+          --temp-dir "${{ runner.temp }}"
 
-    - name: Restore workloads
-      shell: bash
-      run: dotnet workload restore
+    # # TODO: Figure out how we can not having to do this. 
+    # - name: Restore workloads
+    #   shell: bash
+    #   run: dotnet workload restore
 
-    - name: Update workloads
-      shell: bash
-      run: dotnet workload update
-
-    - name: Log what we have in the workloads
-      shell: bash
-      run: dotnet workload update
+    # - name: Update workloads
+    #   shell: bash
+    #   run: dotnet workload update
       

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -48,13 +48,3 @@ runs:
           ${{ runner.os == 'macOS' && 'maui-ios maui-maccatalyst maui-windows' || '' }} \
           ${{ runner.os == 'Windows' && 'maui-windows' || '' }} \
           --temp-dir "${{ runner.temp }}"
-
-    # # TODO: Figure out how we can not having to do this. 
-    # - name: Restore workloads
-    #   shell: bash
-    #   run: dotnet workload restore
-
-    # - name: Update workloads
-    #   shell: bash
-    #   run: dotnet workload update
-      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Pinning `macos-13` because Microsoft.iOS 16.4 requires Xcode 14.3 which is only built-in in 13
         os: [ubuntu-latest, windows-latest, macos-13]
 
     steps:

--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/actions/buildnative
 
       - name: Install .NET Workloads
-        run: dotnet workload install maui-android --temp-dir "${{ runner.temp }}" --from-rollback-file rollback.json
+        run: dotnet workload install maui-android --temp-dir "${{ runner.temp }}"
 
       - name: Restore .NET Dependencies
         run: dotnet restore test/Sentry.Maui.Device.TestApp --nologo

--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -41,6 +41,14 @@ jobs:
       - name: Build Android Test App
         run: dotnet build test/Sentry.Maui.Device.TestApp -c Release -f net7.0-android --no-restore --nologo
 
+      - name: Install tree
+        run: |
+          sudo apt-get update
+          sudo apt-get install tree
+  
+      - name: Print Folder Structure
+        run: tree test/Sentry.Maui.Device.TestApp/bin/
+
       - name: Upload Android Test App
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -41,14 +41,6 @@ jobs:
       - name: Build Android Test App
         run: dotnet build test/Sentry.Maui.Device.TestApp -c Release -f net7.0-android --no-restore --nologo
 
-      - name: Install tree
-        run: |
-          sudo apt-get update
-          sudo apt-get install tree
-  
-      - name: Print Folder Structure
-        run: tree test/Sentry.Maui.Device.TestApp/bin/
-
       - name: Upload Android Test App
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           name: device-test-android
           if-no-files-found: error
-          path: test/Sentry.Maui.Device.TestApp/bin/Release/net7.0-android/io.sentry.dotnet.maui.device.testapp-Signed.apk
+          path: test/Sentry.Maui.Device.TestApp/bin/Release/net7.0-android/android-x64/io.sentry.dotnet.maui.device.testapp-Signed.apk
 
   android:
     needs: [build]

--- a/.github/workflows/device-tests-ios.yml
+++ b/.github/workflows/device-tests-ios.yml
@@ -9,7 +9,8 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    # Pinning `macos-13` because Microsoft.iOS 16.4 requires Xcode 14.3 which is only built-in in 13
+    runs-on: macos-13
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1

--- a/.github/workflows/device-tests-ios.yml
+++ b/.github/workflows/device-tests-ios.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ./.github/actions/buildcocoasdk
 
       - name: Install .NET Workloads
-        run: dotnet workload install maui-ios --temp-dir "${{ runner.temp }}" --from-rollback-file rollback.json
+        run: dotnet workload install maui-ios --temp-dir "${{ runner.temp }}"
 
       - name: Restore .NET Dependencies
         run: dotnet restore test/Sentry.Maui.Device.TestApp --nologo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-Mobile support:
+Support Changes:
 
 .NET 6 on mobile is out of support since May 2023. With .NET 8 coming,
 it won't be possible to build .NET 6 Mobile specific targets.
@@ -13,6 +13,7 @@ Mobile apps still on .NET 6 will pull the `Sentry` .NET 6, which offers the .NET
 without native/platform specific bindings and SDKs. See [this ticket for more details](https://github.com/getsentry/sentry-dotnet/issues/2623).
 
 - Drop .NET 6 Mobile in favor of .NET 7 ([#2624](https://github.com/getsentry/sentry-dotnet/pull/2604))
+- Drop support for `Tizen` ([#2734](https://github.com/getsentry/sentry-dotnet/pull/2734))
 
 API Changes:
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,6 @@
     <NO_IOS>true</NO_IOS>
     <NO_MACCATALYST>true</NO_MACCATALYST>
     <NO_WINDOWS>true</NO_WINDOWS>
-    <NO_TIZEN>true</NO_TIZEN>
   </PropertyGroup>
 
   <!--
@@ -61,7 +60,6 @@
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'ios'">10.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'android'">21.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'tizen'">6.5</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -9,7 +9,6 @@
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'ios'">10.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'android'">21.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'tizen'">6.5</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>
@@ -27,11 +26,6 @@
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'windows'">
     <Compile Remove="**\*.Windows.cs" />
     <Compile Remove="**\Windows\**\*.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'tizen'">
-    <Compile Remove="**\*.Tizen.cs" />
-    <Compile Remove="**\Tizen\**\*.cs" />
   </ItemGroup>
 
   <!-- Allow setting CLSCompliant via property in any csproj -->
@@ -66,9 +60,6 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(MauiWorkloadVersion)' == ''">
       <NO_WINDOWS>true</NO_WINDOWS>
-    </PropertyGroup>
-    <PropertyGroup Condition="!Exists('$(MSBuildBinPath)\..\..\packs\Samsung.Tizen.Sdk')">
-      <NO_TIZEN>true</NO_TIZEN>
     </PropertyGroup>
 
   </Target>

--- a/rollback.json
+++ b/rollback.json
@@ -1,4 +1,0 @@
-{
-  "microsoft.net.sdk.ios": "16.2.2054/7.0.100",
-  "microsoft.net.sdk.maccatalyst": "16.2.2054/7.0.100"
-}

--- a/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
+++ b/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <!--

--- a/samples/Sentry.Samples.MacCatalyst/Sentry.Samples.MacCatalyst.csproj
+++ b/samples/Sentry.Samples.MacCatalyst/Sentry.Samples.MacCatalyst.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <SupportedOSPlatformVersion>14.2</SupportedOSPlatformVersion>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <!--

--- a/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
+++ b/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
@@ -6,9 +6,9 @@
       On Mac, we'll also build for iOS and MacCatalyst.
       On Windows, we'll also build for Windows 10.
     -->
-    <TargetFramework>net7.0-android</TargetFramework>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFramework);net7.0-windows10.0.19041.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFramework);net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net7.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Sentry.Samples.Maui</RootNamespace>
     <UseMaui>true</UseMaui>
@@ -65,6 +65,10 @@
     <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'ios'          And '$(OSArchitecture)' == 'x64'">iossimulator-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'  And '$(OSArchitecture)' == 'x64'">maccatalyst-x64</RuntimeIdentifier>
   </PropertyGroup>
+
+  <Target Name="LOG IDENTIFIERS" BeforeTargets="build">
+    <Message Importance="high" Text="TargetFramework: $(TargetFramework) - RuntimeIdentifier: $(RuntimeIdentifier)" />
+  </Target>
 
   <ItemGroup>
     <!-- App Icon -->

--- a/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
+++ b/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
@@ -56,6 +56,7 @@
   <PropertyGroup>
     <OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</OSArchitecture>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
+
     <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'android' And '$(OSArchitecture)' == 'Arm64' And ('$(_AndroidRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == '')">android-arm64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'ios' And '$(OSArchitecture)' == 'Arm64' And ('$(_iOSRuntimeIdentifier)' == 'iossimulator-x64' Or ('$(_iOSRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == ''))">iossimulator-arm64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst' And '$(OSArchitecture)' == 'Arm64' And ('$(_MacCatalystRuntimeIdentifier)' == 'maccatalyst-x64' Or ('$(_MacCatalystRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == ''))">maccatalyst-arm64</RuntimeIdentifier>

--- a/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
+++ b/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
@@ -57,10 +57,13 @@
     <OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</OSArchitecture>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
 
-    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'android' And '$(OSArchitecture)' == 'Arm64' And ('$(_AndroidRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == '')">android-arm64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'ios' And '$(OSArchitecture)' == 'Arm64' And ('$(_iOSRuntimeIdentifier)' == 'iossimulator-x64' Or ('$(_iOSRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == ''))">iossimulator-arm64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst' And '$(OSArchitecture)' == 'Arm64' And ('$(_MacCatalystRuntimeIdentifier)' == 'maccatalyst-x64' Or ('$(_MacCatalystRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == ''))">maccatalyst-arm64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst' And '$(OSArchitecture)' == 'x64' And ('$(_MacCatalystRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == '')">maccatalyst-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'android'      And '$(OSArchitecture)' == 'Arm64'">android-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'ios'          And '$(OSArchitecture)' == 'Arm64'">iossimulator-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'  And '$(OSArchitecture)' == 'Arm64'">maccatalyst-arm64</RuntimeIdentifier>
+
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'android'      And '$(OSArchitecture)' == 'x64'">android-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'ios'          And '$(OSArchitecture)' == 'x64'">iossimulator-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'  And '$(OSArchitecture)' == 'x64'">maccatalyst-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
+++ b/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
@@ -6,12 +6,13 @@
       On Mac, we'll also build for iOS and MacCatalyst.
       On Windows, we'll also build for Windows 10.
     -->
-    <TargetFrameworks>net7.0-android</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+    <TargetFramework>net7.0-android</TargetFramework>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFramework);net7.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFramework);net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Sentry.Samples.Maui</RootNamespace>
     <UseMaui>true</UseMaui>
+    <SelfContained>true</SelfContained>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <PublishReadyToRun>false</PublishReadyToRun>
@@ -31,7 +32,7 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
-    <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion   Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 
     <!--
       This avoids attaching a debugger when we crash the app when targeting Windows while running in Visual Studio.
@@ -55,6 +56,7 @@
   <PropertyGroup>
     <OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</OSArchitecture>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'android' And '$(OSArchitecture)' == 'Arm64' And ('$(_AndroidRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == '')">android-arm64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'ios' And '$(OSArchitecture)' == 'Arm64' And ('$(_iOSRuntimeIdentifier)' == 'iossimulator-x64' Or ('$(_iOSRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == ''))">iossimulator-arm64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst' And '$(OSArchitecture)' == 'Arm64' And ('$(_MacCatalystRuntimeIdentifier)' == 'maccatalyst-x64' Or ('$(_MacCatalystRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == ''))">maccatalyst-arm64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst' And '$(OSArchitecture)' == 'x64' And ('$(_MacCatalystRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == '')">maccatalyst-x64</RuntimeIdentifier>

--- a/src/Sentry.Maui/Sentry.Maui.csproj
+++ b/src/Sentry.Maui/Sentry.Maui.csproj
@@ -12,9 +12,6 @@
     <TargetFrameworks Condition="'$(NO_MACCATALYST)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_WINDOWS)' == '' And !$([MSBuild]::IsOSPlatform('Linux'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
 
-    <!-- Target Tizen only if the Tizen SDK workload pack is installed. -->
-    <TargetFrameworks Condition="'$(NO_TIZEN)' == '' And Exists('$(MSBuildBinPath)\..\..\packs\Samsung.Tizen.Sdk')">$(TargetFrameworks);net7.0-tizen</TargetFrameworks>
-
     <!--
       This flag allows us to target Windows-specific code when building on OSX, so we can build and pack all platforms on a single machine.
       See https://learn.microsoft.com/dotnet/core/tools/sdk-errors/netsdk1100

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -93,9 +93,6 @@ public static class SentryMauiAppBuilderExtensions
 #elif WINDOWS
             events.AddWindows(lifecycle => lifecycle.OnLaunching((application, _) =>
                 (application as IPlatformApplication)?.BindMauiEvents()));
-#elif TIZEN
-            events.AddTizen(lifecycle => lifecycle.OnCreate(application =>
-                (application as IPlatformApplication)?.BindMauiEvents()));
 #endif
         });
     }

--- a/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
+++ b/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>Sentry.Maui.Device.TestApp</RootNamespace>
     <AssemblyName>Sentry.Maui.Device.TestApp</AssemblyName>
     <UseMaui>true</UseMaui>
+    <SelfContained>true</SelfContained>
 
     <!-- Display name -->
     <ApplicationTitle>Sentry.Maui.Device.TestApp</ApplicationTitle>
@@ -41,6 +42,7 @@
   <PropertyGroup>
     <OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</OSArchitecture>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'android' And '$(OSArchitecture)' == 'Arm64' And ('$(_AndroidRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == '')">android-arm64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'ios' And '$(OSArchitecture)' == 'Arm64' And ('$(_iOSRuntimeIdentifier)' == 'iossimulator-x64' Or ('$(_iOSRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == ''))">iossimulator-arm64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst' And '$(OSArchitecture)' == 'Arm64' And ('$(_MacCatalystRuntimeIdentifier)' == 'maccatalyst-x64' Or ('$(_MacCatalystRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == ''))">maccatalyst-arm64</RuntimeIdentifier>
   </PropertyGroup>

--- a/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
+++ b/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
@@ -42,9 +42,14 @@
   <PropertyGroup>
     <OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</OSArchitecture>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
-    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'android' And '$(OSArchitecture)' == 'Arm64' And ('$(_AndroidRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == '')">android-arm64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'ios' And '$(OSArchitecture)' == 'Arm64' And ('$(_iOSRuntimeIdentifier)' == 'iossimulator-x64' Or ('$(_iOSRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == ''))">iossimulator-arm64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst' And '$(OSArchitecture)' == 'Arm64' And ('$(_MacCatalystRuntimeIdentifier)' == 'maccatalyst-x64' Or ('$(_MacCatalystRuntimeIdentifier)' == '' And '$(RuntimeIdentifier)' == ''))">maccatalyst-arm64</RuntimeIdentifier>
+
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'android'      And '$(OSArchitecture)' == 'Arm64'">android-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'ios'          And '$(OSArchitecture)' == 'Arm64'">iossimulator-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'  And '$(OSArchitecture)' == 'Arm64'">maccatalyst-arm64</RuntimeIdentifier>
+
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'android'      And '$(OSArchitecture)' == 'x64'">android-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'ios'          And '$(OSArchitecture)' == 'x64'">iossimulator-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'  And '$(OSArchitecture)' == 'x64'">maccatalyst-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/SingleFileTestApp/SingleFileTestApp.csproj
+++ b/test/SingleFileTestApp/SingleFileTestApp.csproj
@@ -7,6 +7,7 @@
     <LangVersion>11</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
     <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The actual fix on top of the initial "make it go green".
Also, added the `SelfContained` from [here](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/runtimespecific-app-default) to the appropriate projects to get rid of:
```
warning NETSDK1201: For projects targeting .NET 8.0 and higher, specifying a RuntimeIdentifier will no longer produce a self contained app by default. To continue building self-contained apps, set the SelfContained property to true or use the --self-contained argument.
```
#skip-changelog