### PR TITLE
Feat: native AOT debug info upload

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,11 +50,6 @@
     <SentryUploadSources>true</SentryUploadSources>
   </PropertyGroup>
 
-  <!-- If running in CI and auth token is not set, disable SentryCLI completely (to avoid logging warnings). -->
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true' And '$(SENTRY_AUTH_TOKEN)' == ''">
-    <UseSentryCLI>false</UseSentryCLI>
-  </PropertyGroup>
-
   <!--
     Note: The following platform-specific properties need to be set in both Directory.Build.props and DirectoryBuild.targets.
     TODO: Figure out how to consolidate to a single location.

--- a/benchmarks/Directory.Build.props
+++ b/benchmarks/Directory.Build.props
@@ -4,7 +4,6 @@
 
   <!-- Never use Sentry CLI for benchmark projects. -->
   <PropertyGroup>
-    <UseSentryCLI>false</UseSentryCLI>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,2 @@
-set UseSentryCLI=false
 dotnet build Sentry.sln -c Release
 dotnet test Sentry.sln -c Release --no-build

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,2 @@
-export UseSentryCLI=false
 dotnet build Sentry.sln -c Release
 dotnet test Sentry.sln -c Release --no-build

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -6,11 +6,6 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <!-- Never use Sentry CLI for sample projects when building in CI. -->
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <UseSentryCLI>false</UseSentryCLI>
-  </PropertyGroup>
-
   <!--
     This sets the default DSN for all sample projects.  Sentry employees and contractors
     can view events at https://sentry-sdks.sentry.io/projects/sentry-dotnet.

--- a/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
+++ b/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <PublishAot>true</PublishAot>
   </PropertyGroup>
 

--- a/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
+++ b/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
@@ -7,6 +7,7 @@
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
 
     <!-- AOT not supported for osx-arm64 on .NET 7 -->
+	<!-- TODO, consider updating after changes from #2732 come into effect -->
     <PublishAot Condition="!$([MSBuild]::IsOSPlatform('OSX')) or '$(TargetFramework)' == 'net8.0'">true</PublishAot>
   </PropertyGroup>
 

--- a/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
+++ b/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
@@ -4,14 +4,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-  <!-- Remove after switching to .NET 8 SDK -->
-  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-    <TargetFramework>net6.0</TargetFramework>
-    <PublishAot>false</PublishAot>
-  </PropertyGroup>
-  <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('OSX'))">
     <TargetFramework>net7.0</TargetFramework>
     <PublishAot>true</PublishAot>
   </PropertyGroup>

--- a/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
+++ b/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
@@ -5,7 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
-    <PublishAot>true</PublishAot>
+
+    <!-- AOT not supported for osx-arm64 on .NET 7 -->
+    <PublishAot Condition="!$([MSBuild]::IsOSPlatform('OSX')) or '$(TargetFramework)' == 'net8.0'">true</PublishAot>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -149,9 +149,11 @@
     <SentryCLIUploadSymbolType Include="dsym" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'" />
   </ItemGroup>
 
-  <!-- Upload symbols to Sentry after the build. -->
+  <!-- Upload symbols to Sentry after the build. 
+       We're explicitly skipping uploads for Sentry project because it would interfere with integration tests. 
+       Also, it only ever gets triggered for Sentry within this repository. -->
   <Target Name="UploadDebugInfoToSentry" AfterTargets="$(SentryCLIUploadAfterTargets)" DependsOnTargets="PrepareSentryCLI"
