### PR TITLE
fix: log only if transaction exists

### DIFF
--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -437,12 +437,12 @@ internal class Hub : IHubEx, IDisposable
             actualScope.LastEventId = id;
             actualScope.SessionUpdate = null;
 
-            if (evt.HasTerminalException())
+            if (evt.HasTerminalException() && actualScope.Transaction is transaction)
             {
                 // Event contains a terminal exception -> finish any current transaction as aborted
                 // Do this *after* the event was captured, so that the event is still linked to the transaction.
                 _options.LogDebug("Ending transaction as Aborted, due to unhandled exception.");
-                actualScope.Transaction?.Finish(SpanStatus.Aborted);
+                transaction.Finish(SpanStatus.Aborted);
             }
 
             return id;

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -437,7 +437,7 @@ internal class Hub : IHubEx, IDisposable
             actualScope.LastEventId = id;
             actualScope.SessionUpdate = null;
 
-            if (evt.HasTerminalException() && actualScope.Transaction is transaction)
+            if (evt.HasTerminalException() && actualScope.Transaction is { } transaction)
             {
                 // Event contains a terminal exception -> finish any current transaction as aborted
                 // Do this *after* the event was captured, so that the event is still linked to the transaction.


### PR DESCRIPTION
I see this on the log output:

```
  Debug: Ending transaction as Aborted, due to unhandled exception.
```

When no transaction is going on. Got me quite confused at first

#skip-changelog