### PR TITLE
Only set FrameworkSupportsAot for net8.0+

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -35,8 +35,8 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <!-- Only compile with IsAotCompatible on .NET 6.0 and later. Our Device Tests fail for net7.0-android with this enabled as well -->
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net7.0-android' AND $([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^(?!net5\.|net4\d{2}|netstandard)net\d+'))">
+  <!-- Only compile with IsAotCompatible on .NET 8.0 and later -->
+  <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', 'net8\.|net9\.|net\d{2,}\.'))">
     <FrameworkSupportsAot>true</FrameworkSupportsAot>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -37,6 +37,11 @@
 
   <!-- Only compile with IsAotCompatible on .NET 8.0 and later -->
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', 'net8\.|net9\.|net\d{2,}\.'))">
+    <!-- `FrameworkSupportsAot` is a custom property we use to centralise this logic for enabling `IsAotCompatible`. As
+    of very recently, this logic is fairly simple (net8.0 or later) but it's historically been more complex and very
+    volatile (as we learn more about the constraints of targeting AOT compilation). We may be able to remove this custom
+    property once we have confidence that this logic is unlikely to change again.
+    -->
     <FrameworkSupportsAot>true</FrameworkSupportsAot>
   </PropertyGroup>
 

--- a/src/Sentry.Extensions.Logging/Sentry.Extensions.Logging.csproj
+++ b/src/Sentry.Extensions.Logging/Sentry.Extensions.Logging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.0</TargetFrameworks>
     <PackageTags>$(PackageTags);Logging;Microsoft.Extensions.Logging</PackageTags>
     <Description>Official Microsoft.Extensions.Logging integration for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
   </PropertyGroup>
@@ -20,10 +20,13 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sentry.Extensions.Logging/Sentry.Extensions.Logging.csproj
+++ b/src/Sentry.Extensions.Logging/Sentry.Extensions.Logging.csproj
@@ -20,13 +20,15 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sentry.Extensions.Logging/SentryLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryLogger.cs
@@ -23,7 +23,12 @@ internal sealed class SentryLogger : ILogger
         _hub = hub;
     }
 
+#if NET8_0_OR_GREATER
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull
+        => _hub.PushScope(state);
+#else
     public IDisposable BeginScope<TState>(TState state) => _hub.PushScope(state);
+#endif
 
     public bool IsEnabled(LogLevel logLevel)
         => _hub.IsEnabled


### PR DESCRIPTION
#skip-changelog

Resolves https://github.com/getsentry/sentry-dotnet/issues/2886

No Changelog required as this is already consistent with our description for AOT support in the Changelog. 