### PR TITLE
fix: Propagate `merge_target` to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,4 @@ jobs:
         with:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
+          merge_target: ${{ github.event.inputs.merge_target }}


### PR DESCRIPTION
#skip-changelog