### PR TITLE
Fixed `BG8403 Type-Name-Matches-Namespace-Name` warnings in Android Bindings

### DIFF
--- a/src/Sentry.Bindings.Android/Transforms/Metadata.xml
+++ b/src/Sentry.Bindings.Android/Transforms/Metadata.xml
@@ -26,7 +26,8 @@
   <attr path="/api/package[@name='io.sentry.android.ndk']" name="managedName">Sentry.JavaSdk.Android.Ndk</attr>
   <attr path="/api/package[@name='io.sentry.android.supplemental']" name="managedName">Sentry.JavaSdk.Android.Supplemental</attr>
   <attr path="/api/package[@name='io.sentry.cache']" name="managedName">Sentry.JavaSdk.Cache</attr>
-  <attr path="/api/package[@name='io.sentry.clientreport']" name="managedName">Sentry.JavaSdk.ClientReport</attr>
+  <!-- Renaming 'clientreport' to 'clientreports' (plural) as a workaround for typename matching namespace: io.sentry.clientreport.clientreport -->
+  <attr path="/api/package[@name='io.sentry.clientreport']" name="managedName">Sentry.JavaSdk.ClientReports</attr>
   <attr path="/api/package[@name='io.sentry.config']" name="managedName">Sentry.JavaSdk.Config</attr>
   <attr path="/api/package[@name='io.sentry.exception']" name="managedName">Sentry.JavaSdk.Exception</attr>
   <attr path="/api/package[@name='io.sentry.hints']" name="managedName">Sentry.JavaSdk.Hints</attr>


### PR DESCRIPTION
The Java SDK has `io.sentry.clientreport` as namespace that contains the type `clientreport`.
Based on the strategy to resolve such issues outlined [here](https://github.com/xamarin/java.interop/wiki/Warning-BG8403---Type-Name-Matches-Namespace-Name), I renamed the namespace to `clientreports` (plural).

Resolves:
`BINDINGSGENERATOR : warning BG8403: Type 'Sentry.JavaSdk.ClientReport.ClientReport' has a type name which matches the enclosing namespace name. See https://aka.ms/BG8403 for more information. [/Users/bitfox/Workspace/sentry-dotnet/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj]`

#skip-changelog