### PR TITLE
fix: Sessions not getting finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- The SDK no longer fails to finish sessions while capturing an event. This fixes broken crash-free rates ([#2895](https://github.com/getsentry/sentry-dotnet/pull/2895))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.16.0 to v8.16.1 ([#2891](https://github.com/getsentry/sentry-dotnet/pull/2891))

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -47,9 +47,9 @@ internal class Hub : IHubEx, IDisposable
 
         _options = options;
         _randomValuesFactory = randomValuesFactory ?? new SynchronizedRandomValuesFactory();
-        _ownedClient = client ?? new SentryClient(options, randomValuesFactory: _randomValuesFactory);
-        _clock = clock ?? SystemClock.Clock;
         _sessionManager = sessionManager ?? new GlobalSessionManager(options);
+        _ownedClient = client ?? new SentryClient(options, randomValuesFactory: _randomValuesFactory, sessionManager: _sessionManager);
+        _clock = clock ?? SystemClock.Clock;
 
         ScopeManager = scopeManager ?? new SentryScopeManager(options, _ownedClient);
 

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -18,7 +18,7 @@ public partial class SentryClientTests
 
         public IBackgroundWorker BackgroundWorker { get; set; } = Substitute.For<IBackgroundWorker, IDisposable>();
         public IClientReportRecorder ClientReportRecorder { get; } = Substitute.For<IClientReportRecorder>();
-        public ISessionManager SessionManager { get; } = Substitute.For<ISessionManager>();
+        public ISessionManager SessionManager { get; set; } = Substitute.For<ISessionManager>();
 
         public Fixture()
         {
@@ -697,6 +697,47 @@ public partial class SentryClientTests
             "SampleRate"
         };
         processingOrder.Should().Equal(expectedOrder);
+    }
+
+    [Fact]
+    public void CaptureEvent_SessionRunningAndHasException_ReportsErrorButDoesNotEndSession()
+    {
+        _fixture.BackgroundWorker.EnqueueEnvelope(Arg.Do<Envelope>(envelope =>
+        {
+            var sessionItems = envelope.Items.Where(x => x.TryGetType() == "session");
+            foreach (var item in sessionItems)
+            {
+                var session = (SessionUpdate)((JsonSerializable)item.Payload).Source;
+                Assert.Equal(1, session.ErrorCount);
+                Assert.Null(session.EndStatus);
+            }
+        }));
+        _fixture.SessionManager = new GlobalSessionManager(_fixture.SentryOptions);
+        _fixture.SessionManager.StartSession();
+
+        _fixture.GetSut().CaptureEvent(new SentryEvent(new Exception("test exception")));
+    }
+
+    [Fact]
+    public void CaptureEvent_SessionRunningAndHasTerminalException_ReportsErrorAndEndsSessionAsCrashed()
+    {
+        _fixture.BackgroundWorker.EnqueueEnvelope(Arg.Do<Envelope>(envelope =>
+        {
+            var sessionItems = envelope.Items.Where(x => x.TryGetType() == "session");
+            foreach (var item in sessionItems)
+            {
+                var session = (SessionUpdate)((JsonSerializable)item.Payload).Source;
+                Assert.Equal(1, session.ErrorCount);
+                Assert.NotNull(session.EndStatus);
+                Assert.Equal(SessionEndStatus.Crashed, session.EndStatus);
+            }
+        }));
+        _fixture.SessionManager = new GlobalSessionManager(_fixture.SentryOptions);
+        _fixture.SessionManager.StartSession();
+
+        var exception = new Exception("test exception");
+        exception.SetSentryMechanism("test mechanism", handled: false);
+        _fixture.GetSut().CaptureEvent(new SentryEvent(exception));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/2863 and https://github.com/getsentry/sentry-dotnet/issues/2551

With https://github.com/getsentry/sentry-dotnet/pull/2496 we moved updating the session to the `client` to be able to align with the rest of the SDKs regarding the order of filtering and whether dropped events affect the session.

But we forgot to pass the `GlobalSessionManager` from the `hub` to the `client`. So both the `hub` and the `client` had their own `GlobalSessionManager`.

Ideally, I'd like to fix this properly by keeping the SessionManager solely on the `hub` and passing the session at the time down to the scope during capture instead of holding the state in the client. But with https://github.com/getsentry/rfcs/pull/122 on the horizon, this might be a waste of time and effort.