### PR TITLE
Made SentrySinkExtensions.ConfigureSentrySerilogOptions internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- SentrySinkExtensions.ConfigureSentrySerilogOptions is now internal. This change shouldn't impact SDK users as the method was likely only ever used for testing. ([#2902](https://github.com/getsentry/sentry-dotnet/pull/2902)) 
+
 ## 4.0.0-beta.2
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- SentrySinkExtensions.ConfigureSentrySerilogOptions is now internal. This change shouldn't impact SDK users as the method was likely only ever used for testing. ([#2902](https://github.com/getsentry/sentry-dotnet/pull/2902)) 
+- SentrySinkExtensions.ConfigureSentrySerilogOptions is now internal. If you were using this method, please use one of the `SentrySinkExtensions.Sentry` extension methods instead. ([#2902](https://github.com/getsentry/sentry-dotnet/pull/2902)) 
 
 ## 4.0.0-beta.2
 

--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -135,35 +135,7 @@ public static class SentrySinkExtensions
             defaultTags));
     }
 
-    /// <summary>
-    /// Configure the Sentry Serilog Sink.
-    /// </summary>
-    /// <param name="sentrySerilogOptions">The logger configuration to configure with the given parameters.</param>
-    /// <param name="dsn">The Sentry DSN. <seealso cref="SentryOptions.Dsn"/></param>
-    /// <param name="minimumEventLevel">Minimum log level to send an event. <seealso cref="SentrySerilogOptions.MinimumEventLevel"/></param>
-    /// <param name="minimumBreadcrumbLevel">Minimum log level to record a breadcrumb. <seealso cref="SentrySerilogOptions.MinimumBreadcrumbLevel"/></param>
-    /// <param name="formatProvider">The Serilog format provider. <seealso cref="IFormatProvider"/></param>
-    /// <param name="textFormatter">The Serilog text formatter. <seealso cref="ITextFormatter"/></param>
-    /// <param name="sendDefaultPii">Whether to include default Personal Identifiable information. <seealso cref="SentryOptions.SendDefaultPii"/></param>
-    /// <param name="isEnvironmentUser">Whether to report the <see cref="System.Environment.UserName"/> as the User affected in the event. <seealso cref="SentryOptions.IsEnvironmentUser"/></param>
-    /// <param name="serverName">Gets or sets the name of the server running the application. <seealso cref="SentryOptions.ServerName"/></param>
-    /// <param name="attachStackTrace">Whether to send the stack trace of a event captured without an exception. <seealso cref="SentryOptions.AttachStacktrace"/></param>
-    /// <param name="maxBreadcrumbs">Gets or sets the maximum breadcrumbs. <seealso cref="SentryOptions.MaxBreadcrumbs"/></param>
-    /// <param name="sampleRate">The rate to sample events. <seealso cref="SentryOptions.SampleRate"/></param>
-    /// <param name="release">The release version of the application. <seealso cref="SentryOptions.Release"/></param>
-    /// <param name="environment">The environment the application is running. <seealso cref="SentryOptions.Environment"/></param>
-    /// <param name="maxQueueItems">The maximum number of events to keep while the worker attempts to send them. <seealso cref="SentryOptions.MaxQueueItems"/></param>
-    /// <param name="shutdownTimeout">How long to wait for events to be sent before shutdown. <seealso cref="SentryOptions.ShutdownTimeout"/></param>
-    /// <param name="decompressionMethods">Decompression methods accepted. <seealso cref="SentryOptions.DecompressionMethods"/></param>
-    /// <param name="requestBodyCompressionLevel">The level of which to compress the <see cref="SentryEvent"/> before sending to Sentry. <seealso cref="SentryOptions.RequestBodyCompressionLevel"/></param>
-    /// <param name="requestBodyCompressionBuffered">Whether the body compression is buffered and the request 'Content-Length' known in advance. <seealso cref="SentryOptions.RequestBodyCompressionBuffered"/></param>
-    /// <param name="debug">Whether to log diagnostics messages. <seealso cref="SentryOptions.Debug"/></param>
-    /// <param name="diagnosticLevel">The diagnostics level to be used. <seealso cref="SentryOptions.DiagnosticLevel"/></param>
-    /// <param name="reportAssembliesMode">What mode to use for reporting referenced assemblies in each event sent to sentry. Defaults to <see cref="Sentry.ReportAssembliesMode.Version"/></param>
-    /// <param name="deduplicateMode">What modes to use for event automatic de-duplication. <seealso cref="SentryOptions.DeduplicateMode"/></param>
-    /// <param name="initializeSdk">Whether to initialize this SDK through this integration. <seealso cref="SentrySerilogOptions.InitializeSdk"/></param>
-    /// <param name="defaultTags">Defaults tags to add to all events. <seealso cref="SentryOptions.DefaultTags"/></param>
-    public static void ConfigureSentrySerilogOptions(
+    internal static void ConfigureSentrySerilogOptions(
         SentrySerilogOptions sentrySerilogOptions,
         string? dsn = null,
         LogEventLevel? minimumEventLevel = null,

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -15,32 +15,6 @@ namespace Serilog
 {
     public static class SentrySinkExtensions
     {
-        public static void ConfigureSentrySerilogOptions(
-                    Sentry.Serilog.SentrySerilogOptions sentrySerilogOptions,
-                    string? dsn = null,
-                    Serilog.Events.LogEventLevel? minimumEventLevel = default,
-                    Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default,
-                    System.IFormatProvider? formatProvider = null,
-                    Serilog.Formatting.ITextFormatter? textFormatter = null,
-                    bool? sendDefaultPii = default,
-                    bool? isEnvironmentUser = default,
-                    string? serverName = null,
-                    bool? attachStackTrace = default,
-                    int? maxBreadcrumbs = default,
-                    float? sampleRate = default,
-                    string? release = null,
-                    string? environment = null,
-                    int? maxQueueItems = default,
-                    System.TimeSpan? shutdownTimeout = default,
-                    System.Net.DecompressionMethods? decompressionMethods = default,
-                    System.IO.Compression.CompressionLevel? requestBodyCompressionLevel = default,
-                    bool? requestBodyCompressionBuffered = default,
-                    bool? debug = default,
-                    Sentry.SentryLevel? diagnosticLevel = default,
-                    Sentry.ReportAssembliesMode? reportAssembliesMode = default,
-                    Sentry.DeduplicateMode? deduplicateMode = default,
-                    bool? initializeSdk = default,
-                    System.Collections.Generic.Dictionary<string, string>? defaultTags = null) { }
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -15,32 +15,6 @@ namespace Serilog
 {
     public static class SentrySinkExtensions
     {
-        public static void ConfigureSentrySerilogOptions(
-                    Sentry.Serilog.SentrySerilogOptions sentrySerilogOptions,
-                    string? dsn = null,
-                    Serilog.Events.LogEventLevel? minimumEventLevel = default,
-                    Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default,
-                    System.IFormatProvider? formatProvider = null,
-                    Serilog.Formatting.ITextFormatter? textFormatter = null,
-                    bool? sendDefaultPii = default,
-                    bool? isEnvironmentUser = default,
-                    string? serverName = null,
-                    bool? attachStackTrace = default,
-                    int? maxBreadcrumbs = default,
-                    float? sampleRate = default,
-                    string? release = null,
-                    string? environment = null,
-                    int? maxQueueItems = default,
-                    System.TimeSpan? shutdownTimeout = default,
-                    System.Net.DecompressionMethods? decompressionMethods = default,
-                    System.IO.Compression.CompressionLevel? requestBodyCompressionLevel = default,
-                    bool? requestBodyCompressionBuffered = default,
-                    bool? debug = default,
-                    Sentry.SentryLevel? diagnosticLevel = default,
-                    Sentry.ReportAssembliesMode? reportAssembliesMode = default,
-                    Sentry.DeduplicateMode? deduplicateMode = default,
-                    bool? initializeSdk = default,
-                    System.Collections.Generic.Dictionary<string, string>? defaultTags = null) { }
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -15,32 +15,6 @@ namespace Serilog
 {
     public static class SentrySinkExtensions
     {
-        public static void ConfigureSentrySerilogOptions(
-                    Sentry.Serilog.SentrySerilogOptions sentrySerilogOptions,
-                    string? dsn = null,
-                    Serilog.Events.LogEventLevel? minimumEventLevel = default,
-                    Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default,
-                    System.IFormatProvider? formatProvider = null,
-                    Serilog.Formatting.ITextFormatter? textFormatter = null,
-                    bool? sendDefaultPii = default,
-                    bool? isEnvironmentUser = default,
-                    string? serverName = null,
-                    bool? attachStackTrace = default,
-                    int? maxBreadcrumbs = default,
-                    float? sampleRate = default,
-                    string? release = null,
-                    string? environment = null,
-                    int? maxQueueItems = default,
-                    System.TimeSpan? shutdownTimeout = default,
-                    System.Net.DecompressionMethods? decompressionMethods = default,
-                    System.IO.Compression.CompressionLevel? requestBodyCompressionLevel = default,
-                    bool? requestBodyCompressionBuffered = default,
-                    bool? debug = default,
-                    Sentry.SentryLevel? diagnosticLevel = default,
-                    Sentry.ReportAssembliesMode? reportAssembliesMode = default,
-                    Sentry.DeduplicateMode? deduplicateMode = default,
-                    bool? initializeSdk = default,
-                    System.Collections.Generic.Dictionary<string, string>? defaultTags = null) { }
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -15,32 +15,6 @@ namespace Serilog
 {
     public static class SentrySinkExtensions
     {
-        public static void ConfigureSentrySerilogOptions(
-                    Sentry.Serilog.SentrySerilogOptions sentrySerilogOptions,
-                    string? dsn = null,
-                    Serilog.Events.LogEventLevel? minimumEventLevel = default,
-                    Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default,
-                    System.IFormatProvider? formatProvider = null,
-                    Serilog.Formatting.ITextFormatter? textFormatter = null,
-                    bool? sendDefaultPii = default,
-                    bool? isEnvironmentUser = default,
-                    string? serverName = null,
-                    bool? attachStackTrace = default,
-                    int? maxBreadcrumbs = default,
-                    float? sampleRate = default,
-                    string? release = null,
-                    string? environment = null,
-                    int? maxQueueItems = default,
-                    System.TimeSpan? shutdownTimeout = default,
-                    System.Net.DecompressionMethods? decompressionMethods = default,
-                    System.IO.Compression.CompressionLevel? requestBodyCompressionLevel = default,
-                    bool? requestBodyCompressionBuffered = default,
-                    bool? debug = default,
-                    Sentry.SentryLevel? diagnosticLevel = default,
-                    Sentry.ReportAssembliesMode? reportAssembliesMode = default,
-                    Sentry.DeduplicateMode? deduplicateMode = default,
-                    bool? initializeSdk = default,
-                    System.Collections.Generic.Dictionary<string, string>? defaultTags = null) { }
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,


### PR DESCRIPTION
The first part of https://github.com/getsentry/sentry-dotnet/issues/2885 - just makes this internal so that later (when we have time post the 4.0.0 release) we can remove this and refactor the relevant unit tests. 

There are 3 extension methods in [this class](https://github.com/getsentry/sentry-dotnet/blob/b9ffcfff5dfe9a069ffe60b145219c705aedf11b/src/Sentry.Serilog/SentrySinkExtensions.cs). They're all variants to allow the SDK user to set one or more properties on the `SentrySerilogOptions`. 
1. The first method let's you pass each option as an argument/parameter to the extension method
2. The second method does the same but instead of passing the properties separately, you pass a `ConfigureSentrySerilogOptions` class that contains each of the properties as nullables (instead of optional named arguments)
3. The third method takes an `Action<SentrySerilogOptions>` so you can do whatever you want

There's nothing you can do with the first two methods that can't be done with the 3rd... Although it's maybe nice to be able to call `WriteTo().Sentry("mydsn")` instead of having to wrap that in an action, so I can see an argument for retaining No. 1 and No. 3. The second extension method does nothing useful... the only place it's used is in our unit tests (and we can easily refactor that code)