### PR TITLE
feat: cocoa SDK integration for macOS

### DIFF
--- a/.github/actions/buildcocoasdk/action.yml
+++ b/.github/actions/buildcocoasdk/action.yml
@@ -4,23 +4,17 @@ runs:
   using: composite
 
   steps:
-
-    - name: Fetch version tags for Sentry Cocoa SDK
+  
+    - name: Get submodule status
       shell: bash
-      run: git fetch --tags --quiet
-      working-directory: modules/sentry-cocoa
-
-    - name: Get Sentry Cocoa SHA
-      shell: bash
-      run: echo "SENTRY_COCOA_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
-      working-directory: modules/sentry-cocoa
+      run: cat .git/modules/modules/sentry-cocoa/HEAD
 
     - name: Cache Sentry Cocoa SDK
       id: cache-sentry-cocoa
       uses: actions/cache@v3
       with:
         path: modules/sentry-cocoa/Carthage
-        key: sentry-cocoa-${{ env.SENTRY_COCOA_SHA }}
+        key: sentry-cocoa-${{ hashFiles('scripts/build-sentry-cocoa.sh', '.git/modules/modules/sentry-cocoa/HEAD') }}
 
     - name: Build Sentry Cocoa SDK
       if: ${{ steps.cache-sentry-cocoa.outputs.cache-hit != 'true' }}

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -25,10 +25,10 @@ runs:
       with:
         dotnet-version: |
           3.1.x
-          6.0.x 
+          6.0.x
           7.0.x
           8.0.x
-        
+
     - name: Dependency Caching
       uses: actions/cache@v3
       # Cache is too slow on Windows to be useful.  See https://github.com/actions/cache/issues/752
@@ -45,6 +45,6 @@ runs:
       run: >
         dotnet workload install \
           maui-android \
-          ${{ runner.os == 'macOS' && 'maui-ios maui-maccatalyst maui-windows' || '' }} \
+          ${{ runner.os == 'macOS' && 'macos maui-ios maui-maccatalyst maui-windows' || '' }} \
           ${{ runner.os == 'Windows' && 'maui-windows' || '' }} \
           --temp-dir "${{ runner.temp }}"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -67,6 +67,8 @@
   <!-- This is helpful in code to distinguish neutral targets. -->
   <PropertyGroup>
     <DefineConstants Condition="'$(TargetPlatformIdentifier)' == ''">$(DefineConstants);PLATFORM_NEUTRAL</DefineConstants>
+    <DefineConstants Condition="'$(TargetPlatformIdentifier)' == 'ios'">$(DefineConstants);SENTRY_UIKIT_AVAILABLE</DefineConstants>
+    <DefineConstants Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'">$(DefineConstants);SENTRY_UIKIT_AVAILABLE</DefineConstants>
   </PropertyGroup>
 
   <!-- We're aware it's out of support but this is a library and it doesn't require nca3.1.  -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -57,6 +57,7 @@
   <PropertyGroup>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'ios'">10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'macos'">13.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,6 +7,7 @@
   <PropertyGroup>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'ios'">10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'macos'">13.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
@@ -18,7 +19,7 @@
     <Compile Remove="**\Android\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'ios' And '$(TargetPlatformIdentifier)' != 'maccatalyst'">
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'ios' And '$(TargetPlatformIdentifier)' != 'macos' And '$(TargetPlatformIdentifier)' != 'maccatalyst'">
     <Compile Remove="**\*.iOS.cs" />
     <Compile Remove="**\iOS\**\*.cs" />
   </ItemGroup>
@@ -67,7 +68,8 @@
   <!-- Workaround for https://github.com/xamarin/xamarin-macios/issues/15897 -->
   <Target Name="_SetPublishFolderTypeNoneOnDocFileItems"
     BeforeTargets="_ComputePublishLocation"
