### PR TITLE
fix: net8 JSON serialization

### DIFF
--- a/src/Sentry/Internal/AotHelper.cs
+++ b/src/Sentry/Internal/AotHelper.cs
@@ -9,16 +9,16 @@ internal static class AotHelper
         public void Test() { }
     }
 
-    internal static bool IsAot { get; }
+    internal static bool IsNativeAot { get; }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = AotHelper.SuppressionJustification)]
     static AotHelper()
     {
 #if NET6_0_OR_GREATER   // TODO NET7 once we target it
         var stackTrace = new StackTrace(false);
-        IsAot = stackTrace.GetFrame(0)?.GetMethod() is null;
+        IsNativeAot = stackTrace.GetFrame(0)?.GetMethod() is null;
 #else
-        IsAot = false;
+        IsNativeAot = false;
 #endif
     }
 }

--- a/src/Sentry/Internal/DebugStackTrace.cs
+++ b/src/Sentry/Internal/DebugStackTrace.cs
@@ -158,10 +158,9 @@ internal class DebugStackTrace : SentryStackTrace
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = AotHelper.SuppressionJustification)]
     private IEnumerable<SentryStackFrame> CreateFrames(StackTrace stackTrace, bool isCurrentStackTrace)
     {
-        var frames = (!AotHelper.IsAot && _options.StackTraceMode == StackTraceMode.Enhanced)
+        var frames = (!AotHelper.IsNativeAot && _options.StackTraceMode == StackTraceMode.Enhanced)
             ? EnhancedStackTrace.GetFrames(stackTrace).Select(p => new RealStackFrame(p))
-            : stackTrace.GetFrames()
-                .Select(p => new RealStackFrame(p));
+            : stackTrace.GetFrames().Select(p => new RealStackFrame(p));
 
         // Not to throw on code that ignores nullability warnings.
         if (frames.IsNull())
@@ -483,7 +482,7 @@ internal class DebugStackTrace : SentryStackTrace
     [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = AotHelper.SuppressionJustification)]
     private static PEReader? TryReadAssemblyFromDisk(Module module, SentryOptions options, out string? assemblyName)
     {
-        if (AotHelper.IsAot)
+        if (AotHelper.IsNativeAot)
         {
             assemblyName = null;
             return null;

--- a/src/Sentry/Internal/ModuleExtensions.cs
+++ b/src/Sentry/Internal/ModuleExtensions.cs
@@ -9,13 +9,9 @@ internal static class ModuleExtensions
     /// <param name="module">A Module instance</param>
     /// <returns>module.Name, if this is available. module.ScopeName otherwise</returns>
     [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = AotHelper.SuppressionJustification)]
-    public static string? GetNameOrScopeName(this Module module){
-        if (AotHelper.IsAot)
-        {
-            return module?.ScopeName;
-        }
-
-        return (module?.Name is null || module.Name.Equals("<Unknown>"))
+    public static string? GetNameOrScopeName(this Module module)
+    {
+        return (AotHelper.IsNativeAot || module?.Name is null || module.Name.Equals("<Unknown>"))
             ? module?.ScopeName
             : module?.Name;
     }

--- a/src/Sentry/Internal/StackFrame.cs
+++ b/src/Sentry/Internal/StackFrame.cs
@@ -113,7 +113,7 @@ internal class RealStackFrame : IStackFrame
     public int GetILOffset() => _frame.GetILOffset();
 
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = AotHelper.SuppressionJustification)]
-    public MethodBase? GetMethod() => AotHelper.IsAot
+    public MethodBase? GetMethod() => AotHelper.IsNativeAot
         ? null
         : _frame.GetMethod();
 

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SolutionName)' != 'Sentry.Unity'">
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_ANDROID)' == ''">$(TargetFrameworks);net7.0-android</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_MACCATALYST)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-maccatalyst</TargetFrameworks>

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -47,10 +47,10 @@ public class SentryClient : ISentryClient, IDisposable
 
         options.SetupLogging(); // Only relevant if this client wasn't created as a result of calling Init
 
-        if (AotHelper.IsAot) {
-            options.LogDebug("This looks like an AOT application build.");
+        if (AotHelper.IsNativeAot) {
+            options.LogDebug("This looks like an NativeAOT application build.");
         } else {
-            options.LogDebug("This looks like a JIT application build.");
+            options.LogDebug("This looks like a JIT/AOT application build.");
         }
 
         if (worker == null)
@@ -168,7 +168,7 @@ public class SentryClient : ISentryClient, IDisposable
         }
         catch (Exception e)
         {
-            if (!AotHelper.IsAot)
+            if (!AotHelper.IsNativeAot)
             {
                 // Attempt to demystify exceptions before adding them as breadcrumbs.
                 e.Demystify();
@@ -374,7 +374,7 @@ public class SentryClient : ISentryClient, IDisposable
         }
         catch (Exception e)
         {
-            if (!AotHelper.IsAot)
+            if (!AotHelper.IsNativeAot)
             {
                 // Attempt to demystify exceptions before adding them as breadcrumbs.
                 e.Demystify();


### PR DESCRIPTION
closes #2788

See comments in the linked issue for details (and also https://devblogs.microsoft.com/dotnet/system-text-json-in-dotnet-8/). In short, we must check `JsonSerializer.IsReflectionEnabledByDefault` instead of relying on "IsAOT" and also it's only available since net8.0 so we must add a new TF.

- fix: json serialzation on JIT net8 when PublishAot=true (requires adding a net8.0 target for Sentry)
- refactor: rename IsAot to IsNativeAot

TODO: tests (depends on #2791)

#skip-changelog - this hasn't been released yet