### PR TITLE
Chore: .net8 native interop cleanups

### DIFF
--- a/src/Sentry/Platforms/Native/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/Sentry.Native.targets
@@ -13,6 +13,9 @@
     <SentryNativeOutputDirectory-linux-x64>$(SentryNativeOutputDirectory)$(NativeLibRelativePath-linux-x64)\</SentryNativeOutputDirectory-linux-x64>
     <NativeLibRelativePath-osx>osx</NativeLibRelativePath-osx>
     <SentryNativeOutputDirectory-osx>$(SentryNativeOutputDirectory)$(NativeLibRelativePath-osx)\</SentryNativeOutputDirectory-osx>
+    <SentryNativeBuildOutputs Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(SentryNativeOutputDirectory-win-x64)$(SentryNativeLibraryName).lib</SentryNativeBuildOutputs>
+    <SentryNativeBuildOutputs Condition="$([MSBuild]::IsOsPlatform('Linux'))">$(SentryNativeOutputDirectory-linux-x64)lib$(SentryNativeLibraryName).a</SentryNativeBuildOutputs>
+    <SentryNativeBuildOutputs Condition="$([MSBuild]::IsOsPlatform('OSX'))">$(SentryNativeOutputDirectory-osx)lib$(SentryNativeLibraryName).a</SentryNativeBuildOutputs>
   </PropertyGroup>
 
   <!-- Packaging -->
@@ -43,38 +46,19 @@
     </None>
   </ItemGroup>
 
-  <Target Name="CleanNativeSDK" BeforeTargets="CoreClean">
+  <Target Name="CleanNativeSDK" BeforeTargets="CoreClean" Condition="'$(TargetFramework)' == 'net8.0'">
     <Message Text="Inside Custom Clean" Importance="high"/>
     <RemoveDir Directories="$(SentryNativeOutputDirectory)" />
     <RemoveDir Directories="$(SentryNativeSourceDirectory)build" />
   </Target>
 
-  <!-- Build the Sentry Native SDK -->
-  <Target Name="_InnerBuildSentryNativeSDK">
+  <!-- Build the Sentry Native SDK (this only runs on local machines because in CI we expect the SDK to be
+       built already on each native platform and fetched for the final .net build. -->
+  <Target Name="_BuildSentryNativeSDK"
+    BeforeTargets="DispatchToInnerBuilds;BeforeBuild"
+    Condition="'$(TargetFramework)' == 'net8.0' and '$(CI)' != 'true'"
+    Inputs="$(SentryNativeBuildInputs)"
+    Outputs="$(SentryNativeBuildOutputs)">
     <Exec Command="pwsh $(SentryNativeBuildScript)" />
-  </Target>
-
-  <Target Name="_BuildSentryNativeSDK-win-x64"
-    BeforeTargets="DispatchToInnerBuilds;BeforeBuild"
-    Condition="'$(CI)' != 'true' and $([MSBuild]::IsOsPlatform('Windows'))"
-    Inputs="$(SentryNativeBuildInputs)"
-    Outputs="$(SentryNativeOutputDirectory-win-x64)$(SentryNativeLibraryName).lib">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="_InnerBuildSentryNativeSDK" Properties="TargetFramework=net6.0" />
-  </Target>
-
-  <Target Name="_BuildSentryNativeSDK-linux-x64"
-    BeforeTargets="DispatchToInnerBuilds;BeforeBuild"
-    Condition="'$(CI)' != 'true' and $([MSBuild]::IsOsPlatform('Linux'))"
-    Inputs="$(SentryNativeBuildInputs)"
-    Outputs="$(SentryNativeOutputDirectory-linux-x64)lib$(SentryNativeLibraryName).a">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="_InnerBuildSentryNativeSDK" Properties="TargetFramework=net6.0" />
-  </Target>
-
-  <Target Name="_BuildSentryNativeSDK-osx"
-    BeforeTargets="DispatchToInnerBuilds;BeforeBuild"
-    Condition="'$(CI)' != 'true' and $([MSBuild]::IsOsPlatform('OSX'))"
-    Inputs="$(SentryNativeBuildInputs)"
-    Outputs="$(SentryNativeOutputDirectory-osx)lib$(SentryNativeLibraryName).a">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="_InnerBuildSentryNativeSDK" Properties="TargetFramework=net6.0" />
   </Target>
 </Project>

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -1,5 +1,12 @@
+<!--
+  This is run during consumer build and:
+    - generates direct PInvoke
+    - links the native library statically
+  See https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/interop for more details.
+
+  Note:Target framework conditions should be kept synchronized with src/Sentry/buildTransitive/Sentry.Native.targets -->
 <Project>
-  <ItemGroup Condition="'$(OutputType)' == 'Exe' And '$(RuntimeIdentifier)' == 'win-x64'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8')) and '$(OutputType)' == 'Exe' And '$(RuntimeIdentifier)' == 'win-x64'">
     <!-- Generate direct PInvokes for Dependency -->
     <DirectPInvoke Include="sentry-native" />
 
@@ -8,7 +15,7 @@
     <NativeLibrary Include="dbghelp.lib" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(OutputType)' == 'Exe' And '$(RuntimeIdentifier)' == 'linux-x64'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8')) and '$(OutputType)' == 'Exe' And '$(RuntimeIdentifier)' == 'linux-x64'">
     <!-- Generate direct PInvokes for Dependency -->
     <DirectPInvoke Include="sentry-native" />
 
@@ -16,7 +23,7 @@
     <NativeLibrary Include="$(MSBuildThisFileDirectory)..\sentry-native\linux-x64\libsentry-native.a" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(OutputType)' == 'Exe' And ('$(RuntimeIdentifier)' == 'osx-x64' or '$(RuntimeIdentifier)' == 'osx-arm64')">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8')) and '$(OutputType)' == 'Exe' And ('$(RuntimeIdentifier)' == 'osx-x64' or '$(RuntimeIdentifier)' == 'osx-arm64')">
     <!-- Generate direct PInvokes for Dependency -->
     <DirectPInvoke Include="sentry-native" />
 

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -28,6 +28,11 @@
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
+  <!-- Only include Native bindings code on .NET 8 (non-mobile platforms) -->
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
+    <Compile Remove="**\Native\**\*" />
+  </ItemGroup>
+
   <!--
     Ben.Demystifier is compiled directly into Sentry.
     Note: It uses Microsoft.Bcl.AsyncInterfaces, which we get transitively from System.Text.Json.

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -126,8 +126,9 @@
   </Target>
 
   <!-- Native AOT publishing
-       While '_IsPublishing' looks a bit "private", it's also OK if it suddenly stops working and this step runs anyway.
-       See https://github.com/dotnet/sdk/issues/26324#issuecomment-1169236993 -->
+      Note 1: While '_IsPublishing' looks a bit "private", it's also OK if it suddenly stops working and this step runs anyway.
+              See https://github.com/dotnet/sdk/issues/26324#issuecomment-1169236993
+      Note 2: Target framework conditions should be kept synchronized with src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets -->
   <PropertyGroup Condition="
       $(TargetFramework.StartsWith('net8'))
       and '$(PublishDir)' != ''


### PR DESCRIPTION
* exclude native sources everywhere except  - we don't need to build/include them elsewhere
* clean up transitive builds to only reference native lib when needed.

#skip-changelog