-    Condition="'$(OutputType)' == 'Exe' And ('$(TargetPlatformIdentifier)' == 'ios' Or '$(TargetPlatformIdentifier)' == 'maccatalyst')">
+    Condition="'$(OutputType)' == 'Exe'
+               and ('$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'macos' or '$(TargetPlatformIdentifier)' == 'maccatalyst')">
     <ItemGroup>
       <ResolvedFileToPublish
         Update="@(ResolvedFileToPublish)"
@@ -82,7 +84,8 @@
   -->
   <Import Project="$(MSBuildThisFileDirectory)src\Sentry\buildTransitive\Sentry.targets" />
   <Import Project="$(MSBuildThisFileDirectory)src\Sentry.Bindings.Cocoa\buildTransitive\Sentry.Bindings.Cocoa.targets"
-    Condition="'$(OutputType)' == 'Exe' And ('$(TargetPlatformIdentifier)' == 'ios' Or '$(TargetPlatformIdentifier)' == 'maccatalyst')" />
+    Condition="'$(OutputType)' == 'Exe'
+               and ('$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'macos' or '$(TargetPlatformIdentifier)' == 'maccatalyst')"></Import>
   <Import Project="$(MSBuildThisFileDirectory)src\Sentry.Bindings.Native\buildTransitive\Sentry.Bindings.Native.targets" />
 
 </Project>

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -1,67 +1,80 @@
 #!/bin/bash
+set -euo pipefail
 
-pushd "$(dirname "$0")" > /dev/null
+pushd "$(dirname "$0")" >/dev/null
 cd ../modules/sentry-cocoa
 
-if [ $? -eq 0 ]
-then
-    SHA=$(git rev-parse HEAD)
-    SHAFILE=./Carthage/.built-from-sha
-    [ -f $SHAFILE ] && SHAFROMFILE=$(<$SHAFILE)
-    VERSION="$(git describe --tags) ($(git rev-parse --short HEAD))"
+SHA=$(git rev-parse HEAD)
+SHAFILE=./Carthage/.built-from-sha
+if [[ -f $SHAFILE ]]; then
+    SHAFROMFILE=$(<$SHAFILE)
+else
+    SHAFROMFILE=""
+fi
+VERSION="$(git describe --tags) ($(git rev-parse --short HEAD))"
 
-    if [ "$SHA" == "$SHAFROMFILE" ]; then
-        echo "Sentry Cocoa SDK $VERSION was already built"
-    else
-        echo "Building Sentry Cocoa SDK $VERSION"
-        rm -rf Carthage
+if [ "$SHA" == "$SHAFROMFILE" ]; then
+    echo "Sentry Cocoa SDK $VERSION was already built"
+else
+    echo "Building Sentry Cocoa SDK $VERSION"
+    rm -rf Carthage
 
-        # Grabbing the first SDK versions
-        sdks=$(xcodebuild -showsdks)
-        ios_sdk=$(echo "$sdks" | awk '/iOS SDKs/{getline; print $NF}')
-        ios_simulator_sdk=$(echo "$sdks" | awk '/iOS Simulator SDKs/{getline; print $NF}')
+    # Grabbing the first SDK versions
+    sdks=$(xcodebuild -showsdks)
+    ios_sdk=$(echo "$sdks" | awk '/iOS SDKs/{getline; print $NF}')
+    ios_simulator_sdk=$(echo "$sdks" | awk '/iOS Simulator SDKs/{getline; print $NF}')
+    macos_sdk=$(echo "$sdks" | awk '/macOS SDKs/{getline; print $NF}')
 
-        # Note - We keep the build output in separate directories so that .NET
-        # bundles iOS with net6.0-ios and Mac Catalyst with net6.0-maccatalyst.
-        # The lack of symlinks in the ios builds, means we should also be able
-        # to use the package on Windows with "Pair to Mac".
+    # Note - We keep the build output in separate directories so that .NET
+    # bundles iOS with net6.0-ios and Mac Catalyst with net6.0-maccatalyst.
+    # The lack of symlinks in the ios builds, means we should also be able
+    # to use the package on Windows with "Pair to Mac".
 
-        # Build for iOS and iOS simulator.
-        xcodebuild -project Sentry.xcodeproj \
-            -scheme Sentry \
-            -configuration Release \
-            -sdk "$ios_sdk" \
-            -derivedDataPath ./Carthage/output-ios
-        xcodebuild -project Sentry.xcodeproj \
-            -scheme Sentry \
-            -configuration Release \
-            -sdk "$ios_simulator_sdk" \
-            -derivedDataPath ./Carthage/output-ios
-        xcodebuild -create-xcframework \
-            -framework ./Carthage/output-ios/Build/Products/Release-iphoneos/Sentry.framework \
-            -framework ./Carthage/output-ios/Build/Products/Release-iphonesimulator/Sentry.framework \
-            -output ./Carthage/Build-ios/Sentry.xcframework
+    # Build for iOS and iOS simulator.
+    xcodebuild -project Sentry.xcodeproj \
+        -scheme Sentry \
+        -configuration Release \
+        -sdk "$ios_sdk" \
+        -derivedDataPath ./Carthage/output-ios
+    xcodebuild -project Sentry.xcodeproj \
+        -scheme Sentry \
+        -configuration Release \
+        -sdk "$ios_simulator_sdk" \
+        -derivedDataPath ./Carthage/output-ios
+    xcodebuild -create-xcframework \
+        -framework ./Carthage/output-ios/Build/Products/Release-iphoneos/Sentry.framework \
+        -framework ./Carthage/output-ios/Build/Products/Release-iphonesimulator/Sentry.framework \
+        -output ./Carthage/Build-ios/Sentry.xcframework
 
-        # Separately, build for Mac Catalyst
-        xcodebuild -project Sentry.xcodeproj \
-            -scheme Sentry \
-            -configuration Release \
-            -destination 'platform=macOS,variant=Mac Catalyst' \
-            -derivedDataPath ./Carthage/output-maccatalyst
-        xcodebuild -create-xcframework \
-            -framework ./Carthage/output-maccatalyst/Build/Products/Release-maccatalyst/Sentry.framework \
-            -output ./Carthage/Build-maccatalyst/Sentry.xcframework
+    # Build for macOS.
+    xcodebuild -project Sentry.xcodeproj \
+        -scheme Sentry \
+        -configuration Release \
+        -sdk "$macos_sdk" \
+        -derivedDataPath ./Carthage/output-macos
+    xcodebuild -create-xcframework \
+        -framework ./Carthage/output-macos/Build/Products/Release/Sentry.framework \
+        -output ./Carthage/Build-macos/Sentry.xcframework
 
-        # Copy headers - used for generating bindings
-        mkdir Carthage/Headers
-        find Carthage/Build-ios/Sentry.xcframework/ios-arm64 -name '*.h' -exec cp {} Carthage/Headers \;
+    # Separately, build for Mac Catalyst
+    xcodebuild -project Sentry.xcodeproj \
+        -scheme Sentry \
+        -configuration Release \
+        -destination 'platform=macOS,variant=Mac Catalyst' \
+        -derivedDataPath ./Carthage/output-maccatalyst
+    xcodebuild -create-xcframework \
+        -framework ./Carthage/output-maccatalyst/Build/Products/Release-maccatalyst/Sentry.framework \
+        -output ./Carthage/Build-maccatalyst/Sentry.xcframework
 
-        echo "$SHA" > "$SHAFILE"
-        echo ""
-    fi
+    # Copy headers - used for generating bindings
+    mkdir Carthage/Headers
+    find Carthage/Build-ios/Sentry.xcframework/ios-arm64 -name '*.h' -exec cp {} Carthage/Headers \;
 
-    # Remove anything we don't want to bundle in the nuget package.
-    find Carthage/Build* \( -name Headers -o -name PrivateHeaders -o -name Modules \) -exec rm -rf {} +
+    echo "$SHA" >"$SHAFILE"
+    echo ""
 fi
 
-popd > /dev/null
+# Remove anything we don't want to bundle in the nuget package.
+find Carthage/Build* \( -name Headers -o -name PrivateHeaders -o -name Modules \) -exec rm -rf {} +
+
+popd >/dev/null

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -18,6 +18,7 @@ macos_sdk=$(echo "$sdks" | awk '/macOS SDKs/{getline; print $NF}')
 # to use the package on Windows with "Pair to Mac".
 
 # Build for iOS and iOS simulator.
+echo "::group::Building sentry-cocoa for iOS and iOS simulator"
 xcodebuild -project Sentry.xcodeproj \
     -scheme Sentry \
     -configuration Release \
@@ -32,8 +33,10 @@ xcodebuild -create-xcframework \
     -framework ./Carthage/output-ios/Build/Products/Release-iphoneos/Sentry.framework \
     -framework ./Carthage/output-ios/Build/Products/Release-iphonesimulator/Sentry.framework \
     -output ./Carthage/Build-ios/Sentry.xcframework
+echo "::endgroup::"
 
 # Build for macOS.
+echo "::group::Building sentry-cocoa for macOS"
 xcodebuild -project Sentry.xcodeproj \
     -scheme Sentry \
     -configuration Release \
@@ -42,8 +45,10 @@ xcodebuild -project Sentry.xcodeproj \
 xcodebuild -create-xcframework \
     -framework ./Carthage/output-macos/Build/Products/Release/Sentry.framework \
     -output ./Carthage/Build-macos/Sentry.xcframework
+echo "::endgroup::"
 
 # Separately, build for Mac Catalyst
+echo "::group::Building sentry-cocoa for Mac Catalyst"
 xcodebuild -project Sentry.xcodeproj \
     -scheme Sentry \
     -configuration Release \
@@ -52,6 +57,7 @@ xcodebuild -project Sentry.xcodeproj \
 xcodebuild -create-xcframework \
     -framework ./Carthage/output-maccatalyst/Build/Products/Release-maccatalyst/Sentry.framework \
     -output ./Carthage/Build-maccatalyst/Sentry.xcframework
+echo "::endgroup::"
 
 # Copy headers - used for generating bindings
 mkdir Carthage/Headers

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -4,77 +4,64 @@ set -euo pipefail
 pushd "$(dirname "$0")" >/dev/null
 cd ../modules/sentry-cocoa
 
-SHA=$(git rev-parse HEAD)
-SHAFILE=./Carthage/.built-from-sha
-if [[ -f $SHAFILE ]]; then
-    SHAFROMFILE=$(<$SHAFILE)
-else
-    SHAFROMFILE=""
-fi
-VERSION="$(git describe --tags) ($(git rev-parse --short HEAD))"
+rm -rf Carthage
 
-if [ "$SHA" == "$SHAFROMFILE" ]; then
-    echo "Sentry Cocoa SDK $VERSION was already built"
-else
-    echo "Building Sentry Cocoa SDK $VERSION"
-    rm -rf Carthage
+# Grabbing the first SDK versions
+sdks=$(xcodebuild -showsdks)
+ios_sdk=$(echo "$sdks" | awk '/iOS SDKs/{getline; print $NF}')
+ios_simulator_sdk=$(echo "$sdks" | awk '/iOS Simulator SDKs/{getline; print $NF}')
+macos_sdk=$(echo "$sdks" | awk '/macOS SDKs/{getline; print $NF}')
 
-    # Grabbing the first SDK versions
-    sdks=$(xcodebuild -showsdks)
-    ios_sdk=$(echo "$sdks" | awk '/iOS SDKs/{getline; print $NF}')
-    ios_simulator_sdk=$(echo "$sdks" | awk '/iOS Simulator SDKs/{getline; print $NF}')
-    macos_sdk=$(echo "$sdks" | awk '/macOS SDKs/{getline; print $NF}')
+# Note - We keep the build output in separate directories so that .NET
+# bundles iOS with net6.0-ios and Mac Catalyst with net6.0-maccatalyst.
+# The lack of symlinks in the ios builds, means we should also be able
+# to use the package on Windows with "Pair to Mac".
 
-    # Note - We keep the build output in separate directories so that .NET
-    # bundles iOS with net6.0-ios and Mac Catalyst with net6.0-maccatalyst.
-    # The lack of symlinks in the ios builds, means we should also be able
-    # to use the package on Windows with "Pair to Mac".
+# Build for iOS and iOS simulator.
+xcodebuild -project Sentry.xcodeproj \
+    -scheme Sentry \
+    -configuration Release \
+    -sdk "$ios_sdk" \
+    -derivedDataPath ./Carthage/output-ios
+xcodebuild -project Sentry.xcodeproj \
+    -scheme Sentry \
+    -configuration Release \
+    -sdk "$ios_simulator_sdk" \
+    -derivedDataPath ./Carthage/output-ios
+xcodebuild -create-xcframework \
+    -framework ./Carthage/output-ios/Build/Products/Release-iphoneos/Sentry.framework \
+    -framework ./Carthage/output-ios/Build/Products/Release-iphonesimulator/Sentry.framework \
+    -output ./Carthage/Build-ios/Sentry.xcframework
 
-    # Build for iOS and iOS simulator.
-    xcodebuild -project Sentry.xcodeproj \
-        -scheme Sentry \
-        -configuration Release \
-        -sdk "$ios_sdk" \
-        -derivedDataPath ./Carthage/output-ios
-    xcodebuild -project Sentry.xcodeproj \
-        -scheme Sentry \
-        -configuration Release \
-        -sdk "$ios_simulator_sdk" \
-        -derivedDataPath ./Carthage/output-ios
-    xcodebuild -create-xcframework \
-        -framework ./Carthage/output-ios/Build/Products/Release-iphoneos/Sentry.framework \
-        -framework ./Carthage/output-ios/Build/Products/Release-iphonesimulator/Sentry.framework \
-        -output ./Carthage/Build-ios/Sentry.xcframework
+# Build for macOS.
+xcodebuild -project Sentry.xcodeproj \
+    -scheme Sentry \
+    -configuration Release \
+    -sdk "$macos_sdk" \
+    -derivedDataPath ./Carthage/output-macos
+xcodebuild -create-xcframework \
+    -framework ./Carthage/output-macos/Build/Products/Release/Sentry.framework \
+    -output ./Carthage/Build-macos/Sentry.xcframework
 
-    # Build for macOS.
-    xcodebuild -project Sentry.xcodeproj \
-        -scheme Sentry \
-        -configuration Release \
-        -sdk "$macos_sdk" \
-        -derivedDataPath ./Carthage/output-macos
-    xcodebuild -create-xcframework \
-        -framework ./Carthage/output-macos/Build/Products/Release/Sentry.framework \
-        -output ./Carthage/Build-macos/Sentry.xcframework
+# Separately, build for Mac Catalyst
+xcodebuild -project Sentry.xcodeproj \
+    -scheme Sentry \
+    -configuration Release \
+    -destination 'platform=macOS,variant=Mac Catalyst' \
+    -derivedDataPath ./Carthage/output-maccatalyst
+xcodebuild -create-xcframework \
+    -framework ./Carthage/output-maccatalyst/Build/Products/Release-maccatalyst/Sentry.framework \
+    -output ./Carthage/Build-maccatalyst/Sentry.xcframework
 
-    # Separately, build for Mac Catalyst
-    xcodebuild -project Sentry.xcodeproj \
-        -scheme Sentry \
-        -configuration Release \
-        -destination 'platform=macOS,variant=Mac Catalyst' \
-        -derivedDataPath ./Carthage/output-maccatalyst
-    xcodebuild -create-xcframework \
-        -framework ./Carthage/output-maccatalyst/Build/Products/Release-maccatalyst/Sentry.framework \
-        -output ./Carthage/Build-maccatalyst/Sentry.xcframework
-
-    # Copy headers - used for generating bindings
-    mkdir Carthage/Headers
-    find Carthage/Build-ios/Sentry.xcframework/ios-arm64 -name '*.h' -exec cp {} Carthage/Headers \;
-
-    echo "$SHA" >"$SHAFILE"
-    echo ""
-fi
+# Copy headers - used for generating bindings
+mkdir Carthage/Headers
+find Carthage/Build-ios/Sentry.xcframework/ios-arm64 -name '*.h' -exec cp {} Carthage/Headers \;
 
 # Remove anything we don't want to bundle in the nuget package.
 find Carthage/Build* \( -name Headers -o -name PrivateHeaders -o -name Modules \) -exec rm -rf {} +
+rm -rf Carthage/output-*
+
+cp ../../.git/modules/modules/sentry-cocoa/HEAD Carthage/.built-from-sha
+echo ""
 
 popd >/dev/null

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -46,16 +46,17 @@
 
   <!-- Build the Sentry Cocoa SDK -->
   <Target Name="_BuildSentryCocoaSDK" BeforeTargets="DispatchToInnerBuilds;BeforeBuild" Condition="$([MSBuild]::IsOSPlatform('OSX'))"
-    Inputs="..\..\.git\modules\modules\sentry-cocoa\HEAD" Outputs="..\..\modules\sentry-cocoa\Carthage\.built-from-sha">
+    Inputs="../../.git/modules/modules/sentry-cocoa/HEAD" Outputs="../../modules/sentry-cocoa/Carthage/.built-from-sha">
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="_InnerBuildSentryCocoaSDK" Properties="TargetFramework=once" />
   </Target>
   <Target Name="_InnerBuildSentryCocoaSDK">
     <Exec Command="../../scripts/build-sentry-cocoa.sh" />
+    <Copy SourceFiles="../../.git/modules/modules/sentry-cocoa/HEAD" DestinationFolder="../../modules/sentry-cocoa/Carthage/.built-from-sha"/>
   </Target>
 
   <!-- Generate bindings -->
   <Target Name="_GenerateSentryCocoaBindings" AfterTargets="_BuildSentryCocoaSDK" Condition="$([MSBuild]::IsOSPlatform('OSX'))"
-          Inputs="..\..\modules\sentry-cocoa\Carthage\.built-from-sha" Outputs="ApiDefinitions.cs;StructsAndEnums.cs">
+          Inputs="../../modules/sentry-cocoa/Carthage/.built-from-sha" Outputs="ApiDefinitions.cs;StructsAndEnums.cs">
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="_InnerGenerateSentryCocoaBindings" Properties="TargetFramework=once" />
   </Target>
   <Target Name="_InnerGenerateSentryCocoaBindings">

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(NO_IOS)' == '' And '$(NO_MACCATALYST)' == ''">net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="'$(NO_IOS)' == '' And '$(NO_MACCATALYST)' == 'true'">net7.0-ios</TargetFrameworks>
-    <TargetFrameworks Condition="'$(NO_IOS)' == 'true' And '$(NO_MACCATALYST)' == ''">net7.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net7.0-macos</TargetFrameworks>
+    <TargetFrameworks Condition="'$(NO_IOS)' == ''">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="'$(NO_MACCATALYST)' == ''">$(TargetFrameworks);net7.0-maccatalyst</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
     <Description>.NET Bindings for the Sentry Cocoa SDK</Description>

--- a/src/Sentry/CrashType.cs
+++ b/src/Sentry/CrashType.cs
@@ -29,7 +29,7 @@ public enum CrashType
         JavaBackgroundThread,
 #endif
 
-#if __MOBILE__
+#if __MOBILE__ || MACOS
         /// <summary>
         /// A native operation that will crash the application will be performed by a C library.
         /// </summary>

--- a/src/Sentry/Internal/Extensions/StringExtensions.cs
+++ b/src/Sentry/Internal/Extensions/StringExtensions.cs
@@ -11,4 +11,19 @@ internal static class StringExtensions
     /// Otherwise, returns <paramref name="str"/>.
     /// </summary>
     public static string? NullIfWhitespace(this string? str) => string.IsNullOrWhiteSpace(str) ? null : str;
+
+    public static long ParseHexAsLong(this string str)
+    {
+        // It should be in hex format, such as "0x7fff5bf346c0"
+        if (str.StartsWith("0x") &&
+            long.TryParse(str[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result))
+        {
+            return result;
+        }
+        else if (long.TryParse(str, NumberStyles.Number, CultureInfo.InvariantCulture, out result))
+        {
+            return result;
+        }
+        throw new FormatException($"ParseHexAsLong() cannot parse '{str}'");
+    }
 }

--- a/src/Sentry/Platforms/Native/Sentry.Native.props
+++ b/src/Sentry/Platforms/Native/Sentry.Native.props
@@ -2,4 +2,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Sentry.Bindings.Native\Sentry.Bindings.Native.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);SENTRY_NATIVE</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/src/Sentry/Platforms/iOS/SentryOptions.cs
+++ b/src/Sentry/Platforms/iOS/SentryOptions.cs
@@ -281,6 +281,10 @@ public partial class SentryOptions
         /// <remarks>
         /// See https://github.com/getsentry/sentry-cocoa/issues/1168
         /// </remarks>
+#if MACOS
+        // NSUrlSessionDelegate is not CLS compliant
+        [CLSCompliant(false)]
+#endif
         public NSUrlSessionDelegate? UrlSessionDelegate { get; set; } = null;
 
 

--- a/src/Sentry/Platforms/iOS/SentryOptions.cs
+++ b/src/Sentry/Platforms/iOS/SentryOptions.cs
@@ -25,6 +25,7 @@ public partial class SentryOptions
 
         // ---------- From Cocoa's SentryOptions.h ----------
 
+#if SENTRY_UIKIT_AVAILABLE
         /// <summary>
         /// Automatically attaches a screenshot when capturing an error or exception.
         /// The default value is <c>false</c> (disabled).
@@ -33,6 +34,7 @@ public partial class SentryOptions
         /// See https://docs.sentry.io/platforms/apple/guides/ios/configuration/options/#attach-screenshot
         /// </remarks>
         public bool AttachScreenshot { get; set; } = false;
+#endif
 
         /// <summary>
         /// The minimum amount of time an app should be unresponsive to be classified as an App Hanging.
@@ -46,6 +48,7 @@ public partial class SentryOptions
         /// </remarks>
         public TimeSpan AppHangTimeoutInterval { get; set; } = TimeSpan.FromSeconds(2);
 
+#if SENTRY_UIKIT_AVAILABLE
         /// <summary>
         /// How long an idle transaction waits for new children after all its child spans finished.
         /// Only UI event transactions are idle transactions.
@@ -55,6 +58,7 @@ public partial class SentryOptions
         /// See https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#user-interaction-instrumentation
         /// </remarks>
         public TimeSpan IdleTimeout { get; set; } = TimeSpan.FromSeconds(3);
+#endif
 
         /// <summary>
         /// The distribution of the application, associated with the release set in <see cref="Release"/>.
@@ -86,7 +90,7 @@ public partial class SentryOptions
         public bool EnableAutoBreadcrumbTracking { get; set; } = true;
 
         /// <summary>
-        /// When enabled, the SDK tracks performance for <see cref="UIViewController"/> subclasses and HTTP requests
+        /// When enabled, the SDK tracks performance for UIViewController subclasses and HTTP requests
         /// automatically. It also measures the app start and slow and frozen frames.
         /// The default value is <c>true</c> (enabled).
         /// </summary>
@@ -98,7 +102,7 @@ public partial class SentryOptions
         public bool EnableAutoPerformanceTracing { get; set; } = true;
 
         /// <summary>
-        /// When enabled, the SDK tracks performance for <see cref="UIViewController"/> subclasses and HTTP requests
+        /// When enabled, the SDK tracks performance for UIViewController subclasses and HTTP requests
         /// automatically. It also measures the app start and slow and frozen frames.
         /// The default value is <c>true</c> (enabled).
         /// </summary>
@@ -210,15 +214,10 @@ public partial class SentryOptions
         /// Whether the SDK should use swizzling or not.
         /// The default value is <c>true</c> (enabled).
         /// </summary>
-        /// <remarks>
-        /// When turned off the following features are disabled: breadcrumbs for touch events and
-        /// navigation with <see cref="UIViewController"/>, automatic instrumentation for <see cref="UIViewController"/>,
-        /// automatic instrumentation for HTTP requests, automatic instrumentation for file IO with <see cref="NSData"/>,
-        /// and automatically added sentry-trace header to HTTP requests for distributed tracing.
-        /// See https://docs.sentry.io/platforms/apple/configuration/swizzling/
-        /// </remarks>
+        /// <see href="https://docs.sentry.io/platforms/apple/configuration/swizzling/"/>
         public bool EnableSwizzling { get; set; } = true;
 
+#if SENTRY_UIKIT_AVAILABLE
         /// <summary>
         /// When enabled, the SDK tracks performance for <see cref="UIViewController"/> subclasses.
         /// The default value is <c>true</c> (enabled).
@@ -251,6 +250,7 @@ public partial class SentryOptions
         /// See https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#user-interaction-instrumentation
         /// </remarks>
         public bool EnableUserInteractionTracing { get; set; } = false;
+#endif
 
         /// <summary>
         /// This feature is no longer available.  This option does nothing and will be removed in a future release.

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -117,9 +117,7 @@ public static partial class SentrySdk
         // }
 
         // These options are from Cocoa's SentryOptions
-        cocoaOptions.AttachScreenshot = options.iOS.AttachScreenshot;
         cocoaOptions.AppHangTimeoutInterval = options.iOS.AppHangTimeoutInterval.TotalSeconds;
-        cocoaOptions.IdleTimeout = options.iOS.IdleTimeout.TotalSeconds;
         cocoaOptions.Dist = options.Distribution;
         cocoaOptions.EnableAppHangTracking = options.iOS.EnableAppHangTracking;
         cocoaOptions.EnableAutoBreadcrumbTracking = options.iOS.EnableAutoBreadcrumbTracking;
@@ -130,8 +128,12 @@ public static partial class SentrySdk
         cocoaOptions.EnableNetworkTracking = options.iOS.EnableNetworkTracking;
         cocoaOptions.EnableWatchdogTerminationTracking = options.iOS.EnableWatchdogTerminationTracking;
         cocoaOptions.EnableSwizzling = options.iOS.EnableSwizzling;
+#if SENTRY_UIKIT_AVAILABLE
+        cocoaOptions.IdleTimeout = options.iOS.IdleTimeout.TotalSeconds;
+        cocoaOptions.AttachScreenshot = options.iOS.AttachScreenshot;
         cocoaOptions.EnableUIViewControllerTracing = options.iOS.EnableUIViewControllerTracing;
         cocoaOptions.EnableUserInteractionTracing = options.iOS.EnableUserInteractionTracing;
+#endif
         cocoaOptions.UrlSessionDelegate = options.iOS.UrlSessionDelegate;
 
         // StitchAsyncCode removed from Cocoa SDK in 8.6.0 with https://github.com/getsentry/sentry-cocoa/pull/2973

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -25,8 +25,8 @@
   <Import Project="Platforms\Android\Sentry.Android.props" Condition="'$(TargetPlatformIdentifier)' == 'android'" />
   <Import Project="Platforms\iOS\Sentry.iOS.props"
           Condition="'$(TargetPlatformIdentifier)' == 'ios'
-                     Or '$(TargetPlatformIdentifier)' == 'maccatalyst'
-                     Or '$(TargetPlatformIdentifier)' == 'macos'" />
+                     Or '$(TargetPlatformIdentifier)' == 'macos'
+                     Or '$(TargetPlatformIdentifier)' == 'maccatalyst'" />
   <Import Project="Platforms\Native\Sentry.Native.props"
           Condition="('$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net8.0')
                      And ($([MSBuild]::IsOSPlatform('Linux')) Or $([MSBuild]::IsOSPlatform('Windows')))" />

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -4,12 +4,15 @@
     <Description>Official SDK for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
     <NoWarn Condition="'$(TargetFramework)' == 'netstandard2.0'">$(NoWarn);RS0017</NoWarn>
     <CLSCompliant Condition="'$(TargetPlatformIdentifier)' == ''">true</CLSCompliant>
+    <!-- Condition above was used because all mobile targets have non empty string and also shouldn't be CLSCompliant. But ideally we find a better way to do this now-->
+    <CLSCompliant Condition="'$(TargetPlatformIdentifier)' == 'macos'">true</CLSCompliant>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SolutionName)' != 'Sentry.Unity'">
     <TargetFrameworks>net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_ANDROID)' == ''">$(TargetFrameworks);net7.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-macos</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_MACCATALYST)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-maccatalyst</TargetFrameworks>
   </PropertyGroup>
