### PR TITLE
fix: Skipping package signing check during workload installation

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -43,7 +43,7 @@ runs:
           ${{ runner.os == 'macOS' && 'maui-ios maui-maccatalyst maui-windows maui-tizen' || '' }} \
           ${{ runner.os == 'Windows' && 'maui-windows' || '' }} \
           --temp-dir "${{ runner.temp }}" --from-rollback-file rollback.json \
-          -skip-sign-check
+          --skip-sign-check
 
     # We build Sentry.Maui for every supported MAUI target so we can access platform-specific features.
     # That includes Tizen. We don't need the entire Tizen SDK, but we do need the base Tizen workload.

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -42,7 +42,8 @@ runs:
           maui-android \
           ${{ runner.os == 'macOS' && 'maui-ios maui-maccatalyst maui-windows maui-tizen' || '' }} \
           ${{ runner.os == 'Windows' && 'maui-windows' || '' }} \
-          --temp-dir "${{ runner.temp }}" --from-rollback-file rollback.json
+          --temp-dir "${{ runner.temp }}" --from-rollback-file rollback.json \
+          -skip-sign-check
 
     # We build Sentry.Maui for every supported MAUI target so we can access platform-specific features.
     # That includes Tizen. We don't need the entire Tizen SDK, but we do need the base Tizen workload.


### PR DESCRIPTION
Apparently, this is the way to go: https://github.com/dotnet/maui/issues/9573#issuecomment-1224546639
#skip-changelog