### PR TITLE
Add Tests to ensure BindableOptions are consistent with Options

### DIFF
--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -734,7 +734,7 @@ public class SentryOptions
         internal set => _defaultTags = value;
     }
 
-/// <summary>
+    /// <summary>
     /// Indicates whether the performance feature is enabled, via any combination of
     /// <see cref="EnableTracing"/>, <see cref="TracesSampleRate"/>, or <see cref="TracesSampler"/>.
     /// </summary>

--- a/test/Sentry.AspNetCore.Tests/BindableSentryAspNetCoreOptionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/BindableSentryAspNetCoreOptionsTests.cs
@@ -1,0 +1,30 @@
+#if !NETFRAMEWORK
+using Microsoft.Extensions.Configuration;
+
+namespace Sentry.AspNetCore.Tests;
+
+public class BindableSentryAspNetCoreOptionsTests: BindableTests<SentryAspNetCoreOptions>
+{
+    [Fact]
+    public void BindableProperties_MatchOptionsProperties()
+    {
+        var actual = GetPropertyNames<BindableSentryAspNetCoreOptions>();
+        AssertContainsAllOptionsProperties(actual);
+    }
+
+    [Fact]
+    public void ApplyTo_SetsOptionsFromConfig()
+    {
+        // Arrange
+        var actual = new SentryAspNetCoreOptions();
+        var bindable = new BindableSentryAspNetCoreOptions();
+
+        // Act
+        Fixture.Config.Bind(bindable);
+        bindable.ApplyTo(actual);
+
+        // Assert
+        AssertContainsExpectedPropertyValues(actual);
+    }
+}
+#endif

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggingOptionsTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggingOptionsTests.cs
@@ -1,0 +1,31 @@
+#if !NETFRAMEWORK
+using Microsoft.Extensions.Configuration;
+
+namespace Sentry.Extensions.Logging.Tests;
+
+public class SentryLoggingOptionsTests : BindableTests<SentryLoggingOptions>
+{
+    [Fact]
+    public void BindableProperties_MatchOptionsProperties()
+    {
+        var propertyNames = GetPropertyNames<BindableSentryLoggingOptions>();
+        AssertContainsAllOptionsProperties(propertyNames);
+    }
+
+    [Fact]
+    public void ApplyTo_SetsOptionsFromConfig()
+    {
+        // Arrange
+        var actual = new SentryLoggingOptions();
+        var bindable = new BindableSentryLoggingOptions();
+
+        // Act
+        Fixture.Config.Bind(bindable);
+        bindable.ApplyTo(actual);
+
+        // Assert
+        AssertContainsExpectedPropertyValues(actual);
+    }
+}
+#endif
+

--- a/test/Sentry.Testing/BindableTests.cs
+++ b/test/Sentry.Testing/BindableTests.cs
@@ -23,12 +23,15 @@ public abstract class BindableTests<TOptions>
 
     protected TextFixture Fixture { get; } = new();
 
