### PR TITLE
Fixed warnings when generating cocoa bindings

### DIFF
--- a/scripts/generate-cocoa-bindings.ps1
+++ b/scripts/generate-cocoa-bindings.ps1
@@ -139,7 +139,7 @@ $Text = $Text -replace '(?ms)@protocol (SentrySerializable|SentrySpan).+?\[Proto
 $Text = $Text -replace 'interface SentrySpan\b', "[BaseType (typeof(NSObject))]`n`$&"
 
 # Fix string constants
-$Text = $Text -replace 'byte\[\] SentryVersionString', "[return: PlainString]`n    NSString SentryVersionString"
+$Text = $Text -replace 'byte\[\] SentryVersionString', "[PlainString]`n    NSString SentryVersionString"
 $Text = $Text -replace '(?m)(.*\n){2}^\s{4}NSString k.+?\n\n?', ''
 $Text = $Text -replace '(?m)(.*\n){4}^partial interface Constants\n{\n}\n', ''
 $Text = $Text -replace '\[Verify \(ConstantsInterfaceAssociation\)\]\n', ''
@@ -172,6 +172,9 @@ $Text = $Text -replace '([\[,] )iOS \(', '$1Introduced (PlatformName.iOS, '
 
 # Make interface partial if we need to access private APIs.  Other parts will be defined in PrivateApiDefinitions.cs
 $Text = $Text -replace '(?m)^interface SentryScope', 'partial $&'
+
+# Prefix SentryBreadcrumb.Serialize and SentryScope.Serialize with new (since these hide the base method)
+$Text = $Text -replace '(?m)(^\s*\/\/[^\r\n]*$\s*\[Export \("serialize"\)\]$\s*)(NSDictionary)', '${1}new $2'
 
 # Add header and output file
 $Text = "$Header`n`n$Text"

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -20,7 +20,7 @@ partial interface Constants
 
     // extern const unsigned char[] SentryVersionString;
     [Field ("SentryVersionString", "__Internal")]
-    [return: PlainString]
+    [PlainString]
     NSString SentryVersionString { get; }
 }
 
@@ -151,7 +151,7 @@ interface SentryBreadcrumb : SentrySerializable
 
     // -(NSDictionary<NSString *,id> * _Nonnull)serialize;
     [Export ("serialize")]
-    NSDictionary<NSString, NSObject> Serialize();
+    new NSDictionary<NSString, NSObject> Serialize();
 
     // -(BOOL)isEqualToBreadcrumb:(SentryBreadcrumb * _Nonnull)breadcrumb;
     [Export ("isEqualToBreadcrumb:")]
@@ -1798,7 +1798,7 @@ partial interface SentryScope : SentrySerializable
 
     // -(NSDictionary<NSString *,id> * _Nonnull)serialize;
     [Export ("serialize")]
-    NSDictionary<NSString, NSObject> Serialize();
+    new NSDictionary<NSString, NSObject> Serialize();
 
     // -(void)setContextValue:(NSDictionary<NSString *,id> * _Nonnull)value forKey:(NSString * _Nonnull)key __attribute__((swift_name("setContext(value:key:)")));
     [Export ("setContextValue:forKey:")]


### PR DESCRIPTION
#skip-changelog

At some stage in the `feat/4.0.0` branch we introduced some warnings when generating the cocoa bindings. There were some relating to the Serialize methods:

```
2>ApiDefinitions.cs(1801,38): Warning CS0108 : 'SentryScope.Serialize()' hides inherited member 'SentrySerializable.Serialize()'. Use the new keyword if hiding was intended.
2>ApiDefinitions.cs(154,38): Warning CS0108 : 'SentryBreadcrumb.Serialize()' hides inherited member 'SentrySerializable.Serialize()'. Use the new keyword if hiding was intended.
```

And others relating to an invalid binding attribute `[return: PlainString]`.

This PR Fixes both of those