### PR TITLE
Removed ConfigureFromConfigurationOptions<SentryAspNetCoreOptions>

### DIFF
--- a/src/Sentry.AspNetCore/BindableSentryAspNetCoreOptions.cs
+++ b/src/Sentry.AspNetCore/BindableSentryAspNetCoreOptions.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Sentry.Extensibility;
+using Sentry.Extensions.Logging;
+
+#if NETSTANDARD2_0
+using IWebHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+#else
+using Microsoft.Extensions.Hosting;
+#endif
+
+namespace Sentry.AspNetCore;
+
+/// <inheritdoc cref="BindableSentryOptions"/>
+internal class BindableSentryAspNetCoreOptions : BindableSentryLoggingOptions
+{
+    public bool? IncludeActivityData { get; set; }
+    public RequestSize? MaxRequestBodySize { get; set; }
+    public bool? FlushOnCompletedRequest { get; set; }
+    public bool? FlushBeforeRequestCompleted { get; set; }
+    public bool? AdjustStandardEnvironmentNameCasing { get; set; }
+
+    public void ApplyTo(SentryAspNetCoreOptions options)
+    {
+        base.ApplyTo(options);
+        options.IncludeActivityData = IncludeActivityData ?? options.IncludeActivityData;
+        options.MaxRequestBodySize = MaxRequestBodySize ?? options.MaxRequestBodySize;
+        options.FlushOnCompletedRequest = FlushOnCompletedRequest ?? options.FlushOnCompletedRequest;
+        options.FlushBeforeRequestCompleted = FlushBeforeRequestCompleted ?? options.FlushBeforeRequestCompleted;
+        options.AdjustStandardEnvironmentNameCasing = AdjustStandardEnvironmentNameCasing ?? options.AdjustStandardEnvironmentNameCasing;
+    }
+}

--- a/src/Sentry.AspNetCore/Sentry.AspNetCore.csproj
+++ b/src/Sentry.AspNetCore/Sentry.AspNetCore.csproj
@@ -6,6 +6,11 @@
     <Description>Official ASP.NET Core integration for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(FrameworkSupportsAot)' == 'true'">
+    <IsAotCompatible>true</IsAotCompatible>
+    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
   </ItemGroup>
@@ -26,6 +31,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Options;
 using Sentry.Extensions.Logging;
@@ -13,6 +14,7 @@ namespace Sentry.AspNetCore;
 /// <summary>
 /// Sets up ASP.NET Core option for Sentry.
 /// </summary>
+#if NETSTANDARD2_0
 public class SentryAspNetCoreOptionsSetup : ConfigureFromConfigurationOptions<SentryAspNetCoreOptions>
 {
     /// <summary>
@@ -30,7 +32,53 @@ public class SentryAspNetCoreOptionsSetup : ConfigureFromConfigurationOptions<Se
     public override void Configure(SentryAspNetCoreOptions options)
     {
         base.Configure(options);
+        options.AddDiagnosticSourceIntegration();
+        options.DeduplicateUnhandledException();
+    }
+}
 
+#else
+public class SentryAspNetCoreOptionsSetup : IConfigureOptions<SentryAspNetCoreOptions>
+{
+    private readonly IConfiguration _config;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="SentryAspNetCoreOptionsSetup"/>.
+    /// </summary>
+    public SentryAspNetCoreOptionsSetup(ILoggerProviderConfiguration<SentryAspNetCoreLoggerProvider> providerConfiguration)
+        : this(providerConfiguration.Configuration)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="SentryAspNetCoreOptionsSetup"/>.
+    /// </summary>
+    internal SentryAspNetCoreOptionsSetup(IConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        _config = config;
+    }
+
+    /// <summary>
+    /// Configures the <see cref="SentryAspNetCoreOptions"/>.
+    /// </summary>
+    public void Configure(SentryAspNetCoreOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var bindable = new BindableSentryAspNetCoreOptions();
+        _config.Bind(bindable);
+        bindable.ApplyTo(options);
+
+        options.DeduplicateUnhandledException();
+    }
+}
+#endif
+
+internal static class SentryAspNetCoreOptionsExtensions
+{
+    internal static void DeduplicateUnhandledException(this SentryAspNetCoreOptions options)
+    {
         options.AddLogEntryFilter((category, _, eventId, _)
             // https://github.com/aspnet/KestrelHttpServer/blob/0aff4a0440c2f393c0b98e9046a8e66e30a56cb0/src/Kestrel.Core/Internal/Infrastructure/KestrelTrace.cs#L33
             // 13 = Application unhandled exception, which is captured by the middleware so the LogError of kestrel ends up as a duplicate with less info
@@ -39,9 +87,5 @@ public class SentryAspNetCoreOptionsSetup : ConfigureFromConfigurationOptions<Se
                    category,
                    "Microsoft.AspNetCore.Server.Kestrel",
                    StringComparison.Ordinal));
-
-#if NETSTANDARD2_0
-        options.AddDiagnosticSourceIntegration();
-#endif
     }
 }

--- a/src/Sentry.AspNetCore/SentryTunnelMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTunnelMiddleware.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Sentry.Internal.Extensions;
 
 namespace Sentry.AspNetCore;
 