-    private static IEnumerable<PropertyInfo> GetBindableProperties()
+    protected virtual IEnumerable<string> SkipProperties => Enumerable.Empty<string>();
+
+    private IEnumerable<PropertyInfo> GetBindableProperties()
     {
         return typeof(TOptions).GetProperties()
             .Where(p =>
                 !p.PropertyType.IsSubclassOf(typeof(Delegate)) // Exclude delegate properties
                 && !p.PropertyType.IsInterface // Exclude interface properties
+                && !SkipProperties.Contains(p.Name) // Exclude any properties explicitly excluded by derived classes
 #if ANDROID
                 && !(p.PropertyType == typeof(SentryOptions.AndroidOptions)) // Exclude the Mobile sub-property
 #elif __IOS__

--- a/test/Sentry.Testing/BindableTests.cs
+++ b/test/Sentry.Testing/BindableTests.cs
@@ -1,0 +1,114 @@
+#if !NETFRAMEWORK
+using Microsoft.Extensions.Configuration;
+
+namespace Sentry.Testing;
+
+public abstract class BindableTests<TOptions>
+{
+    public class TextFixture
+    {
+        public IEnumerable<string> ExpectedPropertyNames => GetBindableProperties().Select(x => x.Name);
+        public List<KeyValuePair<PropertyInfo, object>> ExpectedPropertyValues { get; }
+
+        public IConfigurationRoot Config { get; }
+
+        public TextFixture()
+        {
+            ExpectedPropertyValues = GetBindableProperties().Select(GetDummyBindableValue).ToList();
+            Config = new ConfigurationBuilder()
+                .AddInMemoryCollection(ExpectedPropertyValues.SelectMany(ToConfigValues))
+                .Build();
+        }
+    }
+
+    protected TextFixture Fixture { get; } = new();
+
+    private static IEnumerable<PropertyInfo> GetBindableProperties()
+    {
+        return typeof(TOptions).GetProperties()
+            .Where(p =>
+                !p.PropertyType.IsSubclassOf(typeof(Delegate)) // Exclude delegate properties
+                && !p.PropertyType.IsInterface // Exclude interface properties
+                );
+    }
+
+    protected IEnumerable<string> GetPropertyNames<T>() => typeof(T).GetProperties().Select(x => x.Name).ToList();
+
+    private static KeyValuePair<PropertyInfo,object> GetDummyBindableValue(PropertyInfo propertyInfo)
+    {
+        var propertyType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? propertyInfo.PropertyType;
+        var value = propertyType switch
+        {
+            not null when propertyType == typeof(bool) => true,
+            not null when propertyType == typeof(string) => $"fake {propertyInfo.Name}",
+            not null when propertyType == typeof(int) => 7,
+            not null when propertyType == typeof(long) => 7,
+            not null when propertyType == typeof(float) => 0.3f,
+            not null when propertyType == typeof(double) => 0.6,
+            not null when propertyType == typeof(TimeSpan) => TimeSpan.FromSeconds(3),
+            not null when propertyType.IsEnum => GetNonDefaultEnumValue(propertyType),
+            not null when propertyType == typeof(Dictionary<string, string>) =>
+                new Dictionary<string, string>
+                {
+                    {$"key1", $"{propertyInfo.Name}value1"},
+                    {$"key2", $"{propertyInfo.Name}value2"}
+                },
+            _ => throw new NotSupportedException($"Unsupported property type on property {propertyInfo.Name}")
+        };
+        return new KeyValuePair<PropertyInfo,object>(propertyInfo, value);
+    }
+
+    private static IEnumerable<KeyValuePair<string, string>> ToConfigValues(KeyValuePair<PropertyInfo, object> item)
+    {
+        var (prop, value) = item;
+        var propertyType = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+        if (propertyType == typeof(Dictionary<string, string>))
+        {
+            foreach (var kvp in (Dictionary<string, string>)value)
+            {
+                yield return new KeyValuePair<string, string>($"{prop.Name}:{kvp.Key}", kvp.Value);
+            }
+        }
+        else
+        {
+            yield return new KeyValuePair<string, string>(prop.Name, value.ToString());
+        }
+    }
+
+    private static object GetNonDefaultEnumValue(Type enumType)
+    {
+        var enumValues = Enum.GetValues(enumType);
+        if (enumValues.Length > 1)
+        {
+            return enumValues.GetValue(1); // return second value
+        }
+        throw new InvalidOperationException("Enum has no non-default values");
+    }
+
+    protected void AssertContainsAllOptionsProperties(IEnumerable<string> actual)
+    {
+        var missing = Fixture.ExpectedPropertyNames.Where(x => !actual.Contains(x));
+
+        missing.Should().BeEmpty();
+    }
+
+    protected void AssertContainsExpectedPropertyValues(TOptions actual)
+    {
+        using (new AssertionScope())
+        {
+            foreach (var (prop, expectedValue) in Fixture.ExpectedPropertyValues)
+            {
+                var actualValue = actual.GetProperty(prop.Name);
+                if (prop.PropertyType == typeof(Dictionary<string, string>))
+                {
+                    actualValue.Should().BeEquivalentTo(expectedValue);
+                }
+                else
+                {
+                    actualValue.Should().Be(expectedValue);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/test/Sentry.Testing/BindableTests.cs
+++ b/test/Sentry.Testing/BindableTests.cs
@@ -29,6 +29,11 @@ public abstract class BindableTests<TOptions>
             .Where(p =>
                 !p.PropertyType.IsSubclassOf(typeof(Delegate)) // Exclude delegate properties
                 && !p.PropertyType.IsInterface // Exclude interface properties
+#if ANDROID
+                && !(p.PropertyType == typeof(SentryOptions.AndroidOptions)) // Exclude the Mobile sub-property
+#elif __IOS__
+                && !(p.PropertyType == typeof(SentryOptions.IosOptions)) // Exclude the Mobile sub-property
+#endif
                 );
     }
 

--- a/test/Sentry.Testing/Sentry.Testing.csproj
+++ b/test/Sentry.Testing/Sentry.Testing.csproj
@@ -22,4 +22,8 @@
     <InternalsVisibleTo Include="Sentry.Tests" PublicKey="$(SentryPublicKey)" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0" />
+  </ItemGroup>
+
 </Project>

--- a/test/Sentry.Tests/BindableSentryOptionsTests.cs
+++ b/test/Sentry.Tests/BindableSentryOptionsTests.cs
@@ -1,0 +1,30 @@
+#if !NETFRAMEWORK
+using Microsoft.Extensions.Configuration;
+
+namespace Sentry.Tests;
+
+public class BindableSentryOptionsTests : BindableTests<SentryOptions>
+{
+    [Fact]
+    public void BindableProperties_MatchOptionsProperties()
+    {
+        var actual = GetPropertyNames<BindableSentryOptions>();
+        AssertContainsAllOptionsProperties(actual);
+    }
+
+    [Fact]
+    public void ApplyTo_SetsOptionsFromConfig()
+    {
+        // Arrange
+        var actual = new SentryOptions();
+        var bindable = new BindableSentryOptions();
+
+        // Act
+        Fixture.Config.Bind(bindable);
+        bindable.ApplyTo(actual);
+
+        // Assert
+        AssertContainsExpectedPropertyValues(actual);
+    }
+}
+#endif

--- a/test/Sentry.Tests/Platforms/Android/BindableSentryOptionsTests.cs
+++ b/test/Sentry.Tests/Platforms/Android/BindableSentryOptionsTests.cs
@@ -5,7 +5,7 @@ namespace Sentry.Tests.Platforms.Android;
 public class BindableSentryOptionsTests
 {
 #if ANDROID
-    [SkippableFact]
+    [Fact]
     public void ApplyTo_SetsAndroidOptionsFromConfig()
     {
         var expected = new SentryOptions.AndroidOptions(new SentryOptions())

--- a/test/Sentry.Tests/Platforms/Android/BindableSentryOptionsTests.cs
+++ b/test/Sentry.Tests/Platforms/Android/BindableSentryOptionsTests.cs
@@ -1,98 +1,30 @@
+#if ANDROID
 using Microsoft.Extensions.Configuration;
 
 namespace Sentry.Tests.Platforms.Android;
 
-public class BindableSentryOptionsTests
+public class BindableSentryOptionsTests : BindableTests<SentryOptions.AndroidOptions>
 {
-#if ANDROID
     [Fact]
-    public void ApplyTo_SetsAndroidOptionsFromConfig()
+    public void BindableProperties_MatchOptionsProperties()
     {
-        var expected = new SentryOptions.AndroidOptions(new SentryOptions())
-        {
-            AnrEnabled = true,
-            AnrReportInDebug = true,
-            AnrTimeoutInterval = TimeSpan.FromSeconds(3),
-            AttachScreenshot = true,
-            EnableActivityLifecycleBreadcrumbs = true,
-            EnableAppComponentBreadcrumbs = true,
-            EnableAppLifecycleBreadcrumbs = true,
-            EnableRootCheck = true,
-            EnableSystemEventBreadcrumbs = true,
-            EnableUserInteractionBreadcrumbs = true,
-            EnableAutoActivityLifecycleTracing = true,
-            EnableActivityLifecycleTracingAutoFinish = true,
-            EnableUserInteractionTracing = true,
-            AttachThreads = true,
-            ConnectionTimeout = TimeSpan.FromSeconds(7),
-            EnableNdk = true,
-            EnableShutdownHook = true,
-            EnableUncaughtExceptionHandler = true,
-            PrintUncaughtStackTrace = true,
-            ReadTimeout = TimeSpan.FromSeconds(13),
-            EnableAndroidSdkTracing = true,
-            EnableAndroidSdkBeforeSend = true,
-        };
+        var actual = GetPropertyNames<BindableSentryOptions.AndroidOptions>();
+        AssertContainsAllOptionsProperties(actual);
+    }
 
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string>
-            {
-                ["AnrEnabled"] = expected.AnrEnabled.ToString(),
-                ["AnrReportInDebug"] = expected.AnrReportInDebug.ToString(),
-                ["AnrTimeoutInterval"] = expected.AnrTimeoutInterval.ToString(),
-                ["AttachScreenshot"] = expected.AttachScreenshot.ToString(),
-                ["EnableActivityLifecycleBreadcrumbs"] = expected.EnableActivityLifecycleBreadcrumbs.ToString(),
-                ["EnableAppComponentBreadcrumbs"] = expected.EnableAppComponentBreadcrumbs.ToString(),
-                ["EnableAppLifecycleBreadcrumbs"] = expected.EnableAppLifecycleBreadcrumbs.ToString(),
-                ["EnableRootCheck"] = expected.EnableRootCheck.ToString(),
-                ["EnableSystemEventBreadcrumbs"] = expected.EnableSystemEventBreadcrumbs.ToString(),
-                ["EnableUserInteractionBreadcrumbs"] = expected.EnableUserInteractionBreadcrumbs.ToString(),
-                ["EnableAutoActivityLifecycleTracing"] = expected.EnableAutoActivityLifecycleTracing.ToString(),
-                ["EnableActivityLifecycleTracingAutoFinish"] = expected.EnableActivityLifecycleTracingAutoFinish.ToString(),
-                ["EnableUserInteractionTracing"] = expected.EnableUserInteractionTracing.ToString(),
-                ["AttachThreads"] = expected.AttachThreads.ToString(),
-                ["ConnectionTimeout"] = expected.ConnectionTimeout.ToString(),
-                ["EnableNdk"] = expected.EnableNdk.ToString(),
-                ["EnableShutdownHook"] = expected.EnableShutdownHook.ToString(),
-                ["EnableUncaughtExceptionHandler"] = expected.EnableUncaughtExceptionHandler.ToString(),
-                ["PrintUncaughtStackTrace"] = expected.PrintUncaughtStackTrace.ToString(),
-                ["ReadTimeout"] = expected.ReadTimeout.ToString(),
-                ["EnableAndroidSdkTracing"] = expected.EnableAndroidSdkTracing.ToString(),
-                ["EnableAndroidSdkBeforeSend"] = expected.EnableAndroidSdkBeforeSend.ToString()
-            }).Build();
-        var bindable = new BindableSentryOptions.AndroidOptions();
+    [Fact]
+    public void ApplyTo_SetsOptionsFromConfig()
+    {
+        // Arrange
         var actual = new SentryOptions.AndroidOptions(new SentryOptions());
+        var bindable = new BindableSentryOptions.AndroidOptions();
 
         // Act
-        config.Bind(bindable);
+        Fixture.Config.Bind(bindable);
         bindable.ApplyTo(actual);
 
         // Assert
-        using (new AssertionScope())
-        {
-            actual.AnrEnabled.Should().Be(expected.AnrEnabled);
-            actual.AnrReportInDebug.Should().Be(expected.AnrReportInDebug);
-            actual.AnrTimeoutInterval.Should().Be(expected.AnrTimeoutInterval);
-            actual.AttachScreenshot.Should().Be(expected.AttachScreenshot);
-            actual.EnableActivityLifecycleBreadcrumbs.Should().Be(expected.EnableActivityLifecycleBreadcrumbs);
-            actual.EnableAppComponentBreadcrumbs.Should().Be(expected.EnableAppComponentBreadcrumbs);
-            actual.EnableAppLifecycleBreadcrumbs.Should().Be(expected.EnableAppLifecycleBreadcrumbs);
-            actual.EnableRootCheck.Should().Be(expected.EnableRootCheck);
-            actual.EnableSystemEventBreadcrumbs.Should().Be(expected.EnableSystemEventBreadcrumbs);
-            actual.EnableUserInteractionBreadcrumbs.Should().Be(expected.EnableUserInteractionBreadcrumbs);
-            actual.EnableAutoActivityLifecycleTracing.Should().Be(expected.EnableAutoActivityLifecycleTracing);
-            actual.EnableActivityLifecycleTracingAutoFinish.Should().Be(expected.EnableActivityLifecycleTracingAutoFinish);
-            actual.EnableUserInteractionTracing.Should().Be(expected.EnableUserInteractionTracing);
-            actual.AttachThreads.Should().Be(expected.AttachThreads);
-            actual.ConnectionTimeout.Should().Be(expected.ConnectionTimeout);
-            actual.EnableNdk.Should().Be(expected.EnableNdk);
-            actual.EnableShutdownHook.Should().Be(expected.EnableShutdownHook);
-            actual.EnableUncaughtExceptionHandler.Should().Be(expected.EnableUncaughtExceptionHandler);
-            actual.PrintUncaughtStackTrace.Should().Be(expected.PrintUncaughtStackTrace);
-            actual.ReadTimeout.Should().Be(expected.ReadTimeout);
-            actual.EnableAndroidSdkTracing.Should().Be(expected.EnableAndroidSdkTracing);
-            actual.EnableAndroidSdkBeforeSend.Should().Be(expected.EnableAndroidSdkBeforeSend);
-        }
+        AssertContainsExpectedPropertyValues(actual);
     }
-#endif
 }
+#endif

--- a/test/Sentry.Tests/Platforms/iOS/BindableSentryOptionsTests.cs
+++ b/test/Sentry.Tests/Platforms/iOS/BindableSentryOptionsTests.cs
@@ -5,8 +5,10 @@ namespace Sentry.Tests.Platforms.iOS;
 
 public class BindableSentryOptionsTests : BindableTests<SentryOptions.IosOptions>
 {
-    protected override IEnumerable<string> SkipProperties =>
-        new[] { nameof(SentryOptions.IosOptions.UrlSessionDelegate) };
+    public BindableSentryOptionsTests()
+    : base(nameof(SentryOptions.IosOptions.UrlSessionDelegate))
+    {
+    }
 
     [Fact]
     public void BindableProperties_MatchOptionsProperties()

--- a/test/Sentry.Tests/Platforms/iOS/BindableSentryOptionsTests.cs
+++ b/test/Sentry.Tests/Platforms/iOS/BindableSentryOptionsTests.cs
@@ -5,6 +5,9 @@ namespace Sentry.Tests.Platforms.iOS;
 
 public class BindableSentryOptionsTests : BindableTests<SentryOptions.IosOptions>
 {
+    protected override IEnumerable<string> SkipProperties =>
+        new[] { nameof(SentryOptions.IosOptions.UrlSessionDelegate) };
+
     [Fact]
     public void BindableProperties_MatchOptionsProperties()
     {

--- a/test/Sentry.Tests/Platforms/iOS/BindableSentryOptionsTests.cs
+++ b/test/Sentry.Tests/Platforms/iOS/BindableSentryOptionsTests.cs
@@ -1,77 +1,30 @@
+# if __IOS__
 using Microsoft.Extensions.Configuration;
 
 namespace Sentry.Tests.Platforms.iOS;
 
-public class BindableSentryOptionsTests
+public class BindableSentryOptionsTests : BindableTests<SentryOptions.IosOptions>
 {
-# if __IOS__
-    [SkippableFact]
-    public void ApplyTo_SetsiOSOptionsFromConfig()
+    [Fact]
+    public void BindableProperties_MatchOptionsProperties()
     {
-        var expected = new SentryOptions.IosOptions(new SentryOptions())
-        {
-            AttachScreenshot = true,
-            AppHangTimeoutInterval = TimeSpan.FromSeconds(3),
-            IdleTimeout = TimeSpan.FromSeconds(5),
-            EnableAppHangTracking = true,
-            EnableAutoBreadcrumbTracking = true,
-            EnableAutoPerformanceTracing = true,
-            EnableCoreDataTracing = true,
-            EnableFileIOTracing = true,
-            EnableNetworkBreadcrumbs = true,
-            EnableNetworkTracking = true,
-            EnableWatchdogTerminationTracking = true,
-            EnableSwizzling = true,
-            EnableUIViewControllerTracing = true,
-            EnableUserInteractionTracing = true,
-            EnableCocoaSdkTracing = true,
-        };
+        var actual = GetPropertyNames<BindableSentryOptions.IosOptions>();
+        AssertContainsAllOptionsProperties(actual);
+    }
 
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string>
-            {
-                ["AttachScreenshot"] = expected.AttachScreenshot.ToString(),
-                ["AppHangTimeoutInterval"] = expected.AppHangTimeoutInterval.ToString(),
-                ["IdleTimeout"] = expected.IdleTimeout.ToString(),
-                ["EnableAppHangTracking"] = expected.EnableAppHangTracking.ToString(),
-                ["EnableAutoBreadcrumbTracking"] = expected.EnableAutoBreadcrumbTracking.ToString(),
-                ["EnableAutoPerformanceTracing"] = expected.EnableAutoPerformanceTracing.ToString(),
-                ["EnableCoreDataTracing"] = expected.EnableCoreDataTracing.ToString(),
-                ["EnableFileIOTracing"] = expected.EnableFileIOTracing.ToString(),
-                ["EnableNetworkBreadcrumbs"] = expected.EnableNetworkBreadcrumbs.ToString(),
-                ["EnableNetworkTracking"] = expected.EnableNetworkTracking.ToString(),
-                ["EnableWatchdogTerminationTracking"] = expected.EnableWatchdogTerminationTracking.ToString(),
-                ["EnableSwizzling"] = expected.EnableSwizzling.ToString(),
-                ["EnableUIViewControllerTracing"] = expected.EnableUIViewControllerTracing.ToString(),
-                ["EnableUserInteractionTracing"] = expected.EnableUserInteractionTracing.ToString(),
-                ["EnableCocoaSdkTracing"] = expected.EnableCocoaSdkTracing.ToString(),
-            }).Build();
-        var bindable = new BindableSentryOptions.IosOptions();
+    [Fact]
+    public void ApplyTo_SetsOptionsFromConfig()
+    {
+        // Arrange
         var actual = new SentryOptions.IosOptions(new SentryOptions());
+        var bindable = new BindableSentryOptions.IosOptions();
 
         // Act
-        config.Bind(bindable);
+        Fixture.Config.Bind(bindable);
         bindable.ApplyTo(actual);
 
         // Assert
-        using (new AssertionScope())
-        {
-            actual.AttachScreenshot.Should().Be(expected.AttachScreenshot);
-            actual.AppHangTimeoutInterval.Should().Be(expected.AppHangTimeoutInterval);
-            actual.IdleTimeout.Should().Be(expected.IdleTimeout);
-            actual.EnableAppHangTracking.Should().Be(expected.EnableAppHangTracking);
-            actual.EnableAutoBreadcrumbTracking.Should().Be(expected.EnableAutoBreadcrumbTracking);
-            actual.EnableAutoPerformanceTracing.Should().Be(expected.EnableAutoPerformanceTracing);
-            actual.EnableCoreDataTracing.Should().Be(expected.EnableCoreDataTracing);
-            actual.EnableFileIOTracing.Should().Be(expected.EnableFileIOTracing);
-            actual.EnableNetworkBreadcrumbs.Should().Be(expected.EnableNetworkBreadcrumbs);
-            actual.EnableNetworkTracking.Should().Be(expected.EnableNetworkTracking);
-            actual.EnableWatchdogTerminationTracking.Should().Be(expected.EnableWatchdogTerminationTracking);
-            actual.EnableSwizzling.Should().Be(expected.EnableSwizzling);
-            actual.EnableUIViewControllerTracing.Should().Be(expected.EnableUIViewControllerTracing);
-            actual.EnableUserInteractionTracing.Should().Be(expected.EnableUserInteractionTracing);
-            actual.EnableCocoaSdkTracing.Should().Be(expected.EnableCocoaSdkTracing);
-        }
+        AssertContainsExpectedPropertyValues(actual);
     }
-#endif
 }
+#endif


### PR DESCRIPTION
#skip-changelog

Resolves https://github.com/getsentry/sentry-dotnet/issues/2872

I also added some reusable logic to test values get loaded from config and applied correctly to actual options classes by the bindingoptions classes... those tests are quite painful to write and maintain by hand otherwise. 