### PR TITLE
Remove ConfigureFromConfigurationOptions<T> from Sentry.Extensions.Logging

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>4.0.0-alpha.0</Version>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>12</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory).assets\Sentry.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>4.0.0-alpha.0</Version>
-    <LangVersion>11</LangVersion>
+    <LangVersion>preview</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory).assets\Sentry.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/Sentry.sln.DotSettings
+++ b/Sentry.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IO/@EntryIndexedValue">IO</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OS/@EntryIndexedValue">OS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=QL/@EntryIndexedValue">QL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>

--- a/Sentry.sln.DotSettings
+++ b/Sentry.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IO/@EntryIndexedValue">IO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=QL/@EntryIndexedValue">QL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -60,7 +60,7 @@ internal static class HttpContextExtensions
 
         try
         {
-            return SentryTraceHeader.Parse(value);
+            return SentryTraceHeader.Parse(value!);
         }
         catch (Exception ex)
         {
@@ -84,7 +84,7 @@ internal static class HttpContextExtensions
 
         try
         {
-            return BaggageHeader.TryParse(value, onlySentry: true);
+            return BaggageHeader.TryParse(value!, onlySentry: true);
         }
         catch (Exception ex)
         {

--- a/src/Sentry.AspNetCore/ScopeExtensions.cs
+++ b/src/Sentry.AspNetCore/ScopeExtensions.cs
@@ -142,7 +142,7 @@ public static class ScopeExtensions
                 continue;
             }
 
-            scope.Request.Headers[requestHeader.Key] = requestHeader.Value;
+            scope.Request.Headers[requestHeader.Key] = requestHeader.Value!;
 
             if (requestHeader.Key == HeaderNames.Cookie)
             {
@@ -163,7 +163,7 @@ public static class ScopeExtensions
 
         if (context.Response.Headers.TryGetValue("Server", out var server))
         {
-            scope.Request.Env["SERVER_SOFTWARE"] = server;
+            scope.Request.Env["SERVER_SOFTWARE"] = server!;
         }
     }
 

--- a/src/Sentry.AspNetCore/SentryTunnelMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTunnelMiddleware.cs
@@ -29,7 +29,7 @@ public class SentryTunnelMiddleware : IMiddleware
         var request = context.Request;
         if (request.Method == "OPTIONS")
         {
-            headers.Add("Access-Control-Allow-Origin", new[] { (string)request.Headers["Origin"] });
+            headers.Add("Access-Control-Allow-Origin", new[] { (string)request.Headers["Origin"]! });
             headers.Add("Access-Control-Allow-Headers", new[] { "Origin, X-Requested-With, Content-Type, Accept" });
             headers.Add("Access-Control-Allow-Methods", new[] { "POST, OPTIONS" });
             headers.Add("Access-Control-Allow-Credentials", new[] { "true" });

--- a/src/Sentry.Extensions.Logging/BindableSentryLoggingOptions.cs
+++ b/src/Sentry.Extensions.Logging/BindableSentryLoggingOptions.cs
@@ -7,11 +7,13 @@ internal class BindableSentryLoggingOptions : BindableSentryOptions
 {
     public LogLevel? MinimumBreadcrumbLevel { get; set; }
     public LogLevel? MinimumEventLevel { get; set; }
+    public bool? InitializeSdk { get; set; }
 
     public void ApplyTo(SentryLoggingOptions options)
     {
         base.ApplyTo(options);
         options.MinimumBreadcrumbLevel = MinimumBreadcrumbLevel ?? options.MinimumBreadcrumbLevel;
         options.MinimumEventLevel = MinimumEventLevel ?? options.MinimumEventLevel;
+        options.InitializeSdk = InitializeSdk?? options.InitializeSdk;
     }
 }

--- a/src/Sentry.Extensions.Logging/BindableSentryLoggingOptions.cs
+++ b/src/Sentry.Extensions.Logging/BindableSentryLoggingOptions.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Logging;
+
+namespace Sentry.Extensions.Logging;
+
+/// <inheritdoc cref="BindableSentryOptions"/>
+internal class BindableSentryLoggingOptions : BindableSentryOptions
+{
+    public LogLevel? MinimumBreadcrumbLevel { get; set; }
+    public LogLevel? MinimumEventLevel { get; set; }
+
+    public void ApplyTo(SentryLoggingOptions options)
+    {
+        base.ApplyTo(options);
+        options.MinimumBreadcrumbLevel = MinimumBreadcrumbLevel ?? options.MinimumBreadcrumbLevel;
+        options.MinimumEventLevel = MinimumEventLevel ?? options.MinimumEventLevel;
+    }
+}

--- a/src/Sentry.Extensions.Logging/Sentry.Extensions.Logging.csproj
+++ b/src/Sentry.Extensions.Logging/Sentry.Extensions.Logging.csproj
@@ -6,6 +6,11 @@
     <Description>Official Microsoft.Extensions.Logging integration for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(FrameworkSupportsAot)' == 'true'">
+    <IsAotCompatible>true</IsAotCompatible>
+    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>
@@ -16,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0-rc.2.23479.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>

--- a/src/Sentry.Extensions.Logging/Sentry.Extensions.Logging.csproj
+++ b/src/Sentry.Extensions.Logging/Sentry.Extensions.Logging.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0-rc.2.23479.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>

--- a/src/Sentry.Extensions.Logging/SentryLoggingOptionsSetup.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggingOptionsSetup.cs
@@ -5,9 +5,6 @@ using Microsoft.Extensions.Options;
 
 namespace Sentry.Extensions.Logging;
 
-// TODO: Re-enable these if we find a solution to https://github.com/dotnet/runtime/discussions/94651
-#pragma warning disable SYSLIB1100
-#pragma warning disable SYSLIB1101
 internal class SentryLoggingOptionsSetup : IConfigureOptions<SentryLoggingOptions>
 {
     private readonly IConfiguration _config;
@@ -18,14 +15,15 @@ internal class SentryLoggingOptionsSetup : IConfigureOptions<SentryLoggingOption
         _config = config.Configuration;
     }
 
-    public virtual void Configure(SentryLoggingOptions options)
+    public void Configure(SentryLoggingOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
-        _config.Bind(options);
+
+        var bindable = new BindableSentryLoggingOptions();
+        _config.Bind(bindable);
+        bindable.ApplyTo(options);
     }
 }
-#pragma warning restore SYSLIB1100
-#pragma warning restore SYSLIB1101
 #else
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Options;

--- a/src/Sentry.Extensions.Logging/SentryLoggingOptionsSetup.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggingOptionsSetup.cs
@@ -5,6 +5,9 @@ using Microsoft.Extensions.Options;
 
 namespace Sentry.Extensions.Logging;
 
+// TODO: Re-enable these if we find a solution to https://github.com/dotnet/runtime/discussions/94651
+#pragma warning disable SYSLIB1100
+#pragma warning disable SYSLIB1101
 internal class SentryLoggingOptionsSetup : IConfigureOptions<SentryLoggingOptions>
 {
     private readonly IConfiguration _config;
@@ -21,6 +24,8 @@ internal class SentryLoggingOptionsSetup : IConfigureOptions<SentryLoggingOption
         _config.Bind(options);
     }
 }
+#pragma warning restore SYSLIB1100
+#pragma warning restore SYSLIB1101
 #else
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Options;

--- a/src/Sentry.Extensions.Logging/SentryLoggingOptionsSetup.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggingOptionsSetup.cs
@@ -1,3 +1,27 @@
+#if NET6_0_OR_GREATER
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Sentry.Extensions.Logging;
+
+internal class SentryLoggingOptionsSetup : IConfigureOptions<SentryLoggingOptions>
+{
+    private readonly IConfiguration _config;
+
+    public SentryLoggingOptionsSetup(ILoggerProviderConfiguration<SentryLoggerProvider> config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        _config = config.Configuration;
+    }
+
+    public virtual void Configure(SentryLoggingOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _config.Bind(options);
+    }
+}
+#else
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Options;
 
@@ -10,3 +34,4 @@ internal class SentryLoggingOptionsSetup : ConfigureFromConfigurationOptions<Sen
         : base(providerConfiguration.Configuration)
     { }
 }
+#endif