@@ -70,10 +71,14 @@ public class SentryTunnelMiddleware : IMiddleware
 
         try
         {
-// TODO: temporary... we need to deserialize to a known type here
-#pragma warning disable IL2026, IL3050
+#if NETSTANDARD2_0
             var headerJson = JsonSerializer.Deserialize<Dictionary<string, object>>(header);
-#pragma warning restore IL2026, IL3050
+#else
+            var headerJson = JsonSerializer.Deserialize(
+                header,
+                SentryJsonContext.Default.DictionaryStringObject
+                );
+#endif
             if (headerJson == null)
             {
                 response.StatusCode = StatusCodes.Status400BadRequest;

--- a/src/Sentry.AspNetCore/SentryTunnelMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTunnelMiddleware.cs
@@ -70,7 +70,10 @@ public class SentryTunnelMiddleware : IMiddleware
 
         try
         {
+// TODO: temporary... we need to deserialize to a known type here
+#pragma warning disable IL2026, IL3050
             var headerJson = JsonSerializer.Deserialize<Dictionary<string, object>>(header);
+#pragma warning restore IL2026, IL3050
             if (headerJson == null)
             {
                 response.StatusCode = StatusCodes.Status400BadRequest;

--- a/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Configuration;
@@ -83,8 +84,13 @@ public static class SentryWebHostBuilderExtensions
             logging.AddConfiguration();
 
             var section = context.Configuration.GetSection("Sentry");
+#if NETSTANDARD2_0
             _ = logging.Services.Configure<SentryAspNetCoreOptions>(section);
-
+#else
+            _ = logging.Services.AddSingleton<IConfigureOptions<SentryAspNetCoreOptions>>(_ =>
+                new SentryAspNetCoreOptionsSetup(section)
+            );
+#endif
             _ = logging.Services
                 .AddSingleton<IConfigureOptions<SentryAspNetCoreOptions>, SentryAspNetCoreOptionsSetup>();
             _ = logging.Services.AddSingleton<ILoggerProvider, SentryAspNetCoreLoggerProvider>();

--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -887,6 +887,7 @@ internal static class JsonExtensions
 
 [JsonSerializable(typeof(GrowableArray<int>))]
 [JsonSerializable(typeof(Dictionary<string, bool>))]
+[JsonSerializable(typeof(Dictionary<string, object>))]
 internal partial class SentryJsonContext : JsonSerializerContext
 {
 }

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -58,10 +58,10 @@ namespace Sentry.AspNetCore
         public Sentry.Extensibility.RequestSize MaxRequestBodySize { get; set; }
         public Sentry.AspNetCore.TransactionNameProvider? TransactionNameProvider { get; set; }
     }
-    public class SentryAspNetCoreOptionsSetup : Microsoft.Extensions.Options.ConfigureFromConfigurationOptions<Sentry.AspNetCore.SentryAspNetCoreOptions>
+    public class SentryAspNetCoreOptionsSetup : Microsoft.Extensions.Options.IConfigureOptions<Sentry.AspNetCore.SentryAspNetCoreOptions>
     {
         public SentryAspNetCoreOptionsSetup(Microsoft.Extensions.Logging.Configuration.ILoggerProviderConfiguration<Sentry.AspNetCore.SentryAspNetCoreLoggerProvider> providerConfiguration) { }
-        public override void Configure(Sentry.AspNetCore.SentryAspNetCoreOptions options) { }
+        public void Configure(Sentry.AspNetCore.SentryAspNetCoreOptions options) { }
     }
     public static class SentryBuilderExtensions
     {

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -58,10 +58,10 @@ namespace Sentry.AspNetCore
         public Sentry.Extensibility.RequestSize MaxRequestBodySize { get; set; }
         public Sentry.AspNetCore.TransactionNameProvider? TransactionNameProvider { get; set; }
     }
-    public class SentryAspNetCoreOptionsSetup : Microsoft.Extensions.Options.ConfigureFromConfigurationOptions<Sentry.AspNetCore.SentryAspNetCoreOptions>
+    public class SentryAspNetCoreOptionsSetup : Microsoft.Extensions.Options.IConfigureOptions<Sentry.AspNetCore.SentryAspNetCoreOptions>
     {
         public SentryAspNetCoreOptionsSetup(Microsoft.Extensions.Logging.Configuration.ILoggerProviderConfiguration<Sentry.AspNetCore.SentryAspNetCoreLoggerProvider> providerConfiguration) { }
-        public override void Configure(Sentry.AspNetCore.SentryAspNetCoreOptions options) { }
+        public void Configure(Sentry.AspNetCore.SentryAspNetCoreOptions options) { }
     }
     public static class SentryBuilderExtensions
     {

--- a/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.AspNetCore.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -58,10 +58,10 @@ namespace Sentry.AspNetCore
         public Sentry.Extensibility.RequestSize MaxRequestBodySize { get; set; }
         public Sentry.AspNetCore.TransactionNameProvider? TransactionNameProvider { get; set; }
     }
-    public class SentryAspNetCoreOptionsSetup : Microsoft.Extensions.Options.ConfigureFromConfigurationOptions<Sentry.AspNetCore.SentryAspNetCoreOptions>
+    public class SentryAspNetCoreOptionsSetup : Microsoft.Extensions.Options.IConfigureOptions<Sentry.AspNetCore.SentryAspNetCoreOptions>
     {
         public SentryAspNetCoreOptionsSetup(Microsoft.Extensions.Logging.Configuration.ILoggerProviderConfiguration<Sentry.AspNetCore.SentryAspNetCoreLoggerProvider> providerConfiguration) { }
-        public override void Configure(Sentry.AspNetCore.SentryAspNetCoreOptions options) { }
+        public void Configure(Sentry.AspNetCore.SentryAspNetCoreOptions options) { }
     }
     public static class SentryBuilderExtensions
     {


### PR DESCRIPTION
#skip-changelog

Resolves https://github.com/getsentry/sentry-dotnet/issues/2846

This change should be transparent to users. We're using the new source generated configuration binders rather than the old reflection based ones, so that we can enable AOT for ASP.NET Core applications. 