### PR TITLE
chore: include debug info in sentry-native static build

### DIFF
--- a/src/Sentry.Bindings.Native/Sentry.Bindings.Native.csproj
+++ b/src/Sentry.Bindings.Native/Sentry.Bindings.Native.csproj
@@ -33,9 +33,7 @@
 
   <!-- Packaging the native library -->
   <ItemGroup Condition="'$(CI_PUBLISHING_BUILD)' == 'true' or $([MSBuild]::IsOsPlatform('Windows'))">
-    <NativeLibs Include="$(SentryNativeOutputDirectory-win-x64)$(SentryNativeLibraryName).lib" />
-    <NativeLibs Include="$(SentryNativeOutputDirectory-win-x64)$(SentryNativeLibraryName).pdb" />
-    <None Include="@(NativeLibs)">
+    <None Include="$(SentryNativeOutputDirectory-win-x64)$(SentryNativeLibraryName).lib">
       <Pack>true</Pack>
       <PackagePath>\runtimes\$(NativeLibRelativePath-win-x64)</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -61,7 +59,7 @@
     BeforeTargets="DispatchToInnerBuilds;BeforeBuild"
     Condition="$([MSBuild]::IsOsPlatform('Windows'))"
     Inputs="..\..\.git\modules\modules\sentry-native\HEAD;$(MSBuildThisFileDirectory)Sentry.Bindings.Native.csproj"
-    Outputs="$(SentryNativeOutputDirectory-win-x64)$(SentryNativeLibraryName).lib;$(SentryNativeOutputDirectory-win-x64)$(SentryNativeLibraryName).pdb">
+    Outputs="$(SentryNativeOutputDirectory-win-x64)$(SentryNativeLibraryName).lib">
     <MSBuild Projects="$(MSBuildProjectFile)"
       Targets="_InnerBuildSentryNativeSDK-win-x64"
       Properties="TargetFramework=once" />
@@ -77,13 +75,13 @@
         -D SENTRY_BUILD_SHARED_LIBS=0 ^
         -D SENTRY_BUILD_RUNTIMESTATIC=1 ^
         -D SENTRY_BACKEND=none ^
-        -D SENTRY_TRANSPORT=none " />
+        -D SENTRY_TRANSPORT=none ^
+        -C $(MSBuildThisFileDirectory)windows-config.cmake" />
     <Exec WorkingDirectory="$(SentryNativeSourceDirectory)"
       Command="cmake --build build --target sentry --config RelWithDebInfo --parallel" />
 
     <ItemGroup>
       <NativeSdkArtifacts Include="$(SentryNativeSourceDirectory)build/RelWithDebInfo/sentry.lib" />
-      <NativeSdkArtifacts Include="$(SentryNativeSourceDirectory)build/RelWithDebInfo/sentry.pdb" />
     </ItemGroup>
 
     <Copy SourceFiles="@(NativeSdkArtifacts)"

--- a/src/Sentry.Bindings.Native/buildTransitive/Sentry.Bindings.Native.targets
+++ b/src/Sentry.Bindings.Native/buildTransitive/Sentry.Bindings.Native.targets
@@ -2,22 +2,16 @@
   <ItemGroup Condition="'$(OutputType)' == 'Exe' And '$(RuntimeIdentifier)' == 'win-x64'">
     <!-- Generate direct PInvokes for Dependency -->
     <DirectPInvoke Include="sentry-native" />
-    
+
     <!-- Link statically -->
     <NativeLibrary Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\sentry-native.lib" />
     <NativeLibrary Include="dbghelp.lib" />
-    
-    <!-- Copy debug symbols to the app output directory so that it can get uploaded by Sentry CLI. -->
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\sentry-native.pdb">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <Link>%(FileName)%(Extension)</Link>
-    </Content>
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(OutputType)' == 'Exe' And '$(RuntimeIdentifier)' == 'linux-x64'">
     <!-- Generate direct PInvokes for Dependency -->
     <DirectPInvoke Include="sentry-native" />
-    
+
     <!-- Link statically -->
     <NativeLibrary Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\native\libsentry-native.a" />
   </ItemGroup>

--- a/src/Sentry.Bindings.Native/windows-config.cmake
+++ b/src/Sentry.Bindings.Native/windows-config.cmake
@@ -1,0 +1,3 @@
+# Include debug info in the static library itself. See https://github.com/getsentry/sentry-native/issues/895 for context.
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "/Z7 /O2 /Ob1 /DNDEBUG" CACHE STRING "C Flags for RelWithDebInfo" FORCE)
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Z7 /O2 /Ob1 /DNDEBUG" CACHE STRING "CXX Flags for RelWithDebInfo" FORCE)


### PR DESCRIPTION
See https://github.com/getsentry/sentry-native/issues/895 for context.
In short we need to pass additional flags so that the sentry-native static lib contains debug info

#skip-changelog