--- a/src/Sentry/BindableSentryOptions.cs
+++ b/src/Sentry/BindableSentryOptions.cs
@@ -9,7 +9,7 @@ internal class BindableSentryOptions
 {
     public bool? IsGlobalModeEnabled { get; set; }
     public bool? EnableScopeSync { get; set; }
-    // public List<SubstringOrRegexPattern>? TagFilters { get; set; }
+    public List<string>? TagFilters { get; set; }
     public bool? SendDefaultPii { get; set; }
     public bool? IsEnvironmentUser { get; set; }
     public string? ServerName { get; set; }
@@ -30,18 +30,16 @@ internal class BindableSentryOptions
     public bool? SendClientReports { get; set; }
     public bool? Debug { get; set; }
     public SentryLevel? DiagnosticLevel { get; set; }
-    // public bool? ReportAssemblies { get; set; }
     public ReportAssembliesMode? ReportAssembliesMode { get; set; }
     public DeduplicateMode? DeduplicateMode { get; set; }
     public string? CacheDirectoryPath { get; set; }
     public bool? CaptureFailedRequests { get; set; }
-    //public List<HttpStatusCodeRange>? FailedRequestStatusCodes { get; set; }
-    //public List<SubstringOrRegexPattern>? FailedRequestTargets { get; set; }
+    public List<string>? FailedRequestTargets { get; set; }
     public TimeSpan? InitCacheFlushTimeout { get; set; }
-    // public Dictionary<string,string> DefaultTags { get; set; }
+    public Dictionary<string, string>? DefaultTags { get; set; }
     public bool? EnableTracing { get; set; }
     public double? TracesSampleRate { get; set; }
-    // public List<SubstringOrRegexPattern>? TracePropagationTargets { get; set; }
+    public List<string>? TracePropagationTargets { get; set; }
     public StackTraceMode? StackTraceMode { get; set; }
     public long? MaxAttachmentSize { get; set; }
     public StartupTimeDetectionMode? DetectStartupTime { get; set; }
@@ -54,7 +52,7 @@ internal class BindableSentryOptions
     {
         options.IsGlobalModeEnabled = IsGlobalModeEnabled ?? options.IsGlobalModeEnabled;
         options.EnableScopeSync = EnableScopeSync ?? options.EnableScopeSync;
-        // Add assertion for TagFilters here if needed
+        options.TagFilters = TagFilters?.Select(s => new SubstringOrRegexPattern(s)).ToList() ?? options.TagFilters;
         options.SendDefaultPii = SendDefaultPii ?? options.SendDefaultPii;
         options.IsEnvironmentUser = IsEnvironmentUser ?? options.IsEnvironmentUser;
         options.ServerName = ServerName ?? options.ServerName;
@@ -79,13 +77,12 @@ internal class BindableSentryOptions
         options.DeduplicateMode = DeduplicateMode ?? options.DeduplicateMode;
         options.CacheDirectoryPath = CacheDirectoryPath ?? options.CacheDirectoryPath;
         options.CaptureFailedRequests = CaptureFailedRequests ?? options.CaptureFailedRequests;
-        // Add assertion for FailedRequestStatusCodes here if needed
-        // Add assertion for FailedRequestTargets here if needed
+        options.FailedRequestTargets = FailedRequestTargets?.Select(s => new SubstringOrRegexPattern(s)).ToList() ?? options.FailedRequestTargets;
         options.InitCacheFlushTimeout = InitCacheFlushTimeout ?? options.InitCacheFlushTimeout;
-        // Add assertion for DefaultTags here if needed
+        options.DefaultTags = DefaultTags ?? options.DefaultTags;
         options.EnableTracing = EnableTracing ?? options.EnableTracing;
         options.TracesSampleRate = TracesSampleRate ?? options.TracesSampleRate;
-        // Add assertion for TracePropagationTargets here if needed
+        options.TracePropagationTargets = TracePropagationTargets?.Select(s => new SubstringOrRegexPattern(s)).ToList() ?? options.TracePropagationTargets;
         options.StackTraceMode = StackTraceMode ?? options.StackTraceMode;
         options.MaxAttachmentSize = MaxAttachmentSize ?? options.MaxAttachmentSize;
         options.DetectStartupTime = DetectStartupTime ?? options.DetectStartupTime;

--- a/src/Sentry/BindableSentryOptions.cs
+++ b/src/Sentry/BindableSentryOptions.cs
@@ -5,7 +5,7 @@ namespace Sentry;
 /// Note that all of these properties are nullable, so that if they are not present in configuration, the values from
 /// the type being bound to will be preserved.
 /// </summary>
-internal class BindableSentryOptions
+internal partial class BindableSentryOptions
 {
     public bool? IsGlobalModeEnabled { get; set; }
     public bool? EnableScopeSync { get; set; }
@@ -90,5 +90,10 @@ internal class BindableSentryOptions
         options.AutoSessionTracking = AutoSessionTracking ?? options.AutoSessionTracking;
         options.UseAsyncFileIO = UseAsyncFileIO ?? options.UseAsyncFileIO;
         options.JsonPreserveReferences = JsonPreserveReferences ?? options.JsonPreserveReferences;
+#if ANDROID
+        Android.ApplyTo(options.Android);
+#elif __IOS__
+        iOS.ApplyTo(options.iOS);
+#endif
     }
 }

--- a/src/Sentry/BindableSentryOptions.cs
+++ b/src/Sentry/BindableSentryOptions.cs
@@ -22,8 +22,8 @@ internal class BindableSentryOptions
     public string? Dsn { get; set; }
     public int? MaxQueueItems { get; set; }
     public int? MaxCacheItems { get; set; }
-    //public TimeSpan? ShutdownTimeout { get; set; }
-    //public TimeSpan? FlushTimeout { get; set; }
+    public TimeSpan? ShutdownTimeout { get; set; }
+    public TimeSpan? FlushTimeout { get; set; }
     public DecompressionMethods? DecompressionMethods { get; set; }
     public CompressionLevel? RequestBodyCompressionLevel { get; set; }
     public bool? RequestBodyCompressionBuffered { get; set; }
@@ -37,7 +37,7 @@ internal class BindableSentryOptions
     public bool? CaptureFailedRequests { get; set; }
     //public List<HttpStatusCodeRange>? FailedRequestStatusCodes { get; set; }
     //public List<SubstringOrRegexPattern>? FailedRequestTargets { get; set; }
-    //public TimeSpan? InitCacheFlushTimeout { get; set; }
+    public TimeSpan? InitCacheFlushTimeout { get; set; }
     // public Dictionary<string,string> DefaultTags { get; set; }
     public bool? EnableTracing { get; set; }
     public double? TracesSampleRate { get; set; }
@@ -45,18 +45,13 @@ internal class BindableSentryOptions
     public StackTraceMode? StackTraceMode { get; set; }
     public long? MaxAttachmentSize { get; set; }
     public StartupTimeDetectionMode? DetectStartupTime { get; set; }
-    // public TimeSpan? AutoSessionTrackingInterval { get; set; }
+    public TimeSpan? AutoSessionTrackingInterval { get; set; }
     public bool? AutoSessionTracking { get; set; }
     public bool? UseAsyncFileIO { get; set; }
-    // public bool? KeepAggregateException { get; set; }
     public bool? JsonPreserveReferences { get; set; }
 
     public void ApplyTo(SentryOptions options)
     {
-        options.Dsn = Dsn ?? options.Dsn;
-        options.Environment = Environment ?? options.Environment;
-        options.EnableScopeSync = EnableScopeSync ?? options.EnableScopeSync;
-        // TODO: all the other options...
         options.IsGlobalModeEnabled = IsGlobalModeEnabled ?? options.IsGlobalModeEnabled;
         options.EnableScopeSync = EnableScopeSync ?? options.EnableScopeSync;
         // Add assertion for TagFilters here if needed
@@ -72,8 +67,8 @@ internal class BindableSentryOptions
         options.Dsn = Dsn ?? options.Dsn;
         options.MaxQueueItems = MaxQueueItems ?? options.MaxQueueItems;
         options.MaxCacheItems = MaxCacheItems ?? options.MaxCacheItems;
-        // Add assertion for ShutdownTimeout here if needed
-        // Add assertion for FlushTimeout here if needed
+        options.ShutdownTimeout = ShutdownTimeout ?? options.ShutdownTimeout;
+        options.FlushTimeout = FlushTimeout ?? options.FlushTimeout;
         options.DecompressionMethods = DecompressionMethods ?? options.DecompressionMethods;
         options.RequestBodyCompressionLevel = RequestBodyCompressionLevel ?? options.RequestBodyCompressionLevel;
         options.RequestBodyCompressionBuffered = RequestBodyCompressionBuffered ?? options.RequestBodyCompressionBuffered;
@@ -86,7 +81,7 @@ internal class BindableSentryOptions
         options.CaptureFailedRequests = CaptureFailedRequests ?? options.CaptureFailedRequests;
         // Add assertion for FailedRequestStatusCodes here if needed
         // Add assertion for FailedRequestTargets here if needed
-        // Add assertion for InitCacheFlushTimeout here if needed
+        options.InitCacheFlushTimeout = InitCacheFlushTimeout ?? options.InitCacheFlushTimeout;
         // Add assertion for DefaultTags here if needed
         options.EnableTracing = EnableTracing ?? options.EnableTracing;
         options.TracesSampleRate = TracesSampleRate ?? options.TracesSampleRate;
@@ -94,7 +89,7 @@ internal class BindableSentryOptions
         options.StackTraceMode = StackTraceMode ?? options.StackTraceMode;
         options.MaxAttachmentSize = MaxAttachmentSize ?? options.MaxAttachmentSize;
         options.DetectStartupTime = DetectStartupTime ?? options.DetectStartupTime;
-        // Add assertion for AutoSessionTrackingInterval here if needed
+        options.AutoSessionTrackingInterval = AutoSessionTrackingInterval ?? options.AutoSessionTrackingInterval;
         options.AutoSessionTracking = AutoSessionTracking ?? options.AutoSessionTracking;
         options.UseAsyncFileIO = UseAsyncFileIO ?? options.UseAsyncFileIO;
         options.JsonPreserveReferences = JsonPreserveReferences ?? options.JsonPreserveReferences;

--- a/src/Sentry/BindableSentryOptions.cs
+++ b/src/Sentry/BindableSentryOptions.cs
@@ -1,0 +1,102 @@
+namespace Sentry;
+
+/// <summary>
+/// Contains representations of the subset of properties in SentryOptions that can be set from ConfigurationBindings.
+/// Note that all of these properties are nullable, so that if they are not present in configuration, the values from
+/// the type being bound to will be preserved.
+/// </summary>
+internal class BindableSentryOptions
+{
+    public bool? IsGlobalModeEnabled { get; set; }
+    public bool? EnableScopeSync { get; set; }
+    // public List<SubstringOrRegexPattern>? TagFilters { get; set; }
+    public bool? SendDefaultPii { get; set; }
+    public bool? IsEnvironmentUser { get; set; }
+    public string? ServerName { get; set; }
+    public bool? AttachStacktrace { get; set; }
+    public int? MaxBreadcrumbs { get; set; }
+    public float? SampleRate { get; set; }
+    public string? Release { get; set; }
+    public string? Distribution { get; set; }
+    public string? Environment { get; set; }
+    public string? Dsn { get; set; }
+    public int? MaxQueueItems { get; set; }
+    public int? MaxCacheItems { get; set; }
+    //public TimeSpan? ShutdownTimeout { get; set; }
+    //public TimeSpan? FlushTimeout { get; set; }
+    public DecompressionMethods? DecompressionMethods { get; set; }
+    public CompressionLevel? RequestBodyCompressionLevel { get; set; }
+    public bool? RequestBodyCompressionBuffered { get; set; }
+    public bool? SendClientReports { get; set; }
+    public bool? Debug { get; set; }
+    public SentryLevel? DiagnosticLevel { get; set; }
+    // public bool? ReportAssemblies { get; set; }
+    public ReportAssembliesMode? ReportAssembliesMode { get; set; }
+    public DeduplicateMode? DeduplicateMode { get; set; }
+    public string? CacheDirectoryPath { get; set; }
+    public bool? CaptureFailedRequests { get; set; }
+    //public List<HttpStatusCodeRange>? FailedRequestStatusCodes { get; set; }
+    //public List<SubstringOrRegexPattern>? FailedRequestTargets { get; set; }
+    //public TimeSpan? InitCacheFlushTimeout { get; set; }
+    // public Dictionary<string,string> DefaultTags { get; set; }
+    public bool? EnableTracing { get; set; }
+    public double? TracesSampleRate { get; set; }
+    // public List<SubstringOrRegexPattern>? TracePropagationTargets { get; set; }
+    public StackTraceMode? StackTraceMode { get; set; }
+    public long? MaxAttachmentSize { get; set; }
+    public StartupTimeDetectionMode? DetectStartupTime { get; set; }
+    // public TimeSpan? AutoSessionTrackingInterval { get; set; }
+    public bool? AutoSessionTracking { get; set; }
+    public bool? UseAsyncFileIO { get; set; }
+    // public bool? KeepAggregateException { get; set; }
+    public bool? JsonPreserveReferences { get; set; }
+
+    public void ApplyTo(SentryOptions options)
+    {
+        options.Dsn = Dsn ?? options.Dsn;
+        options.Environment = Environment ?? options.Environment;
+        options.EnableScopeSync = EnableScopeSync ?? options.EnableScopeSync;
+        // TODO: all the other options...
+        options.IsGlobalModeEnabled = IsGlobalModeEnabled ?? options.IsGlobalModeEnabled;
+        options.EnableScopeSync = EnableScopeSync ?? options.EnableScopeSync;
+        // Add assertion for TagFilters here if needed
+        options.SendDefaultPii = SendDefaultPii ?? options.SendDefaultPii;
+        options.IsEnvironmentUser = IsEnvironmentUser ?? options.IsEnvironmentUser;
+        options.ServerName = ServerName ?? options.ServerName;
+        options.AttachStacktrace = AttachStacktrace ?? options.AttachStacktrace;
+        options.MaxBreadcrumbs = MaxBreadcrumbs ?? options.MaxBreadcrumbs;
+        options.SampleRate = SampleRate ?? options.SampleRate;
+        options.Release = Release ?? options.Release;
+        options.Distribution = Distribution ?? options.Distribution;
+        options.Environment = Environment ?? options.Environment;
+        options.Dsn = Dsn ?? options.Dsn;
+        options.MaxQueueItems = MaxQueueItems ?? options.MaxQueueItems;
+        options.MaxCacheItems = MaxCacheItems ?? options.MaxCacheItems;
+        // Add assertion for ShutdownTimeout here if needed
+        // Add assertion for FlushTimeout here if needed
+        options.DecompressionMethods = DecompressionMethods ?? options.DecompressionMethods;
+        options.RequestBodyCompressionLevel = RequestBodyCompressionLevel ?? options.RequestBodyCompressionLevel;
+        options.RequestBodyCompressionBuffered = RequestBodyCompressionBuffered ?? options.RequestBodyCompressionBuffered;
+        options.SendClientReports = SendClientReports ?? options.SendClientReports;
+        options.Debug = Debug ?? options.Debug;
+        options.DiagnosticLevel = DiagnosticLevel ?? options.DiagnosticLevel;
+        options.ReportAssembliesMode = ReportAssembliesMode ?? options.ReportAssembliesMode;
+        options.DeduplicateMode = DeduplicateMode ?? options.DeduplicateMode;
+        options.CacheDirectoryPath = CacheDirectoryPath ?? options.CacheDirectoryPath;
+        options.CaptureFailedRequests = CaptureFailedRequests ?? options.CaptureFailedRequests;
+        // Add assertion for FailedRequestStatusCodes here if needed
+        // Add assertion for FailedRequestTargets here if needed
+        // Add assertion for InitCacheFlushTimeout here if needed
+        // Add assertion for DefaultTags here if needed
+        options.EnableTracing = EnableTracing ?? options.EnableTracing;
+        options.TracesSampleRate = TracesSampleRate ?? options.TracesSampleRate;
+        // Add assertion for TracePropagationTargets here if needed
+        options.StackTraceMode = StackTraceMode ?? options.StackTraceMode;
+        options.MaxAttachmentSize = MaxAttachmentSize ?? options.MaxAttachmentSize;
+        options.DetectStartupTime = DetectStartupTime ?? options.DetectStartupTime;
+        // Add assertion for AutoSessionTrackingInterval here if needed
+        options.AutoSessionTracking = AutoSessionTracking ?? options.AutoSessionTracking;
+        options.UseAsyncFileIO = UseAsyncFileIO ?? options.UseAsyncFileIO;
+        options.JsonPreserveReferences = JsonPreserveReferences ?? options.JsonPreserveReferences;
+    }
+}

--- a/src/Sentry/Platforms/Android/BindableSentryOptions.cs
+++ b/src/Sentry/Platforms/Android/BindableSentryOptions.cs
@@ -1,0 +1,64 @@
+// ReSharper disable once CheckNamespace
+namespace Sentry;
+
+internal partial class BindableSentryOptions
+{
+    public AndroidOptions Android { get; } = new AndroidOptions();
+
+    /// <summary>
+    /// Provides additional options for the Android platform.
+    /// </summary>
+    public class AndroidOptions
+    {
+        public bool? AnrEnabled { get; set; }
+        public bool? AnrReportInDebug { get; set; }
+        public TimeSpan? AnrTimeoutInterval { get; set; }
+        public bool? AttachScreenshot { get; set; }
+        public bool? EnableActivityLifecycleBreadcrumbs { get; set; }
+        public bool? EnableAppComponentBreadcrumbs { get; set; }
+        public bool? EnableAppLifecycleBreadcrumbs { get; set; }
+        public bool? EnableRootCheck { get; set; }
+        public bool? EnableSystemEventBreadcrumbs { get; set; }
+        public bool? EnableUserInteractionBreadcrumbs { get; set; }
+        public bool? EnableAutoActivityLifecycleTracing { get; set; }
+        public bool? EnableActivityLifecycleTracingAutoFinish { get; set; }
+        public bool? EnableUserInteractionTracing { get; set; }
+        public bool? AttachThreads { get; set; }
+        public TimeSpan? ConnectionTimeout { get; set; }
+        public bool? EnableNdk { get; set; }
+        public bool? EnableShutdownHook { get; set; }
+        public bool? EnableUncaughtExceptionHandler { get; set; }
+        public bool? PrintUncaughtStackTrace { get; set; }
+        public double? ProfilesSampleRate { get; set; }
+        public TimeSpan? ReadTimeout { get; set; }
+        public bool? EnableAndroidSdkTracing { get; set; }
+        public bool? EnableAndroidSdkBeforeSend { get; set; }
+
+        public void ApplyTo(SentryOptions.AndroidOptions options)
+        {
+            options.AnrEnabled = AnrEnabled ?? options.AnrEnabled;
+            options.AnrReportInDebug = AnrReportInDebug ?? options.AnrReportInDebug;
+            options.AnrTimeoutInterval = AnrTimeoutInterval ?? options.AnrTimeoutInterval;
+            options.AttachScreenshot = AttachScreenshot ?? options.AttachScreenshot;
+            options.EnableActivityLifecycleBreadcrumbs = EnableActivityLifecycleBreadcrumbs ?? options.EnableActivityLifecycleBreadcrumbs;
+            options.EnableAppComponentBreadcrumbs = EnableAppComponentBreadcrumbs ?? options.EnableAppComponentBreadcrumbs;
+            options.EnableAppLifecycleBreadcrumbs = EnableAppLifecycleBreadcrumbs ?? options.EnableAppLifecycleBreadcrumbs;
+            options.EnableRootCheck = EnableRootCheck ?? options.EnableRootCheck;
+            options.EnableSystemEventBreadcrumbs = EnableSystemEventBreadcrumbs ?? options.EnableSystemEventBreadcrumbs;
+            options.EnableUserInteractionBreadcrumbs = EnableUserInteractionBreadcrumbs ?? options.EnableUserInteractionBreadcrumbs;
+            options.EnableAutoActivityLifecycleTracing = EnableAutoActivityLifecycleTracing ?? options.EnableAutoActivityLifecycleTracing;
+            options.EnableActivityLifecycleTracingAutoFinish = EnableActivityLifecycleTracingAutoFinish ?? options.EnableActivityLifecycleTracingAutoFinish;
+            options.EnableUserInteractionTracing = EnableUserInteractionTracing ?? options.EnableUserInteractionTracing;
+            options.AttachThreads = AttachThreads ?? options.AttachThreads;
+            options.ConnectionTimeout = ConnectionTimeout ?? options.ConnectionTimeout;
+            options.EnableNdk = EnableNdk ?? options.EnableNdk;
+            options.EnableShutdownHook = EnableShutdownHook ?? options.EnableShutdownHook;
+            options.EnableUncaughtExceptionHandler = EnableUncaughtExceptionHandler ?? options.EnableUncaughtExceptionHandler;
+            options.PrintUncaughtStackTrace = PrintUncaughtStackTrace ?? options.PrintUncaughtStackTrace;
+            options.ProfilesSampleRate = ProfilesSampleRate ?? options.ProfilesSampleRate;
+            options.ReadTimeout = ReadTimeout ?? options.ReadTimeout;
+            options.EnableAndroidSdkTracing = EnableAndroidSdkTracing ?? options.EnableAndroidSdkTracing;
+            options.EnableAndroidSdkBeforeSend = EnableAndroidSdkBeforeSend ?? options.EnableAndroidSdkBeforeSend;
+        }
+    }
+}

--- a/src/Sentry/Platforms/iOS/BindableSentryOptions.cs
+++ b/src/Sentry/Platforms/iOS/BindableSentryOptions.cs
@@ -1,0 +1,48 @@
+// ReSharper disable once CheckNamespace
+namespace Sentry;
+
+internal partial class BindableSentryOptions
+{
+    public IosOptions iOS { get; } = new IosOptions();
+
+    /// <summary>
+    /// Provides additional options for the Android platform.
+    /// </summary>
+    public class IosOptions
+    {
+        public bool? AttachScreenshot { get; set; }
+        public TimeSpan? AppHangTimeoutInterval { get; set; }
+        public TimeSpan? IdleTimeout { get; set; }
+        public bool? EnableAppHangTracking { get; set; }
+        public bool? EnableAutoBreadcrumbTracking { get; set; }
+        public bool? EnableAutoPerformanceTracing { get; set; }
+        public bool? EnableCoreDataTracing { get; set; }
+        public bool? EnableFileIOTracing { get; set; }
+        public bool? EnableNetworkBreadcrumbs { get; set; }
+        public bool? EnableNetworkTracking { get; set; }
+        public bool? EnableWatchdogTerminationTracking { get; set; }
+        public bool? EnableSwizzling { get; set; }
+        public bool? EnableUIViewControllerTracing { get; set; }
+        public bool? EnableUserInteractionTracing { get; set; }
+        public bool? EnableCocoaSdkTracing { get; set; }
+
+        public void ApplyTo(SentryOptions.IosOptions options)
+        {
+            options.AttachScreenshot = AttachScreenshot ?? options.AttachScreenshot;
+            options.AppHangTimeoutInterval = AppHangTimeoutInterval ?? options.AppHangTimeoutInterval;
+            options.IdleTimeout = IdleTimeout ?? options.IdleTimeout;
+            options.EnableAppHangTracking = EnableAppHangTracking ?? options.EnableAppHangTracking;
+            options.EnableAutoBreadcrumbTracking = EnableAutoBreadcrumbTracking ?? options.EnableAutoBreadcrumbTracking;
+            options.EnableAutoPerformanceTracing = EnableAutoPerformanceTracing ?? options.EnableAutoPerformanceTracing;
+            options.EnableCoreDataTracing = EnableCoreDataTracing ?? options.EnableCoreDataTracing;
+            options.EnableFileIOTracing = EnableFileIOTracing ?? options.EnableFileIOTracing;
+            options.EnableNetworkBreadcrumbs = EnableNetworkBreadcrumbs ?? options.EnableNetworkBreadcrumbs;
+            options.EnableNetworkTracking = EnableNetworkTracking ?? options.EnableNetworkTracking;
+            options.EnableWatchdogTerminationTracking = EnableWatchdogTerminationTracking ?? options.EnableWatchdogTerminationTracking;
+            options.EnableSwizzling = EnableSwizzling ?? options.EnableSwizzling;
+            options.EnableUIViewControllerTracing = EnableUIViewControllerTracing ?? options.EnableUIViewControllerTracing;
+            options.EnableUserInteractionTracing = EnableUserInteractionTracing ?? options.EnableUserInteractionTracing;
+            options.EnableCocoaSdkTracing = EnableCocoaSdkTracing ?? options.EnableCocoaSdkTracing;
+        }
+    }
+}

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -297,6 +297,7 @@ public class SentryOptions
     public int MaxBreadcrumbs { get; set; } = DefaultMaxBreadcrumbs;
 
     private float? _sampleRate;
+
     /// <summary>
     /// The rate to sample error and crash events.
     /// </summary>
@@ -315,8 +316,10 @@ public class SentryOptions
         {
             if (value is > 1 or <= 0)
             {
-                throw new InvalidOperationException($"The value {value} is not valid. Use null to disable or values between 0.01 (inclusive) and 1.0 (exclusive) ");
+                throw new InvalidOperationException(
+                    $"The value {value} is not valid. Use null to disable or values between 0.01 (inclusive) and 1.0 (exclusive) ");
             }
+
             _sampleRate = value;
         }
     }
@@ -373,6 +376,7 @@ public class SentryOptions
     public string? Environment { get; set; }
 
     private string? _dsn;
+
     /// <summary>
     /// The Data Source Name of a given project in Sentry.
     /// </summary>
@@ -534,8 +538,10 @@ public class SentryOptions
         {
             if (value < 1)
             {
-                throw new ArgumentOutOfRangeException(nameof(value), value, "At least 1 item must be allowed in the queue.");
+                throw new ArgumentOutOfRangeException(nameof(value), value,
+                    "At least 1 item must be allowed in the queue.");
             }
+
             _maxQueueItems = value;
         }
     }
