### PR TITLE
fix: don't add WinUI integration on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ Additionally, we're dropping support for some of the old target frameworks, plea
 - Contexts now inherits from `IDictionary` rather than `ConcurrentDictionary`. The specific dictionary being used is an implementation detail. ([#2729](https://github.com/getsentry/sentry-dotnet/pull/2729))
 - Transaction names for ASP.NET Core are now consistently named `HTTP-VERB /path` (e.g. `GET /home`). Previously the leading forward slash was missing for some endpoints. ([#2808](https://github.com/getsentry/sentry-dotnet/pull/2808))
 
+### Fixes
+
+- Don't add WinUI exception integration on mobile platforms ([#2821](https://github.com/getsentry/sentry-dotnet/pull/2821))
+
 ### Features
 
 #### Native AOT

--- a/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
@@ -1,4 +1,4 @@
-#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER && !__MOBILE__
 using Sentry.Extensibility;
 using Sentry.Internal;
 

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -186,7 +186,7 @@ public class SentryOptions
             }
 #endif
 
-#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER && !__MOBILE__
             if ((_defaultIntegrations & DefaultIntegrations.WinUiUnhandledExceptionIntegration) != 0)
             {
                 yield return new WinUIUnhandledExceptionIntegration();
@@ -1184,7 +1184,7 @@ public class SentryOptions
 #if HAS_DIAGNOSTIC_INTEGRATION
                                | DefaultIntegrations.SentryDiagnosticListenerIntegration
 #endif
-#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER && !__MOBILE__
                                | DefaultIntegrations.WinUiUnhandledExceptionIntegration
 #endif
                                ;
@@ -1283,7 +1283,7 @@ public class SentryOptions
 #if HAS_DIAGNOSTIC_INTEGRATION
         SentryDiagnosticListenerIntegration = 1 << 5,
 #endif
-#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER && !__MOBILE__
         WinUiUnhandledExceptionIntegration = 1 << 6,
 #endif
     }

--- a/src/Sentry/SentryOptionsExtensions.cs
+++ b/src/Sentry/SentryOptionsExtensions.cs
@@ -83,7 +83,7 @@ public static class SentryOptionsExtensions
     public static void DisableAppDomainProcessExitFlush(this SentryOptions options) =>
         options.RemoveDefaultIntegration(SentryOptions.DefaultIntegrations.AppDomainProcessExitIntegration);
 
-#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER && !__MOBILE__
     /// <summary>
     /// Disables WinUI exception handler
     /// </summary>


### PR DESCRIPTION
I've noticed we do this when testing NativeAOT on iOS