### PR TITLE
Make Sentry.PlatformAbstractions.Runtime.Identifier get only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ API Changes:
     - `SentrySdk.CaptureEvent(SentryEvent @event, Action<Scope> scopeCallback)`
     - `SentrySdk.CaptureMessage(string message, Action<Scope> scopeCallback)`
     - `SentrySdk.CaptureException(Exception exception, Action<Scope> scopeCallback)`
-- Removed obsolete setter from Sentry.PlatformAbstractions.Runtime.Identifier ([2764](https://github.com/getsentry/sentry-dotnet/pull/2764))
   
   #### Before
   ```
@@ -60,6 +59,7 @@ API Changes:
   });
   ```
 - `ISpan` and `ITransaction` have been renamed to `ISpanTracer` and `ITransactionTracer`. You will need to update any references to these interfaces in your code to use the new interface names ([#2731](https://github.com/getsentry/sentry-dotnet/pull/2731))
+- Removed obsolete setter from `Sentry.PlatformAbstractions.Runtime.Identifier` ([2764](https://github.com/getsentry/sentry-dotnet/pull/2764))
 
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ API Changes:
     - `SentrySdk.CaptureEvent(SentryEvent @event, Action<Scope> scopeCallback)`
     - `SentrySdk.CaptureMessage(string message, Action<Scope> scopeCallback)`
     - `SentrySdk.CaptureException(Exception exception, Action<Scope> scopeCallback)`
+- Removed obsolete setter from Sentry.PlatformAbstractions.Runtime.Identifier, so this is readonly now ([2764](https://github.com/getsentry/sentry-dotnet/pull/2764))
   
   #### Before
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ API Changes:
     - `SentrySdk.CaptureEvent(SentryEvent @event, Action<Scope> scopeCallback)`
     - `SentrySdk.CaptureMessage(string message, Action<Scope> scopeCallback)`
     - `SentrySdk.CaptureException(Exception exception, Action<Scope> scopeCallback)`
-- Removed obsolete setter from Sentry.PlatformAbstractions.Runtime.Identifier, so this is readonly now ([2764](https://github.com/getsentry/sentry-dotnet/pull/2764))
+- Removed obsolete setter from Sentry.PlatformAbstractions.Runtime.Identifier ([2764](https://github.com/getsentry/sentry-dotnet/pull/2764))
   
   #### Before
   ```

--- a/src/Sentry/PlatformAbstractions/Runtime.cs
+++ b/src/Sentry/PlatformAbstractions/Runtime.cs
@@ -54,18 +54,7 @@ public class Runtime : IEquatable<Runtime>
     /// <remarks>
     /// This property will be populated for .NET 5 and newer, or <c>null</c> otherwise.
     /// </remarks>
-    public string? Identifier
-    {
-        get => _identifier;
-
-        [Obsolete("This setter is nonfunctional, and will be removed in a future version.")]
-        // ReSharper disable ValueParameterNotUsed
-        set { }
-        // ReSharper restore ValueParameterNotUsed
-    }
-
-    // TODO: Convert to get-only auto-property in next major version
-    private readonly string? _identifier;
+    public string? Identifier { get; }
 
     /// <summary>
     /// Creates a new Runtime instance
@@ -81,7 +70,7 @@ public class Runtime : IEquatable<Runtime>
             Version = version;
             FrameworkInstallation = frameworkInstallation;
             Raw = raw;
-            _identifier = null;
+            Identifier = null;
         }
 #else
     public Runtime(
@@ -93,7 +82,7 @@ public class Runtime : IEquatable<Runtime>
         Name = name;
         Version = version;
         Raw = raw;
-        _identifier = identifier;
+        Identifier = identifier;
     }
 #endif
 
@@ -183,7 +172,7 @@ public class Runtime : IEquatable<Runtime>
 #if NETFRAMEWORK
                 hashCode = (hashCode * 397) ^ (FrameworkInstallation?.GetHashCode() ?? 0);
 #else
-            hashCode = (hashCode * 397) ^ (_identifier?.GetHashCode() ?? 0);
+            hashCode = (hashCode * 397) ^ (Identifier?.GetHashCode() ?? 0);
 #endif
             return hashCode;
         }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -1468,8 +1468,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
     {
         public Runtime(string? name = null, string? version = null, string? raw = null, string? identifier = null) { }
-        [set: System.Obsolete("This setter is nonfunctional, and will be removed in a future version.")]
-        public string? Identifier { get; set; }
+        public string? Identifier { get; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1469,8 +1469,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
     {
         public Runtime(string? name = null, string? version = null, string? raw = null, string? identifier = null) { }
-        [set: System.Obsolete("This setter is nonfunctional, and will be removed in a future version.")]
-        public string? Identifier { get; set; }
+        public string? Identifier { get; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1469,8 +1469,7 @@ namespace Sentry.PlatformAbstractions
     public class Runtime : System.IEquatable<Sentry.PlatformAbstractions.Runtime>
     {
         public Runtime(string? name = null, string? version = null, string? raw = null, string? identifier = null) { }
-        [set: System.Obsolete("This setter is nonfunctional, and will be removed in a future version.")]
-        public string? Identifier { get; set; }
+        public string? Identifier { get; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -1468,8 +1468,7 @@ namespace Sentry.PlatformAbstractions
     {
         public Runtime(string? name = null, string? version = null, Sentry.PlatformAbstractions.FrameworkInstallation? frameworkInstallation = null, string? raw = null) { }
         public Sentry.PlatformAbstractions.FrameworkInstallation? FrameworkInstallation { get; }
-        [set: System.Obsolete("This setter is nonfunctional, and will be removed in a future version.")]
-        public string? Identifier { get; set; }
+        public string? Identifier { get; }
         public string? Name { get; }
         public string? Raw { get; }
         public string? Version { get; }


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/2662

Sentry.PlatformAbstractions.Runtime.Identifier is now a get only property.

Note - we have this in the changelog but for some reason our danger check still fails.... so:
##skip-changelog