@@ -553,7 +559,8 @@ public class SentryOptions
         {
             if (value < 1)
             {
-                throw new ArgumentOutOfRangeException(nameof(value), value, "At least 1 item must be allowed in the cache.");
+                throw new ArgumentOutOfRangeException(nameof(value), value,
+                    "At least 1 item must be allowed in the cache.");
             }
 
             _maxCacheItems = value;
@@ -589,7 +596,7 @@ public class SentryOptions
     /// By default accepts all available compression methods supported by the platform
     /// </remarks>
     public DecompressionMethods DecompressionMethods { get; set; }
-        // Note the ~ enabling all bits
+    // Note the ~ enabling all bits
         = ~DecompressionMethods.None;
 
     /// <summary>
@@ -691,7 +698,8 @@ public class SentryOptions
         {
             if (value is null)
             {
-                _diagnosticLogger?.LogDebug("Sentry will not emit SDK debug messages because debug mode has been turned off.");
+                _diagnosticLogger?.LogDebug(
+                    "Sentry will not emit SDK debug messages because debug mode has been turned off.");
             }
             else
             {
@@ -744,11 +752,15 @@ public class SentryOptions
     /// <para>The SDK will only capture HTTP Client errors if the HTTP Response status code is within these defined ranges.</para>
     /// <para>Defaults to 500-599 (Server error responses only).</para>
     /// </summary>
-    public IList<HttpStatusCodeRange> FailedRequestStatusCodes { get; set; } = new List<HttpStatusCodeRange> { (500, 599) };
+    public IList<HttpStatusCodeRange> FailedRequestStatusCodes { get; set; } = new List<HttpStatusCodeRange>
+    {
+        (500, 599)
+    };
 
     // The default failed request target list will match anything, but adding to the list should clear that.
-    private Lazy<IList<SubstringOrRegexPattern>> _failedRequestTargets = new(() => new AutoClearingList<SubstringOrRegexPattern>(
-        new[] { new SubstringOrRegexPattern(".*") }, clearOnNextAdd: true));
+    private Lazy<IList<SubstringOrRegexPattern>> _failedRequestTargets = new(() =>
+        new AutoClearingList<SubstringOrRegexPattern>(
+            new[] { new SubstringOrRegexPattern(".*") }, clearOnNextAdd: true));
 
     /// <summary>
     /// <para>The SDK will only capture HTTP Client errors if the HTTP Request URL is a match for any of the failedRequestsTargets.</para>
@@ -785,9 +797,12 @@ public class SentryOptions
     /// <remarks>
     /// If the key already exists in the event, it will not be overwritten by a default tag.
     /// </remarks>
-    public Dictionary<string, string> DefaultTags => _defaultTags ??= new Dictionary<string, string>();
+    public Dictionary<string, string> DefaultTags {
+        get => _defaultTags ??= new Dictionary<string, string>();
+        internal set => _defaultTags = value;
+    }
 
-    /// <summary>
+/// <summary>
     /// Indicates whether the performance feature is enabled, via any combination of
     /// <see cref="EnableTracing"/>, <see cref="TracesSampleRate"/>, or <see cref="TracesSampler"/>.
     /// </summary>

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -1287,5 +1287,4 @@ public class SentryOptions
         WinUiUnhandledExceptionIntegration = 1 << 6,
 #endif
     }
-
 }

--- a/test/Sentry.AspNetCore.TestUtils/Sentry.AspNetCore.TestUtils.csproj
+++ b/test/Sentry.AspNetCore.TestUtils/Sentry.AspNetCore.TestUtils.csproj
@@ -50,7 +50,7 @@
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.2.23480.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
     <PackageReference Include="Verify.AspNetCore" Version="3.4.1" />
     <PackageReference Include="Verify.Http" Version="4.3.2" />
   </ItemGroup>

--- a/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/Sentry.DiagnosticSource.IntegrationTests.csproj
@@ -7,8 +7,8 @@
   <!-- Test EF Core 8 on .NET 8 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Verify.EntityFramework" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0-rc.2.23480.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0-rc.2.23480.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
   </ItemGroup>
 
   <!--

--- a/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
+++ b/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
@@ -6,8 +6,8 @@
 
   <!-- Test EF Core 8 on .NET 8 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0-rc.2.23480.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-rc.2.23480.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
   </ItemGroup>
 
   <!-- Test EF Core 7 on .NET 7 -->

--- a/test/Sentry.Extensions.Logging.Tests/ConfigurationOptionsTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/ConfigurationOptionsTests.cs
@@ -47,9 +47,12 @@ public class ConfigurationOptionsTests
         var provider = _fixture.GetSut();
         var sentryLoggingOptions = provider.GetRequiredService<IOptions<SentryLoggingOptions>>().Value;
 
-        Assert.False(sentryLoggingOptions.InitializeSdk);
-        Assert.Equal(LogLevel.Warning, sentryLoggingOptions.MinimumBreadcrumbLevel);
-        Assert.Equal(LogLevel.Critical, sentryLoggingOptions.MinimumEventLevel);
+        using (new AssertionScope())
+        {
+            sentryLoggingOptions.InitializeSdk.Should().BeFalse();
+            sentryLoggingOptions.MinimumBreadcrumbLevel.Should().Be(LogLevel.Warning);
+            sentryLoggingOptions.MinimumEventLevel.Should().Be(LogLevel.Critical);
+        }
     }
 
     [Fact]
