### PR TITLE
fix: Making `AssemblyExtentions` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - `SentrySinkExtensions.ConfigureSentrySerilogOptions` is now internal, use one of the `SentrySinkExtensions.Sentry` extension methods instead. ([#2902](https://github.com/getsentry/sentry-dotnet/pull/2902))
 
+#### Changed APIs
+
+- `AssemblyExtensions` have been made public again. ([#2917](https://github.com/getsentry/sentry-dotnet/pull/2917))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.16.1 to v8.17.0 ([#2910](https://github.com/getsentry/sentry-dotnet/pull/2910))

--- a/src/Sentry/Reflection/AssemblyExtensions.cs
+++ b/src/Sentry/Reflection/AssemblyExtensions.cs
@@ -4,7 +4,7 @@ namespace Sentry.Reflection;
 /// Extension methods to <see cref="Assembly"/>.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
-internal static class AssemblyExtensions
+public static class AssemblyExtensions
 {
     /// <summary>
     /// Get the assemblies Name and Version.

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1688,6 +1688,13 @@ namespace Sentry.Protocol.Envelopes
         System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default);
     }
 }
+namespace Sentry.Reflection
+{
+    public static class AssemblyExtensions
+    {
+        public static Sentry.SdkVersion GetNameAndVersion(this System.Reflection.Assembly asm) { }
+    }
+}
 public static class SentryExceptionExtensions
 {
     public static void AddSentryContext(this System.Exception ex, string name, System.Collections.Generic.IReadOnlyDictionary<string, object> data) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1688,6 +1688,13 @@ namespace Sentry.Protocol.Envelopes
         System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default);
     }
 }
+namespace Sentry.Reflection
+{
+    public static class AssemblyExtensions
+    {
+        public static Sentry.SdkVersion GetNameAndVersion(this System.Reflection.Assembly asm) { }
+    }
+}
 public static class SentryExceptionExtensions
 {
     public static void AddSentryContext(this System.Exception ex, string name, System.Collections.Generic.IReadOnlyDictionary<string, object> data) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -1688,6 +1688,13 @@ namespace Sentry.Protocol.Envelopes
         System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default);
     }
 }
+namespace Sentry.Reflection
+{
+    public static class AssemblyExtensions
+    {
+        public static Sentry.SdkVersion GetNameAndVersion(this System.Reflection.Assembly asm) { }
+    }
+}
 public static class SentryExceptionExtensions
 {
     public static void AddSentryContext(this System.Exception ex, string name, System.Collections.Generic.IReadOnlyDictionary<string, object> data) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -1686,6 +1686,13 @@ namespace Sentry.Protocol.Envelopes
         System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default);
     }
 }
+namespace Sentry.Reflection
+{
+    public static class AssemblyExtensions
+    {
+        public static Sentry.SdkVersion GetNameAndVersion(this System.Reflection.Assembly asm) { }
+    }
+}
 public static class SentryExceptionExtensions
 {
     public static void AddSentryContext(this System.Exception ex, string name, System.Collections.Generic.IReadOnlyDictionary<string, object> data) { }


### PR DESCRIPTION
The Unity SDK relies on them.
https://github.com/getsentry/sentry-unity/blob/50ce016591d32813caf27803fe8f60f4fef6aab4/src/Sentry.Unity/Integrations/UnityScopeIntegration.cs#L12 

This is either a prompt to figure out a way to make internals visible to the Unity SDK, copy-pasta those 3 lines over, or to find a new way to get to the version.