### PR TITLE
Ignore UnobservedTaskException QUIC exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Ignore UnobservedTaskException for QUIC exceptions. See: https://github.com/dotnet/runtime/issues/80111 ([#2894](https://github.com/getsentry/sentry-dotnet/pull/2894))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.16.0 to v8.16.1 ([#2891](https://github.com/getsentry/sentry-dotnet/pull/2891))

--- a/src/Sentry/Integrations/UnobservedTaskExceptionIntegration.cs
+++ b/src/Sentry/Integrations/UnobservedTaskExceptionIntegration.cs
@@ -35,6 +35,15 @@ internal class UnobservedTaskExceptionIntegration : ISdkIntegration
         var ex = e.Exception!;
 #endif
 
+        // System.Net.Quic is leaking UnobservedTaskExceptions
+        // See: https://github.com/dotnet/runtime/issues/80111 . That will be fix maybe in net9.0
+#if NET7_0_OR_GREATER
+        if (ex.InnerExceptions.All(static exception => exception is System.Net.Quic.QuicException))
+        {
+            return;
+        }
+#endif
+
         ex.SetSentryMechanism(
             MechanismKey,
             "This exception was thrown from a task that was unobserved, such as from an async void method, or " +


### PR DESCRIPTION
### System.Net.Quick is leaking
See: https://github.com/dotnet/runtime/issues/80111

### Purpose of Changes
I make a lot of requests using HttpClient in my console application. This generates an `UnobservedTaskException` exceptions in Sentry because the  System.Net.Quick is leaking.

It seemed like a good idea to ignore these errors until they are fixed in the next version of net

### Screenshot
<img width="437" alt="image" src="https://github.com/getsentry/sentry-dotnet/assets/22912194/ee308e16-464d-4d7d-960f-789055c70f2b">
