### PR TITLE
Updated Sentry.Samples.AspNetCore.Serilog to work with .net6.0

### DIFF
--- a/samples/Sentry.Samples.AspNetCore.Serilog/appsettings.json
+++ b/samples/Sentry.Samples.AspNetCore.Serilog/appsettings.json
@@ -3,7 +3,7 @@
   // All Sentry settings can also be configured via code or environment variables:
   "Sentry": {
     // The DSN can also be set via environment variable
-    "Dsn": "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537",
+    "Dsn": "https://b887218a80114d26a9b1a51c5f88e0b4@o447951.ingest.sentry.io/6601807",
     // Enable Sentry tracing features
     "EnableTracing": true,
     // Opt-in for payload submission


### PR DESCRIPTION
#skip-changelog

`Sentry.Samples.AspNetCore.Serilog` probably hasn't worked since we upgraded it to .NET 6.0 in [this commit](https://github.com/getsentry/sentry-dotnet/commit/d6dc82ba6429b821e4f205a8354dbf1effa52abf).

It compiled, but when you tried to run it you'd get [this error](https://learn.microsoft.com/en-us/aspnet/core/diagnostics/asp0008?view=aspnetcore-8.0)... which is a bit cryptic but David Fowler explains how to update the project to work properly [here](https://learn.microsoft.com/en-us/aspnet/core/migration/50-to-60?view=aspnetcore-6.0&tabs=visual-studio#use-startup-with-the-new-minimal-hosting-model).  