### PR TITLE
chore: support NativeAOT only on net8+

### DIFF
--- a/integration-test/cli.Tests.ps1
+++ b/integration-test/cli.Tests.ps1
@@ -4,7 +4,6 @@ $ErrorActionPreference = 'Stop'
 . $PSScriptRoot/common.ps1
 
 Describe 'Console apps (<framework>) - normal build' -ForEach @(
-    @{ framework = "net7.0" },
     @{ framework = "net8.0" }
 ) {
     BeforeAll {
@@ -41,7 +40,6 @@ Describe 'Console apps (<framework>) - normal build' -ForEach @(
 }
 
 Describe 'Console apps (<framework>) - native AOT publish' -ForEach @(
-    @{ framework = "net7.0" },
     @{ framework = "net8.0" }
 ) {
     BeforeAll {
@@ -52,10 +50,10 @@ Describe 'Console apps (<framework>) - native AOT publish' -ForEach @(
         Remove-Item "./console-app/bin/Release/$framework/publish" -Recurse -ErrorAction SilentlyContinue
     }
 
-    It "uploads symbols and sources" -Skip:($IsMacOS -and $framework -eq 'net7.0') {
+    It "uploads symbols and sources" {
         $result = RunDotnetWithSentryCLI 'publish' 'console-app' $True $True $framework
         $result.ScriptOutput | Should -AnyElementMatch "Preparing upload to Sentry for project 'console-app'"
-        if ($IsWindows -or ($IsLinux -and $framework -eq 'net7.0'))
+        if ($IsWindows)
         {
             $extension = $IsLinux ? '' : '.pdb'
             $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @("console-app$extension")
@@ -73,10 +71,10 @@ Describe 'Console apps (<framework>) - native AOT publish' -ForEach @(
         }
     }
 
-    It "uploads symbols" -Skip:($IsMacOS -and $framework -eq 'net7.0') {
+    It "uploads symbols" {
         $result = RunDotnetWithSentryCLI 'publish' 'console-app' $True $False $framework
         $result.ScriptOutput | Should -AnyElementMatch "Preparing upload to Sentry for project 'console-app'"
-        if ($IsWindows -or ($IsLinux -and $framework -eq 'net7.0'))
+        if ($IsWindows)
         {
             $extension = $IsLinux ? '' : '.pdb'
             $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @("console-app$extension")
@@ -92,18 +90,18 @@ Describe 'Console apps (<framework>) - native AOT publish' -ForEach @(
         }
     }
 
-    It "uploads sources" -Skip:($IsMacOS -and $framework -eq 'net7.0') {
+    It "uploads sources" {
         $result = RunDotnetWithSentryCLI 'publish' 'console-app' $False $True $framework
         $result.ScriptOutput | Should -AnyElementMatch "Preparing upload to Sentry for project 'console-app'"
         $sourceBundle = 'console-app.src.zip'
-        if ($IsMacOS -or ($IsLinux -and $framework -eq 'net7.0'))
+        if ($IsMacOS)
         {
             $sourceBundle = 'console-app.src.zip'
         }
         $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @($sourceBundle)
     }
 
-    It "uploads nothing when disabled" -Skip:($IsMacOS -and $framework -eq 'net7.0') {
+    It "uploads nothing when disabled" {
         $result = RunDotnetWithSentryCLI 'publish' 'console-app' $False $False $framework
         $result.UploadedDebugFiles() | Should -BeNullOrEmpty
     }

--- a/integration-test/cli.Tests.ps1
+++ b/integration-test/cli.Tests.ps1
@@ -55,8 +55,7 @@ Describe 'Console apps (<framework>) - native AOT publish' -ForEach @(
         $result.ScriptOutput | Should -AnyElementMatch "Preparing upload to Sentry for project 'console-app'"
         if ($IsWindows)
         {
-            $extension = $IsLinux ? '' : '.pdb'
-            $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @("console-app$extension")
+            $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @("console-app.pdb")
             $result.ScriptOutput | Should -AnyElementMatch 'Found 1 debug information file'
             $result.ScriptOutput | Should -AnyElementMatch 'Resolved source code for 1 debug information file'
         }
@@ -76,8 +75,7 @@ Describe 'Console apps (<framework>) - native AOT publish' -ForEach @(
         $result.ScriptOutput | Should -AnyElementMatch "Preparing upload to Sentry for project 'console-app'"
         if ($IsWindows)
         {
-            $extension = $IsLinux ? '' : '.pdb'
-            $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @("console-app$extension")
+            $result.UploadedDebugFiles() | Sort-Object -Unique | Should -Be @("console-app.pdb")
             $result.ScriptOutput | Should -AnyElementMatch 'Found 1 debug information file'
         }
         else

--- a/integration-test/common.ps1
+++ b/integration-test/common.ps1
@@ -92,7 +92,7 @@ BeforeAll {
     New-Item -ItemType Directory -Path "$PSScriptRoot/packages" | Out-Null
     RegisterLocalPackage 'Sentry'
 
-    function RunDotnetWithSentryCLI([string] $action, [string]$project, [bool]$Symbols, [bool]$Sources, [string]$TargetFramework = 'net7.0')
+    function RunDotnetWithSentryCLI([string] $action, [string]$project, [bool]$Symbols, [bool]$Sources, [string]$TargetFramework)
     {
         $rootDir = $PSScriptRoot
 

--- a/src/Sentry/Internal/AotHelper.cs
+++ b/src/Sentry/Internal/AotHelper.cs
@@ -9,16 +9,17 @@ internal static class AotHelper
         public void Test() { }
     }
 
+#if NET8_0_OR_GREATER
     internal static bool IsNativeAot { get; }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = AotHelper.SuppressionJustification)]
     static AotHelper()
     {
-#if NET6_0_OR_GREATER   // TODO NET7 once we target it
         var stackTrace = new StackTrace(false);
         IsNativeAot = stackTrace.GetFrame(0)?.GetMethod() is null;
-#else
-        IsNativeAot = false;
-#endif
     }
+#else
+    // This is a compile-time const so that the irrelevant code is removed during compilation.
+    internal const bool IsNativeAot = false;
+#endif
 }

--- a/src/Sentry/Internal/DebugStackTrace.cs
+++ b/src/Sentry/Internal/DebugStackTrace.cs
@@ -17,7 +17,7 @@ internal class DebugStackTrace : SentryStackTrace
     private const int DebugImageMissing = -1;
     private bool _debugImagesMerged;
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private Dictionary<long, DebugImage>? _nativeDebugImages;
     private HashSet<long> _usedNativeDebugImages = new();
 #endif
@@ -222,7 +222,7 @@ internal class DebugStackTrace : SentryStackTrace
         }
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Native AOT implementation of CreateFrame.
     /// Native frames have only limited method information at runtime (and even that can be disabled).
@@ -364,7 +364,7 @@ internal class DebugStackTrace : SentryStackTrace
     internal SentryStackFrame? CreateFrame(IStackFrame stackFrame)
     {
         var frame = TryCreateManagedFrame(stackFrame);
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         frame ??= TryCreateNativeAOTFrame(stackFrame);
 #endif
         if (frame is null)
@@ -499,8 +499,10 @@ internal class DebugStackTrace : SentryStackTrace
     {
         if (AotHelper.IsNativeAot)
         {
+            #pragma warning disable 0162 // Unreachable code on old .NET frameworks
             assemblyName = null;
             return null;
+            #pragma warning restore 0162
         }
 
         assemblyName = module.FullyQualifiedName;

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -50,7 +50,9 @@ public class SentryClient : ISentryClient, IDisposable
         options.SetupLogging(); // Only relevant if this client wasn't created as a result of calling Init
 
         if (AotHelper.IsNativeAot) {
+            #pragma warning disable 0162 // Unreachable code on old .NET frameworks
             options.LogDebug("This looks like a NativeAOT application build.");
+            #pragma warning restore 0162
         } else {
             options.LogDebug("This looks like a standard JIT/AOT application build.");
         }

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -129,7 +129,8 @@
        While '_IsPublishing' looks a bit "private", it's also OK if it suddenly stops working and this step runs anyway.
        See https://github.com/dotnet/sdk/issues/26324#issuecomment-1169236993 -->
   <PropertyGroup Condition="
-      '$(PublishDir)' != ''
+      $(TargetFramework.StartsWith('net8'))
+      and '$(PublishDir)' != ''
       and '$(PublishAot)' == 'true'
       and '$(_IsPublishing)' == 'true'
       and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'ios'
@@ -138,8 +139,7 @@
     <SentryCLIUploadDirectory>$(PublishDir)</SentryCLIUploadDirectory>
     <!-- We must run after "_CopyAotSymbols" (not "Publish"), because that is the one that actually copies debug symbols to the publish directory. -->
     <!-- See also https://github.com/dotnet/runtime/blob/v8.0.0/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets#L100 -->
-    <SentryCLIUploadAfterTargets Condition="!$(TargetFramework.StartsWith('net7'))">_CopyAotSymbols</SentryCLIUploadAfterTargets>
-    <SentryCLIUploadAfterTargets Condition="$(TargetFramework.StartsWith('net7'))">CopyNativeBinary</SentryCLIUploadAfterTargets>
+    <SentryCLIUploadAfterTargets>_CopyAotSymbols</SentryCLIUploadAfterTargets>
   </PropertyGroup>
   <ItemGroup Condition="'$(SentryCLIUploadNativeAOT)' == 'true'">
     <SentryCLIUploadSymbolType Include="pdb" />

--- a/test/Sentry.Tests/Internals/DebugStackTraceTests.verify.cs
+++ b/test/Sentry.Tests/Internals/DebugStackTraceTests.verify.cs
@@ -192,7 +192,7 @@ public class DebugStackTraceTests
         }
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [Fact]
     public void ParseNativeAOTToString()
     {

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
@@ -231,7 +231,7 @@ public class SentryStackFrameTests
         Assert.Null(sut.InApp);
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [Fact]
     public void ConfigureAppFrame_NativeAOTWithoutMethodInfo_InAppIsSet()
     {

--- a/test/Sentry.Tests/SerializationTests.verify.cs
+++ b/test/Sentry.Tests/SerializationTests.verify.cs
@@ -1,4 +1,4 @@
-#if NET7_0_OR_GREATER
+#if NET6_0_OR_GREATER
 using System.Text.Json.Serialization.Metadata;
 #endif
 
@@ -22,7 +22,7 @@ public class SerializationTests
         await Verify(json).UseParameters(name);
     }
 
-#if NET7_0_OR_GREATER
+#if NET6_0_OR_GREATER
     internal class NestedStringClass { public string Value { get; set; } }
     internal class NestedIntClass { public int Value { get; set; } }
     internal class NestedNIntClass { public nint Value { get; set; } }
@@ -95,7 +95,7 @@ public class SerializationTests
     }
 }
 
-#if NET7_0_OR_GREATER
+#if NET6_0_OR_GREATER
 [JsonSerializable(typeof(SerializationTests.CustomObject))]
 [JsonSerializable(typeof(SerializationTests.NestedStringClass))]
 [JsonSerializable(typeof(SerializationTests.NestedIntClass))]

--- a/test/Sentry.Tests/SerializationTests.verify.cs
+++ b/test/Sentry.Tests/SerializationTests.verify.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 using System.Text.Json.Serialization.Metadata;
 #endif
 
@@ -22,7 +22,7 @@ public class SerializationTests
         await Verify(json).UseParameters(name);
     }
 
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
     internal class NestedStringClass { public string Value { get; set; } }
     internal class NestedIntClass { public int Value { get; set; } }
     internal class NestedNIntClass { public nint Value { get; set; } }
@@ -95,7 +95,7 @@ public class SerializationTests
     }
 }
 
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [JsonSerializable(typeof(SerializationTests.CustomObject))]
 [JsonSerializable(typeof(SerializationTests.NestedStringClass))]
 [JsonSerializable(typeof(SerializationTests.NestedIntClass))]


### PR DESCRIPTION
Follows up on #2889 getting rid of all the conditions to enable partial support of NativeAOT on net7. The support hasn't been out other than on a pre-release and .net7 is not an LTS release and it's unlikely many projects would choose to keep using it with NativeAOT now that net8 is out and improves it greatly. Also see discussions on #2886

#skip-changelog