@@ -20,8 +23,13 @@
 
   <!-- Platform-specific props included here -->
   <Import Project="Platforms\Android\Sentry.Android.props" Condition="'$(TargetPlatformIdentifier)' == 'android'" />
-  <Import Project="Platforms\iOS\Sentry.iOS.props" Condition="'$(TargetPlatformIdentifier)' == 'ios' Or '$(TargetPlatformIdentifier)' == 'maccatalyst'" />
-  <Import Project="Platforms\Native\Sentry.Native.props" Condition="('$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net8.0') And ($([MSBuild]::IsOSPlatform('Linux')) Or $([MSBuild]::IsOSPlatform('Windows')))" />
+  <Import Project="Platforms\iOS\Sentry.iOS.props"
+          Condition="'$(TargetPlatformIdentifier)' == 'ios'
+                     Or '$(TargetPlatformIdentifier)' == 'maccatalyst'
+                     Or '$(TargetPlatformIdentifier)' == 'macos'" />
+  <Import Project="Platforms\Native\Sentry.Native.props"
+          Condition="('$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net8.0')
+                     And ($([MSBuild]::IsOSPlatform('Linux')) Or $([MSBuild]::IsOSPlatform('Windows')))" />
 
   <!--
     Ben.Demystifier is compiled directly into Sentry.

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -22,7 +22,7 @@ namespace Sentry;
 /// <summary>
 /// Sentry SDK options
 /// </summary>
