### PR TITLE
Made Sentry.Values<T> internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ API Changes:
   ```
 - `ISpan` and `ITransaction` have been renamed to `ISpanTracer` and `ITransactionTracer`. You will need to update any references to these interfaces in your code to use the new interface names ([#2731](https://github.com/getsentry/sentry-dotnet/pull/2731))
 - Removed obsolete setter from `Sentry.PlatformAbstractions.Runtime.Identifier` ([2764](https://github.com/getsentry/sentry-dotnet/pull/2764))
+- `Sentry.Values<T>` is now internal as it is never exposed in the public API ([2771](https://github.com/getsentry/sentry-dotnet/pull/2771))
 
 ## Unreleased
 

--- a/src/Sentry/SentryValues.cs
+++ b/src/Sentry/SentryValues.cs
@@ -6,8 +6,7 @@ namespace Sentry;
 /// <summary>
 /// Helps serialization of Sentry protocol types which include a values property.
 /// </summary>
-// TODO: consider removing this as we control the serialization now
-public sealed class SentryValues<T> : IJsonSerializable
+internal sealed class SentryValues<T> : IJsonSerializable
 {
     /// <summary>
     /// The values.

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Core3_1.verified.txt
@@ -835,12 +835,6 @@ namespace Sentry
         public override string ToString() { }
         public static Sentry.SentryTraceHeader Parse(string value) { }
     }
-    public sealed class SentryValues<T> : Sentry.IJsonSerializable
-    {
-        public SentryValues(System.Collections.Generic.IEnumerable<T>? values) { }
-        public System.Collections.Generic.IEnumerable<T> Values { get; }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-    }
     public class Session : Sentry.ISession
     {
         public Session(string? distinctId, string release, string? environment) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -836,12 +836,6 @@ namespace Sentry
         public override string ToString() { }
         public static Sentry.SentryTraceHeader Parse(string value) { }
     }
-    public sealed class SentryValues<T> : Sentry.IJsonSerializable
-    {
-        public SentryValues(System.Collections.Generic.IEnumerable<T>? values) { }
-        public System.Collections.Generic.IEnumerable<T> Values { get; }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-    }
     public class Session : Sentry.ISession
     {
         public Session(string? distinctId, string release, string? environment) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -836,12 +836,6 @@ namespace Sentry
         public override string ToString() { }
         public static Sentry.SentryTraceHeader Parse(string value) { }
     }
-    public sealed class SentryValues<T> : Sentry.IJsonSerializable
-    {
-        public SentryValues(System.Collections.Generic.IEnumerable<T>? values) { }
-        public System.Collections.Generic.IEnumerable<T> Values { get; }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-    }
     public class Session : Sentry.ISession
     {
         public Session(string? distinctId, string release, string? environment) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -834,12 +834,6 @@ namespace Sentry
         public override string ToString() { }
         public static Sentry.SentryTraceHeader Parse(string value) { }
     }
-    public sealed class SentryValues<T> : Sentry.IJsonSerializable
-    {
-        public SentryValues(System.Collections.Generic.IEnumerable<T>? values) { }
-        public System.Collections.Generic.IEnumerable<T> Values { get; }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-    }
     public class Session : Sentry.ISession
     {
         public Session(string? distinctId, string release, string? environment) { }


### PR DESCRIPTION

Resolves https://github.com/getsentry/sentry-dotnet/issues/2665

Sentry.Values<T> is only used internally. Publicly this is exposed in two places and in both cases as `IEnumerable<T>`:
https://github.com/getsentry/sentry-dotnet/blob/56e5b06f0aee72e24ee392d3394d25d52a6becd1/src/Sentry/SentryEvent.cs#L74-L95