@@ -85,7 +88,8 @@ public class ConfigurationOptionsTests
         var provider = _fixture.GetSut();
         var sentryLoggingOptions = provider.GetRequiredService<IOptions<SentryLoggingOptions>>().Value;
 
-        Assert.Equal(expectedValue, sentryLoggingOptions.DefaultTags[expectedKey]);
+        sentryLoggingOptions.DefaultTags.Should().ContainKey(expectedKey);
+        sentryLoggingOptions.DefaultTags[expectedKey].Should().Be(expectedValue);
     }
 
     [Fact]

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggingOptionsSetupTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggingOptionsSetupTests.cs
@@ -14,7 +14,7 @@ public class SentryLoggingOptionsSetupTests
         {
             IsGlobalModeEnabled = true,
             EnableScopeSync = true,
-            // TagFilters = ICollection<SubstringOrRegexPattern>,
+            TagFilters = new List<SubstringOrRegexPattern> { "tag1", "tag2" },
             SendDefaultPii = true,
             IsEnvironmentUser = true,
             ServerName = "FakeServerName",
@@ -28,7 +28,7 @@ public class SentryLoggingOptionsSetupTests
             MaxQueueItems = 8,
             MaxCacheItems = 9,
             ShutdownTimeout = TimeSpan.FromSeconds(13),
-            // FlushTimeout = TimeSpan,
+            FlushTimeout = TimeSpan.FromSeconds(17),
             DecompressionMethods = DecompressionMethods.GZip | DecompressionMethods.Deflate,
             RequestBodyCompressionLevel = CompressionLevel.Fastest,
             RequestBodyCompressionBuffered = true,
@@ -40,12 +40,12 @@ public class SentryLoggingOptionsSetupTests
             CacheDirectoryPath = "~/test",
             CaptureFailedRequests = true,
             // FailedRequestStatusCodes = IList<HttpStatusCodeRange>,
-            // FailedRequestTargets = IList<SubstringOrRegexPattern>,
+            FailedRequestTargets = new List<SubstringOrRegexPattern> { "target1", "target2" },
             InitCacheFlushTimeout = TimeSpan.FromSeconds(27),
             // DefaultTags = Dictionary<string,string>,
             EnableTracing = true,
             TracesSampleRate = 0.8f,
-            // TracePropagationTargets = IList<SubstringOrRegexPattern>,
+            TracePropagationTargets = new List<SubstringOrRegexPattern> { "target3", "target4" },
             StackTraceMode = StackTraceMode.Enhanced,
             MaxAttachmentSize = 21478,
             DetectStartupTime = StartupTimeDetectionMode.Fast,
@@ -55,55 +55,59 @@ public class SentryLoggingOptionsSetupTests
             JsonPreserveReferences = true,
 
             MinimumBreadcrumbLevel = LogLevel.Debug,
-            MinimumEventLevel = LogLevel.Error
+            MinimumEventLevel = LogLevel.Error,
+            InitializeSdk = true
         };
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new[]
+            .AddInMemoryCollection(new Dictionary<string, string>
             {
-                new KeyValuePair<string, string>("IsGlobalModeEnabled", expected.IsGlobalModeEnabled.ToString()),
-                new KeyValuePair<string, string>("EnableScopeSync", expected.EnableScopeSync.ToString()),
-                // new KeyValuePair<string, string>("TagFilters", expected.TagFilters.ToString()),
-                new KeyValuePair<string, string>("SendDefaultPii", expected.SendDefaultPii.ToString()),
-                new KeyValuePair<string, string>("IsEnvironmentUser", expected.IsEnvironmentUser.ToString()),
-                new KeyValuePair<string, string>("ServerName", expected.ServerName),
-                new KeyValuePair<string, string>("AttachStacktrace", expected.AttachStacktrace.ToString()),
-                new KeyValuePair<string, string>("MaxBreadcrumbs", expected.MaxBreadcrumbs.ToString()),
-                new KeyValuePair<string, string>("SampleRate", expected.SampleRate.ToString()),
-                new KeyValuePair<string, string>("Release", expected.Release),
-                new KeyValuePair<string, string>("Distribution", expected.Distribution),
-                new KeyValuePair<string, string>("Environment", expected.Environment),
-                new KeyValuePair<string, string>("Dsn", expected.Dsn),
-                new KeyValuePair<string, string>("MaxQueueItems", expected.MaxQueueItems.ToString()),
-                new KeyValuePair<string, string>("MaxCacheItems", expected.MaxCacheItems.ToString()),
-                new KeyValuePair<string, string>("ShutdownTimeout", expected.ShutdownTimeout.ToString()),
-                new KeyValuePair<string, string>("FlushTimeout", expected.FlushTimeout.ToString()),
-                new KeyValuePair<string, string>("DecompressionMethods", expected.DecompressionMethods.ToString()),
-                new KeyValuePair<string, string>("RequestBodyCompressionLevel", expected.RequestBodyCompressionLevel.ToString()),
-                new KeyValuePair<string, string>("RequestBodyCompressionBuffered", expected.RequestBodyCompressionBuffered.ToString()),
-                new KeyValuePair<string, string>("SendClientReports", expected.SendClientReports.ToString()),
-                new KeyValuePair<string, string>("Debug", expected.Debug.ToString()),
-                new KeyValuePair<string, string>("DiagnosticLevel", expected.DiagnosticLevel.ToString()),
-                new KeyValuePair<string, string>("ReportAssembliesMode", expected.ReportAssembliesMode.ToString()),
-                new KeyValuePair<string, string>("DeduplicateMode", expected.DeduplicateMode.ToString()),
-                new KeyValuePair<string, string>("CacheDirectoryPath", expected.CacheDirectoryPath.ToString()),
-                new KeyValuePair<string, string>("CaptureFailedRequests", expected.CaptureFailedRequests.ToString()),
-                // new KeyValuePair<string, string>("FailedRequestStatusCodes", expected.FailedRequestStatusCodes.ToString()),
-                // new KeyValuePair<string, string>("FailedRequestTargets", expected.FailedRequestTargets.ToString()),
-                new KeyValuePair<string, string>("InitCacheFlushTimeout", expected.InitCacheFlushTimeout.ToString()),
-                // new KeyValuePair<string, string>("DefaultTags", expected.DefaultTags.ToString()),
-                new KeyValuePair<string, string>("EnableTracing", expected.EnableTracing.ToString()),
-                new KeyValuePair<string, string>("TracesSampleRate", expected.TracesSampleRate.ToString()),
-                // new KeyValuePair<string, string>("TracePropagationTargets", expected.TracePropagationTargets.ToString()),
-                new KeyValuePair<string, string>("StackTraceMode", expected.StackTraceMode.ToString()),
-                new KeyValuePair<string, string>("MaxAttachmentSize", expected.MaxAttachmentSize.ToString()),
-                new KeyValuePair<string, string>("DetectStartupTime", expected.DetectStartupTime.ToString()),
-                new KeyValuePair<string, string>("AutoSessionTrackingInterval", expected.AutoSessionTrackingInterval.ToString()),
-                new KeyValuePair<string, string>("AutoSessionTracking", expected.AutoSessionTracking.ToString()),
-                new KeyValuePair<string, string>("UseAsyncFileIO", expected.UseAsyncFileIO.ToString()),
-                new KeyValuePair<string, string>("JsonPreserveReferences", expected.JsonPreserveReferences.ToString()),
-
-                new KeyValuePair<string, string>("MinimumBreadcrumbLevel", expected.MinimumBreadcrumbLevel.ToString()),
-                new KeyValuePair<string, string>("MinimumEventLevel", expected.MinimumEventLevel.ToString()),
+                ["IsGlobalModeEnabled"] = expected.IsGlobalModeEnabled.ToString(),
+                ["EnableScopeSync"] = expected.EnableScopeSync.ToString(),
+                ["TagFilters:0"] = "tag1",
+                ["TagFilters:1"] = "tag2",
+                ["SendDefaultPii"] = expected.SendDefaultPii.ToString(),
+                ["IsEnvironmentUser"] = expected.IsEnvironmentUser.ToString(),
+                ["ServerName"] = expected.ServerName,
+                ["AttachStacktrace"] = expected.AttachStacktrace.ToString(),
+                ["MaxBreadcrumbs"] = expected.MaxBreadcrumbs.ToString(),
+                ["SampleRate"] = expected.SampleRate.ToString(),
+                ["Release"] = expected.Release,
+                ["Distribution"] = expected.Distribution,
+                ["Environment"] = expected.Environment,
+                ["Dsn"] = expected.Dsn,
+                ["MaxQueueItems"] = expected.MaxQueueItems.ToString(),
+                ["MaxCacheItems"] = expected.MaxCacheItems.ToString(),
+                ["ShutdownTimeout"] = expected.ShutdownTimeout.ToString(),
+                ["FlushTimeout"] = expected.FlushTimeout.ToString(),
+                ["DecompressionMethods"] = expected.DecompressionMethods.ToString(),
+                ["RequestBodyCompressionLevel"] = expected.RequestBodyCompressionLevel.ToString(),
+                ["RequestBodyCompressionBuffered"] = expected.RequestBodyCompressionBuffered.ToString(),
+                ["SendClientReports"] = expected.SendClientReports.ToString(),
+                ["Debug"] = expected.Debug.ToString(),
+                ["DiagnosticLevel"] = expected.DiagnosticLevel.ToString(),
+                ["ReportAssembliesMode"] = expected.ReportAssembliesMode.ToString(),
+                ["DeduplicateMode"] = expected.DeduplicateMode.ToString(),
+                ["CacheDirectoryPath"] = expected.CacheDirectoryPath.ToString(),
+                ["CaptureFailedRequests"] = expected.CaptureFailedRequests.ToString(),
+                ["FailedRequestStatusCodes"] = expected.FailedRequestStatusCodes.ToString(),
+                ["FailedRequestTargets:0"] = expected.FailedRequestTargets.First().ToString(),
+                ["FailedRequestTargets:1"] = expected.FailedRequestTargets.Last().ToString(),
+                ["InitCacheFlushTimeout"] = expected.InitCacheFlushTimeout.ToString(),
+                ["DefaultTags"] = expected.DefaultTags.ToString(),
+                ["EnableTracing"] = expected.EnableTracing.ToString(),
+                ["TracesSampleRate"] = expected.TracesSampleRate.ToString(),
+                ["TracePropagationTargets:0"] = expected.TracePropagationTargets.First().ToString(),
+                ["TracePropagationTargets:1"] = expected.TracePropagationTargets.Last().ToString(),
+                ["StackTraceMode"] = expected.StackTraceMode.ToString(),
+                ["MaxAttachmentSize"] = expected.MaxAttachmentSize.ToString(),
+                ["DetectStartupTime"] = expected.DetectStartupTime.ToString(),
+                ["AutoSessionTrackingInterval"] = expected.AutoSessionTrackingInterval.ToString(),
+                ["AutoSessionTracking"] = expected.AutoSessionTracking.ToString(),
+                ["UseAsyncFileIO"] = expected.UseAsyncFileIO.ToString(),
+                ["JsonPreserveReferences"] = expected.JsonPreserveReferences.ToString(),
+                ["MinimumBreadcrumbLevel"] = expected.MinimumBreadcrumbLevel.ToString(),
+                ["MinimumEventLevel"] = expected.MinimumEventLevel.ToString(),
+                ["InitializeSdk"] = expected.InitializeSdk.ToString(),
             })
             .Build();
 