-#if __MOBILE__
+#if __MOBILE__ || MACOS
 public partial class SentryOptions
 #else
 public class SentryOptions
@@ -1102,8 +1102,8 @@ public class SentryOptions
         var reader = new Lazy<IAndroidAssemblyReader?>(() => AndroidHelpers.GetAndroidAssemblyReader(DiagnosticLogger));
         AssemblyReader = name => reader.Value?.TryReadAssembly(name);
 
-#elif __IOS__
-        iOS = new IosOptions(this);
+#elif __IOS__ || MACOS
+        iOS = new IosOptions(this); // TODO rename to CocoaOptions
 #endif
 
         InAppExclude = new() {

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -12,7 +12,7 @@ namespace Sentry;
 /// It allows safe static access to a client and scope management.
 /// When the SDK is uninitialized, calls to this class result in no-op so no callbacks are invoked.
 /// </remarks>
-#if __MOBILE__
+#if __MOBILE__ || MACOS
 public static partial class SentrySdk
 #else
 public static class SentrySdk
@@ -52,15 +52,10 @@ public static class SentrySdk
         }
 
         // Initialize native platform SDKs here
-#if __MOBILE__
-        if (options.InitNativeSdks)
-        {
-#if __IOS__
-            InitSentryCocoaSdk(options);
+#if __IOS__ || MACOS
+        if (options.InitNativeSdks) InitSentryCocoaSdk(options);
 #elif ANDROID
-            InitSentryAndroidSdk(options);
-#endif
-        }
+        if (options.InitNativeSdks) InitSentryAndroidSdk(options);
 #endif
         return new Hub(options);
     }
