### PR TITLE
Dropping support for `Tizen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-Mobile support:
+Support Changes:
 
 .NET 6 on mobile is out of support since May 2023. With .NET 8 coming,
 it won't be possible to build .NET 6 Mobile specific targets.
@@ -13,6 +13,7 @@ Mobile apps still on .NET 6 will pull the `Sentry` .NET 6, which offers the .NET
 without native/platform specific bindings and SDKs. See [this ticket for more details](https://github.com/getsentry/sentry-dotnet/issues/2623).
 
 - Drop .NET 6 Mobile in favor of .NET 7 ([#2624](https://github.com/getsentry/sentry-dotnet/pull/2604))
+- Drop support for `Tizen` ([#2734](https://github.com/getsentry/sentry-dotnet/pull/2734))
 
 API Changes:
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,6 @@
     <NO_IOS>true</NO_IOS>
     <NO_MACCATALYST>true</NO_MACCATALYST>
     <NO_WINDOWS>true</NO_WINDOWS>
-    <NO_TIZEN>true</NO_TIZEN>
   </PropertyGroup>
 
   <!--
@@ -61,7 +60,6 @@
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'ios'">10.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'android'">21.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'tizen'">6.5</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -9,7 +9,6 @@
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'ios'">10.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'android'">21.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'tizen'">6.5</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>
@@ -27,11 +26,6 @@
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'windows'">
     <Compile Remove="**\*.Windows.cs" />
     <Compile Remove="**\Windows\**\*.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'tizen'">
-    <Compile Remove="**\*.Tizen.cs" />
-    <Compile Remove="**\Tizen\**\*.cs" />
   </ItemGroup>
 
   <!-- Allow setting CLSCompliant via property in any csproj -->
@@ -66,9 +60,6 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(MauiWorkloadVersion)' == ''">
       <NO_WINDOWS>true</NO_WINDOWS>
-    </PropertyGroup>
-    <PropertyGroup Condition="!Exists('$(MSBuildBinPath)\..\..\packs\Samsung.Tizen.Sdk')">
-      <NO_TIZEN>true</NO_TIZEN>
     </PropertyGroup>
 
   </Target>

--- a/src/Sentry.Maui/Sentry.Maui.csproj
+++ b/src/Sentry.Maui/Sentry.Maui.csproj
@@ -12,9 +12,6 @@
     <TargetFrameworks Condition="'$(NO_MACCATALYST)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_WINDOWS)' == '' And !$([MSBuild]::IsOSPlatform('Linux'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
 
-    <!-- Target Tizen only if the Tizen SDK workload pack is installed. -->
-    <TargetFrameworks Condition="'$(NO_TIZEN)' == '' And Exists('$(MSBuildBinPath)\..\..\packs\Samsung.Tizen.Sdk')">$(TargetFrameworks);net7.0-tizen</TargetFrameworks>
-
     <!--
       This flag allows us to target Windows-specific code when building on OSX, so we can build and pack all platforms on a single machine.
       See https://learn.microsoft.com/dotnet/core/tools/sdk-errors/netsdk1100

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -93,9 +93,6 @@ public static class SentryMauiAppBuilderExtensions
 #elif WINDOWS
             events.AddWindows(lifecycle => lifecycle.OnLaunching((application, _) =>
                 (application as IPlatformApplication)?.BindMauiEvents()));
-#elif TIZEN
-            events.AddTizen(lifecycle => lifecycle.OnCreate(application =>
-                (application as IPlatformApplication)?.BindMauiEvents()));
 #endif
         });
     }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/2562
The rest to get rid of `Tizen`.