@@ -121,7 +125,7 @@ public class SentryLoggingOptionsSetupTests
         {
             actual.IsGlobalModeEnabled.Should().Be(expected.IsGlobalModeEnabled);
             actual.EnableScopeSync.Should().Be(expected.EnableScopeSync);
-            // Add assertion for TagFilters here if needed
+            actual.TagFilters.Should().BeEquivalentTo(expected.TagFilters);
             actual.SendDefaultPii.Should().Be(expected.SendDefaultPii);
             actual.IsEnvironmentUser.Should().Be(expected.IsEnvironmentUser);
             actual.ServerName.Should().Be(expected.ServerName);
@@ -146,13 +150,11 @@ public class SentryLoggingOptionsSetupTests
             actual.DeduplicateMode.Should().Be(expected.DeduplicateMode);
             actual.CacheDirectoryPath.Should().Be(expected.CacheDirectoryPath);
             actual.CaptureFailedRequests.Should().Be(expected.CaptureFailedRequests);
-            // Add assertion for FailedRequestStatusCodes here if needed
-            // Add assertion for FailedRequestTargets here if needed
+            actual.FailedRequestTargets.Should().BeEquivalentTo(expected.FailedRequestTargets);
             actual.InitCacheFlushTimeout.Should().Be(expected.InitCacheFlushTimeout);
-            // Add assertion for DefaultTags here if needed
             actual.EnableTracing.Should().Be(expected.EnableTracing);
             actual.TracesSampleRate.Should().Be(expected.TracesSampleRate);
-            // Add assertion for TracePropagationTargets here if needed
+            actual.TracePropagationTargets.Should().BeEquivalentTo(expected.TracePropagationTargets);
             actual.StackTraceMode.Should().Be(expected.StackTraceMode);
             actual.MaxAttachmentSize.Should().Be(expected.MaxAttachmentSize);
             actual.DetectStartupTime.Should().Be(expected.DetectStartupTime);
@@ -163,6 +165,7 @@ public class SentryLoggingOptionsSetupTests
 
             actual.MinimumBreadcrumbLevel.Should().Be(expected.MinimumBreadcrumbLevel);
             actual.MinimumEventLevel.Should().Be(expected.MinimumEventLevel);
+            actual.InitializeSdk.Should().Be(expected.InitializeSdk);
         }
     }
 }

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggingOptionsSetupTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggingOptionsSetupTests.cs
@@ -27,7 +27,7 @@ public class SentryLoggingOptionsSetupTests
             Dsn = "https://d4d82fc1c2c4032a83f3a29aa3a3aff@fake-sentry.io:65535/2147483647",
             MaxQueueItems = 8,
             MaxCacheItems = 9,
-            // ShutdownTimeout = TimeSpan,
+            ShutdownTimeout = TimeSpan.FromSeconds(13),
             // FlushTimeout = TimeSpan,
             DecompressionMethods = DecompressionMethods.GZip | DecompressionMethods.Deflate,
             RequestBodyCompressionLevel = CompressionLevel.Fastest,
