### PR TITLE
Mark profiling as alpha

### DIFF
--- a/src/Sentry.Profiling/Sentry.Profiling.csproj
+++ b/src/Sentry.Profiling/Sentry.Profiling.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- TODO check and update the list of supported frameworks. -->
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <VersionSuffix>-alpha.0</VersionSuffix>
     <PackageTags>$(PackageTags);Profiling;Diagnostic</PackageTags>
     <Description>Performance profiling support for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
   </PropertyGroup>


### PR DESCRIPTION
# Not to be merged before we're ready for 4.0.0 GA!

To avoid `4.0.0-beta.2-alpha.0` lets wait on merging this into 4.0.0 until we're ready to merge into `main` (release 4.0.0 without suffix)

#skip-changelog