### PR TITLE
delete global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-    "version": "7.0.100",
-    "rollForward": "latestMinor",
-    "allowPrerelease": false
-  }
-}


### PR DESCRIPTION
craft checks out the branch it publishes and pinning 7.0 fails because we already bumped 8.0 on it.

Removing global.json from main

https://github.com/getsentry/publish/actions/runs/6962570877/job/18946542580

#skip-changelog