@@ -41,7 +41,7 @@ public class SentryLoggingOptionsSetupTests
             CaptureFailedRequests = true,
             // FailedRequestStatusCodes = IList<HttpStatusCodeRange>,
             // FailedRequestTargets = IList<SubstringOrRegexPattern>,
-            // InitCacheFlushTimeout = TimeSpan,
+            InitCacheFlushTimeout = TimeSpan.FromSeconds(27),
             // DefaultTags = Dictionary<string,string>,
             EnableTracing = true,
             TracesSampleRate = 0.8f,
@@ -49,7 +49,7 @@ public class SentryLoggingOptionsSetupTests
             StackTraceMode = StackTraceMode.Enhanced,
             MaxAttachmentSize = 21478,
             DetectStartupTime = StartupTimeDetectionMode.Fast,
-            // AutoSessionTrackingInterval = TimeSpan,
+            AutoSessionTrackingInterval = TimeSpan.FromHours(3),
             AutoSessionTracking = true,
             UseAsyncFileIO = true,
             JsonPreserveReferences = true,
@@ -75,8 +75,8 @@ public class SentryLoggingOptionsSetupTests
                 new KeyValuePair<string, string>("Dsn", expected.Dsn),
                 new KeyValuePair<string, string>("MaxQueueItems", expected.MaxQueueItems.ToString()),
                 new KeyValuePair<string, string>("MaxCacheItems", expected.MaxCacheItems.ToString()),
-                // new KeyValuePair<string, string>("ShutdownTimeout", expected.ShutdownTimeout.ToString()),
-                // new KeyValuePair<string, string>("FlushTimeout", expected.FlushTimeout.ToString()),
+                new KeyValuePair<string, string>("ShutdownTimeout", expected.ShutdownTimeout.ToString()),
+                new KeyValuePair<string, string>("FlushTimeout", expected.FlushTimeout.ToString()),
                 new KeyValuePair<string, string>("DecompressionMethods", expected.DecompressionMethods.ToString()),
                 new KeyValuePair<string, string>("RequestBodyCompressionLevel", expected.RequestBodyCompressionLevel.ToString()),
                 new KeyValuePair<string, string>("RequestBodyCompressionBuffered", expected.RequestBodyCompressionBuffered.ToString()),
@@ -89,7 +89,7 @@ public class SentryLoggingOptionsSetupTests
                 new KeyValuePair<string, string>("CaptureFailedRequests", expected.CaptureFailedRequests.ToString()),
                 // new KeyValuePair<string, string>("FailedRequestStatusCodes", expected.FailedRequestStatusCodes.ToString()),
                 // new KeyValuePair<string, string>("FailedRequestTargets", expected.FailedRequestTargets.ToString()),
-                // new KeyValuePair<string, string>("InitCacheFlushTimeout", expected.InitCacheFlushTimeout.ToString()),
+                new KeyValuePair<string, string>("InitCacheFlushTimeout", expected.InitCacheFlushTimeout.ToString()),
                 // new KeyValuePair<string, string>("DefaultTags", expected.DefaultTags.ToString()),
                 new KeyValuePair<string, string>("EnableTracing", expected.EnableTracing.ToString()),
                 new KeyValuePair<string, string>("TracesSampleRate", expected.TracesSampleRate.ToString()),
@@ -97,7 +97,7 @@ public class SentryLoggingOptionsSetupTests
                 new KeyValuePair<string, string>("StackTraceMode", expected.StackTraceMode.ToString()),
                 new KeyValuePair<string, string>("MaxAttachmentSize", expected.MaxAttachmentSize.ToString()),
                 new KeyValuePair<string, string>("DetectStartupTime", expected.DetectStartupTime.ToString()),
-                // new KeyValuePair<string, string>("AutoSessionTrackingInterval", expected.AutoSessionTrackingInterval.ToString()),
+                new KeyValuePair<string, string>("AutoSessionTrackingInterval", expected.AutoSessionTrackingInterval.ToString()),
                 new KeyValuePair<string, string>("AutoSessionTracking", expected.AutoSessionTracking.ToString()),
                 new KeyValuePair<string, string>("UseAsyncFileIO", expected.UseAsyncFileIO.ToString()),
                 new KeyValuePair<string, string>("JsonPreserveReferences", expected.JsonPreserveReferences.ToString()),
@@ -134,8 +134,8 @@ public class SentryLoggingOptionsSetupTests
             actual.Dsn.Should().Be(expected.Dsn);
             actual.MaxQueueItems.Should().Be(expected.MaxQueueItems);
             actual.MaxCacheItems.Should().Be(expected.MaxCacheItems);
-            // Add assertion for ShutdownTimeout here if needed
-            // Add assertion for FlushTimeout here if needed
+            actual.ShutdownTimeout.Should().Be(expected.ShutdownTimeout);
+            actual.FlushTimeout.Should().Be(expected.FlushTimeout);
             actual.DecompressionMethods.Should().Be(expected.DecompressionMethods);
             actual.RequestBodyCompressionLevel.Should().Be(expected.RequestBodyCompressionLevel);
             actual.RequestBodyCompressionBuffered.Should().Be(expected.RequestBodyCompressionBuffered);
@@ -148,7 +148,7 @@ public class SentryLoggingOptionsSetupTests
             actual.CaptureFailedRequests.Should().Be(expected.CaptureFailedRequests);
             // Add assertion for FailedRequestStatusCodes here if needed
             // Add assertion for FailedRequestTargets here if needed
-            // Add assertion for InitCacheFlushTimeout here if needed
+            actual.InitCacheFlushTimeout.Should().Be(expected.InitCacheFlushTimeout);
             // Add assertion for DefaultTags here if needed
             actual.EnableTracing.Should().Be(expected.EnableTracing);
             actual.TracesSampleRate.Should().Be(expected.TracesSampleRate);
@@ -156,7 +156,7 @@ public class SentryLoggingOptionsSetupTests
             actual.StackTraceMode.Should().Be(expected.StackTraceMode);
             actual.MaxAttachmentSize.Should().Be(expected.MaxAttachmentSize);
             actual.DetectStartupTime.Should().Be(expected.DetectStartupTime);
