### PR TITLE
fix: Binding tests for all `singles`

### DIFF
--- a/test/Sentry.Testing/BindableTests.cs
+++ b/test/Sentry.Testing/BindableTests.cs
@@ -78,7 +78,7 @@ public abstract class BindableTests<TOptions>(params string[] skipProperties)
         }
         else
         {
-            yield return new KeyValuePair<string, string>(prop.Name, value.ToString());
+            yield return new KeyValuePair<string, string>(prop.Name, Convert.ToString(value, CultureInfo.InvariantCulture));
         }
     }
 


### PR DESCRIPTION
When running tests locally I kept bumping into errors regarding `0.3` not being the same as `0,3`. Fair enough, ToString(CultureInfo.InvariantCulture) it is!
@jamescrosswell is this something we should look out for in general and not just in tests?

```
System.InvalidOperationException: Failed to convert configuration value at 'SampleRate' to type 'System.Single'.

System.InvalidOperationException
Failed to convert configuration value at 'SampleRate' to type 'System.Single'.
   at Microsoft.Extensions.Configuration.ConfigurationBinder.BindInstance(Type type, Object instance, IConfiguration config, BinderOptions options)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.GetPropertyValue(PropertyInfo property, Object instance, IConfiguration config, BinderOptions options)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.BindProperty(PropertyInfo property, Object instance, IConfiguration config, BinderOptions options)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.BindNonScalar(IConfiguration configuration, Object instance, BinderOptions options)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.BindInstance(Type type, Object instance, IConfiguration config, BinderOptions options)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.Bind(IConfiguration configuration, Object instance, Action`1 configureOptions)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.Bind(IConfiguration configuration, Object instance)
   at Sentry.AspNetCore.Tests.BindableSentryAspNetCoreOptionsTests.ApplyTo_SetsOptionsFromConfig() in /Users/bitfox/Workspace/sentry-dotnet/test/Sentry.AspNetCore.Tests/BindableSentryAspNetCoreOptionsTests.cs:line 23

System.ArgumentException
0,3 is not a valid value for Single. (Parameter 'value')
   at System.ComponentModel.BaseNumberConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   at System.ComponentModel.TypeConverter.ConvertFromInvariantString(String text)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.TryConvertValue(Type type, String value, String path, Object& result, Exception& error)

System.FormatException
Input string was not in a correct format.
   at System.Number.ThrowOverflowOrFormatException(ParsingStatus status, TypeCode type)
   at System.Single.Parse(String s, NumberStyles style, IFormatProvider provider)
   at System.ComponentModel.SingleConverter.FromString(String value, NumberFormatInfo formatInfo)
   at System.ComponentModel.BaseNumberConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
```

#skip-changelog