### PR TITLE
ci: run solution filters tests separately

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Rebuild Solution Filters
-        shell: pwsh
-        run: scripts/generate-solution-filters.ps1
-
-      - name: Ensure Solution Filters are up to date
-        shell: pwsh
-        run: scripts/dirty-check.ps1 -PathToCheck ./*.sln* -GuidanceOnFailure "Uncommitted changes to the solution filters detected. Run `scripts/generate-solution-filters.ps1` locally and commit changes."
-
       # We use macOS for the final publishing build so we we get all the iOS/macCatalyst targets in the packages
       - name: Set Environment Variables
         if: startsWith(matrix.os, 'macos') && startsWith(github.ref_name, 'release/')
@@ -93,3 +85,19 @@ jobs:
           path: |
             ${{ github.workspace }}/src/**/Release/*.nupkg
             ${{ github.workspace }}/src/**/Release/*.snupkg
+
+  test-solution-filters:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Rebuild Solution Filters
+        shell: pwsh
+        run: pwsh scripts/generate-solution-filters.ps1
+
+      - name: Ensure Solution Filters are up to date
+        shell: pwsh
+        run: scripts/dirty-check.ps1 -PathToCheck ./*.sln* -GuidanceOnFailure "Uncommitted changes to the solution filters detected. Run `scripts/generate-solution-filters.ps1` locally and commit changes."

--- a/scripts/dirty-check.ps1
+++ b/scripts/dirty-check.ps1
@@ -8,14 +8,12 @@ $ErrorActionPreference = "Stop"
 
 # Any value will be truthy in PS so if our check returns something, we've got tracked changes
 $changes = git diff --name-only $PathToCheck
-if($changes){
-    Write-Debug "Path: $PathToCheck"
-    Write-Debug "Changes:`n$changes"
-    Write-Error "$GuidanceOnFailure" `
-        -CategoryActivity Error -ErrorAction Stop
+if ($changes)
+{
+    git diff $PathToCheck
+    Write-Error "$GuidanceOnFailure"
 }
 else
 {
-    Write-Debug '$PathToCheck matches HEAD.'
+    Write-Host "$PathToCheck matches HEAD."
 }
-


### PR DESCRIPTION
It takes some time (I've seen even two minutes sometimes, no idea why) so let's speed up the overall workflow by running the test separately.

#skip-changelog