### PR TITLE
fix: NativeAOT inApp setting

### DIFF
--- a/integration-test/runtime.Tests.ps1
+++ b/integration-test/runtime.Tests.ps1
@@ -81,7 +81,7 @@ internal class FakeTransport : ITransport
     }
 
     It "sends stack trace native addresses" {
-        runConsoleApp | Should -AnyElementMatch '"stacktrace":{"frames":\[{"in_app":true,"image_addr":"0x[a-f0-9]+","instruction_addr":"0x[a-f0-9]+"}'
+        runConsoleApp | Should -AnyElementMatch '"stacktrace":{"frames":\[{"image_addr":"0x[a-f0-9]+","instruction_addr":"0x[a-f0-9]+"}'
     }
 
     It "publish directory contains expected files" {

--- a/src/Sentry/SentryStackFrame.cs
+++ b/src/Sentry/SentryStackFrame.cs
@@ -182,7 +182,7 @@ public sealed class SentryStackFrame : IJsonSerializable
         {
             ConfigureAppFrame(options, Function, mustIncludeSeparator: true);
         }
-        else
+        else if (ImageAddress is null or 0 && InstructionAddress is null or 0) // Leave InApp=null on NativeAOT
         {
             InApp = true;
         }

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
@@ -213,4 +213,36 @@ public class SentryStackFrameTests
         // Assert
         Assert.True(sut.InApp, "InApp started as true but ConfigureAppFrame changed it to false.");
     }
+
+    [Fact]
+    public void ConfigureAppFrame_NativeAOTWithoutMethodInfo_InAppIsNull()
+    {
+        // See values set by TryCreateNativeAOTFrame
+        var sut = new SentryStackFrame
+        {
+            ImageAddress = 1,
+            InstructionAddress = 2
+        };
+
+        // Act
+        sut.ConfigureAppFrame(new());
+
+        // Assert
+        Assert.Null(sut.InApp);
+    }
+
+    [Fact]
+    public void ConfigureAppFrame_NativeAOTWithoutMethodInfo_InAppIsSet()
+    {
+        var sut = DebugStackTrace.ParseNativeAOTToString(
+            "System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task) + 0x42 at offset 66 in file:line:column <filename unknown>:0:0");
+        sut.ConfigureAppFrame(new());
+        Assert.False(sut.InApp);
+
+        sut = DebugStackTrace.ParseNativeAOTToString(
+            "Program.<<Main>$>d__0.MoveNext() + 0xdd at offset 221 in file:line:column <filename unknown>:0:0");
+        sut.ConfigureAppFrame(new());
+        Assert.True(sut.InApp);
+    }
+
 }


### PR DESCRIPTION
closes #2817 

#skip-changelog the original code hasn't been released yet (outside of alpha)