### PR TITLE
Fixed Sentry SDK has not been initialised 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fixed Sentry SDK has not been initialised when using ASP.NET Core, Serilog and OpenTelemetry ([#2911](https://github.com/getsentry/sentry-dotnet/pull/2911))
+- Fixed Sentry SDK has not been initialised when using ASP.NET Core, Serilog and OpenTelemetry ([#2918](https://github.com/getsentry/sentry-dotnet/pull/2918))
 
 ## 3.41.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixed Sentry SDK has not been initialised when using ASP.NET Core, Serilog and OpenTelemetry ([#2911](https://github.com/getsentry/sentry-dotnet/pull/2911))
+
 ## 3.41.2
 
 ### Fixes

--- a/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -41,7 +41,8 @@ public static class TracerProviderBuilderExtensions
                 enrichers.Add(new AspNetCoreEnricher(userFactory));
             }
 
-            return new SentrySpanProcessor(SentrySdk.CurrentHub, enrichers);
+            var hub = services.GetRequiredService<IHub>();
+            return new SentrySpanProcessor(hub, enrichers);
         });
     }
 }


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/2738

Backporting to version 3.41. See https://github.com/getsentry/sentry-dotnet/pull/2911 for full details. 

#skip-changelog
There is actually a changelog... our Danger check doesn't seem to work here for some reason. 