@@ -637,7 +632,7 @@ public static class SentrySdk
                 case CrashType.Native:
                     NativeCrash();
                     break;
-#elif __IOS__
+#elif __IOS__ || MACOS
             case CrashType.Native:
                 SentryCocoaSdk.Crash();
                 break;

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -151,6 +151,7 @@
     <SentryCLIUploadSymbolType Include="pdb" />
     <SentryCLIUploadSymbolType Include="portablepdb" />
     <SentryCLIUploadSymbolType Include="dsym" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'" />
+    <SentryCLIUploadSymbolType Include="dsym" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'" />
     <SentryCLIUploadSymbolType Include="dsym" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'" />
   </ItemGroup>
 

--- a/test/CommonModuleInit.cs
+++ b/test/CommonModuleInit.cs
@@ -1,8 +1,6 @@
-#if !__MOBILE__
 public static class CommonModuleInit
 {
     [ModuleInitializer]
     public static void Init() =>
         VerifyDiffPlex.Initialize();
 }
-#endif

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -50,7 +50,7 @@
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="19.2.29" />
   </ItemGroup>
 
-  <!-- only non-platform-specific projects (and net*.0-macos) should include these packages -->
+  <!-- only non-platform-specific projects should include these packages -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)'==''">
     <PackageReference Include="Verify.Xunit" Version="20.0.0" />
     <PackageReference Include="Verify.DiffPlex" Version="2.2.1" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <!-- only non-platform-specific projects (and net*.0-macos) should include these packages -->
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)'=='' or '$(TargetPlatformIdentifier)'=='macos'">
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)'==''">
     <PackageReference Include="Verify.Xunit" Version="20.0.0" />
     <PackageReference Include="Verify.DiffPlex" Version="2.2.1" />
     <PackageReference Include="PublicApiGenerator" Version="11.0.0" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -50,8 +50,8 @@
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="19.2.29" />
   </ItemGroup>
 
