### PR TITLE
Fix no mobile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Ensure Solution Filters are up to date
         shell: pwsh
-        run: scripts/dirty-check.ps1 -PathToCheck ./*.slnf -GuidanceOnFailure "Uncommitted changes to the solution filters detected. Run `scripts/generate-solution-filters.ps1` locally and commit changes."
+        run: scripts/dirty-check.ps1 -PathToCheck ./*.sln* -GuidanceOnFailure "Uncommitted changes to the solution filters detected. Run `scripts/generate-solution-filters.ps1` locally and commit changes."
 
       # We use macOS for the final publishing build so we we get all the iOS/macCatalyst targets in the packages
       - name: Set Environment Variables

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,10 @@
     <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(SolutionName)' == 'Sentry.NoMobile'">
+    <NO_MOBILE>true</NO_MOBILE>
+  </PropertyGroup>
+
   <!-- NO_MOBILE can be passed in via an environment variable or a build property to disable all mobile targets -->
   <PropertyGroup Condition="'$(NO_MOBILE)' == 'true'">
     <NO_ANDROID>true</NO_ANDROID>

--- a/Sentry.NoMobile.sln
+++ b/Sentry.NoMobile.sln
@@ -1,0 +1,542 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{7D4D7A6A-3F5C-4B4C-A198-AC51F9220231}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Benchmarks", "benchmarks\Sentry.Benchmarks\Sentry.Benchmarks.csproj", "{8328B70C-B808-4ED1-BB16-8555B2752CB6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{21B42F60-5802-404E-90F0-AEBCC56760C0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.Android", "samples\Sentry.Samples.Android\Sentry.Samples.Android.csproj", "{1368AFBF-BCB7-4585-B8A9-C0E767792BC1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.AspNetCore.Basic", "samples\Sentry.Samples.AspNetCore.Basic\Sentry.Samples.AspNetCore.Basic.csproj", "{3E5E5AAD-4563-4428-8577-2A2A46137BFC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.AspNetCore.Blazor.Server", "samples\Sentry.Samples.AspNetCore.Blazor.Server\Sentry.Samples.AspNetCore.Blazor.Server.csproj", "{789A9F8A-08A9-4211-A4AB-F45633960D94}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.AspNetCore.Blazor.Wasm", "samples\Sentry.Samples.AspNetCore.Blazor.Wasm\Sentry.Samples.AspNetCore.Blazor.Wasm.csproj", "{E683FB73-A305-462A-8F76-880E7A2F7F74}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.AspNetCore.Grpc", "samples\Sentry.Samples.AspNetCore.Grpc\Sentry.Samples.AspNetCore.Grpc.csproj", "{E53C49EE-FC70-4B26-A62A-63CAD51DB399}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.AspNetCore.Mvc", "samples\Sentry.Samples.AspNetCore.Mvc\Sentry.Samples.AspNetCore.Mvc.csproj", "{F749CC16-C32B-441D-9ACE-E8F748E977E0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.AspNetCore.Serilog", "samples\Sentry.Samples.AspNetCore.Serilog\Sentry.Samples.AspNetCore.Serilog.csproj", "{609D99ED-3E50-49DF-A3CC-2371FD02520A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.Aws.Lambda.AspNetCoreServer", "samples\Sentry.Samples.Aws.Lambda.AspNetCoreServer\Sentry.Samples.Aws.Lambda.AspNetCoreServer.csproj", "{50116F9A-646D-4BF7-9760-66E37CB9C459}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.Azure.Functions.Worker", "samples\Sentry.Samples.Azure.Functions.Worker\Sentry.Samples.Azure.Functions.Worker.csproj", "{1F44075F-ABD6-49A4-8EA1-DBB70304AD24}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.Console.Basic", "samples\Sentry.Samples.Console.Basic\Sentry.Samples.Console.Basic.csproj", "{B793249D-3E52-4B0D-964F-BC022CD8A753}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.Console.Customized", "samples\Sentry.Samples.Console.Customized\Sentry.Samples.Console.Customized.csproj", "{8FA2FE59-9333-47B8-A226-E2B0CDBB5847}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.Console.Profiling", "samples\Sentry.Samples.Console.Profiling\Sentry.Samples.Console.Profiling.csproj", "{0D9861C5-D081-40F7-9DFC-7032840471AB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.EntityFramework", "samples\Sentry.Samples.EntityFramework\Sentry.Samples.EntityFramework.csproj", "{EEBE64CF-B1B5-4C54-B9B4-47ED7E5E760A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.GenericHost", "samples\Sentry.Samples.GenericHost\Sentry.Samples.GenericHost.csproj", "{9658457F-075C-4C44-A7AD-947365938B6C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.Google.Cloud.Functions", "samples\Sentry.Samples.Google.Cloud.Functions\Sentry.Samples.Google.Cloud.Functions.csproj", "{AB93DF75-C53F-43F7-B1EB-B679240D112B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.GraphQL.Client.Http", "samples\Sentry.Samples.GraphQL.Client.Http\Sentry.Samples.GraphQL.Client.Http.csproj", "{1E5E7A45-9826-4F06-8C68-B9F1DB05C4F2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.GraphQL.Server", "samples\Sentry.Samples.GraphQL.Server\Sentry.Samples.GraphQL.Server.csproj", "{D58B814E-1F19-43AE-89D1-769BC7681A56}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.Ios", "samples\Sentry.Samples.Ios\Sentry.Samples.Ios.csproj", "{C181C7D4-CA45-4FAE-8315-A9825F034D53}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.Log4Net", "samples\Sentry.Samples.Log4Net\Sentry.Samples.Log4Net.csproj", "{4056B8FD-F355-41A3-A34F-60B350598B33}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.ME.Logging", "samples\Sentry.Samples.ME.Logging\Sentry.Samples.ME.Logging.csproj", "{6D383054-4712-4D03-A0B1-B9D4E1CC6F95}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.MacCatalyst", "samples\Sentry.Samples.MacCatalyst\Sentry.Samples.MacCatalyst.csproj", "{4E0DC405-C372-4396-A5DF-F6AA108DA01C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.Maui", "samples\Sentry.Samples.Maui\Sentry.Samples.Maui.csproj", "{9B175EC8-6B64-4345-A158-091CB8876077}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.NLog", "samples\Sentry.Samples.NLog\Sentry.Samples.NLog.csproj", "{EE0DC846-52F3-46AF-BC0D-DEF81150CEC0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.OpenTelemetry.AspNetCore", "samples\Sentry.Samples.OpenTelemetry.AspNetCore\Sentry.Samples.OpenTelemetry.AspNetCore.csproj", "{E37818EC-03D2-4B97-BE46-4C3F61465004}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.OpenTelemetry.Console", "samples\Sentry.Samples.OpenTelemetry.Console\Sentry.Samples.OpenTelemetry.Console.csproj", "{E5141EAC-9420-48EA-995F-848CBBF0BD4B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Samples.Serilog", "samples\Sentry.Samples.Serilog\Sentry.Samples.Serilog.csproj", "{AA98FD8D-1254-4B34-840C-06BB263933DE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{230B9384-90FD-4551-A5DE-1A5C197F25B6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Android.AssemblyReader", "src\Sentry.Android.AssemblyReader\Sentry.Android.AssemblyReader.csproj", "{20386BBE-1F55-4503-9F5F-F2C6B29DE865}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.AspNet", "src\Sentry.AspNet\Sentry.AspNet.csproj", "{A7F651AD-51D3-4473-9641-7C76D2A0E3B7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.AspNetCore.Grpc", "src\Sentry.AspNetCore.Grpc\Sentry.AspNetCore.Grpc.csproj", "{DF785142-3E65-4176-8A6E-CAAD6BBF771F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.AspNetCore", "src\Sentry.AspNetCore\Sentry.AspNetCore.csproj", "{4B323BCC-0E8D-43CE-9AC2-4B708278C7C2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Azure.Functions.Worker", "src\Sentry.Azure.Functions.Worker\Sentry.Azure.Functions.Worker.csproj", "{52262FBB-40D0-4F08-B00F-B298185FF6BD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Bindings.Android", "src\Sentry.Bindings.Android\Sentry.Bindings.Android.csproj", "{759D9E53-4717-491D-9970-B3A3367C65E7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Bindings.Cocoa", "src\Sentry.Bindings.Cocoa\Sentry.Bindings.Cocoa.csproj", "{33336B98-A69E-4F28-A71A-1D8753F3BA24}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.DiagnosticSource", "src\Sentry.DiagnosticSource\Sentry.DiagnosticSource.csproj", "{22E4E3F5-8D6E-433D-9456-F60DFB1EFC82}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.EntityFramework", "src\Sentry.EntityFramework\Sentry.EntityFramework.csproj", "{2AEC3A6E-886F-43DA-8EA6-82EBF916E89A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Extensions.Logging", "src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj", "{F97EE360-3733-4993-823A-A81D004D417E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Google.Cloud.Functions", "src\Sentry.Google.Cloud.Functions\Sentry.Google.Cloud.Functions.csproj", "{1D66CB6F-6268-4595-AD49-09DFD1784DDB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Log4Net", "src\Sentry.Log4Net\Sentry.Log4Net.csproj", "{EA4BB6FE-57B5-4A2B-88AD-FCCD96ECE19F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Maui", "src\Sentry.Maui\Sentry.Maui.csproj", "{DC89F322-155F-488B-8B80-3824B433F046}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.NLog", "src\Sentry.NLog\Sentry.NLog.csproj", "{4E74CAAD-062F-4AF9-8B29-2ED4B2CC0E77}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.OpenTelemetry", "src\Sentry.OpenTelemetry\Sentry.OpenTelemetry.csproj", "{957DFFC0-0FA3-48CC-AEDD-F9BBC3F0FADC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Profiling", "src\Sentry.Profiling\Sentry.Profiling.csproj", "{2E239FE2-F3B2-41B6-AE9E-561F6ACE5BA6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Serilog", "src\Sentry.Serilog\Sentry.Serilog.csproj", "{854EBD1B-73EE-4B93-89DF-E70436FF14CB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry", "src\Sentry\Sentry.csproj", "{5F253D7F-BF27-46F5-9382-73A66EC247BF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{6987A1CC-608E-4868-A02C-09D30C8B7B2D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AndroidTestApp", "test\AndroidTestApp\AndroidTestApp.csproj", "{99E2D1A4-1853-49F9-96B6-59C70FA3DE3A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MauiTestUtils", "MauiTestUtils", "{A11512A4-26BD-4936-B7A6-6FCE2E78FA80}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtils.DeviceTests.Runners.SourceGen", "test\MauiTestUtils\DeviceTests.Runners.SourceGen\TestUtils.DeviceTests.Runners.SourceGen.csproj", "{7C1A1318-137E-4E1E-ADB3-C0CE2B10F779}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtils.DeviceTests.Runners", "test\MauiTestUtils\DeviceTests.Runners\TestUtils.DeviceTests.Runners.csproj", "{1C6F1CB1-2339-4E8B-9941-80998B940DCC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtils.DeviceTests", "test\MauiTestUtils\DeviceTests\TestUtils.DeviceTests.csproj", "{E92F0A4E-2653-4341-8732-2AC9CF766739}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Android.AssemblyReader.Tests", "test\Sentry.Android.AssemblyReader.Tests\Sentry.Android.AssemblyReader.Tests.csproj", "{3C543CED-F801-4843-BA48-76142843E1B9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.AspNet.Tests", "test\Sentry.AspNet.Tests\Sentry.AspNet.Tests.csproj", "{7ABAA536-7BEC-46D7-9C61-82440DDC9AA8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.AspNetCore.Grpc.Tests", "test\Sentry.AspNetCore.Grpc.Tests\Sentry.AspNetCore.Grpc.Tests.csproj", "{D7D1EA68-ACE3-4DF3-A33C-EBB5B74701F5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.AspNetCore.TestUtils", "test\Sentry.AspNetCore.TestUtils\Sentry.AspNetCore.TestUtils.csproj", "{563FEA1C-FDAE-4EDE-9ABF-22D76F2DA048}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.AspNetCore.Tests", "test\Sentry.AspNetCore.Tests\Sentry.AspNetCore.Tests.csproj", "{6D9EB590-CED1-47C2-87B1-E65EE0EEBB9E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Azure.Functions.Worker.Tests", "test\Sentry.Azure.Functions.Worker.Tests\Sentry.Azure.Functions.Worker.Tests.csproj", "{39F7BB08-908B-49F9-A96B-E14C16B69090}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.DiagnosticSource.IntegrationTests", "test\Sentry.DiagnosticSource.IntegrationTests\Sentry.DiagnosticSource.IntegrationTests.csproj", "{59742E7E-4380-4B40-BCC8-5AB314290198}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.DiagnosticSource.Tests", "test\Sentry.DiagnosticSource.Tests\Sentry.DiagnosticSource.Tests.csproj", "{6222BF96-2F1F-42DA-AF43-388B20151A5A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.EntityFramework.Tests", "test\Sentry.EntityFramework.Tests\Sentry.EntityFramework.Tests.csproj", "{18FDE2B5-6023-487C-A349-E492F3F34B4A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Extensions.Logging.Tests", "test\Sentry.Extensions.Logging.Tests\Sentry.Extensions.Logging.Tests.csproj", "{357D2522-4481-4135-8379-C228C743DD69}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Google.Cloud.Functions.Tests", "test\Sentry.Google.Cloud.Functions.Tests\Sentry.Google.Cloud.Functions.Tests.csproj", "{321A2E5D-6A3E-44B6-BECE-D1FFA94D58B9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Log4Net.Tests", "test\Sentry.Log4Net.Tests\Sentry.Log4Net.Tests.csproj", "{A454B861-62B4-4F4D-8E31-725C4592D169}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Maui.Device.TestApp", "test\Sentry.Maui.Device.TestApp\Sentry.Maui.Device.TestApp.csproj", "{F89C3981-6D5A-4D63-8CD0-FB35E55C5835}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Maui.Tests", "test\Sentry.Maui.Tests\Sentry.Maui.Tests.csproj", "{A8FFC45B-7FC3-44B3-B8AF-CA9642E66546}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.NLog.Tests", "test\Sentry.NLog.Tests\Sentry.NLog.Tests.csproj", "{9D3631D0-C7DA-4283-BA24-A14424B0F7BE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.OpenTelemetry.Tests", "test\Sentry.OpenTelemetry.Tests\Sentry.OpenTelemetry.Tests.csproj", "{CDB5B2C4-4CD6-4AE0-9C4B-451B3170FB55}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Profiling.Tests", "test\Sentry.Profiling.Tests\Sentry.Profiling.Tests.csproj", "{CC0FE166-E649-4CA4-AACD-C0205ECDF896}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Serilog.Tests", "test\Sentry.Serilog.Tests\Sentry.Serilog.Tests.csproj", "{C97D62CF-A541-4393-A49A-92F53F1E1983}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Testing.CrashableApp", "test\Sentry.Testing.CrashableApp\Sentry.Testing.CrashableApp.csproj", "{36ADA62A-0AD5-461A-B28C-A5DBAF718B59}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Testing", "test\Sentry.Testing\Sentry.Testing.csproj", "{A2AD0EF1-6943-46E0-BEED-0704D362FA48}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sentry.Tests", "test\Sentry.Tests\Sentry.Tests.csproj", "{9272A135-C1F7-4317-8AEA-1BFDEE2DC683}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SingleFileTestApp", "test\SingleFileTestApp\SingleFileTestApp.csproj", "{162A1CAE-ACEE-45CA-A6D0-7702ADE4D3DE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "modules", "modules", "{A3CCA27E-4DF8-479D-833C-CAA0950715AA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TraceEvent", "modules\perfview\src\TraceEvent\TraceEvent.csproj", "{67269916-C417-4CEE-BD7D-CA66C3830AEE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastSerialization", "modules\perfview\src\FastSerialization\FastSerialization.csproj", "{8032310D-3C06-442C-A318-F365BCC4C804}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8328B70C-B808-4ED1-BB16-8555B2752CB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8328B70C-B808-4ED1-BB16-8555B2752CB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8328B70C-B808-4ED1-BB16-8555B2752CB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8328B70C-B808-4ED1-BB16-8555B2752CB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1368AFBF-BCB7-4585-B8A9-C0E767792BC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1368AFBF-BCB7-4585-B8A9-C0E767792BC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1368AFBF-BCB7-4585-B8A9-C0E767792BC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1368AFBF-BCB7-4585-B8A9-C0E767792BC1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E5E5AAD-4563-4428-8577-2A2A46137BFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E5E5AAD-4563-4428-8577-2A2A46137BFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E5E5AAD-4563-4428-8577-2A2A46137BFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E5E5AAD-4563-4428-8577-2A2A46137BFC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{789A9F8A-08A9-4211-A4AB-F45633960D94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{789A9F8A-08A9-4211-A4AB-F45633960D94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{789A9F8A-08A9-4211-A4AB-F45633960D94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{789A9F8A-08A9-4211-A4AB-F45633960D94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E683FB73-A305-462A-8F76-880E7A2F7F74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E683FB73-A305-462A-8F76-880E7A2F7F74}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E683FB73-A305-462A-8F76-880E7A2F7F74}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E683FB73-A305-462A-8F76-880E7A2F7F74}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E53C49EE-FC70-4B26-A62A-63CAD51DB399}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E53C49EE-FC70-4B26-A62A-63CAD51DB399}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E53C49EE-FC70-4B26-A62A-63CAD51DB399}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E53C49EE-FC70-4B26-A62A-63CAD51DB399}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F749CC16-C32B-441D-9ACE-E8F748E977E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F749CC16-C32B-441D-9ACE-E8F748E977E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F749CC16-C32B-441D-9ACE-E8F748E977E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F749CC16-C32B-441D-9ACE-E8F748E977E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{609D99ED-3E50-49DF-A3CC-2371FD02520A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{609D99ED-3E50-49DF-A3CC-2371FD02520A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{609D99ED-3E50-49DF-A3CC-2371FD02520A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{609D99ED-3E50-49DF-A3CC-2371FD02520A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50116F9A-646D-4BF7-9760-66E37CB9C459}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50116F9A-646D-4BF7-9760-66E37CB9C459}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50116F9A-646D-4BF7-9760-66E37CB9C459}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50116F9A-646D-4BF7-9760-66E37CB9C459}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F44075F-ABD6-49A4-8EA1-DBB70304AD24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F44075F-ABD6-49A4-8EA1-DBB70304AD24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F44075F-ABD6-49A4-8EA1-DBB70304AD24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F44075F-ABD6-49A4-8EA1-DBB70304AD24}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B793249D-3E52-4B0D-964F-BC022CD8A753}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B793249D-3E52-4B0D-964F-BC022CD8A753}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B793249D-3E52-4B0D-964F-BC022CD8A753}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B793249D-3E52-4B0D-964F-BC022CD8A753}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8FA2FE59-9333-47B8-A226-E2B0CDBB5847}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8FA2FE59-9333-47B8-A226-E2B0CDBB5847}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8FA2FE59-9333-47B8-A226-E2B0CDBB5847}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8FA2FE59-9333-47B8-A226-E2B0CDBB5847}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D9861C5-D081-40F7-9DFC-7032840471AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D9861C5-D081-40F7-9DFC-7032840471AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D9861C5-D081-40F7-9DFC-7032840471AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D9861C5-D081-40F7-9DFC-7032840471AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEBE64CF-B1B5-4C54-B9B4-47ED7E5E760A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEBE64CF-B1B5-4C54-B9B4-47ED7E5E760A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEBE64CF-B1B5-4C54-B9B4-47ED7E5E760A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEBE64CF-B1B5-4C54-B9B4-47ED7E5E760A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9658457F-075C-4C44-A7AD-947365938B6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9658457F-075C-4C44-A7AD-947365938B6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9658457F-075C-4C44-A7AD-947365938B6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9658457F-075C-4C44-A7AD-947365938B6C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB93DF75-C53F-43F7-B1EB-B679240D112B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB93DF75-C53F-43F7-B1EB-B679240D112B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB93DF75-C53F-43F7-B1EB-B679240D112B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB93DF75-C53F-43F7-B1EB-B679240D112B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E5E7A45-9826-4F06-8C68-B9F1DB05C4F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E5E7A45-9826-4F06-8C68-B9F1DB05C4F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E5E7A45-9826-4F06-8C68-B9F1DB05C4F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E5E7A45-9826-4F06-8C68-B9F1DB05C4F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D58B814E-1F19-43AE-89D1-769BC7681A56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D58B814E-1F19-43AE-89D1-769BC7681A56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D58B814E-1F19-43AE-89D1-769BC7681A56}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D58B814E-1F19-43AE-89D1-769BC7681A56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C181C7D4-CA45-4FAE-8315-A9825F034D53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C181C7D4-CA45-4FAE-8315-A9825F034D53}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C181C7D4-CA45-4FAE-8315-A9825F034D53}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C181C7D4-CA45-4FAE-8315-A9825F034D53}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4056B8FD-F355-41A3-A34F-60B350598B33}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4056B8FD-F355-41A3-A34F-60B350598B33}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4056B8FD-F355-41A3-A34F-60B350598B33}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4056B8FD-F355-41A3-A34F-60B350598B33}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D383054-4712-4D03-A0B1-B9D4E1CC6F95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D383054-4712-4D03-A0B1-B9D4E1CC6F95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D383054-4712-4D03-A0B1-B9D4E1CC6F95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D383054-4712-4D03-A0B1-B9D4E1CC6F95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E0DC405-C372-4396-A5DF-F6AA108DA01C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E0DC405-C372-4396-A5DF-F6AA108DA01C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E0DC405-C372-4396-A5DF-F6AA108DA01C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E0DC405-C372-4396-A5DF-F6AA108DA01C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B175EC8-6B64-4345-A158-091CB8876077}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B175EC8-6B64-4345-A158-091CB8876077}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B175EC8-6B64-4345-A158-091CB8876077}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B175EC8-6B64-4345-A158-091CB8876077}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE0DC846-52F3-46AF-BC0D-DEF81150CEC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE0DC846-52F3-46AF-BC0D-DEF81150CEC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE0DC846-52F3-46AF-BC0D-DEF81150CEC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE0DC846-52F3-46AF-BC0D-DEF81150CEC0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E37818EC-03D2-4B97-BE46-4C3F61465004}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E37818EC-03D2-4B97-BE46-4C3F61465004}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E37818EC-03D2-4B97-BE46-4C3F61465004}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E37818EC-03D2-4B97-BE46-4C3F61465004}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5141EAC-9420-48EA-995F-848CBBF0BD4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5141EAC-9420-48EA-995F-848CBBF0BD4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5141EAC-9420-48EA-995F-848CBBF0BD4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5141EAC-9420-48EA-995F-848CBBF0BD4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA98FD8D-1254-4B34-840C-06BB263933DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA98FD8D-1254-4B34-840C-06BB263933DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA98FD8D-1254-4B34-840C-06BB263933DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA98FD8D-1254-4B34-840C-06BB263933DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20386BBE-1F55-4503-9F5F-F2C6B29DE865}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20386BBE-1F55-4503-9F5F-F2C6B29DE865}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20386BBE-1F55-4503-9F5F-F2C6B29DE865}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20386BBE-1F55-4503-9F5F-F2C6B29DE865}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7F651AD-51D3-4473-9641-7C76D2A0E3B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7F651AD-51D3-4473-9641-7C76D2A0E3B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7F651AD-51D3-4473-9641-7C76D2A0E3B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7F651AD-51D3-4473-9641-7C76D2A0E3B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF785142-3E65-4176-8A6E-CAAD6BBF771F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF785142-3E65-4176-8A6E-CAAD6BBF771F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF785142-3E65-4176-8A6E-CAAD6BBF771F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF785142-3E65-4176-8A6E-CAAD6BBF771F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4B323BCC-0E8D-43CE-9AC2-4B708278C7C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B323BCC-0E8D-43CE-9AC2-4B708278C7C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B323BCC-0E8D-43CE-9AC2-4B708278C7C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B323BCC-0E8D-43CE-9AC2-4B708278C7C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52262FBB-40D0-4F08-B00F-B298185FF6BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52262FBB-40D0-4F08-B00F-B298185FF6BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52262FBB-40D0-4F08-B00F-B298185FF6BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52262FBB-40D0-4F08-B00F-B298185FF6BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{759D9E53-4717-491D-9970-B3A3367C65E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{759D9E53-4717-491D-9970-B3A3367C65E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{759D9E53-4717-491D-9970-B3A3367C65E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{759D9E53-4717-491D-9970-B3A3367C65E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33336B98-A69E-4F28-A71A-1D8753F3BA24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33336B98-A69E-4F28-A71A-1D8753F3BA24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33336B98-A69E-4F28-A71A-1D8753F3BA24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33336B98-A69E-4F28-A71A-1D8753F3BA24}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22E4E3F5-8D6E-433D-9456-F60DFB1EFC82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22E4E3F5-8D6E-433D-9456-F60DFB1EFC82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22E4E3F5-8D6E-433D-9456-F60DFB1EFC82}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22E4E3F5-8D6E-433D-9456-F60DFB1EFC82}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2AEC3A6E-886F-43DA-8EA6-82EBF916E89A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2AEC3A6E-886F-43DA-8EA6-82EBF916E89A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2AEC3A6E-886F-43DA-8EA6-82EBF916E89A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2AEC3A6E-886F-43DA-8EA6-82EBF916E89A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F97EE360-3733-4993-823A-A81D004D417E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F97EE360-3733-4993-823A-A81D004D417E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F97EE360-3733-4993-823A-A81D004D417E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F97EE360-3733-4993-823A-A81D004D417E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D66CB6F-6268-4595-AD49-09DFD1784DDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D66CB6F-6268-4595-AD49-09DFD1784DDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D66CB6F-6268-4595-AD49-09DFD1784DDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D66CB6F-6268-4595-AD49-09DFD1784DDB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA4BB6FE-57B5-4A2B-88AD-FCCD96ECE19F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA4BB6FE-57B5-4A2B-88AD-FCCD96ECE19F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA4BB6FE-57B5-4A2B-88AD-FCCD96ECE19F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA4BB6FE-57B5-4A2B-88AD-FCCD96ECE19F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DC89F322-155F-488B-8B80-3824B433F046}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC89F322-155F-488B-8B80-3824B433F046}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC89F322-155F-488B-8B80-3824B433F046}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC89F322-155F-488B-8B80-3824B433F046}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E74CAAD-062F-4AF9-8B29-2ED4B2CC0E77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E74CAAD-062F-4AF9-8B29-2ED4B2CC0E77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E74CAAD-062F-4AF9-8B29-2ED4B2CC0E77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E74CAAD-062F-4AF9-8B29-2ED4B2CC0E77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{957DFFC0-0FA3-48CC-AEDD-F9BBC3F0FADC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{957DFFC0-0FA3-48CC-AEDD-F9BBC3F0FADC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{957DFFC0-0FA3-48CC-AEDD-F9BBC3F0FADC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{957DFFC0-0FA3-48CC-AEDD-F9BBC3F0FADC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E239FE2-F3B2-41B6-AE9E-561F6ACE5BA6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E239FE2-F3B2-41B6-AE9E-561F6ACE5BA6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E239FE2-F3B2-41B6-AE9E-561F6ACE5BA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E239FE2-F3B2-41B6-AE9E-561F6ACE5BA6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{854EBD1B-73EE-4B93-89DF-E70436FF14CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{854EBD1B-73EE-4B93-89DF-E70436FF14CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{854EBD1B-73EE-4B93-89DF-E70436FF14CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{854EBD1B-73EE-4B93-89DF-E70436FF14CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F253D7F-BF27-46F5-9382-73A66EC247BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F253D7F-BF27-46F5-9382-73A66EC247BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F253D7F-BF27-46F5-9382-73A66EC247BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F253D7F-BF27-46F5-9382-73A66EC247BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99E2D1A4-1853-49F9-96B6-59C70FA3DE3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99E2D1A4-1853-49F9-96B6-59C70FA3DE3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99E2D1A4-1853-49F9-96B6-59C70FA3DE3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99E2D1A4-1853-49F9-96B6-59C70FA3DE3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C1A1318-137E-4E1E-ADB3-C0CE2B10F779}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C1A1318-137E-4E1E-ADB3-C0CE2B10F779}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C1A1318-137E-4E1E-ADB3-C0CE2B10F779}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C1A1318-137E-4E1E-ADB3-C0CE2B10F779}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1C6F1CB1-2339-4E8B-9941-80998B940DCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1C6F1CB1-2339-4E8B-9941-80998B940DCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1C6F1CB1-2339-4E8B-9941-80998B940DCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1C6F1CB1-2339-4E8B-9941-80998B940DCC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E92F0A4E-2653-4341-8732-2AC9CF766739}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E92F0A4E-2653-4341-8732-2AC9CF766739}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E92F0A4E-2653-4341-8732-2AC9CF766739}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E92F0A4E-2653-4341-8732-2AC9CF766739}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C543CED-F801-4843-BA48-76142843E1B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C543CED-F801-4843-BA48-76142843E1B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C543CED-F801-4843-BA48-76142843E1B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C543CED-F801-4843-BA48-76142843E1B9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7ABAA536-7BEC-46D7-9C61-82440DDC9AA8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7ABAA536-7BEC-46D7-9C61-82440DDC9AA8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7ABAA536-7BEC-46D7-9C61-82440DDC9AA8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7ABAA536-7BEC-46D7-9C61-82440DDC9AA8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7D1EA68-ACE3-4DF3-A33C-EBB5B74701F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7D1EA68-ACE3-4DF3-A33C-EBB5B74701F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7D1EA68-ACE3-4DF3-A33C-EBB5B74701F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7D1EA68-ACE3-4DF3-A33C-EBB5B74701F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{563FEA1C-FDAE-4EDE-9ABF-22D76F2DA048}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{563FEA1C-FDAE-4EDE-9ABF-22D76F2DA048}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{563FEA1C-FDAE-4EDE-9ABF-22D76F2DA048}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{563FEA1C-FDAE-4EDE-9ABF-22D76F2DA048}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D9EB590-CED1-47C2-87B1-E65EE0EEBB9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D9EB590-CED1-47C2-87B1-E65EE0EEBB9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D9EB590-CED1-47C2-87B1-E65EE0EEBB9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D9EB590-CED1-47C2-87B1-E65EE0EEBB9E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39F7BB08-908B-49F9-A96B-E14C16B69090}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39F7BB08-908B-49F9-A96B-E14C16B69090}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39F7BB08-908B-49F9-A96B-E14C16B69090}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39F7BB08-908B-49F9-A96B-E14C16B69090}.Release|Any CPU.Build.0 = Release|Any CPU
+		{59742E7E-4380-4B40-BCC8-5AB314290198}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{59742E7E-4380-4B40-BCC8-5AB314290198}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{59742E7E-4380-4B40-BCC8-5AB314290198}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{59742E7E-4380-4B40-BCC8-5AB314290198}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6222BF96-2F1F-42DA-AF43-388B20151A5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6222BF96-2F1F-42DA-AF43-388B20151A5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6222BF96-2F1F-42DA-AF43-388B20151A5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6222BF96-2F1F-42DA-AF43-388B20151A5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18FDE2B5-6023-487C-A349-E492F3F34B4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18FDE2B5-6023-487C-A349-E492F3F34B4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18FDE2B5-6023-487C-A349-E492F3F34B4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18FDE2B5-6023-487C-A349-E492F3F34B4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{357D2522-4481-4135-8379-C228C743DD69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{357D2522-4481-4135-8379-C228C743DD69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{357D2522-4481-4135-8379-C228C743DD69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{357D2522-4481-4135-8379-C228C743DD69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{321A2E5D-6A3E-44B6-BECE-D1FFA94D58B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{321A2E5D-6A3E-44B6-BECE-D1FFA94D58B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{321A2E5D-6A3E-44B6-BECE-D1FFA94D58B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{321A2E5D-6A3E-44B6-BECE-D1FFA94D58B9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A454B861-62B4-4F4D-8E31-725C4592D169}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A454B861-62B4-4F4D-8E31-725C4592D169}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A454B861-62B4-4F4D-8E31-725C4592D169}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A454B861-62B4-4F4D-8E31-725C4592D169}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F89C3981-6D5A-4D63-8CD0-FB35E55C5835}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F89C3981-6D5A-4D63-8CD0-FB35E55C5835}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F89C3981-6D5A-4D63-8CD0-FB35E55C5835}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F89C3981-6D5A-4D63-8CD0-FB35E55C5835}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8FFC45B-7FC3-44B3-B8AF-CA9642E66546}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8FFC45B-7FC3-44B3-B8AF-CA9642E66546}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8FFC45B-7FC3-44B3-B8AF-CA9642E66546}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8FFC45B-7FC3-44B3-B8AF-CA9642E66546}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D3631D0-C7DA-4283-BA24-A14424B0F7BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D3631D0-C7DA-4283-BA24-A14424B0F7BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D3631D0-C7DA-4283-BA24-A14424B0F7BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D3631D0-C7DA-4283-BA24-A14424B0F7BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CDB5B2C4-4CD6-4AE0-9C4B-451B3170FB55}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDB5B2C4-4CD6-4AE0-9C4B-451B3170FB55}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDB5B2C4-4CD6-4AE0-9C4B-451B3170FB55}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDB5B2C4-4CD6-4AE0-9C4B-451B3170FB55}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC0FE166-E649-4CA4-AACD-C0205ECDF896}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC0FE166-E649-4CA4-AACD-C0205ECDF896}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC0FE166-E649-4CA4-AACD-C0205ECDF896}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC0FE166-E649-4CA4-AACD-C0205ECDF896}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C97D62CF-A541-4393-A49A-92F53F1E1983}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C97D62CF-A541-4393-A49A-92F53F1E1983}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C97D62CF-A541-4393-A49A-92F53F1E1983}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C97D62CF-A541-4393-A49A-92F53F1E1983}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36ADA62A-0AD5-461A-B28C-A5DBAF718B59}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36ADA62A-0AD5-461A-B28C-A5DBAF718B59}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36ADA62A-0AD5-461A-B28C-A5DBAF718B59}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36ADA62A-0AD5-461A-B28C-A5DBAF718B59}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2AD0EF1-6943-46E0-BEED-0704D362FA48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2AD0EF1-6943-46E0-BEED-0704D362FA48}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2AD0EF1-6943-46E0-BEED-0704D362FA48}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2AD0EF1-6943-46E0-BEED-0704D362FA48}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9272A135-C1F7-4317-8AEA-1BFDEE2DC683}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9272A135-C1F7-4317-8AEA-1BFDEE2DC683}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9272A135-C1F7-4317-8AEA-1BFDEE2DC683}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9272A135-C1F7-4317-8AEA-1BFDEE2DC683}.Release|Any CPU.Build.0 = Release|Any CPU
+		{162A1CAE-ACEE-45CA-A6D0-7702ADE4D3DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{162A1CAE-ACEE-45CA-A6D0-7702ADE4D3DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{162A1CAE-ACEE-45CA-A6D0-7702ADE4D3DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{162A1CAE-ACEE-45CA-A6D0-7702ADE4D3DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67269916-C417-4CEE-BD7D-CA66C3830AEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67269916-C417-4CEE-BD7D-CA66C3830AEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67269916-C417-4CEE-BD7D-CA66C3830AEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67269916-C417-4CEE-BD7D-CA66C3830AEE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8032310D-3C06-442C-A318-F365BCC4C804}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8032310D-3C06-442C-A318-F365BCC4C804}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8032310D-3C06-442C-A318-F365BCC4C804}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8032310D-3C06-442C-A318-F365BCC4C804}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{8328B70C-B808-4ED1-BB16-8555B2752CB6} = {7D4D7A6A-3F5C-4B4C-A198-AC51F9220231}
+		{1368AFBF-BCB7-4585-B8A9-C0E767792BC1} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{3E5E5AAD-4563-4428-8577-2A2A46137BFC} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{789A9F8A-08A9-4211-A4AB-F45633960D94} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{E683FB73-A305-462A-8F76-880E7A2F7F74} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{E53C49EE-FC70-4B26-A62A-63CAD51DB399} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{F749CC16-C32B-441D-9ACE-E8F748E977E0} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{609D99ED-3E50-49DF-A3CC-2371FD02520A} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{50116F9A-646D-4BF7-9760-66E37CB9C459} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{1F44075F-ABD6-49A4-8EA1-DBB70304AD24} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{B793249D-3E52-4B0D-964F-BC022CD8A753} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{8FA2FE59-9333-47B8-A226-E2B0CDBB5847} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{0D9861C5-D081-40F7-9DFC-7032840471AB} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{EEBE64CF-B1B5-4C54-B9B4-47ED7E5E760A} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{9658457F-075C-4C44-A7AD-947365938B6C} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{AB93DF75-C53F-43F7-B1EB-B679240D112B} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{1E5E7A45-9826-4F06-8C68-B9F1DB05C4F2} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{D58B814E-1F19-43AE-89D1-769BC7681A56} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{C181C7D4-CA45-4FAE-8315-A9825F034D53} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{4056B8FD-F355-41A3-A34F-60B350598B33} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{6D383054-4712-4D03-A0B1-B9D4E1CC6F95} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{4E0DC405-C372-4396-A5DF-F6AA108DA01C} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{9B175EC8-6B64-4345-A158-091CB8876077} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{EE0DC846-52F3-46AF-BC0D-DEF81150CEC0} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{E37818EC-03D2-4B97-BE46-4C3F61465004} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{E5141EAC-9420-48EA-995F-848CBBF0BD4B} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{AA98FD8D-1254-4B34-840C-06BB263933DE} = {21B42F60-5802-404E-90F0-AEBCC56760C0}
+		{20386BBE-1F55-4503-9F5F-F2C6B29DE865} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{A7F651AD-51D3-4473-9641-7C76D2A0E3B7} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{DF785142-3E65-4176-8A6E-CAAD6BBF771F} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{4B323BCC-0E8D-43CE-9AC2-4B708278C7C2} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{52262FBB-40D0-4F08-B00F-B298185FF6BD} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{759D9E53-4717-491D-9970-B3A3367C65E7} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{33336B98-A69E-4F28-A71A-1D8753F3BA24} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{22E4E3F5-8D6E-433D-9456-F60DFB1EFC82} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{2AEC3A6E-886F-43DA-8EA6-82EBF916E89A} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{F97EE360-3733-4993-823A-A81D004D417E} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{1D66CB6F-6268-4595-AD49-09DFD1784DDB} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{EA4BB6FE-57B5-4A2B-88AD-FCCD96ECE19F} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{DC89F322-155F-488B-8B80-3824B433F046} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{4E74CAAD-062F-4AF9-8B29-2ED4B2CC0E77} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{957DFFC0-0FA3-48CC-AEDD-F9BBC3F0FADC} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{2E239FE2-F3B2-41B6-AE9E-561F6ACE5BA6} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{854EBD1B-73EE-4B93-89DF-E70436FF14CB} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{5F253D7F-BF27-46F5-9382-73A66EC247BF} = {230B9384-90FD-4551-A5DE-1A5C197F25B6}
+		{99E2D1A4-1853-49F9-96B6-59C70FA3DE3A} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{A11512A4-26BD-4936-B7A6-6FCE2E78FA80} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{7C1A1318-137E-4E1E-ADB3-C0CE2B10F779} = {A11512A4-26BD-4936-B7A6-6FCE2E78FA80}
+		{1C6F1CB1-2339-4E8B-9941-80998B940DCC} = {A11512A4-26BD-4936-B7A6-6FCE2E78FA80}
+		{E92F0A4E-2653-4341-8732-2AC9CF766739} = {A11512A4-26BD-4936-B7A6-6FCE2E78FA80}
+		{3C543CED-F801-4843-BA48-76142843E1B9} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{7ABAA536-7BEC-46D7-9C61-82440DDC9AA8} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{D7D1EA68-ACE3-4DF3-A33C-EBB5B74701F5} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{563FEA1C-FDAE-4EDE-9ABF-22D76F2DA048} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{6D9EB590-CED1-47C2-87B1-E65EE0EEBB9E} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{39F7BB08-908B-49F9-A96B-E14C16B69090} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{59742E7E-4380-4B40-BCC8-5AB314290198} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{6222BF96-2F1F-42DA-AF43-388B20151A5A} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{18FDE2B5-6023-487C-A349-E492F3F34B4A} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{357D2522-4481-4135-8379-C228C743DD69} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{321A2E5D-6A3E-44B6-BECE-D1FFA94D58B9} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{A454B861-62B4-4F4D-8E31-725C4592D169} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{F89C3981-6D5A-4D63-8CD0-FB35E55C5835} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{A8FFC45B-7FC3-44B3-B8AF-CA9642E66546} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{9D3631D0-C7DA-4283-BA24-A14424B0F7BE} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{CDB5B2C4-4CD6-4AE0-9C4B-451B3170FB55} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{CC0FE166-E649-4CA4-AACD-C0205ECDF896} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{C97D62CF-A541-4393-A49A-92F53F1E1983} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{36ADA62A-0AD5-461A-B28C-A5DBAF718B59} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{A2AD0EF1-6943-46E0-BEED-0704D362FA48} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{9272A135-C1F7-4317-8AEA-1BFDEE2DC683} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{162A1CAE-ACEE-45CA-A6D0-7702ADE4D3DE} = {6987A1CC-608E-4868-A02C-09D30C8B7B2D}
+		{67269916-C417-4CEE-BD7D-CA66C3830AEE} = {A3CCA27E-4DF8-479D-833C-CAA0950715AA}
+		{8032310D-3C06-442C-A318-F365BCC4C804} = {A3CCA27E-4DF8-479D-833C-CAA0950715AA}
+	EndGlobalSection
+EndGlobal

--- a/SentryAspNetCore.slnf
+++ b/SentryAspNetCore.slnf
@@ -1,6 +1,6 @@
 {
   "solution": {
-    "path": "Sentry.sln",
+    "path": "Sentry.NoMobile.sln",
     "projects": [
       "samples\\Sentry.Samples.AspNetCore.Basic\\Sentry.Samples.AspNetCore.Basic.csproj",
       "samples\\Sentry.Samples.AspNetCore.Blazor.Server\\Sentry.Samples.AspNetCore.Blazor.Server.csproj",

--- a/SentryCore.slnf
+++ b/SentryCore.slnf
@@ -1,6 +1,6 @@
 {
   "solution": {
-    "path": "Sentry.sln",
+    "path": "Sentry.NoMobile.sln",
     "projects": [
       "benchmarks\\Sentry.Benchmarks\\Sentry.Benchmarks.csproj",
       "samples\\Sentry.Samples.Console.Basic\\Sentry.Samples.Console.Basic.csproj",

--- a/SentryDiagnosticSource.slnf
+++ b/SentryDiagnosticSource.slnf
@@ -1,6 +1,6 @@
 {
   "solution": {
-    "path": "Sentry.sln",
+    "path": "Sentry.NoMobile.sln",
     "projects": [
       "src\\Sentry.DiagnosticSource\\Sentry.DiagnosticSource.csproj",
       "src\\Sentry.Extensions.Logging\\Sentry.Extensions.Logging.csproj",

--- a/SentryNoMobile.slnf
+++ b/SentryNoMobile.slnf
@@ -1,6 +1,6 @@
 {
   "solution": {
-    "path": "Sentry.sln",
+    "path": "Sentry.NoMobile.sln",
     "projects": [
       "benchmarks\\Sentry.Benchmarks\\Sentry.Benchmarks.csproj",
       "samples\\Sentry.Samples.AspNetCore.Basic\\Sentry.Samples.AspNetCore.Basic.csproj",

--- a/scripts/generate-solution-filters-config.yaml
+++ b/scripts/generate-solution-filters-config.yaml
@@ -3,7 +3,7 @@
 # the *.slnf solution filters for the Sentry solution.
 ################################################################
 
-solution: Sentry.sln
+defaultSolution: Sentry.sln
 
 groupConfigs:
   allProjects:
@@ -78,6 +78,7 @@ filterConfigs:
         - "test/**/*.csproj"
 
   - outputPath: SentryAspNetCore.slnf