-    Condition="'$(SentryCLI)' != '' and ('$(SentryUploadSymbols)' == 'true' or '$(SentryUploadSources)' == 'true')">
+    Condition="'$(MSBuildProjectName)' != 'Sentry' and '$(SentryCLI)' != '' and ('$(SentryUploadSymbols)' == 'true' or '$(SentryUploadSources)' == 'true')">
 
     <!-- if (UploadSymbols && UploadSources) { -->
       <Message Importance="High"
@@ -175,8 +177,10 @@
       </Exec>
     <!-- } else if (!UploadSymbols && UploadSources) { -->
       <PropertyGroup>
-        <SentryCLIDebugInfoFile>@(IntermediateAssembly->'$(SentryCLIUploadDirectory)%(FileName).pdb')</SentryCLIDebugInfoFile>
+        <SentryCLIDebugInfoFile Condition="'$(NativeBinary)' != ''">$(NativeBinary)$(NativeSymbolExt)</SentryCLIDebugInfoFile>
+        <SentryCLIDebugInfoFile Condition="'$(NativeBinary)' == '' or !Exists('$(SentryCLIDebugInfoFile)')">@(IntermediateAssembly->'$(SentryCLIUploadDirectory)%(FileName).pdb')</SentryCLIDebugInfoFile>
         <SentryCLIDebugInfoFile Condition="!Exists('$(SentryCLIDebugInfoFile)')">@(IntermediateAssembly->'$(SentryCLIUploadDirectory)%(FileName)%(Extension)')</SentryCLIDebugInfoFile>
+        <SentryCLIUploadSourcesDirectory>$([System.IO.Path]::GetDirectoryName('$(SentryCLIDebugInfoFile)'))</SentryCLIUploadSourcesDirectory>
       </PropertyGroup>
       <Message Importance="High"
         Condition="'$(SentryUploadSymbols)' != 'true' and '$(SentryUploadSources)' == 'true'"
@@ -189,7 +193,7 @@
       <Warning Condition="'$(_SentryCLIExitCode)' != '0'" Text="Sentry CLI could not upload debug files." />
       <Exec
         Condition="'$(SentryUploadSymbols)' != 'true' and '$(SentryUploadSources)' == 'true' and '$(_SentryCLIExitCode)' == '0'"
-        Command="$(SentryCLIDebugFilesUploadCommand) -t sourcebundle $(SentryCLIUploadDirectory)"
+        Command="$(SentryCLIDebugFilesUploadCommand) -t sourcebundle $(SentryCLIUploadSourcesDirectory)"
         IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
         <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
       </Exec>

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -40,7 +40,7 @@
         '$(UseSentryCLI)' == ''
         and ('$(SentryUploadSymbols)' == 'true' or '$(SentryUploadSources)' == 'true' or $(SentryUploadAndroidProguardMapping) == 'true')
         and ('$(MSBuildProjectName)' != 'Sentry')
-        and ($(MSBuildProjectName.StartsWith('Sentry.Samples')) or !$(MSBuildProjectName.StartsWith('Sentry.')))">true</UseSentryCLI>
+        and (!$(MSBuildProjectName.StartsWith('Sentry.')) or '$(MSBuildProjectName)' == '$(SentryCLIIntegrationTestProject)')">true</UseSentryCLI>
     </PropertyGroup>
   </Target>
 
@@ -206,7 +206,7 @@
 
   <!-- Upload Android Proguard mapping file to Sentry after the build. -->
   <Target Name="UploadAndroidProguardMappingFileToSentry" AfterTargets="Build" DependsOnTargets="PrepareSentryCLI"
-          Condition="'$(SentryUploadAndroidProguardMapping)' == 'true' And '$(AndroidProguardMappingFile)' != ''">
+          Condition="'$(SentryCLI)' != '' and '$(SentryUploadAndroidProguardMapping)' == 'true' And '$(AndroidProguardMappingFile)' != ''">
 
     <Message Importance="High" Text="Preparing to upload Android Proguard mapping to Sentry for '$(MSBuildProjectName)': $(AndroidProguardMappingFile))" />
 

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -34,8 +34,13 @@
       <SentryUploadSymbols Condition="'$(SentryUploadSymbols)' == ''">false</SentryUploadSymbols>
       <SentryUploadSources Condition="'$(SentryUploadSources)' == ''">false</SentryUploadSources>
 
-      <!-- This property controls if the Sentry CLI is to be used at all.  Setting false will disable all Sentry CLI usage. -->
-      <UseSentryCLI Condition="'$(UseSentryCLI)' == '' And ('$(SentryUploadSymbols)' == 'true' Or '$(SentryUploadSources)' == 'true' Or $(SentryUploadAndroidProguardMapping) == 'true')">true</UseSentryCLI>
+      <!-- This property controls if the Sentry CLI is to be used at all. Setting false will disable all Sentry CLI usage.
+           We're explicitly skipping uploads for Sentry projects (except samples) because they interfere with CLI integration test asserts. -->
+      <UseSentryCLI Condition="
+        '$(UseSentryCLI)' == ''
+        and ('$(SentryUploadSymbols)' == 'true' or '$(SentryUploadSources)' == 'true' or $(SentryUploadAndroidProguardMapping) == 'true')
+        and ('$(MSBuildProjectName)' != 'Sentry')
+        and ($(MSBuildProjectName.StartsWith('Sentry.Samples')) or !$(MSBuildProjectName.StartsWith('Sentry.')))">true</UseSentryCLI>
     </PropertyGroup>
   </Target>
 
@@ -126,7 +131,7 @@
   <PropertyGroup Condition="'$(PublishDir)' != '' and '$(PublishAot)' == 'true' and '$(_IsPublishing)' == 'true'">
     <SentryCLIUploadNativeAOT>true</SentryCLIUploadNativeAOT>
     <SentryCLIUploadDirectory>$(PublishDir)</SentryCLIUploadDirectory>
-    <!-- We must run after "CopyNativeBinary" (not "Publish"), 
+    <!-- We must run after "CopyNativeBinary" (not "Publish"),
          because that is the one that actually copies native AOT symbols to the publish directory. -->
     <SentryCLIUploadAfterTargets>CopyNativeBinary</SentryCLIUploadAfterTargets>
   </PropertyGroup>
@@ -149,11 +154,9 @@
     <SentryCLIUploadSymbolType Include="dsym" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'" />
   </ItemGroup>
 
-  <!-- Upload symbols to Sentry after the build. 
-       We're explicitly skipping uploads for Sentry project because it would interfere with integration tests. 
-       Also, it only ever gets triggered for Sentry within this repository. -->
+  <!-- Upload symbols to Sentry after the build. -->
   <Target Name="UploadDebugInfoToSentry" AfterTargets="$(SentryCLIUploadAfterTargets)" DependsOnTargets="PrepareSentryCLI"
-    Condition="'$(MSBuildProjectName)' != 'Sentry' and '$(SentryCLI)' != '' and ('$(SentryUploadSymbols)' == 'true' or '$(SentryUploadSources)' == 'true')">
+    Condition="'$(SentryCLI)' != '' and ('$(SentryUploadSymbols)' == 'true' or '$(SentryUploadSources)' == 'true')">
 
     <!-- if (UploadSymbols && UploadSources) { -->
       <Message Importance="High"
@@ -202,7 +205,7 @@
   </Target>
 
   <!-- Upload Android Proguard mapping file to Sentry after the build. -->
-  <Target Name="UploadAndroidProguardMappingFileToSentry" AfterTargets="Build"
+  <Target Name="UploadAndroidProguardMappingFileToSentry" AfterTargets="Build" DependsOnTargets="PrepareSentryCLI"
           Condition="'$(SentryUploadAndroidProguardMapping)' == 'true' And '$(AndroidProguardMappingFile)' != ''">
 
     <Message Importance="High" Text="Preparing to upload Android Proguard mapping to Sentry for '$(MSBuildProjectName)': $(AndroidProguardMappingFile))" />

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -126,7 +126,8 @@
   <PropertyGroup Condition="'$(PublishDir)' != '' and '$(PublishAot)' == 'true' and '$(_IsPublishing)' == 'true'">
     <SentryCLIUploadNativeAOT>true</SentryCLIUploadNativeAOT>
     <SentryCLIUploadDirectory>$(PublishDir)</SentryCLIUploadDirectory>
-    <!-- Note: For Native AOT we must run after "CopyNativeBinary", not "Publish" because the former is the one that actually copies native AOT symbols to the publish directory. -->
+    <!-- We must run after "CopyNativeBinary" (not "Publish"), 
+         because that is the one that actually copies native AOT symbols to the publish directory. -->
     <SentryCLIUploadAfterTargets>CopyNativeBinary</SentryCLIUploadAfterTargets>
   </PropertyGroup>
   <ItemGroup Condition="'$(SentryCLIUploadNativeAOT)' == 'true'">

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -120,48 +120,80 @@
 
   </Target>
 
+  <!-- Native AOT publishing
+       While '_IsPublishing' looks a bit "private", it's also OK if it suddenly stops working and this step runs anyway.
+       See https://github.com/dotnet/sdk/issues/26324#issuecomment-1169236993 -->
+  <PropertyGroup Condition="'$(PublishDir)' != '' and '$(PublishAot)' == 'true' and '$(_IsPublishing)' == 'true'">
+    <SentryCLIUploadNativeAOT>true</SentryCLIUploadNativeAOT>
+    <SentryCLIUploadDirectory>$(PublishDir)</SentryCLIUploadDirectory>
+    <!-- Note: For Native AOT we must run after "CopyNativeBinary", not "Publish" because the former is the one that actually copies native AOT symbols to the publish directory. -->
+    <SentryCLIUploadAfterTargets>CopyNativeBinary</SentryCLIUploadAfterTargets>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(SentryCLIUploadNativeAOT)' == 'true'">
+    <SentryCLIUploadSymbolType Include="pdb" />
+    <SentryCLIUploadSymbolType Include="dsym" />
+    <SentryCLIUploadSymbolType Include="elf" />
+  </ItemGroup>
+
+  <!-- "Standard" managed build -->
+  <PropertyGroup Condition="'$(SentryCLIUploadNativeAOT)' != 'true'">
+    <SentryCLIUploadNativeAOT>false</SentryCLIUploadNativeAOT>
+    <SentryCLIUploadDirectory>$(OutputPath)</SentryCLIUploadDirectory>
+    <SentryCLIUploadAfterTargets>Build</SentryCLIUploadAfterTargets>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(SentryCLIUploadNativeAOT)' != 'true'">
+    <SentryCLIUploadSymbolType Include="pdb" />
+    <SentryCLIUploadSymbolType Include="portablepdb" />
+    <SentryCLIUploadSymbolType Include="dsym" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'" />
+    <SentryCLIUploadSymbolType Include="dsym" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'" />
+  </ItemGroup>
+
   <!-- Upload symbols to Sentry after the build. -->
-  <Target Name="UploadSymbolsToSentry" AfterTargets="Build;Publish" DependsOnTargets="PrepareSentryCLI"
-    Condition="'$(SentryUploadSymbols)' == 'true' And '$(SentryCLI)' != ''">
+  <Target Name="UploadDebugInfoToSentry" AfterTargets="$(SentryCLIUploadAfterTargets)" DependsOnTargets="PrepareSentryCLI"
+    Condition="'$(SentryCLI)' != '' and ('$(SentryUploadSymbols)' == 'true' or '$(SentryUploadSources)' == 'true')">
 
-    <Message Importance="High"
-      Text="Preparing to upload debug symbols to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
-
-    <ItemGroup>
-      <SentryCLIUploadSymbolType Include="pdb" />
-      <SentryCLIUploadSymbolType Include="portablepdb" />
-      <SentryCLIUploadSymbolType Include="dsym" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'" />
-      <SentryCLIUploadSymbolType Include="dsym" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'" />
-    </ItemGroup>
-
-    <Exec Command="$(SentryCLIDebugFilesUploadCommand) @(SentryCLIUploadSymbolType -> '-t %(Identity)', ' ') $(OutputPath)" IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
-      <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
-    </Exec>
-
+    <!-- if (UploadSymbols && UploadSources) { -->
+      <Message Importance="High"
+        Condition="'$(SentryUploadSymbols)' == 'true' and '$(SentryUploadSources)' == 'true'"
+        Text="Preparing upload to Sentry for project '$(MSBuildProjectName)' ($(Configuration)/$(TargetFramework)): collecting debug symbols and referenced source code from $(SentryCLIUploadDirectory)" />
+      <Exec
+        Condition="'$(SentryUploadSymbols)' == 'true' and '$(SentryUploadSources)' == 'true'"
+        Command="$(SentryCLIDebugFilesUploadCommand) @(SentryCLIUploadSymbolType -> '-t %(Identity)', ' ') --include-sources $(SentryCLIUploadDirectory)"
+        IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
+        <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
+      </Exec>
+    <!-- } else if (UploadSymbols && !UploadSources) { -->
+      <Message Importance="High"
+        Condition="'$(SentryUploadSymbols)' == 'true' and '$(SentryUploadSources)' != 'true'"
+        Text="Preparing upload to Sentry for project '$(MSBuildProjectName)' ($(Configuration)/$(TargetFramework)): collecting debug symbols from $(SentryCLIUploadDirectory)" />
+      <Exec
+        Condition="'$(SentryUploadSymbols)' == 'true' and '$(SentryUploadSources)' != 'true'"
+        Command="$(SentryCLIDebugFilesUploadCommand) @(SentryCLIUploadSymbolType -> '-t %(Identity)', ' ') $(SentryCLIUploadDirectory)"
+        IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
+        <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
+      </Exec>
+    <!-- } else if (!UploadSymbols && UploadSources) { -->
+      <PropertyGroup>
+        <SentryCLIDebugInfoFile>@(IntermediateAssembly->'$(SentryCLIUploadDirectory)%(FileName).pdb')</SentryCLIDebugInfoFile>
+        <SentryCLIDebugInfoFile Condition="!Exists('$(SentryCLIDebugInfoFile)')">@(IntermediateAssembly->'$(SentryCLIUploadDirectory)%(FileName)%(Extension)')</SentryCLIDebugInfoFile>
+      </PropertyGroup>
+      <Message Importance="High"
+        Condition="'$(SentryUploadSymbols)' != 'true' and '$(SentryUploadSources)' == 'true'"
+        Text="Preparing upload to Sentry for project '$(MSBuildProjectName)' ($(Configuration)/$(TargetFramework)): collecting source code referenced by $(SentryCLIDebugInfoFile)" />
+      <Exec
+        Condition="'$(SentryUploadSymbols)' != 'true' and '$(SentryUploadSources)' == 'true'"
+        Command="&quot;$(SentryCLI)&quot; debug-files bundle-sources $(SentryCLIDebugInfoFile) " IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
+        <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
+      </Exec>
+      <Warning Condition="'$(_SentryCLIExitCode)' != '0'" Text="Sentry CLI could not upload debug files." />
+      <Exec
+        Condition="'$(SentryUploadSymbols)' != 'true' and '$(SentryUploadSources)' == 'true' and '$(_SentryCLIExitCode)' == '0'"
+        Command="$(SentryCLIDebugFilesUploadCommand) -t sourcebundle $(SentryCLIUploadDirectory)"
+        IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
+        <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
+      </Exec>
+    <!-- } -->
     <Warning Condition="'$(_SentryCLIExitCode)' != '0'" Text="Sentry CLI could not upload debug files." />
-
-  </Target>
-
-  <!-- Upload sources to Sentry after the build. -->
-  <Target Name="UploadSourcesToSentry" AfterTargets="Build;UploadSymbolsToSentry" DependsOnTargets="PrepareSentryCLI"
-    Condition="'$(SentryUploadSources)' == 'true' And '$(SentryCLI)' != ''">
-
-    <Message Importance="High" Condition="'$(SentryUploadSources)' == 'true'"
-      Text="Preparing to upload sources to Sentry for $(MSBuildProjectName) ($(Configuration)/$(TargetFramework))" />
-
-    <PropertyGroup>
-      <_SentryDebugInfoFile>@(IntermediateAssembly->'$(IntermediateOutputPath)%(FileName).pdb')</_SentryDebugInfoFile>
-      <_SentryDebugInfoFile Condition="!Exists('$(_SentryDebugInfoFile)')">@(IntermediateAssembly->'$(IntermediateOutputPath)%(FileName)%(Extension)')</_SentryDebugInfoFile>
-      <_SentrySourceBundle>@(IntermediateAssembly->'$(IntermediateOutputPath)%(FileName).src.zip')</_SentrySourceBundle>
-    </PropertyGroup>
-
-    <Exec Command="&quot;$(SentryCLI)&quot; debug-files bundle-sources $(_SentryDebugInfoFile)" IgnoreExitCode="true" ContinueOnError="WarnAndContinue" />
-    <Exec Command="$(SentryCLIDebugFilesUploadCommand) $(_SentrySourceBundle)" IgnoreExitCode="true" ContinueOnError="WarnAndContinue" Condition="Exists('$(_SentrySourceBundle)')">
-      <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
-    </Exec>
-
-    <Warning Condition="'$(_SentryCLIExitCode)' != '0'" Text="Sentry CLI could not upload sources." />
-
   </Target>
 
   <!-- Upload Android Proguard mapping file to Sentry after the build. -->

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -35,7 +35,7 @@
       <SentryUploadSources Condition="'$(SentryUploadSources)' == ''">false</SentryUploadSources>
 
       <!-- This property controls if the Sentry CLI is to be used at all. Setting false will disable all Sentry CLI usage.
-           We're explicitly skipping uploads for Sentry projects (except samples) because they interfere with CLI integration test asserts. -->
+           We're explicitly skipping uploads for Sentry projects because they interfere with CLI integration test asserts. -->
       <UseSentryCLI Condition="
         '$(UseSentryCLI)' == ''
         and ('$(SentryUploadSymbols)' == 'true' or '$(SentryUploadSources)' == 'true' or $(SentryUploadAndroidProguardMapping) == 'true')

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -9,11 +9,6 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
-  <!-- Never use Sentry CLI for test projects. -->
-  <PropertyGroup>
-    <UseSentryCLI>false</UseSentryCLI>
-  </PropertyGroup>
-
   <!--
     Workaround for Verify issue with scrubbing when running in Rider on Windows.
     Ensures that the volume label is upper cased ("C:" instead of "c:"), which is read

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -3,6 +3,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# So that this works in VS Code testing integration. Otherwise the script is run within its directory.
 Push-Location $PSScriptRoot/../
 
 # In CI, the module is loaded automatically

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -170,6 +170,7 @@ Describe 'Console apps - native AOT publish (<framework>)' -ForEach @(
         git clean -ffxd samples/Sentry.Samples.Console.Basic
         $runtime = $IsWindows ? 'win-x64' : $IsLinux ? 'linux-x64' : "osx-$(uname -m)"
         Write-Host "Running dotnet restore for Sentry.Samples.Console.Basic, runtime: $runtime"
+        dotnet restore samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
         dotnet restore samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj --runtime $runtime
     }
 

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -170,17 +170,12 @@ Describe 'Console apps - native AOT publish (<framework>)' -ForEach @(
     }
     
     It "uploads symbols and sources (<framework>)" {
-        $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $True $True 'net7.0'
+        $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $True $True $framework
         $result.ScriptOutput | Should -AnyElementMatch "Preparing upload to Sentry for project 'Sentry.Samples.Console.Basic'"
-        if ($IsWindows) 
+        if ($IsWindows -or ($IsLinux -and $framework -eq 'net7.0'))
         {
-            $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @('Sentry.Samples.Console.Basic.pdb')
-            $result.ScriptOutput | Should -AnyElementMatch 'Found 1 debug information file'
-            $result.ScriptOutput | Should -AnyElementMatch 'Resolved source code for 1 debug information file'
-        }
-        elseif ($IsLinux -and $framework -eq 'net7.0')
-        {
-            $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @('Sentry.Samples.Console.Basic')
+            $extension = $IsLinux ? '' : '.pdb'
+            $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @("Sentry.Samples.Console.Basic$extension")
             $result.ScriptOutput | Should -AnyElementMatch 'Found 1 debug information file'
             $result.ScriptOutput | Should -AnyElementMatch 'Resolved source code for 1 debug information file'
         }
@@ -194,38 +189,32 @@ Describe 'Console apps - native AOT publish (<framework>)' -ForEach @(
     }
 
     It "uploads symbols (<framework>)" {
-        $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $True $False 'net7.0'
+        $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $True $False $framework
         $result.ScriptOutput | Should -AnyElementMatch "Preparing upload to Sentry for project 'Sentry.Samples.Console.Basic'"
-        if ($IsWindows)
+        if ($IsWindows -or ($IsLinux -and $framework -eq 'net7.0'))
         {
-            $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @('Sentry.Samples.Console.Basic.pdb')
+            $extension = $IsLinux ? '' : '.pdb'
+            $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @("Sentry.Samples.Console.Basic$extension")
             $result.ScriptOutput | Should -AnyElementMatch 'Found 1 debug information file'
-        }
-        elseif ($IsLinux -and $framework -eq 'net7.0')
-        {         
-            $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @('Sentry.Samples.Console.Basic')
-            $result.ScriptOutput | Should -AnyElementMatch 'Found 1 debug information file'
-            $result.ScriptOutput | Should -AnyElementMatch 'Resolved source code for 1 debug information file'
         }
         else
         {
             $debugExtension = $IsLinux ? '.dbg' : '.dSYM'
             $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
                 'Sentry.Samples.Console.Basic', "Sentry.Samples.Console.Basic$debugExtension")
-            $result.ScriptOutput | Should -AnyElementMatch 'Found 2 debug information files'
-            $result.ScriptOutput | Should -AnyElementMatch 'Resolved source code for 1 debug information file'   
+            $result.ScriptOutput | Should -AnyElementMatch 'Found 2 debug information files' 
         }
     }
  
     It "uploads sources (<framework>)" {
-        $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $False $True 'net7.0'
+        $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $False $True $framework
         $result.ScriptOutput | Should -AnyElementMatch "Preparing upload to Sentry for project 'Sentry.Samples.Console.Basic'"
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
-            $IsWindows ? 'Sentry.Samples.Console.Basic.src.zip' : 'Sentry.Samples.Console.src.zip')
+            ($IsWindows -or $framework -eq 'net8.0') ? 'Sentry.Samples.Console.Basic.src.zip' : 'Sentry.Samples.Console.src.zip')
     }
 
     It "uploads nothing when disabled (<framework>)" {
-        $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $False $False 'net7.0'
+        $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $False $False $framework
         $result.UploadedDebugFiles() | Should -BeNullOrEmpty
     }
 }

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -168,9 +168,8 @@ Describe 'Console apps - native AOT publish (<framework>)' -ForEach @(
     BeforeAll {
         # Make sure we start with a clean project so that we get the same builds as in CI.
         git clean -ffxd samples/Sentry.Samples.Console.Basic
-        $runtime = $IsWindows ? 'win-x64' : $IsLinux ? 'linux-x64' : "osx-$(uname -m)"
+        $runtime = $IsWindows ? 'win-x64' : $IsLinux ? 'linux-x64' : "osx-" + ($(uname -m) -eq 'arm64' ? 'arm64' : 'x64');
         Write-Host "Running dotnet restore for Sentry.Samples.Console.Basic, runtime: $runtime"
-        dotnet restore samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
         dotnet restore samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj --runtime $runtime
     }
 

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -68,7 +68,6 @@ BeforeAll {
             try
             {
                 dotnet $action "samples/$sample/$sample.csproj" -c Release -f $TargetFramework --no-restore --nologo `
-                    /p:UseSentryCLI=true `
                     /p:SentryUploadSymbols=$Symbols `
                     /p:SentryUploadSources=$Sources `
                     /p:SentryOrg=org `
@@ -101,7 +100,7 @@ BeforeAll {
                 Write-Host "::endgroup::"
             }
         }
-        
+
         if ($action -eq "build")
         {
             $result.ScriptOutput | Should -Contain 'Build succeeded.'
@@ -109,7 +108,7 @@ BeforeAll {
         elseif ($action -eq "publish")
         {
             $result.ScriptOutput | Should -AnyElementMatch "$sample -> .*samples/$sample/bin/Release/$TargetFramework/.*/publish"
-        } 
+        }
         $result.ScriptOutput | Should -Not -AnyElementMatch "Preparing upload to Sentry for project 'Sentry'"
         $result.HasErrors() | Should -BeFalse
         $result
@@ -118,16 +117,16 @@ BeforeAll {
 
 Describe 'Console apps - normal build' {
     BeforeAll {
-        Remove-Item 'samples/Sentry.Samples.Console.Basic/bin/' -Recurse -Verbose 
+        Remove-Item 'samples/Sentry.Samples.Console.Basic/bin/' -Recurse -Verbose
     }
-    
+
     BeforeEach {
         if (Get-Item 'samples/Sentry.Samples.Console.Basic/bin/Release/*/*.src.zip' -ErrorAction SilentlyContinue)
         {
             Remove-Item 'samples/Sentry.Samples.Console.Basic/bin/Release/*/*.src.zip'
         }
     }
-    
+
     It "uploads symbols and sources" {
         $result = RunDotnet 'build' 'Sentry.Samples.Console.Basic' $True $True
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
@@ -164,11 +163,11 @@ Describe 'Console apps - native AOT publish (<framework>)' -ForEach @(
     BeforeAll {
         dotnet restore samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj --use-current-runtime
     }
-    
+
     BeforeEach {
-        Remove-Item 'samples/Sentry.Samples.Console.Basic/bin/Release/*/*/publish' -Recurse -Verbose 
+        Remove-Item 'samples/Sentry.Samples.Console.Basic/bin/Release/*/*/publish' -Recurse -Verbose
     }
-    
+
     It "uploads symbols and sources (<framework>)" {
         $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $True $True $framework
         $result.ScriptOutput | Should -AnyElementMatch "Preparing upload to Sentry for project 'Sentry.Samples.Console.Basic'"
@@ -184,7 +183,7 @@ Describe 'Console apps - native AOT publish (<framework>)' -ForEach @(
             $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
                 'Sentry.Samples.Console.Basic', 'Sentry.Samples.Console.Basic.dbg')
             $result.ScriptOutput | Should -AnyElementMatch 'Found 2 debug information files'
-            $result.ScriptOutput | Should -AnyElementMatch 'Resolved source code for 1 debug information file'            
+            $result.ScriptOutput | Should -AnyElementMatch 'Resolved source code for 1 debug information file'
         }
     }
 
@@ -202,10 +201,10 @@ Describe 'Console apps - native AOT publish (<framework>)' -ForEach @(
             $debugExtension = $IsLinux ? '.dbg' : '.dSYM'
             $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
                 'Sentry.Samples.Console.Basic', "Sentry.Samples.Console.Basic$debugExtension")
-            $result.ScriptOutput | Should -AnyElementMatch 'Found 2 debug information files' 
+            $result.ScriptOutput | Should -AnyElementMatch 'Found 2 debug information files'
         }
     }
- 
+
     It "uploads sources (<framework>)" {
         $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $False $True $framework
         $result.ScriptOutput | Should -AnyElementMatch "Preparing upload to Sentry for project 'Sentry.Samples.Console.Basic'"
@@ -230,9 +229,9 @@ Describe 'MAUI' {
             'Sentry.pdb',
             'Sentry.Samples.Maui.pdb'
         )
-        $result.ScriptOutput | Should -AnyElementMatch 'Skipping embedded source file: .*/samples/Sentry.Samples.Maui/MauiProgram.cs'
+        $result.ScriptOutput | Should -AnyElementMatch 'Found 6 debug information files \(6 with embedded sources\)'
     }
-    
+
     It "uploads symbols and sources for an iOS build" -Skip:(!$IsMacOS) {
         $result = RunDotnet 'build' 'Sentry.Samples.Maui' $True $True 'net7.0-ios'
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -3,6 +3,8 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+Push-Location $PSScriptRoot/../
+
 # In CI, the module is loaded automatically
 if (!(Test-Path env:CI ))
 {
@@ -167,16 +169,16 @@ Describe 'Console apps - native AOT publish (<framework>)' -ForEach @(
         Remove-Item 'samples/Sentry.Samples.Console.Basic/bin/Release/*/*/publish' -Recurse -Verbose 
     }
     
-    It "uploads symbols and sources" {
+    It "uploads symbols and sources (<framework>)" {
         $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $True $True 'net7.0'
         $result.ScriptOutput | Should -AnyElementMatch "Preparing upload to Sentry for project 'Sentry.Samples.Console.Basic'"
         if ($IsWindows) 
         {
             $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @('Sentry.Samples.Console.Basic.pdb')
-            $result.ScriptOutput | Should -AnyElementMatch 'Found 1 debug information file \(1 with embedded sources\)'
-            $result.ScriptOutput | Should -AnyElementMatch 'Resolved source code for 0 debug information files'
+            $result.ScriptOutput | Should -AnyElementMatch 'Found 1 debug information file'
+            $result.ScriptOutput | Should -AnyElementMatch 'Resolved source code for 1 debug information file'
         }
-        elseif ($IsLinux && $framework -eq 'net7.0')
+        elseif ($IsLinux -and $framework -eq 'net7.0')
         {
             $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @('Sentry.Samples.Console.Basic')
             $result.ScriptOutput | Should -AnyElementMatch 'Found 1 debug information file'
@@ -191,7 +193,7 @@ Describe 'Console apps - native AOT publish (<framework>)' -ForEach @(
         }
     }
 
-    It "uploads symbols" {
+    It "uploads symbols (<framework>)" {
         $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $True $False 'net7.0'
         $result.ScriptOutput | Should -AnyElementMatch "Preparing upload to Sentry for project 'Sentry.Samples.Console.Basic'"
         if ($IsWindows)
@@ -199,7 +201,7 @@ Describe 'Console apps - native AOT publish (<framework>)' -ForEach @(
             $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @('Sentry.Samples.Console.Basic.pdb')
             $result.ScriptOutput | Should -AnyElementMatch 'Found 1 debug information file'
         }
-        if ($IsLinux && $framework -eq 'net7.0')
+        elseif ($IsLinux -and $framework -eq 'net7.0')
         {         
             $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @('Sentry.Samples.Console.Basic')
             $result.ScriptOutput | Should -AnyElementMatch 'Found 1 debug information file'
@@ -215,14 +217,14 @@ Describe 'Console apps - native AOT publish (<framework>)' -ForEach @(
         }
     }
  
-    It "uploads sources" {
+    It "uploads sources (<framework>)" {
         $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $False $True 'net7.0'
         $result.ScriptOutput | Should -AnyElementMatch "Preparing upload to Sentry for project 'Sentry.Samples.Console.Basic'"
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
             $IsWindows ? 'Sentry.Samples.Console.Basic.src.zip' : 'Sentry.Samples.Console.src.zip')
     }
 
-    It "uploads nothing when disabled" {
+    It "uploads nothing when disabled (<framework>)" {
         $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $False $False 'net7.0'
         $result.UploadedDebugFiles() | Should -BeNullOrEmpty
     }

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -155,6 +155,10 @@ Describe 'Console apps - normal build' {
 }
 
 Describe 'Console apps - native AOT publish' {
+    BeforeAll {
+        dotnet workload restore samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj --use-current-runtime
+    }
+    
     BeforeEach {
         Remove-Item 'samples/Sentry.Samples.Console.Basic/bin/Release/*/*/publish' -Recurse -Verbose 
     }
@@ -163,7 +167,7 @@ Describe 'Console apps - native AOT publish' {
         $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $True $True
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
             'Sentry.pdb',
-            'Sentry.Samples.Console.Basic.pdb')
+            ($IsWindows ? 'Sentry.Samples.Console.Basic.pdb' : 'Sentry.Samples.Console.Basic'))
         $result.ScriptOutput | Should -AnyElementMatch 'Found 1 debug information file \(1 with embedded sources\)'
         $result.ScriptOutput | Should -AnyElementMatch 'Resolved source code for 0 debug information files'
     }
@@ -172,14 +176,14 @@ Describe 'Console apps - native AOT publish' {
         $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $True $False
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
             'Sentry.pdb',
-            'Sentry.Samples.Console.Basic.pdb')
+            ($IsWindows ? 'Sentry.Samples.Console.Basic.pdb' : 'Sentry.Samples.Console.Basic'))
         $result.ScriptOutput | Should -AnyElementMatch 'Found 1 debug information file \(1 with embedded sources\)'
     }
  
     It "uploads sources" {
         $result = RunDotnet 'publish' 'Sentry.Samples.Console.Basic' $False $True
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
-            'Sentry.Samples.Console.Basic.src.zip')
+            $IsWindows ? 'Sentry.Samples.Console.Basic.src.zip' : 'Sentry.Samples.Console.src.zip')
     }
 
     It "uploads nothing when disabled" {

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -59,7 +59,7 @@ BeforeAll {
         $result = Invoke-SentryServer {
             Param([string]$url)
             Write-Host "Building $Sample"
-            dotnet $action "samples/$sample/$sample.csproj" -c Release -f $TargetFramework --no-restore --nologo -v d `
+            dotnet $action "samples/$sample/$sample.csproj" -c Release -f $TargetFramework --no-restore --nologo `
                 /p:UseSentryCLI=true `
                 /p:SentryUploadSymbols=$Symbols `
                 /p:SentryUploadSources=$Sources `

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -68,6 +68,7 @@ BeforeAll {
             try
             {
                 dotnet $action "samples/$sample/$sample.csproj" -c Release -f $TargetFramework --no-restore --nologo `
+                    /p:SentryCLIIntegrationTestProject=$sample `
                     /p:SentryUploadSymbols=$Symbols `
                     /p:SentryUploadSources=$Sources `
                     /p:SentryOrg=org `

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -178,7 +178,7 @@ Describe 'Console apps - native AOT publish' {
 }
 
 Describe 'MAUI' {
-    It "uploads symbols and sources" {
+    It "uploads symbols and sources for an Android build" {
         $result = RunDotnet 'build' 'Sentry.Samples.Maui' $True $True 'net7.0-android'
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
             'Sentry.Android.AssemblyReader.pdb',
@@ -191,7 +191,7 @@ Describe 'MAUI' {
         $result.ScriptOutput | Should -AnyElementMatch 'Skipping embedded source file: .*/samples/Sentry.Samples.Maui/MauiProgram.cs'
     }
     
-    It "uploads symbols and sources" -Skip:(!$IsMacOS) {
+    It "uploads symbols and sources for an iOS build" -Skip:(!$IsMacOS) {
         $result = RunDotnet 'build' 'Sentry.Samples.Maui' $True $True 'net7.0-ios'
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @(
             'libmono-component-debugger.dylib',

--- a/test/sentry-cli-integration.Tests.ps1
+++ b/test/sentry-cli-integration.Tests.ps1
@@ -118,7 +118,10 @@ BeforeAll {
 
 Describe 'Console apps - normal build' {
     BeforeAll {
-        Remove-Item 'samples/Sentry.Samples.Console.Basic/bin/' -Recurse -Verbose
+        # Make sure we start with a clean project so that we get the same builds as in CI.
+        git clean -ffxd samples/Sentry.Samples.Console.Basic
+        Write-Host "Running dotnet restore for Sentry.Samples.Console.Basic"
+        dotnet restore samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
     }
 
     BeforeEach {
@@ -162,13 +165,18 @@ Describe 'Console apps - native AOT publish (<framework>)' -ForEach @(
     @{ framework = "net8.0" }
 ) {
     BeforeAll {
+        # Make sure we start with a clean project so that we get the same builds as in CI.
+        git clean -ffxd samples/Sentry.Samples.Console.Basic
         $runtime = $IsWindows ? 'win-x64' : $IsLinux ? 'linux-x64' : "osx-$(uname -m)"
         Write-Host "Running dotnet restore for Sentry.Samples.Console.Basic, runtime: $runtime"
         dotnet restore samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj --runtime $runtime
     }
 
     BeforeEach {
-        Remove-Item 'samples/Sentry.Samples.Console.Basic/bin/Release/*/*/publish' -Recurse -Verbose
+        if (Get-Item 'samples/Sentry.Samples.Console.Basic/bin/Release/*/*/publish' -ErrorAction SilentlyContinue)
+        {
+            Remove-Item 'samples/Sentry.Samples.Console.Basic/bin/Release/*/*/publish' -Recurse -Verbose
+        }
     }
 
     It "uploads symbols and sources (<framework>)" -Skip:($IsMacOS -and $framework -eq 'net7.0') {


### PR DESCRIPTION
closes #2692

This is mostly done in `Sentry.targets` - I've merged the two jobs (one uploading debug files, the second one uploading sources) because it was getting unwieldy when trying to handle both native AOT and managed symbols (and referenced sources) in both jobs. 

I've also had to rework the PrepareCLI workflow a bit so that we get consistent integration test runs. Ppreviously, the integration test build would also upload symbols for the Sentry project itself, which is not what would happen when building actual user projects, because that project would have come from a nuget package.

### TODO: 
* [ ] force some source bundles to be uploaded for managed apps? it seems all sources are embedded with .net 8 SDK... How can we do it though? I'm open to suggestions
* [x] test on Linux
* [x] test on macOS (although the actual native integration will only come as a part of #2625)

#skip-changelog (This is part of a bigger task to support Native AOT)