-  <!-- only non-platform-specific projects should include these packages -->
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)'==''">
+  <!-- only non-platform-specific projects (and net*.0-macos) should include these packages -->
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)'=='' or '$(TargetPlatformIdentifier)'=='macos'">
     <PackageReference Include="Verify.Xunit" Version="20.0.0" />
     <PackageReference Include="Verify.DiffPlex" Version="2.2.1" />
     <PackageReference Include="PublicApiGenerator" Version="11.0.0" />

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -9,6 +9,10 @@
   <!-- platform-specific targets cannot currently run snapshot verification tests -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''">
     <Compile Remove="**\*.verify.cs" />
+    <Compile Remove="$(MSBuildThisFileDirectory)Sentry.Tests/ModuleInit.cs" />
+    <Compile Remove="$(MSBuildThisFileDirectory)Sentry.Testing/VerifyExtensions.cs" />
+    <Compile Remove="$(MSBuildThisFileDirectory)Sentry.Testing/ApiExtensions.cs" />
+    <Compile Remove="$(MSBuildThisFileDirectory)CommonModuleInit.cs" />
   </ItemGroup>
 
   <!-- common module init for all test projects -->

--- a/test/Sentry.Extensions.Logging.Tests/Sentry.Extensions.Logging.Tests.csproj
+++ b/test/Sentry.Extensions.Logging.Tests/Sentry.Extensions.Logging.Tests.csproj
@@ -24,7 +24,7 @@
     <None Remove="appsettings.json" />
     <AndroidAsset Include="appsettings.json" Condition="'$(TargetPlatformIdentifier)' == 'android'" />
     <Content Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource"
