### PR TITLE
ci: cache supplemental build

### DIFF
--- a/.github/actions/buildnative/action.yml
+++ b/.github/actions/buildnative/action.yml
@@ -9,26 +9,39 @@ runs:
       shell: bash
       run: echo "JAVA_HOME_11=$JAVA_HOME_11_X64" >> $GITHUB_ENV
 
+    - uses: actions/cache@v3
+      id: cache-c
+      with:
+        path: lib/sentrysupplemental/bin
+        key: supplemental-c-${{ runner.os }}-${{ hashFiles('lib/sentrysupplemental/*.*') }}
+
     - name: Install Ninja
+      if: ${{ steps.cache-c.outputs.cache-hit != 'true' }}
       shell: bash
       run: ${{ runner.os == 'macOS' && 'brew install ninja' || runner.os == 'Windows' && 'choco install ninja' || 'sudo apt-get update && sudo apt-get install ninja-build' }}
 
     - name: Build C Project
-      if: runner.os == 'Linux' || runner.os == 'macOS'
+      if: ${{ steps.cache-c.outputs.cache-hit != 'true' && (runner.os == 'Linux' || runner.os == 'macOS') }}
       shell: bash
       run: lib/sentrysupplemental/build.sh
 
     - name: Build C Project
-      if: runner.os == 'Windows'
+      if: ${{ steps.cache-c.outputs.cache-hit != 'true' && runner.os == 'Windows' }}
       shell: cmd
       run: lib\sentrysupplemental\build.cmd
 
+    - uses: actions/cache@v3
+      id: cache-android
+      with:
+        path: lib/sentry-android-supplemental/bin
+        key: supplemental-android-${{ runner.os }}-${{ hashFiles('lib/sentry-android-supplemental/*.*') }}
+
     - name: Build Java Project
-      if: runner.os == 'Linux' || runner.os == 'macOS'
+      if: ${{ steps.cache-android.outputs.cache-hit != 'true' && runner.os == 'Linux' || runner.os == 'macOS' }}
       shell: bash
       run: lib/sentry-android-supplemental/build.sh
 
     - name: Build Java Project
-      if: runner.os == 'Windows'
+      if: ${{ steps.cache-android.outputs.cache-hit != 'true' && runner.os == 'Windows' }}
       shell: cmd
       run: lib\sentry-android-supplemental\build.cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,14 +84,6 @@ jobs:
           fail-on-cache-miss: true
           enableCrossOsArchive: true
 
-      - name: Rebuild Solution Filters
-        shell: pwsh
-        run: scripts/generate-solution-filters.ps1
-
-      - name: Ensure Solution Filters are up to date
-        shell: pwsh
-        run: scripts/dirty-check.ps1 -PathToCheck ./*.sln* -GuidanceOnFailure "Uncommitted changes to the solution filters detected. Run `scripts/generate-solution-filters.ps1` locally and commit changes."
-
       - name: Setup Environment
         uses: ./.github/actions/environment
 

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -10,7 +10,6 @@ rm -rf Carthage
 sdks=$(xcodebuild -showsdks)
 ios_sdk=$(echo "$sdks" | awk '/iOS SDKs/{getline; print $NF}')
 ios_simulator_sdk=$(echo "$sdks" | awk '/iOS Simulator SDKs/{getline; print $NF}')
-macos_sdk=$(echo "$sdks" | awk '/macOS SDKs/{getline; print $NF}')
 
 # Note - We keep the build output in separate directories so that .NET
 # bundles iOS with net6.0-ios and Mac Catalyst with net6.0-maccatalyst.


### PR DESCRIPTION
While I'm not convinced this stuff is needed to be separate binaries, at least it shouldn't slow down CI (on Windows it's sometimes slow) because it never changes.