### PR TITLE
fix: aspnetcore dependency

### DIFF
--- a/src/Sentry.AspNetCore/Sentry.AspNetCore.csproj
+++ b/src/Sentry.AspNetCore/Sentry.AspNetCore.csproj
@@ -31,6 +31,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <!-- <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+  </ItemGroup> -->
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/Sentry.AspNetCore/Sentry.AspNetCore.csproj
+++ b/src/Sentry.AspNetCore/Sentry.AspNetCore.csproj
@@ -33,10 +33,6 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <!-- <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-  </ItemGroup> -->
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
   </ItemGroup>


### PR DESCRIPTION
On `main` we don't have any dependencies, so this was introduced on net8.0:

https://github.com/getsentry/sentry-dotnet/blob/4d239a5156550b20b294e9b92968920f50f43240/src/Sentry.AspNetCore/Sentry.AspNetCore.csproj#L28

If that's the case, we don't need to add when running on net6.0/7.0.

If not, we should define the lowest version per TFM

#skip-changelog