-             Condition="'$(TargetPlatformIdentifier)' == 'ios' Or '$(TargetPlatformIdentifier)' == 'maccatalyst'" />
+             Condition="'$(TargetPlatformIdentifier)' == 'ios' Or '$(TargetPlatformIdentifier)' == 'macos' Or '$(TargetPlatformIdentifier)' == 'maccatalyst'" />
   </ItemGroup>
 
 </Project>

--- a/test/Sentry.Testing/ApiExtensions.cs
+++ b/test/Sentry.Testing/ApiExtensions.cs
@@ -1,4 +1,3 @@
-#if !__MOBILE__
 using System.Runtime.Versioning;
 using PublicApiGenerator;
 
@@ -30,4 +29,3 @@ public static class ApiExtensions
             .ScrubEmptyLines();
     }
 }
-#endif

--- a/test/Sentry.Testing/Sentry.Testing.csproj
+++ b/test/Sentry.Testing/Sentry.Testing.csproj
@@ -7,6 +7,7 @@
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_MACCATALYST)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-maccatalyst</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
+    <ApplicationId Condition="$(TargetFramework.EndsWith('macos'))">io.sentry.dotnet.test.sentry-testing</ApplicationId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Sentry.Testing/Sentry.Testing.csproj
+++ b/test/Sentry.Testing/Sentry.Testing.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_ANDROID)' == ''">$(TargetFrameworks);net7.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-macos</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_MACCATALYST)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-maccatalyst</TargetFrameworks>
     <IsTestProject>false</IsTestProject>

