### PR TITLE
feat: sentry-native macOS integration

### DIFF
--- a/Sentry-CI-Build-macOS.slnf
+++ b/Sentry-CI-Build-macOS.slnf
@@ -37,6 +37,7 @@
       "src\\Sentry.Azure.Functions.Worker\\Sentry.Azure.Functions.Worker.csproj",
       "src\\Sentry.Bindings.Android\\Sentry.Bindings.Android.csproj",
       "src\\Sentry.Bindings.Cocoa\\Sentry.Bindings.Cocoa.csproj",
+      "src\\Sentry.Bindings.Native\\Sentry.Bindings.Native.csproj",
       "src\\Sentry.DiagnosticSource\\Sentry.DiagnosticSource.csproj",
       "src\\Sentry.EntityFramework\\Sentry.EntityFramework.csproj",
       "src\\Sentry.Extensions.Logging\\Sentry.Extensions.Logging.csproj",

--- a/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
+++ b/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
@@ -27,11 +27,10 @@
     <!--
     After the above properties are configured, you can use the following features.
     Uploading sources to Sentry during the build will enable Source Context in the Sentry issue details page.
-    Uploading symbols to Sentry will enable server-side symbolication.  However, that is not necessary here
-    because the PDB file is present at runtime. Thus, .NET will symbolicate stack traces client-side.
+    Uploading symbols to Sentry will enable server-side symbolication (i.e. when the PDB is not present at runtime, or for AOT published programs).
     -->
     <SentryUploadSources>true</SentryUploadSources>
-    <SentryUploadSymbols>false</SentryUploadSymbols>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
   </PropertyGroup>
 
 

--- a/scripts/generate-solution-filters-config.yaml
+++ b/scripts/generate-solution-filters-config.yaml
@@ -50,7 +50,6 @@ filterConfigs:
         - "**/*Maui.Device.TestApp.csproj"
         - "**/*SourceGen.csproj"
         - "**/Sentry.Samples.Android.csproj"
-        - "**/Sentry.Bindings.Native.csproj"
 
   - outputPath: Sentry-CI-Build-Windows.slnf
     include:

--- a/src/Sentry.Bindings.Native/Sentry.Bindings.Native.csproj
+++ b/src/Sentry.Bindings.Native/Sentry.Bindings.Native.csproj
@@ -11,6 +11,8 @@
     <SentryNativeOutputDirectory-win-x64>$(SentryNativeOutputDirectory)$(NativeLibRelativePath-win-x64)</SentryNativeOutputDirectory-win-x64>
     <NativeLibRelativePath-linux-x64>linux-x64\native\</NativeLibRelativePath-linux-x64>
     <SentryNativeOutputDirectory-linux-x64>$(SentryNativeOutputDirectory)$(NativeLibRelativePath-linux-x64)</SentryNativeOutputDirectory-linux-x64>
+    <NativeLibRelativePath-osx>osx\native\</NativeLibRelativePath-osx>
+    <SentryNativeOutputDirectory-osx>$(SentryNativeOutputDirectory)$(NativeLibRelativePath-osx)</SentryNativeOutputDirectory-osx>
   </PropertyGroup>
 
   <!-- Packaging -->
@@ -46,6 +48,14 @@
     <None Include="$(SentryNativeOutputDirectory-linux-x64)lib$(SentryNativeLibraryName).a">
       <Pack>true</Pack>
       <PackagePath>\runtimes\$(NativeLibRelativePath-linux-x64)</PackagePath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(CI_PUBLISHING_BUILD)' == 'true' or $([MSBuild]::IsOsPlatform('OSX'))">
+    <None Include="$(SentryNativeOutputDirectory-osx)lib$(SentryNativeLibraryName).a">
+      <Pack>true</Pack>
+      <PackagePath>\runtimes\$(NativeLibRelativePath-osx)</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
@@ -121,5 +131,36 @@
     </ItemGroup>
     <Copy SourceFiles="@(NativeSdkArtifacts)"
       DestinationFiles="@(NativeSdkArtifacts->'$(SentryNativeOutputDirectory-linux-x64)%(Filename)-native%(Extension)')" />
