### PR TITLE
fix: Support for CaptureFailedRequests on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2213)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.21.2...2.21.3)
 
+### Fixes
+
+ - Fixed CaptureFailedRequests and FailedRequestStatusCodes not affecting the Cocoa layer ([#2744](https://github.com/getsentry/sentry-dotnet/issues/2744))
+
+
 ## 3.41.0
 
 - Speed up SDK init ([#2784](https://github.com/getsentry/sentry-dotnet/pull/2784))

--- a/src/Sentry/Platforms/iOS/SentrySdk.cs
+++ b/src/Sentry/Platforms/iOS/SentrySdk.cs
@@ -27,6 +27,8 @@ public static partial class SentrySdk
         cocoaOptions.DiagnosticLevel = options.DiagnosticLevel.ToCocoaSentryLevel();
         cocoaOptions.Dsn = options.Dsn;
         cocoaOptions.EnableAutoSessionTracking = options.AutoSessionTracking;
+        cocoaOptions.EnableCaptureFailedRequests = options.CaptureFailedRequests;
+        cocoaOptions.FailedRequestStatusCodes = GetFailedRequestStatusCodes(options.FailedRequestStatusCodes);
         cocoaOptions.MaxAttachmentSize = (nuint) options.MaxAttachmentSize;
         cocoaOptions.MaxBreadcrumbs = (nuint) options.MaxBreadcrumbs;
         cocoaOptions.MaxCacheItems = (nuint) options.MaxCacheItems;
@@ -201,4 +203,16 @@ public static partial class SentrySdk
     private static string GetDefaultDistributionString() => GetBundleValue("CFBundleVersion");
 
     private static string GetBundleValue(string key) => NSBundle.MainBundle.ObjectForInfoDictionary(key).ToString();
+
+    private static CocoaSdk.SentryHttpStatusCodeRange[] GetFailedRequestStatusCodes(IList<HttpStatusCodeRange> httpStatusCodeRanges)
+    {
+        var nativeRanges = new CocoaSdk.SentryHttpStatusCodeRange[httpStatusCodeRanges.Count];
+        for (var i = 0; i < httpStatusCodeRanges.Count; i++)
+        {
+            var range = httpStatusCodeRanges[i];
+            nativeRanges[i] = new CocoaSdk.SentryHttpStatusCodeRange(range.Start, range.End);
+        }
+
+        return nativeRanges;
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/2744

Setting either `CaptureFailedRequests` or `FailedRequestStatusCodes` previously only affected the .NET layer and was not passed to sentry-cocoa.

In production, this meant that failed requests were being tracked despite the setting being set to false in the .NET layer, which quickly added up in tracked errors on a hosted Sentry plan. This PR ensures we pass this value at init, and properly support failed status code ranges.