--- a/test/Sentry.Testing/VerifyExtensions.cs
+++ b/test/Sentry.Testing/VerifyExtensions.cs
@@ -1,4 +1,3 @@
-#if !__MOBILE__
 using Argon;
 using Sentry.PlatformAbstractions;
 
@@ -129,4 +128,3 @@ public static class VerifyExtensions
 
     private static string ScrubAlphaNum(string str) => str?.Replace(AlphaNumRegex, "_");
 }
-#endif

--- a/test/Sentry.Tests/ModuleInit.cs
+++ b/test/Sentry.Tests/ModuleInit.cs
@@ -1,4 +1,3 @@
-#if !__MOBILE__
 public static class ModuleInit
 {
     [ModuleInitializer]
@@ -27,4 +26,3 @@ public static class ModuleInit
             });
     }
 }
-#endif

--- a/test/Sentry.Tests/Sentry.Tests.csproj
+++ b/test/Sentry.Tests/Sentry.Tests.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == ''">
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == '' or '$(TargetPlatformIdentifier)' == 'macos'">
     <ProjectReference Include="..\Sentry.Testing.CrashableApp\Sentry.Testing.CrashableApp.csproj" />
   </ItemGroup>
 

--- a/test/Sentry.Tests/Sentry.Tests.csproj
+++ b/test/Sentry.Tests/Sentry.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_ANDROID)' == ''">$(TargetFrameworks);net7.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-macos</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_MACCATALYST)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-maccatalyst</TargetFrameworks>
   </PropertyGroup>

--- a/test/Sentry.Tests/Sentry.Tests.csproj
+++ b/test/Sentry.Tests/Sentry.Tests.csproj
@@ -6,6 +6,7 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-macos</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_MACCATALYST)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-maccatalyst</TargetFrameworks>
+    <ApplicationId Condition="$(TargetFramework.EndsWith('macos'))">io.sentry.dotnet.test.sentry-tests</ApplicationId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follows up #2704 by enabling the Cocoa SDK for macOS. This is loosely based on #2625 but approaches the integration from a different angle: instead of adding another build and binding code, we try to leverage objective-sharpie generated bindings.

Closes #2700

#skip-changelog - we'll have a single item for #2247