+  </Target>
+
+  <Target Name="_BuildSentryNativeSDK-osx"
+    BeforeTargets="DispatchToInnerBuilds;BeforeBuild"
+    Condition="$([MSBuild]::IsOsPlatform('OSX'))"
+    Inputs="..\..\.git\modules\modules\sentry-native\HEAD;$(MSBuildThisFileDirectory)Sentry.Bindings.Native.csproj"
+    Outputs="$(SentryNativeOutputDirectory-osx)lib$(SentryNativeLibraryName).a">
+    <MSBuild Projects="$(MSBuildProjectFile)"
+      Targets="_InnerBuildSentryNativeSDK-osx"
+      Properties="TargetFramework=once" />
+  </Target>
+
+  <Target Name="_InnerBuildSentryNativeSDK-osx">
+    <Message Importance="High"
+      Text="Building artifacts of Sentry Native SDK for osx." />
+
+    <Exec WorkingDirectory="$(SentryNativeSourceDirectory)"
+      Command="cmake -B build -S . \
+        -D CMAKE_BUILD_TYPE=RelWithDebInfo \
+        -D SENTRY_SDK_NAME=sentry.native.dotnet \
+        -D SENTRY_BUILD_SHARED_LIBS=0 \
+        -D SENTRY_BACKEND=none \
+        -D SENTRY_TRANSPORT=none \
+        -DCMAKE_OSX_ARCHITECTURES=&quot;arm64;x86_64&quot;" />
+    <Exec WorkingDirectory="$(SentryNativeSourceDirectory)" Command="cmake --build build --target sentry --parallel" />
+
+    <ItemGroup>
+      <NativeSdkArtifacts Include="$(SentryNativeSourceDirectory)build/libsentry.a" />
+    </ItemGroup>
+    <Copy SourceFiles="@(NativeSdkArtifacts)"
+      DestinationFiles="@(NativeSdkArtifacts->'$(SentryNativeOutputDirectory-osx)%(Filename)-native%(Extension)')" />
   </Target>
 </Project>

--- a/src/Sentry.Bindings.Native/buildTransitive/Sentry.Bindings.Native.targets
+++ b/src/Sentry.Bindings.Native/buildTransitive/Sentry.Bindings.Native.targets
@@ -2,23 +2,31 @@
   <ItemGroup Condition="'$(OutputType)' == 'Exe' And '$(RuntimeIdentifier)' == 'win-x64'">
     <!-- Generate direct PInvokes for Dependency -->
     <DirectPInvoke Include="sentry-native" />
-    
+
     <!-- Link statically -->
     <NativeLibrary Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\sentry-native.lib" />
     <NativeLibrary Include="dbghelp.lib" />
-    
+
     <!-- Copy debug symbols to the app output directory so that it can get uploaded by Sentry CLI. -->
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\sentry-native.pdb">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Link>%(FileName)%(Extension)</Link>
     </Content>
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(OutputType)' == 'Exe' And '$(RuntimeIdentifier)' == 'linux-x64'">
     <!-- Generate direct PInvokes for Dependency -->
     <DirectPInvoke Include="sentry-native" />
-    
+
     <!-- Link statically -->
     <NativeLibrary Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\native\libsentry-native.a" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(OutputType)' == 'Exe' And ('$(RuntimeIdentifier)' == 'osx-x64' or '$(RuntimeIdentifier)' == 'osx-arm64')">
+    <!-- Generate direct PInvokes for Dependency -->
+    <DirectPInvoke Include="sentry-native" />
+
+    <!-- Link statically -->
+    <NativeLibrary Include="$(MSBuildThisFileDirectory)..\runtimes\osx\native\libsentry-native.a" />
   </ItemGroup>
 </Project>

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -21,7 +21,7 @@
   <!-- Platform-specific props included here -->
   <Import Project="Platforms\Android\Sentry.Android.props" Condition="'$(TargetPlatformIdentifier)' == 'android'" />
   <Import Project="Platforms\iOS\Sentry.iOS.props" Condition="'$(TargetPlatformIdentifier)' == 'ios' Or '$(TargetPlatformIdentifier)' == 'maccatalyst'" />
-  <Import Project="Platforms\Native\Sentry.Native.props" Condition="('$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net8.0') And ($([MSBuild]::IsOSPlatform('Linux')) Or $([MSBuild]::IsOSPlatform('Windows')))" />
+  <Import Project="Platforms\Native\Sentry.Native.props" Condition="('$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net8.0')" />
 
   <!--
     Ben.Demystifier is compiled directly into Sentry.


### PR DESCRIPTION
Replaces #2750 - instead of trying to make sentry-cocoa work, which is getting complicated due to objective-c integration, let's just use sentry-native for now - we're only loading debug images anyway. If there's need for features that are only present in sentry-cocoa, we can use that later.

closes #2700 - this was the last missing piece

#skip-changelog - we'll have a single item for https://github.com/getsentry/sentry-dotnet/issues/2247