-            // Add assertion for AutoSessionTrackingInterval here if needed
+            actual.AutoSessionTrackingInterval.Should().Be(expected.AutoSessionTrackingInterval);
             actual.AutoSessionTracking.Should().Be(expected.AutoSessionTracking);
             actual.UseAsyncFileIO.Should().Be(expected.UseAsyncFileIO);
             actual.JsonPreserveReferences.Should().Be(expected.JsonPreserveReferences);

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggingOptionsSetupTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggingOptionsSetupTests.cs
@@ -1,0 +1,168 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Configuration;
+
+namespace Sentry.Extensions.Logging.Tests;
+
+public class SentryLoggingOptionsSetupTests
+{
+    [Fact]
+    public void Configure_BindsConfigurationToOptions()
+    {
+        // Arrange
+        var expected = new SentryLoggingOptions
+        {
+            IsGlobalModeEnabled = true,
+            EnableScopeSync = true,
+            // TagFilters = ICollection<SubstringOrRegexPattern>,
+            SendDefaultPii = true,
+            IsEnvironmentUser = true,
+            ServerName = "FakeServerName",
+            AttachStacktrace = true,
+            MaxBreadcrumbs = 7,
+            SampleRate = 0.7f,
+            Release = "FakeRelease",
+            Distribution = "FakeDistribution",
+            Environment = "Test",
+            Dsn = "https://d4d82fc1c2c4032a83f3a29aa3a3aff@fake-sentry.io:65535/2147483647",
+            MaxQueueItems = 8,
+            MaxCacheItems = 9,
+            // ShutdownTimeout = TimeSpan,
+            // FlushTimeout = TimeSpan,
+            DecompressionMethods = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            RequestBodyCompressionLevel = CompressionLevel.Fastest,
+            RequestBodyCompressionBuffered = true,
+            SendClientReports = true,
+            Debug = true,
+            DiagnosticLevel = SentryLevel.Warning,
+            ReportAssembliesMode = ReportAssembliesMode.InformationalVersion,
+            DeduplicateMode = DeduplicateMode.AggregateException,
+            CacheDirectoryPath = "~/test",
+            CaptureFailedRequests = true,
+            // FailedRequestStatusCodes = IList<HttpStatusCodeRange>,
+            // FailedRequestTargets = IList<SubstringOrRegexPattern>,
+            // InitCacheFlushTimeout = TimeSpan,
+            // DefaultTags = Dictionary<string,string>,
+            EnableTracing = true,
+            TracesSampleRate = 0.8f,
+            // TracePropagationTargets = IList<SubstringOrRegexPattern>,
+            StackTraceMode = StackTraceMode.Enhanced,
+            MaxAttachmentSize = 21478,
+            DetectStartupTime = StartupTimeDetectionMode.Fast,
+            // AutoSessionTrackingInterval = TimeSpan,
+            AutoSessionTracking = true,
+            UseAsyncFileIO = true,
+            JsonPreserveReferences = true,
+
+            MinimumBreadcrumbLevel = LogLevel.Debug,
+            MinimumEventLevel = LogLevel.Error
+        };
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new[]
+            {
+                new KeyValuePair<string, string>("IsGlobalModeEnabled", expected.IsGlobalModeEnabled.ToString()),
+                new KeyValuePair<string, string>("EnableScopeSync", expected.EnableScopeSync.ToString()),
+                // new KeyValuePair<string, string>("TagFilters", expected.TagFilters.ToString()),
+                new KeyValuePair<string, string>("SendDefaultPii", expected.SendDefaultPii.ToString()),
+                new KeyValuePair<string, string>("IsEnvironmentUser", expected.IsEnvironmentUser.ToString()),
+                new KeyValuePair<string, string>("ServerName", expected.ServerName),
+                new KeyValuePair<string, string>("AttachStacktrace", expected.AttachStacktrace.ToString()),
+                new KeyValuePair<string, string>("MaxBreadcrumbs", expected.MaxBreadcrumbs.ToString()),
+                new KeyValuePair<string, string>("SampleRate", expected.SampleRate.ToString()),
+                new KeyValuePair<string, string>("Release", expected.Release),
+                new KeyValuePair<string, string>("Distribution", expected.Distribution),
+                new KeyValuePair<string, string>("Environment", expected.Environment),
+                new KeyValuePair<string, string>("Dsn", expected.Dsn),
+                new KeyValuePair<string, string>("MaxQueueItems", expected.MaxQueueItems.ToString()),
+                new KeyValuePair<string, string>("MaxCacheItems", expected.MaxCacheItems.ToString()),
+                // new KeyValuePair<string, string>("ShutdownTimeout", expected.ShutdownTimeout.ToString()),
+                // new KeyValuePair<string, string>("FlushTimeout", expected.FlushTimeout.ToString()),
+                new KeyValuePair<string, string>("DecompressionMethods", expected.DecompressionMethods.ToString()),
+                new KeyValuePair<string, string>("RequestBodyCompressionLevel", expected.RequestBodyCompressionLevel.ToString()),
+                new KeyValuePair<string, string>("RequestBodyCompressionBuffered", expected.RequestBodyCompressionBuffered.ToString()),
+                new KeyValuePair<string, string>("SendClientReports", expected.SendClientReports.ToString()),
+                new KeyValuePair<string, string>("Debug", expected.Debug.ToString()),
+                new KeyValuePair<string, string>("DiagnosticLevel", expected.DiagnosticLevel.ToString()),
+                new KeyValuePair<string, string>("ReportAssembliesMode", expected.ReportAssembliesMode.ToString()),
+                new KeyValuePair<string, string>("DeduplicateMode", expected.DeduplicateMode.ToString()),
+                new KeyValuePair<string, string>("CacheDirectoryPath", expected.CacheDirectoryPath.ToString()),
+                new KeyValuePair<string, string>("CaptureFailedRequests", expected.CaptureFailedRequests.ToString()),
+                // new KeyValuePair<string, string>("FailedRequestStatusCodes", expected.FailedRequestStatusCodes.ToString()),
+                // new KeyValuePair<string, string>("FailedRequestTargets", expected.FailedRequestTargets.ToString()),
+                // new KeyValuePair<string, string>("InitCacheFlushTimeout", expected.InitCacheFlushTimeout.ToString()),
+                // new KeyValuePair<string, string>("DefaultTags", expected.DefaultTags.ToString()),
+                new KeyValuePair<string, string>("EnableTracing", expected.EnableTracing.ToString()),
+                new KeyValuePair<string, string>("TracesSampleRate", expected.TracesSampleRate.ToString()),
+                // new KeyValuePair<string, string>("TracePropagationTargets", expected.TracePropagationTargets.ToString()),
+                new KeyValuePair<string, string>("StackTraceMode", expected.StackTraceMode.ToString()),
+                new KeyValuePair<string, string>("MaxAttachmentSize", expected.MaxAttachmentSize.ToString()),
+                new KeyValuePair<string, string>("DetectStartupTime", expected.DetectStartupTime.ToString()),
+                // new KeyValuePair<string, string>("AutoSessionTrackingInterval", expected.AutoSessionTrackingInterval.ToString()),
+                new KeyValuePair<string, string>("AutoSessionTracking", expected.AutoSessionTracking.ToString()),
+                new KeyValuePair<string, string>("UseAsyncFileIO", expected.UseAsyncFileIO.ToString()),
+                new KeyValuePair<string, string>("JsonPreserveReferences", expected.JsonPreserveReferences.ToString()),
+
+                new KeyValuePair<string, string>("MinimumBreadcrumbLevel", expected.MinimumBreadcrumbLevel.ToString()),
+                new KeyValuePair<string, string>("MinimumEventLevel", expected.MinimumEventLevel.ToString()),
+            })
+            .Build();
+
+        var providerConfig = Substitute.For<ILoggerProviderConfiguration<SentryLoggerProvider>>();
+        providerConfig.Configuration.Returns(config);
+        var actual = new SentryLoggingOptions();
+
+        var setup = new SentryLoggingOptionsSetup(providerConfig);
+
+        // Act
+        setup.Configure(actual);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            actual.IsGlobalModeEnabled.Should().Be(expected.IsGlobalModeEnabled);
+            actual.EnableScopeSync.Should().Be(expected.EnableScopeSync);
+            // Add assertion for TagFilters here if needed
+            actual.SendDefaultPii.Should().Be(expected.SendDefaultPii);
+            actual.IsEnvironmentUser.Should().Be(expected.IsEnvironmentUser);
+            actual.ServerName.Should().Be(expected.ServerName);
+            actual.AttachStacktrace.Should().Be(expected.AttachStacktrace);
+            actual.MaxBreadcrumbs.Should().Be(expected.MaxBreadcrumbs);
+            actual.SampleRate.Should().Be(expected.SampleRate);
+            actual.Release.Should().Be(expected.Release);
+            actual.Distribution.Should().Be(expected.Distribution);
+            actual.Environment.Should().Be(expected.Environment);
+            actual.Dsn.Should().Be(expected.Dsn);
+            actual.MaxQueueItems.Should().Be(expected.MaxQueueItems);
+            actual.MaxCacheItems.Should().Be(expected.MaxCacheItems);
+            // Add assertion for ShutdownTimeout here if needed
+            // Add assertion for FlushTimeout here if needed
+            actual.DecompressionMethods.Should().Be(expected.DecompressionMethods);
+            actual.RequestBodyCompressionLevel.Should().Be(expected.RequestBodyCompressionLevel);
+            actual.RequestBodyCompressionBuffered.Should().Be(expected.RequestBodyCompressionBuffered);
+            actual.SendClientReports.Should().Be(expected.SendClientReports);
+            actual.Debug.Should().Be(expected.Debug);
+            actual.DiagnosticLevel.Should().Be(expected.DiagnosticLevel);
+            actual.ReportAssembliesMode.Should().Be(expected.ReportAssembliesMode);
+            actual.DeduplicateMode.Should().Be(expected.DeduplicateMode);
+            actual.CacheDirectoryPath.Should().Be(expected.CacheDirectoryPath);
+            actual.CaptureFailedRequests.Should().Be(expected.CaptureFailedRequests);
+            // Add assertion for FailedRequestStatusCodes here if needed
+            // Add assertion for FailedRequestTargets here if needed
+            // Add assertion for InitCacheFlushTimeout here if needed
+            // Add assertion for DefaultTags here if needed
+            actual.EnableTracing.Should().Be(expected.EnableTracing);
+            actual.TracesSampleRate.Should().Be(expected.TracesSampleRate);
+            // Add assertion for TracePropagationTargets here if needed
+            actual.StackTraceMode.Should().Be(expected.StackTraceMode);
+            actual.MaxAttachmentSize.Should().Be(expected.MaxAttachmentSize);
+            actual.DetectStartupTime.Should().Be(expected.DetectStartupTime);
+            // Add assertion for AutoSessionTrackingInterval here if needed
+            actual.AutoSessionTracking.Should().Be(expected.AutoSessionTracking);
+            actual.UseAsyncFileIO.Should().Be(expected.UseAsyncFileIO);
+            actual.JsonPreserveReferences.Should().Be(expected.JsonPreserveReferences);
+
+            actual.MinimumBreadcrumbLevel.Should().Be(expected.MinimumBreadcrumbLevel);
+            actual.MinimumEventLevel.Should().Be(expected.MinimumEventLevel);
+        }
+    }
+}

--- a/test/Sentry.Tests/Platforms/Android/BindableSentryOptionsTests.cs
+++ b/test/Sentry.Tests/Platforms/Android/BindableSentryOptionsTests.cs
@@ -8,7 +8,6 @@ public class BindableSentryOptionsTests
     [SkippableFact]
     public void ApplyTo_SetsAndroidOptionsFromConfig()
     {
-        Skip.If(true,"I couldn't work out how to get this test to run");
         var expected = new SentryOptions.AndroidOptions(new SentryOptions())
         {
             AnrEnabled = true,

--- a/test/Sentry.Tests/Platforms/Android/BindableSentryOptionsTests.cs
+++ b/test/Sentry.Tests/Platforms/Android/BindableSentryOptionsTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Sentry.Tests.Platforms.Android;
+
+public class BindableSentryOptionsTests
+{
+#if ANDROID
+    [SkippableFact]
+    public void ApplyTo_SetsAndroidOptionsFromConfig()
+    {
+        Skip.If(true,"I couldn't work out how to get this test to run");
+        var expected = new SentryOptions.AndroidOptions(new SentryOptions())
+        {
+            AnrEnabled = true,
+            AnrReportInDebug = true,
+            AnrTimeoutInterval = TimeSpan.FromSeconds(3),
+            AttachScreenshot = true,
+            EnableActivityLifecycleBreadcrumbs = true,
+            EnableAppComponentBreadcrumbs = true,
+            EnableAppLifecycleBreadcrumbs = true,
+            EnableRootCheck = true,
+            EnableSystemEventBreadcrumbs = true,
+            EnableUserInteractionBreadcrumbs = true,
+            EnableAutoActivityLifecycleTracing = true,
+            EnableActivityLifecycleTracingAutoFinish = true,
+            EnableUserInteractionTracing = true,
+            AttachThreads = true,
+            ConnectionTimeout = TimeSpan.FromSeconds(7),
+            EnableNdk = true,
+            EnableShutdownHook = true,
+            EnableUncaughtExceptionHandler = true,
+            PrintUncaughtStackTrace = true,
+            ReadTimeout = TimeSpan.FromSeconds(13),
+            EnableAndroidSdkTracing = true,
+            EnableAndroidSdkBeforeSend = true,
+        };
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["AnrEnabled"] = expected.AnrEnabled.ToString(),
+                ["AnrReportInDebug"] = expected.AnrReportInDebug.ToString(),
+                ["AnrTimeoutInterval"] = expected.AnrTimeoutInterval.ToString(),
+                ["AttachScreenshot"] = expected.AttachScreenshot.ToString(),
+                ["EnableActivityLifecycleBreadcrumbs"] = expected.EnableActivityLifecycleBreadcrumbs.ToString(),
+                ["EnableAppComponentBreadcrumbs"] = expected.EnableAppComponentBreadcrumbs.ToString(),
+                ["EnableAppLifecycleBreadcrumbs"] = expected.EnableAppLifecycleBreadcrumbs.ToString(),
+                ["EnableRootCheck"] = expected.EnableRootCheck.ToString(),
+                ["EnableSystemEventBreadcrumbs"] = expected.EnableSystemEventBreadcrumbs.ToString(),
+                ["EnableUserInteractionBreadcrumbs"] = expected.EnableUserInteractionBreadcrumbs.ToString(),
+                ["EnableAutoActivityLifecycleTracing"] = expected.EnableAutoActivityLifecycleTracing.ToString(),
+                ["EnableActivityLifecycleTracingAutoFinish"] = expected.EnableActivityLifecycleTracingAutoFinish.ToString(),
+                ["EnableUserInteractionTracing"] = expected.EnableUserInteractionTracing.ToString(),
+                ["AttachThreads"] = expected.AttachThreads.ToString(),
+                ["ConnectionTimeout"] = expected.ConnectionTimeout.ToString(),
+                ["EnableNdk"] = expected.EnableNdk.ToString(),
+                ["EnableShutdownHook"] = expected.EnableShutdownHook.ToString(),
+                ["EnableUncaughtExceptionHandler"] = expected.EnableUncaughtExceptionHandler.ToString(),
+                ["PrintUncaughtStackTrace"] = expected.PrintUncaughtStackTrace.ToString(),
+                ["ReadTimeout"] = expected.ReadTimeout.ToString(),
+                ["EnableAndroidSdkTracing"] = expected.EnableAndroidSdkTracing.ToString(),
+                ["EnableAndroidSdkBeforeSend"] = expected.EnableAndroidSdkBeforeSend.ToString()
+            }).Build();
+        var bindable = new BindableSentryOptions.AndroidOptions();
+        var actual = new SentryOptions.AndroidOptions(new SentryOptions());
+
+        // Act
+        config.Bind(bindable);
+        bindable.ApplyTo(actual);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            actual.AnrEnabled.Should().Be(expected.AnrEnabled);
+            actual.AnrReportInDebug.Should().Be(expected.AnrReportInDebug);
+            actual.AnrTimeoutInterval.Should().Be(expected.AnrTimeoutInterval);
+            actual.AttachScreenshot.Should().Be(expected.AttachScreenshot);
+            actual.EnableActivityLifecycleBreadcrumbs.Should().Be(expected.EnableActivityLifecycleBreadcrumbs);
+            actual.EnableAppComponentBreadcrumbs.Should().Be(expected.EnableAppComponentBreadcrumbs);
+            actual.EnableAppLifecycleBreadcrumbs.Should().Be(expected.EnableAppLifecycleBreadcrumbs);
+            actual.EnableRootCheck.Should().Be(expected.EnableRootCheck);
+            actual.EnableSystemEventBreadcrumbs.Should().Be(expected.EnableSystemEventBreadcrumbs);
+            actual.EnableUserInteractionBreadcrumbs.Should().Be(expected.EnableUserInteractionBreadcrumbs);
+            actual.EnableAutoActivityLifecycleTracing.Should().Be(expected.EnableAutoActivityLifecycleTracing);
+            actual.EnableActivityLifecycleTracingAutoFinish.Should().Be(expected.EnableActivityLifecycleTracingAutoFinish);
+            actual.EnableUserInteractionTracing.Should().Be(expected.EnableUserInteractionTracing);
+            actual.AttachThreads.Should().Be(expected.AttachThreads);
+            actual.ConnectionTimeout.Should().Be(expected.ConnectionTimeout);
+            actual.EnableNdk.Should().Be(expected.EnableNdk);
+            actual.EnableShutdownHook.Should().Be(expected.EnableShutdownHook);
+            actual.EnableUncaughtExceptionHandler.Should().Be(expected.EnableUncaughtExceptionHandler);
+            actual.PrintUncaughtStackTrace.Should().Be(expected.PrintUncaughtStackTrace);
+            actual.ReadTimeout.Should().Be(expected.ReadTimeout);
+            actual.EnableAndroidSdkTracing.Should().Be(expected.EnableAndroidSdkTracing);
+            actual.EnableAndroidSdkBeforeSend.Should().Be(expected.EnableAndroidSdkBeforeSend);
+        }
+    }
+#endif
+}

