### PR TITLE
chore: pin .net version in global.json

### DIFF
--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -29,11 +29,11 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
+      - name: Setup Environment
+        uses: ./.github/actions/environment
+
       - name: Build Native Dependencies
         uses: ./.github/actions/buildnative
-
-      - name: Install .NET Workloads
-        run: dotnet workload install maui-android --temp-dir "${{ runner.temp }}"
 
       - name: Restore .NET Dependencies
         run: dotnet restore test/Sentry.Maui.Device.TestApp --nologo

--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Set Java Version
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: "temurin"
+          java-version: "11"
 
       - name: Setup Environment
         uses: ./.github/actions/environment
@@ -63,13 +63,12 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
     steps:
-
       # See https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
       - name: Enable KVM group perms
         run: |
-            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-            sudo udevadm control --reload-rules
-            sudo udevadm trigger --name-match=kvm
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -79,6 +78,9 @@ jobs:
         with:
           name: device-test-android
           path: bin
+
+      - name: Setup Environment
+        uses: ./.github/actions/environment
 
       - name: Install XHarness
         run: dotnet tool install Microsoft.DotNet.XHarness.CLI --global --version "1.*-*"

--- a/.github/workflows/device-tests-ios.yml
+++ b/.github/workflows/device-tests-ios.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Build Cocoa SDK
         uses: ./.github/actions/buildcocoasdk
 
-      - name: Install .NET Workloads
-        run: dotnet workload install maui-ios --temp-dir "${{ runner.temp }}"
+      - name: Setup Environment
+        uses: ./.github/actions/environment
 
       - name: Restore .NET Dependencies
         run: dotnet restore test/Sentry.Maui.Device.TestApp --nologo

--- a/.github/workflows/device-tests-ios.yml
+++ b/.github/workflows/device-tests-ios.yml
@@ -55,7 +55,6 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
     steps:
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -64,6 +63,9 @@ jobs:
         with:
           name: device-test-ios
           path: bin/Sentry.Maui.Device.TestApp.app
+
+      - name: Setup Environment
+        uses: ./.github/actions/environment
 
       - name: Install XHarness
         run: dotnet tool install Microsoft.DotNet.XHarness.CLI --global --version "1.*-*"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.*",
+    "version": "8.0.100-rc.2.23502.2",
     "rollForward": "latestMinor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
This is to avoid surprises when locally everything seems to work but in CI, builds fail because it's running on a newer version. Before #2622 we've had a fixed .net version in global.json and I think we should roll back to that.

#skip-changelog