+    solution: Sentry.NoMobile.sln
     include:
       patterns:
         - "**/*AspNetCore*.csproj"
@@ -101,6 +102,7 @@ filterConfigs:
         - "**/Sentry.Tests.csproj"
 
   - outputPath: SentryCore.slnf
+    solution: Sentry.NoMobile.sln
     include:
       patterns:
         - "**/Sentry.Benchmarks.csproj"
@@ -114,6 +116,7 @@ filterConfigs:
         - "**/Sentry.Tests.csproj"
 
   - outputPath: SentryDiagnosticSource.slnf
+    solution: Sentry.NoMobile.sln
     include:
       patterns:
         - "**/*DiagnosticSource*.csproj"
@@ -144,6 +147,7 @@ filterConfigs:
         - "test/MauiTestUtils/**/*.csproj"
 
   - outputPath: SentryNoMobile.slnf
+    solution: Sentry.NoMobile.sln
     include:
       groups:
         - "allProjects"

--- a/scripts/generate-solution-filters.ps1
+++ b/scripts/generate-solution-filters.ps1
@@ -101,9 +101,14 @@ foreach($filter in $config.filterConfigs){
     Write-Debug "Writing filter matching $($includedProjects.Count) projects"
 
     # Start filter file
+    $solution = if ($filter.ContainsKey('solution')) {
+      $filter.solution
+    } else {
+      $config.defaultSolution
+    }
     $content = "{
   `"solution`": {
-    `"path`": `"$($config.solution)`",
+    `"path`": `"$($solution)`",
     `"projects`": ["
 
     # Add all the projects we want to include
@@ -132,3 +137,8 @@ foreach($filter in $config.filterConfigs){
   $content | Set-Content $outputPath
   Write-Debug "Created $outputPath"
 }
+
+# Update solution files from Sentry.sln
+$source = Join-Path $repoRoot "Sentry.sln"
+$destination = Join-Path $repoRoot "Sentry.NoMobile.sln"
+Copy-Item -Path $source -Destination $destination -Force


### PR DESCRIPTION
##skip-changelog

When we started [generating solution filters automatically](https://github.com/getsentry/sentry-dotnet/pull/2576) from a single `Sentry.sln` solution file, we lost one quite important convenience. Our previous build process maintained separate solution files that were used in our solution filters to determine whether or not mobile targets should be enabled:

![image](https://github.com/getsentry/sentry-dotnet/assets/728212/cc78ca7d-db2d-4762-8a60-e58bd47b4a8c)

This PR re-enables that same behaviour but **_still lets us maintain a single Sentry.sln solution file_**. 

Once this PR is merged into main, we should be able to merge it into the `feat/4.0.0` branches and use a similar technique to maintain solution filters that can be used to test and build AOT packages by setting `<PublishAot>true</PublishAot>` in the build props if the solution is `Sentry.Native.sln` (or something like that). 