### PR TITLE
remove ns2.1 from nlog

### DIFF
--- a/src/Sentry.NLog/Sentry.NLog.csproj
+++ b/src/Sentry.NLog/Sentry.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.0;net462</TargetFrameworks>
     <PackageTags>$(PackageTags);Logging;NLog</PackageTags>
     <Description>Official NLog integration for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
     <CLSCompliant>true</CLSCompliant>


### PR DESCRIPTION
#skip-changelog

Reasoning: https://github.com/getsentry/sentry-dotnet/pull/2852#discussion_r1398313425

I was hoping we would get rid of ns2.1 if we can, but avoid adding it to more libraries.
~It's fair that the lib supports it~ and so does the Sentry core SDK. But the package is fairly lower in terms of usage: [nugettrends.com/packages?months=72&ids=Sentry.NLog&ids=Sentry](https://nugettrends.com/packages?months=72&ids=Sentry.NLog&ids=Sentry)

NLog doesn't have a ns2.1 target: https://www.nuget.org/packages/NLog#dependencies-body-tab

And most people are updating their runtimes. .NET Standard 2.1 came to help bridge .NET Framework and .NET Core 3.1. We had .NET 5,6,7,8 now so hoping we can get rid of those netstandard

How about we remove this?