### PR TITLE
Refactor: move DebugImage and DebugMeta to Sentry.Protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Additionally, we're dropping support for some of the old target frameworks, plea
 - `DebugImage.ImageAddress` changed to `long?`. ([#2725](https://github.com/getsentry/sentry-dotnet/pull/2725))
 - Contexts now inherits from `IDictionary` rather than `ConcurrentDictionary`. The specific dictionary being used is an implementation detail. ([#2729](https://github.com/getsentry/sentry-dotnet/pull/2729))
 - Transaction names for ASP.NET Core are now consistently named `HTTP-VERB /path` (e.g. `GET /home`). Previously the leading forward slash was missing for some endpoints. ([#2808](https://github.com/getsentry/sentry-dotnet/pull/2808))
+- `DebugImage` and `DebugMeta` moved to `Sentry.Protocol` namespace. ([#2815](https://github.com/getsentry/sentry-dotnet/pull/2815))
 
 ### Fixes
 

--- a/src/Sentry/Internal/DebugStackTrace.cs
+++ b/src/Sentry/Internal/DebugStackTrace.cs
@@ -2,6 +2,7 @@ using Sentry.Internal.Extensions;
 using Sentry.Extensibility;
 using Sentry.Native;
 using Sentry.Internal.ILSpy;
+using Sentry.Protocol;
 
 namespace Sentry.Internal;
 

--- a/src/Sentry/Internal/Extensions/PEReaderExtensions.cs
+++ b/src/Sentry/Internal/Extensions/PEReaderExtensions.cs
@@ -1,4 +1,5 @@
 using Sentry.Extensibility;
+using Sentry.Protocol;
 
 namespace Sentry.Internal.Extensions;
 

--- a/src/Sentry/Internal/ILSpy/SingleFileApp.cs
+++ b/src/Sentry/Internal/ILSpy/SingleFileApp.cs
@@ -1,5 +1,6 @@
 using Sentry.Extensibility;
 using Sentry.Internal.Extensions;
+using Sentry.Protocol;
 
 namespace Sentry.Internal.ILSpy;
 

--- a/src/Sentry/Platforms/Native/CFunctions.cs
+++ b/src/Sentry/Platforms/Native/CFunctions.cs
@@ -1,5 +1,6 @@
 using Sentry.Extensibility;
 using Sentry.Internal.Extensions;
+using Sentry.Protocol;
 
 namespace Sentry.Native;
 

--- a/src/Sentry/Protocol/DebugImage.cs
+++ b/src/Sentry/Protocol/DebugImage.cs
@@ -1,7 +1,7 @@
 using Sentry.Extensibility;
 using Sentry.Internal.Extensions;
 
-namespace Sentry;
+namespace Sentry.Protocol;
 
 /// <summary>
 /// The Sentry Debug Meta Images interface.

--- a/src/Sentry/Protocol/DebugMeta.cs
+++ b/src/Sentry/Protocol/DebugMeta.cs
@@ -1,7 +1,7 @@
 using Sentry.Extensibility;
 using Sentry.Internal.Extensions;
 
-namespace Sentry;
+namespace Sentry.Protocol;
 
 /// <summary>
 /// The Sentry Debug Meta interface.

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -97,20 +97,6 @@ namespace Sentry
         Managed = 0,
         ManagedBackgroundThread = 1,
     }
-    public sealed class DebugImage : Sentry.IJsonSerializable
-    {
-        public DebugImage() { }
-        public string? CodeFile { get; set; }
-        public string? CodeId { get; set; }
-        public string? DebugChecksum { get; set; }
-        public string? DebugFile { get; set; }
-        public string? DebugId { get; set; }
-        public long? ImageAddress { get; set; }
-        public long? ImageSize { get; set; }
-        public string? Type { get; set; }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.DebugImage FromJson(System.Text.Json.JsonElement json) { }
-    }
     [System.Flags]
     public enum DeduplicateMode
     {
@@ -517,7 +503,7 @@ namespace Sentry
         public SentryEvent(System.Exception? exception) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
         public Sentry.Contexts Contexts { get; set; }
-        public System.Collections.Generic.List<Sentry.DebugImage>? DebugImages { get; set; }
+        public System.Collections.Generic.List<Sentry.Protocol.DebugImage>? DebugImages { get; set; }
         public string? Distribution { get; set; }
         public string? Environment { get; set; }
         public Sentry.SentryId EventId { get; }
@@ -1501,6 +1487,20 @@ namespace Sentry.Protocol
         public string? Version { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.Browser FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class DebugImage : Sentry.IJsonSerializable
+    {
+        public DebugImage() { }
+        public string? CodeFile { get; set; }
+        public string? CodeId { get; set; }
+        public string? DebugChecksum { get; set; }
+        public string? DebugFile { get; set; }
+        public string? DebugId { get; set; }
+        public long? ImageAddress { get; set; }
+        public long? ImageSize { get; set; }
+        public string? Type { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Protocol.DebugImage FromJson(System.Text.Json.JsonElement json) { }
     }
     public sealed class Device : Sentry.IJsonSerializable
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -97,20 +97,6 @@ namespace Sentry
         Managed = 0,
         ManagedBackgroundThread = 1,
     }
-    public sealed class DebugImage : Sentry.IJsonSerializable
-    {
-        public DebugImage() { }
-        public string? CodeFile { get; set; }
-        public string? CodeId { get; set; }
-        public string? DebugChecksum { get; set; }
-        public string? DebugFile { get; set; }
-        public string? DebugId { get; set; }
-        public long? ImageAddress { get; set; }
-        public long? ImageSize { get; set; }
-        public string? Type { get; set; }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.DebugImage FromJson(System.Text.Json.JsonElement json) { }
-    }
     [System.Flags]
     public enum DeduplicateMode
     {
@@ -517,7 +503,7 @@ namespace Sentry
         public SentryEvent(System.Exception? exception) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
         public Sentry.Contexts Contexts { get; set; }
-        public System.Collections.Generic.List<Sentry.DebugImage>? DebugImages { get; set; }
+        public System.Collections.Generic.List<Sentry.Protocol.DebugImage>? DebugImages { get; set; }
         public string? Distribution { get; set; }
         public string? Environment { get; set; }
         public Sentry.SentryId EventId { get; }
@@ -1501,6 +1487,20 @@ namespace Sentry.Protocol
         public string? Version { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.Browser FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class DebugImage : Sentry.IJsonSerializable
+    {
+        public DebugImage() { }
+        public string? CodeFile { get; set; }
+        public string? CodeId { get; set; }
+        public string? DebugChecksum { get; set; }
+        public string? DebugFile { get; set; }
+        public string? DebugId { get; set; }
+        public long? ImageAddress { get; set; }
+        public long? ImageSize { get; set; }
+        public string? Type { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Protocol.DebugImage FromJson(System.Text.Json.JsonElement json) { }
     }
     public sealed class Device : Sentry.IJsonSerializable
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -97,20 +97,6 @@ namespace Sentry
         Managed = 0,
         ManagedBackgroundThread = 1,
     }
-    public sealed class DebugImage : Sentry.IJsonSerializable
-    {
-        public DebugImage() { }
-        public string? CodeFile { get; set; }
-        public string? CodeId { get; set; }
-        public string? DebugChecksum { get; set; }
-        public string? DebugFile { get; set; }
-        public string? DebugId { get; set; }
-        public long? ImageAddress { get; set; }
-        public long? ImageSize { get; set; }
-        public string? Type { get; set; }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.DebugImage FromJson(System.Text.Json.JsonElement json) { }
-    }
     [System.Flags]
     public enum DeduplicateMode
     {
@@ -517,7 +503,7 @@ namespace Sentry
         public SentryEvent(System.Exception? exception) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
         public Sentry.Contexts Contexts { get; set; }
-        public System.Collections.Generic.List<Sentry.DebugImage>? DebugImages { get; set; }
+        public System.Collections.Generic.List<Sentry.Protocol.DebugImage>? DebugImages { get; set; }
         public string? Distribution { get; set; }
         public string? Environment { get; set; }
         public Sentry.SentryId EventId { get; }
@@ -1501,6 +1487,20 @@ namespace Sentry.Protocol
         public string? Version { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.Browser FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class DebugImage : Sentry.IJsonSerializable
+    {
+        public DebugImage() { }
+        public string? CodeFile { get; set; }
+        public string? CodeId { get; set; }
+        public string? DebugChecksum { get; set; }
+        public string? DebugFile { get; set; }
+        public string? DebugId { get; set; }
+        public long? ImageAddress { get; set; }
+        public long? ImageSize { get; set; }
+        public string? Type { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Protocol.DebugImage FromJson(System.Text.Json.JsonElement json) { }
     }
     public sealed class Device : Sentry.IJsonSerializable
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -97,20 +97,6 @@ namespace Sentry
         Managed = 0,
         ManagedBackgroundThread = 1,
     }
-    public sealed class DebugImage : Sentry.IJsonSerializable
-    {
-        public DebugImage() { }
-        public string? CodeFile { get; set; }
-        public string? CodeId { get; set; }
-        public string? DebugChecksum { get; set; }
-        public string? DebugFile { get; set; }
-        public string? DebugId { get; set; }
-        public long? ImageAddress { get; set; }
-        public long? ImageSize { get; set; }
-        public string? Type { get; set; }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.DebugImage FromJson(System.Text.Json.JsonElement json) { }
-    }
     [System.Flags]
     public enum DeduplicateMode
     {
@@ -516,7 +502,7 @@ namespace Sentry
         public SentryEvent(System.Exception? exception) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
         public Sentry.Contexts Contexts { get; set; }
-        public System.Collections.Generic.List<Sentry.DebugImage>? DebugImages { get; set; }
+        public System.Collections.Generic.List<Sentry.Protocol.DebugImage>? DebugImages { get; set; }
         public string? Distribution { get; set; }
         public string? Environment { get; set; }
         public Sentry.SentryId EventId { get; }
@@ -1499,6 +1485,20 @@ namespace Sentry.Protocol
         public string? Version { get; set; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.Browser FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class DebugImage : Sentry.IJsonSerializable
+    {
+        public DebugImage() { }
+        public string? CodeFile { get; set; }
+        public string? CodeId { get; set; }
+        public string? DebugChecksum { get; set; }
+        public string? DebugFile { get; set; }
+        public string? DebugId { get; set; }
+        public long? ImageAddress { get; set; }
+        public long? ImageSize { get; set; }
+        public string? Type { get; set; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.Protocol.DebugImage FromJson(System.Text.Json.JsonElement json) { }
     }
     public sealed class Device : Sentry.IJsonSerializable
     {


### PR DESCRIPTION
Reasoning: some of the protocol classes (those sent to Sentry, mostly POCO) are residing directly in the Sentry namespace. Maybe we should move them to Protocol, although, it's a case-by-case decision because some may be used too frequently by SDK users so the migration wouldn't be worth any small benefit from the cleanup done here.

Let me know if you think any of these should move, or if I should abandon this completely. The list is a simple search of `: IJsonSerializable`
```
C:\dev\dotnet\src\Sentry\Breadcrumb.cs
  11,32: public sealed class Breadcrumb : IJsonSerializable

C:\dev\dotnet\src\Sentry\Package.cs
  9,29: public sealed class Package : IJsonSerializable

C:\dev\dotnet\src\Sentry\PersistedSessionUpdate.cs
  6,39: internal class PersistedSessionUpdate : IJsonSerializable

C:\dev\dotnet\src\Sentry\Request.cs
  28,29: public sealed class Request : IJsonSerializable

C:\dev\dotnet\src\Sentry\SdkVersion.cs
  11,32: public sealed class SdkVersion : IJsonSerializable

C:\dev\dotnet\src\Sentry\SentryMessage.cs
  19,35: public sealed class SentryMessage : IJsonSerializable

C:\dev\dotnet\src\Sentry\SentryStackFrame.cs
  10,38: public sealed class SentryStackFrame : IJsonSerializable

C:\dev\dotnet\src\Sentry\SentryStackTrace.cs
  43,31: public class SentryStackTrace : IJsonSerializable

C:\dev\dotnet\src\Sentry\SentryThread.cs
  10,34: public sealed class SentryThread : IJsonSerializable

C:\dev\dotnet\src\Sentry\SentryValues.cs
  9,39: internal sealed class SentryValues<T> : IJsonSerializable

C:\dev\dotnet\src\Sentry\User.cs
  10,26: public sealed class User : IJsonSerializable

C:\dev\dotnet\src\Sentry\UserFeedback.cs
  9,34: public sealed class UserFeedback : IJsonSerializable

C:\dev\dotnet\src\Sentry\ViewHierarchy.cs
  9,39:     public sealed class ViewHierarchy : IJsonSerializable

C:\dev\dotnet\src\Sentry\ViewHierarchyNode.cs
  8,41: public abstract class ViewHierarchyNode : IJsonSerializable
  ```

### Note
There are also these types that implement IJsonSerializable in addition to other interfaces:
```
public sealed class Contexts : IDictionary<string, object>, IJsonSerializable
public sealed class SentryEvent : IEventLike, IJsonSerializable
public readonly struct SentryId : IEquatable<SentryId>, IJsonSerializable
public sealed class SentryStackFrame : IJsonSerializable
public class SessionUpdate : ISession, IJsonSerializable
public class Span : ISpanData, IJsonSerializable
public readonly struct SpanId : IEquatable<SpanId>, IJsonSerializable
public class Transaction : ITransactionData, IJsonSerializable
```