### PR TITLE
ci: dotnet workload restore instead of individual platform-specific installs

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -48,7 +48,7 @@ runs:
     # TODO: Figure out how to cache workloads, as they're not quite the same as nuget packages.
     - name: Install .NET Workloads
       shell: pwsh
-      run: ./scripts/dotnet-workload-restore.ps1 Sentry-CI-Build-${{ runner.os }}.slnf
+      run: ./scripts/dotnet-workload-restore.ps1
 
     # We build Sentry.Maui for every supported MAUI target so we can access platform-specific features.
     # That includes Tizen. We don't need the entire Tizen SDK, but we do need the base Tizen workload.

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -48,7 +48,7 @@ runs:
     # TODO: Figure out how to cache workloads, as they're not quite the same as nuget packages.
     - name: Install .NET Workloads
       shell: pwsh
-      run: ./scripts/dotnet-workload-restore.ps1
+      run: ./scripts/dotnet-workload-restore.ps1 Sentry-CI-Build-${{ runner.os }}.slnf
 
     # We build Sentry.Maui for every supported MAUI target so we can access platform-specific features.
     # That includes Tizen. We don't need the entire Tizen SDK, but we do need the base Tizen workload.

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -47,13 +47,8 @@ runs:
 
     # TODO: Figure out how to cache workloads, as they're not quite the same as nuget packages.
     - name: Install .NET Workloads
-      shell: bash
-      run: >
-        dotnet workload install \
-          maui-android \
-          ${{ runner.os == 'macOS' && 'maui-ios maui-maccatalyst maui-windows maui-tizen' || '' }} \
-          ${{ runner.os == 'Windows' && 'maui-windows' || '' }} \
-          --temp-dir "${{ runner.temp }}" --from-rollback-file rollback.json
+      shell: pwsh
+      run: ./scripts/dotnet-workload-restore.ps1
 
     # We build Sentry.Maui for every supported MAUI target so we can access platform-specific features.
     # That includes Tizen. We don't need the entire Tizen SDK, but we do need the base Tizen workload.

--- a/scripts/dotnet-workload-restore.ps1
+++ b/scripts/dotnet-workload-restore.ps1
@@ -1,0 +1,47 @@
+# `dotnet workload restore` sometimes doesn't fetch all workloads on the first run
+# This script runs the same command until it stops fetching new workloads
+param([string] $ProjectOrSolution = 'Sentry.sln')
+
+Set-StrictMode -Version latest
+$ErrorActionPreference = "Stop"
+
+
+# Restore workloads and return the list of installed ones.
+$dotnetWorkloadRestore = {
+    $matchText = "Successfully installed workload\(s\) "
+    Write-Host "Restoring $ProjectOrSolution"
+    $tempArg = (Test-Path env:RUNNER_TEMP) ? @("--temp-dir", $env:RUNNER_TEMP) : ''
+    dotnet workload restore $ProjectOrSolution --from-rollback-file rollback.json $tempArg | ForEach-Object {
+        Write-Host "  $_"
+        if ($_ -match $matchText)
+        {
+            $installed = $_
+            $installed = $installed -replace $matchText, ''
+            $installed = $installed -replace '\.', '' # trailing dot
+            $installed = $installed.Trim() -split ' '
+            $installed | Sort-Object -Unique
+        }
+    }
+}
+
+$maxRuns = 5
+$prevInstalled = @();
+while ($true)
+{
+    $installed = $dotnetWorkloadRestore.Invoke()
+    if ("$installed" -eq "")
+    {
+        throw "Installation error"
+    }
+    elseif ("$installed" -eq "$prevInstalled")
+    {
+        Write-Host "No new packages installed since the previous run, stopping."
+        break
+    }
+    $prevInstalled = $installed
+    
+    if (--$maxRuns -le 0)
+    {
+        throw "Too many retries to install all workloads"
+    }
+}