--- a/test/Sentry.Tests/Platforms/iOS/BindableSentryOptionsTests.cs
+++ b/test/Sentry.Tests/Platforms/iOS/BindableSentryOptionsTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Sentry.Tests.Platforms.iOS;
+
+public class BindableSentryOptionsTests
+{
+# if __IOS__
+    [SkippableFact]
+    public void ApplyTo_SetsiOSOptionsFromConfig()
+    {
+        Skip.If(true,"I couldn't work out how to get this test to run");
+        var expected = new SentryOptions.IosOptions(new SentryOptions())
+        {
+            AttachScreenshot = true,
+            AppHangTimeoutInterval = TimeSpan.FromSeconds(3),
+            IdleTimeout = TimeSpan.FromSeconds(5),
+            EnableAppHangTracking = true,
+            EnableAutoBreadcrumbTracking = true,
+            EnableAutoPerformanceTracing = true,
+            EnableCoreDataTracing = true,
+            EnableFileIOTracing = true,
+            EnableNetworkBreadcrumbs = true,
+            EnableNetworkTracking = true,
+            EnableWatchdogTerminationTracking = true,
+            EnableSwizzling = true,
+            EnableUIViewControllerTracing = true,
+            EnableUserInteractionTracing = true,
+            EnableCocoaSdkTracing = true,
+        };
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["AttachScreenshot"] = expected.AttachScreenshot.ToString(),
+                ["AppHangTimeoutInterval"] = expected.AppHangTimeoutInterval.ToString(),
+                ["IdleTimeout"] = expected.IdleTimeout.ToString(),
+                ["EnableAppHangTracking"] = expected.EnableAppHangTracking.ToString(),
+                ["EnableAutoBreadcrumbTracking"] = expected.EnableAutoBreadcrumbTracking.ToString(),
+                ["EnableAutoPerformanceTracing"] = expected.EnableAutoPerformanceTracing.ToString(),
+                ["EnableCoreDataTracing"] = expected.EnableCoreDataTracing.ToString(),
+                ["EnableFileIOTracing"] = expected.EnableFileIOTracing.ToString(),
+                ["EnableNetworkBreadcrumbs"] = expected.EnableNetworkBreadcrumbs.ToString(),
+                ["EnableNetworkTracking"] = expected.EnableNetworkTracking.ToString(),
+                ["EnableWatchdogTerminationTracking"] = expected.EnableWatchdogTerminationTracking.ToString(),
+                ["EnableSwizzling"] = expected.EnableSwizzling.ToString(),
+                ["EnableUIViewControllerTracing"] = expected.EnableUIViewControllerTracing.ToString(),
+                ["EnableUserInteractionTracing"] = expected.EnableUserInteractionTracing.ToString(),
+                ["EnableCocoaSdkTracing"] = expected.EnableCocoaSdkTracing.ToString(),
+            }).Build();
+        var bindable = new BindableSentryOptions.IosOptions();
+        var actual = new SentryOptions.IosOptions(new SentryOptions());
+
+        // Act
+        config.Bind(bindable);
+        bindable.ApplyTo(actual);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            actual.AttachScreenshot.Should().Be(expected.AttachScreenshot);
+            actual.AppHangTimeoutInterval.Should().Be(expected.AppHangTimeoutInterval);
+            actual.IdleTimeout.Should().Be(expected.IdleTimeout);
+            actual.EnableAppHangTracking.Should().Be(expected.EnableAppHangTracking);
+            actual.EnableAutoBreadcrumbTracking.Should().Be(expected.EnableAutoBreadcrumbTracking);
+            actual.EnableAutoPerformanceTracing.Should().Be(expected.EnableAutoPerformanceTracing);
+            actual.EnableCoreDataTracing.Should().Be(expected.EnableCoreDataTracing);
+            actual.EnableFileIOTracing.Should().Be(expected.EnableFileIOTracing);
+            actual.EnableNetworkBreadcrumbs.Should().Be(expected.EnableNetworkBreadcrumbs);
+            actual.EnableNetworkTracking.Should().Be(expected.EnableNetworkTracking);
+            actual.EnableWatchdogTerminationTracking.Should().Be(expected.EnableWatchdogTerminationTracking);
+            actual.EnableSwizzling.Should().Be(expected.EnableSwizzling);
+            actual.EnableUIViewControllerTracing.Should().Be(expected.EnableUIViewControllerTracing);
+            actual.EnableUserInteractionTracing.Should().Be(expected.EnableUserInteractionTracing);
+            actual.EnableCocoaSdkTracing.Should().Be(expected.EnableCocoaSdkTracing);
+        }
+    }
+#endif
+}

--- a/test/Sentry.Tests/Platforms/iOS/BindableSentryOptionsTests.cs
+++ b/test/Sentry.Tests/Platforms/iOS/BindableSentryOptionsTests.cs
@@ -8,7 +8,6 @@ public class BindableSentryOptionsTests
     [SkippableFact]
     public void ApplyTo_SetsiOSOptionsFromConfig()
     {
-        Skip.If(true,"I couldn't work out how to get this test to run");
         var expected = new SentryOptions.IosOptions(new SentryOptions())
         {
             AttachScreenshot = true,

--- a/test/Sentry.Tests/Sentry.Tests.csproj
+++ b/test/Sentry.Tests/Sentry.Tests.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Sentry.Tests/Sentry.Tests.csproj
+++ b/test/Sentry.Tests/Sentry.Tests.csproj
@@ -39,4 +39,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
#skip-changelog

This change shouldn't impact SDK users at all.

## Configure the new source generators

Adding the new source generators is simple enough - we can put something like the following in the respective `*.csproj` files (simplified somewhat):
```
  <PropertyGroup Condition="'$(FrameworkSupportsAot)' == 'true'">
    <IsAotCompatible>true</IsAotCompatible>
    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
  </PropertyGroup>

  ...

  <ItemGroup Condition="$(IfItsNotAlreadyIncludedAndFrameworkSupportsAot)">
    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0-rc.2.23479.6" />
  </ItemGroup>
```

## Remove `ConfigureFromConfigurationOptions` classes

We then need to remove the `ConfigureFromConfigurationOptions<TOptions>` classes we're using:
https://github.com/getsentry/sentry-dotnet/blob/3d0eb8b9762d88d81eeae9f9f1a3487ca8112e01/src/Sentry.Extensions.Logging/SentryLoggingOptionsSetup.cs#L6-L12

These aren't actually doing much. The `SentryLoggingOptionsSetup` here gets an `ILoggerProviderConfiguration` via dependency injection and uses that for the configuration binding. We can do the same with:
https://github.com/getsentry/sentry-dotnet/blob/9f616f16c6d14c80101a105ba95950a99208af15/src/Sentry.Extensions.Logging/SentryLoggingOptionsSetup.cs#L11-L26

At that point however, we get a bunch of [SYSLIB1100 and SYSLIB1101 errors](https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib1100-1118), because the configuration binding source generators don't know how to handle lots of the members of the `SentryOptions` class. It struggles with custom types like `SubstringOrRegex`, it fails completely with members of type `Func` or `Action` and even then, it creates code with a bunch of nullability warnings. In the technical spikes we did, we couldn't overcome any of these when binding to the `SentryOptions` type. 

## Solution

The workaround that is used in this PR is to create a much simpler `BindableSentryOptions` class that won't trip up the configuration binding source generators . This class uses nullable primitives like `string?` instead of `SubstringOrRegexPattern` and then takes care of any conversions from those string values to the more complex types we actually use, when applying that `BindableSentryOptions` type to the actual `SentryOptions`. 

https://github.com/getsentry/sentry-dotnet/blob/8ca7fd7640a2bfbcd4caac33ec466ea3cf6894f4/src/Sentry.Extensions.Logging/SentryLoggingOptionsSetup.cs#L8-L26

### For posterity

Some discussions kicked off in the dotnet/runtime repo:
* https://github.com/dotnet/runtime/discussions/94651
* https://github.com/dotnet/runtime/discussions/94686

Issues that are relevant to alternative potential solutions in the future:
* https://github.com/dotnet/runtime/issues/83599
* https://github.com/dotnet/runtime/issues/94105