--- a/scripts/dotnet-workload-restore.ps1
+++ b/scripts/dotnet-workload-restore.ps1
@@ -11,7 +11,7 @@ $dotnetWorkloadRestore = {
     $matchText = "Successfully installed workload\(s\) "
     Write-Host "Restoring $ProjectOrSolution"
     $tempArg = (Test-Path env:RUNNER_TEMP) ? @("--temp-dir", $env:RUNNER_TEMP) : ''
-    dotnet workload restore $ProjectOrSolution --from-rollback-file rollback.json $tempArg | ForEach-Object {
+    dotnet workload restore $ProjectOrSolution --from-rollback-file rollback.json $tempArg --nologo | ForEach-Object {
         Write-Host "  $_"
         if ($_ -match $matchText)
         {

--- a/scripts/dotnet-workload-restore.ps1
+++ b/scripts/dotnet-workload-restore.ps1
@@ -1,6 +1,5 @@
 # `dotnet workload restore` sometimes doesn't fetch all workloads on the first run
 # This script runs the same command until it stops fetching new workloads
-# Note: the parameter cannot be a solution filter - it's not supported by `dotnet workload restore`.
 param([string] $ProjectOrSolution = 'Sentry.sln')
 
 Set-StrictMode -Version latest
@@ -8,13 +7,14 @@ $ErrorActionPreference = "Stop"
 
 
 # Restore workloads and return the list of installed ones.
-$dotnetWorkloadRestore = {
+function DotnetWorkloadRestore([string] $target)
+{
     $matchText = "Successfully installed workload\(s\) "
-    Write-Host "::group::Restoring workloads for $ProjectOrSolution"
+    Write-Host "::group::Restoring workloads for $target"
     try
     {
         $tempArg = (Test-Path env:RUNNER_TEMP) ? @("--temp-dir", $env:RUNNER_TEMP) : ''
-        dotnet workload restore $ProjectOrSolution --from-rollback-file rollback.json $tempArg --nologo | ForEach-Object {
+        dotnet workload restore $target --from-rollback-file rollback.json $tempArg --nologo | ForEach-Object {
             Write-Host "  $_"
             if ($_ -match $matchText)
             {
@@ -32,24 +32,35 @@ $dotnetWorkloadRestore = {
     }
 }
 
-$maxRuns = 5
-$prevInstalled = @();
-while ($true)
+# Solution filters are not accepted by `dotnet workload restore`. See https://github.com/dotnet/sdk/issues/36277
+$projects = @($ProjectOrSolution)
+if ($ProjectOrSolution -match "\.slnf$")
 {
-    $installed = $dotnetWorkloadRestore.Invoke()
-    if ("$installed" -eq "")
+    $slnf = Get-Content -Raw .\Sentry-CI-Build-Windows.slnf | ConvertFrom-Json
+    $projects = $slnf.solution.projects 
+}
+
+$prevInstalled = @();
+$projects | ForEach-Object {
+    $project = $_
+    $maxRuns = 5
+    while ($true)
     {
-        throw "Installation error"
-    }
-    elseif ("$installed" -eq "$prevInstalled")
-    {
-        Write-Host "No new packages installed since the previous run, stopping."
-        break
-    }
-    $prevInstalled = $installed
+        $installed = DotnetWorkloadRestore $project
+        if ("$installed" -eq "")
+        {
+            throw "Installation error"
+        }
+        elseif ("$installed" -eq "$prevInstalled")
+        {
+            Write-Host "No new packages installed since the previous run, stopping."
+            break
+        }
+        $prevInstalled = $installed
     
-    if (--$maxRuns -le 0)
-    {
-        throw "Too many retries to install all workloads"
+        if (--$maxRuns -le 0)
+        {
+            throw "Too many retries to install all workloads"
+        }
     }
 }


### PR DESCRIPTION
While I think this script should work, it doesn't seem to... But maybe that's just a temporary error?

```
Failed to update the advertising manifest microsoft.net.sdk.maccatalyst: Failed to validate package signing.
    
    Verifying Microsoft.NET.Sdk.MacCatalyst.Manifest-7.0.100.16.4.7107
    
    Signature type: Author
      Subject Name: CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
      SHA256 hash: 566A31882BE208BE4422F7CFD66ED09F5D4524A59[94](https://github.com/getsentry/sentry-dotnet/actions/runs/6577785584/job/17870163358?pr=2743#step:7:102)F50CCC8B05EC0528C1353
      Valid from: 7/27/2023 12:00:00 AM to 10/17/2026 11:59:59 PM
    
    Signature type: Repository
      Subject Name: CN=NuGet.org Repository by Microsoft, O=NuGet.org Repository by Microsoft, L=Redmond, S=Washington, C=US
      SHA256 hash: 5A2901D6ADA3D18260B9C6DFE2133C[95](https://github.com/getsentry/sentry-dotnet/actions/runs/6577785584/job/17870163358?pr=2743#step:7:103)D74B9EEF6AE0E5DC334C8454D1477DF4
      Valid from: 2/16/2021 12:00:00 AM to 5/15/2024 11:59:59 PM
    
    .
    Failed to update the advertising manifest microsoft.net.sdk.maui: Failed to validate package signing.
...
```