### PR TITLE
Refactor ConfigureSentrySerilogOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### API breaking Changes
 
+- The method used to configure a Sentry Sink for Serilog now has an additional overload. Calling `WriteTo.Sentry()` with no arguments will no longer attempt to initialize the SDK (it has optional arguments to configure the behavrious of the Sink only). If you want to initialize Sentry at the same time you configure the Sentry Sink then you will need to use the overload of this method that accepts a DSN as the first parameter (e.g. `WriteTo.Sentry("https://d4d82fc1c2c4032a83f3a29aa3a3aff@fake-sentry.io:65535/2147483647")`). ([#2928](https://github.com/getsentry/sentry-dotnet/pull/2928))
+
 #### Removed APIs
 
 - SentrySinkExtensions.ConfigureSentrySerilogOptions is now internal. If you were using this method, please use one of the `SentrySinkExtensions.Sentry` extension methods instead. ([#2902](https://github.com/getsentry/sentry-dotnet/pull/2902)) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### API breaking Changes
 
-- The method used to configure a Sentry Sink for Serilog now has an additional overload. Calling `WriteTo.Sentry()` with no arguments will no longer attempt to initialize the SDK (it has optional arguments to configure the behavrious of the Sink only). If you want to initialize Sentry at the same time you configure the Sentry Sink then you will need to use the overload of this method that accepts a DSN as the first parameter (e.g. `WriteTo.Sentry("https://d4d82fc1c2c4032a83f3a29aa3a3aff@fake-sentry.io:65535/2147483647")`). ([#2928](https://github.com/getsentry/sentry-dotnet/pull/2928))
+- The method used to configure a Sentry Sink for Serilog now has an additional overload. Calling `WriteTo.Sentry()` with no arguments will no longer attempt to initialize the SDK (it has optional arguments to configure the behaviour of the Sink only). If you want to initialize Sentry at the same time you configure the Sentry Sink then you will need to use the overload of this method that accepts a DSN as the first parameter (e.g. `WriteTo.Sentry("https://d4d82fc1c2c4032a83f3a29aa3a3aff@fake-sentry.io:65535/2147483647")`). ([#2928](https://github.com/getsentry/sentry-dotnet/pull/2928))
 
 #### Removed APIs
 

--- a/src/Sentry.Serilog/SentrySerilogOptions.cs
+++ b/src/Sentry.Serilog/SentrySerilogOptions.cs
@@ -9,7 +9,7 @@ public class SentrySerilogOptions : SentryOptions
     /// <summary>
     /// Whether to initialize this SDK through this integration
     /// </summary>
-    internal bool InitializeSdk { get; set; } = true;
+    public bool InitializeSdk { get; set; } = true;
 
     /// <summary>
     /// Minimum log level to send an event.

--- a/src/Sentry.Serilog/SentrySerilogOptions.cs
+++ b/src/Sentry.Serilog/SentrySerilogOptions.cs
@@ -9,7 +9,7 @@ public class SentrySerilogOptions : SentryOptions
     /// <summary>
     /// Whether to initialize this SDK through this integration
     /// </summary>
-    public bool InitializeSdk { get; set; } = true;
+    internal bool InitializeSdk { get; set; } = true;
 
     /// <summary>
     /// Minimum log level to send an event.

--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -132,7 +132,11 @@ public static class SentrySinkExtensions
     }
 
     /// <summary>
-    /// Adds a Sentry Sink for Serilog.
+    /// <para>Adds a Sentry Sink for Serilog.</para>
+    /// <remarks>
+    /// Note this overload doesn't initialize Sentry for you, so you'll need to have already done so. Alternatively you
+    /// can use use the overload of this extension method, passing a DSN string in the first argument.
+    /// </remarks>
     /// </summary>
     /// <param name="loggerConfiguration">The logger configuration .<seealso cref="LoggerSinkConfiguration"/></param>
     /// <param name="minimumEventLevel">Minimum log level to send an event. <seealso cref="SentrySerilogOptions.MinimumEventLevel"/></param>
@@ -163,10 +167,10 @@ public static class SentrySinkExtensions
     /// </example>
     public static LoggerConfiguration Sentry(
         this LoggerSinkConfiguration loggerConfiguration,
-        LogEventLevel? minimumEventLevel,
-        LogEventLevel? minimumBreadcrumbLevel,
-        IFormatProvider? formatProvider,
-        ITextFormatter? textFormatter
+        LogEventLevel? minimumEventLevel = null,
+        LogEventLevel? minimumBreadcrumbLevel = null,
+        IFormatProvider? formatProvider = null,
+        ITextFormatter? textFormatter = null
         )
     {
         return loggerConfiguration.Sentry(o => ConfigureSentrySerilogOptions(o,

--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -207,40 +207,118 @@ public static class SentrySinkExtensions
         DeduplicateMode? deduplicateMode = null,
         Dictionary<string, string>? defaultTags = null)
     {
-        sentrySerilogOptions.Dsn = dsn ?? sentrySerilogOptions.Dsn;
-        sentrySerilogOptions.MinimumEventLevel = minimumEventLevel ?? sentrySerilogOptions.MinimumEventLevel;
-        sentrySerilogOptions.MinimumBreadcrumbLevel = minimumBreadcrumbLevel ?? sentrySerilogOptions.MinimumBreadcrumbLevel;
-        sentrySerilogOptions.FormatProvider = formatProvider ?? sentrySerilogOptions.FormatProvider;
-        sentrySerilogOptions.TextFormatter = textFormatter ?? sentrySerilogOptions.TextFormatter;
-        sentrySerilogOptions.SendDefaultPii = sendDefaultPii ?? sentrySerilogOptions.SendDefaultPii;
-        sentrySerilogOptions.IsEnvironmentUser = isEnvironmentUser ?? sentrySerilogOptions.IsEnvironmentUser;
+        if (dsn is not null)
+        {
+            sentrySerilogOptions.Dsn = dsn;
+        }
+
+        if (minimumEventLevel.HasValue)
+        {
+            sentrySerilogOptions.MinimumEventLevel = minimumEventLevel.Value;
+        }
+
+        if (minimumBreadcrumbLevel.HasValue)
+        {
+            sentrySerilogOptions.MinimumBreadcrumbLevel = minimumBreadcrumbLevel.Value;
+        }
+
+        if (formatProvider != null)
+        {
+            sentrySerilogOptions.FormatProvider = formatProvider;
+        }
+
+        if (textFormatter != null)
+        {
+            sentrySerilogOptions.TextFormatter = textFormatter;
+        }
+
+        if (sendDefaultPii.HasValue)
+        {
+            sentrySerilogOptions.SendDefaultPii = sendDefaultPii.Value;
+        }
+
+        if (isEnvironmentUser.HasValue)
+        {
+            sentrySerilogOptions.IsEnvironmentUser = isEnvironmentUser.Value;
+        }
+
         if (!string.IsNullOrWhiteSpace(serverName))
         {
             sentrySerilogOptions.ServerName = serverName;
         }
-        sentrySerilogOptions.AttachStacktrace = attachStackTrace ?? sentrySerilogOptions.AttachStacktrace;
-        sentrySerilogOptions.MaxBreadcrumbs = maxBreadcrumbs ?? sentrySerilogOptions.MaxBreadcrumbs;
-        sentrySerilogOptions.SampleRate = sampleRate ?? sentrySerilogOptions.SampleRate;
+
+        if (attachStackTrace.HasValue)
+        {
+            sentrySerilogOptions.AttachStacktrace = attachStackTrace.Value;
+        }
+
+        if (maxBreadcrumbs.HasValue)
+        {
+            sentrySerilogOptions.MaxBreadcrumbs = maxBreadcrumbs.Value;
+        }
+
+        if (sampleRate.HasValue)
+        {
+            sentrySerilogOptions.SampleRate = sampleRate;
+        }
+
         if (!string.IsNullOrWhiteSpace(release))
         {
             sentrySerilogOptions.Release = release;
         }
+
         if (!string.IsNullOrWhiteSpace(environment))
         {
             sentrySerilogOptions.Environment = environment;
         }
-        sentrySerilogOptions.MaxQueueItems = maxQueueItems ?? sentrySerilogOptions.MaxQueueItems;
-        sentrySerilogOptions.ShutdownTimeout = shutdownTimeout ?? sentrySerilogOptions.ShutdownTimeout;
-        sentrySerilogOptions.DecompressionMethods = decompressionMethods ?? sentrySerilogOptions.DecompressionMethods;
-        sentrySerilogOptions.RequestBodyCompressionLevel = requestBodyCompressionLevel ?? sentrySerilogOptions.RequestBodyCompressionLevel;
-        sentrySerilogOptions.RequestBodyCompressionBuffered = requestBodyCompressionBuffered ?? sentrySerilogOptions.RequestBodyCompressionBuffered;
-        sentrySerilogOptions.Debug = debug ?? sentrySerilogOptions.Debug;
-        sentrySerilogOptions.DiagnosticLevel = diagnosticLevel ?? sentrySerilogOptions.DiagnosticLevel;
-        sentrySerilogOptions.ReportAssembliesMode = reportAssembliesMode ?? sentrySerilogOptions.ReportAssembliesMode;
-        sentrySerilogOptions.DeduplicateMode = deduplicateMode ?? sentrySerilogOptions.DeduplicateMode;
+
+        if (maxQueueItems.HasValue)
+        {
+            sentrySerilogOptions.MaxQueueItems = maxQueueItems.Value;
+        }
+
+        if (shutdownTimeout.HasValue)
+        {
+            sentrySerilogOptions.ShutdownTimeout = shutdownTimeout.Value;
+        }
+
+        if (decompressionMethods.HasValue)
+        {
+            sentrySerilogOptions.DecompressionMethods = decompressionMethods.Value;
+        }
+
+        if (requestBodyCompressionLevel.HasValue)
+        {
+            sentrySerilogOptions.RequestBodyCompressionLevel = requestBodyCompressionLevel.Value;
+        }
+
+        if (requestBodyCompressionBuffered.HasValue)
+        {
+            sentrySerilogOptions.RequestBodyCompressionBuffered = requestBodyCompressionBuffered.Value;
+        }
+
+        if (debug.HasValue)
+        {
+            sentrySerilogOptions.Debug = debug.Value;
+        }
+
+        if (diagnosticLevel.HasValue)
+        {
+            sentrySerilogOptions.DiagnosticLevel = diagnosticLevel.Value;
+        }
+
+        if (reportAssembliesMode.HasValue)
+        {
+            sentrySerilogOptions.ReportAssembliesMode = reportAssembliesMode.Value;
+        }
+
+        if (deduplicateMode.HasValue)
+        {
+            sentrySerilogOptions.DeduplicateMode = deduplicateMode.Value;
+        }
 
         // Serilog-specific items
-        sentrySerilogOptions.InitializeSdk = dsn is not null;
+        sentrySerilogOptions.InitializeSdk = dsn is not null;  // Inferred from the Sentry overload that is used
         if (defaultTags?.Count > 0)
         {
             foreach (var tag in defaultTags)

--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -207,115 +207,28 @@ public static class SentrySinkExtensions
         DeduplicateMode? deduplicateMode = null,
         Dictionary<string, string>? defaultTags = null)
     {
-        if (dsn is not null)
-        {
-            sentrySerilogOptions.Dsn = dsn;
-        }
-
-        if (minimumEventLevel.HasValue)
-        {
-            sentrySerilogOptions.MinimumEventLevel = minimumEventLevel.Value;
-        }
-
-        if (minimumBreadcrumbLevel.HasValue)
-        {
-            sentrySerilogOptions.MinimumBreadcrumbLevel = minimumBreadcrumbLevel.Value;
-        }
-
-        if (formatProvider != null)
-        {
-            sentrySerilogOptions.FormatProvider = formatProvider;
-        }
-
-        if (textFormatter != null)
-        {
-            sentrySerilogOptions.TextFormatter = textFormatter;
-        }
-
-        if (sendDefaultPii.HasValue)
-        {
-            sentrySerilogOptions.SendDefaultPii = sendDefaultPii.Value;
-        }
-
-        if (isEnvironmentUser.HasValue)
-        {
-            sentrySerilogOptions.IsEnvironmentUser = isEnvironmentUser.Value;
-        }
-
-        if (!string.IsNullOrWhiteSpace(serverName))
-        {
-            sentrySerilogOptions.ServerName = serverName;
-        }
-
-        if (attachStackTrace.HasValue)
-        {
-            sentrySerilogOptions.AttachStacktrace = attachStackTrace.Value;
-        }
-
-        if (maxBreadcrumbs.HasValue)
-        {
-            sentrySerilogOptions.MaxBreadcrumbs = maxBreadcrumbs.Value;
-        }
-
-        if (sampleRate.HasValue)
-        {
-            sentrySerilogOptions.SampleRate = sampleRate;
-        }
-
-        if (!string.IsNullOrWhiteSpace(release))
-        {
-            sentrySerilogOptions.Release = release;
-        }
-
-        if (!string.IsNullOrWhiteSpace(environment))
-        {
-            sentrySerilogOptions.Environment = environment;
-        }
-
-        if (maxQueueItems.HasValue)
-        {
-            sentrySerilogOptions.MaxQueueItems = maxQueueItems.Value;
-        }
-
-        if (shutdownTimeout.HasValue)
-        {
-            sentrySerilogOptions.ShutdownTimeout = shutdownTimeout.Value;
-        }
-
-        if (decompressionMethods.HasValue)
-        {
-            sentrySerilogOptions.DecompressionMethods = decompressionMethods.Value;
-        }
-
-        if (requestBodyCompressionLevel.HasValue)
-        {
-            sentrySerilogOptions.RequestBodyCompressionLevel = requestBodyCompressionLevel.Value;
-        }
-
-        if (requestBodyCompressionBuffered.HasValue)
-        {
-            sentrySerilogOptions.RequestBodyCompressionBuffered = requestBodyCompressionBuffered.Value;
-        }
-
-        if (debug.HasValue)
-        {
-            sentrySerilogOptions.Debug = debug.Value;
-        }
-
-        if (diagnosticLevel.HasValue)
-        {
-            sentrySerilogOptions.DiagnosticLevel = diagnosticLevel.Value;
-        }
-
-        if (reportAssembliesMode.HasValue)
-        {
-            sentrySerilogOptions.ReportAssembliesMode = reportAssembliesMode.Value;
-        }
-
-        if (deduplicateMode.HasValue)
-        {
-            sentrySerilogOptions.DeduplicateMode = deduplicateMode.Value;
-        }
+        SetIfNotNull(dsn, value => sentrySerilogOptions.Dsn = value);
+        SetIfNotNull(minimumEventLevel, value => sentrySerilogOptions.MinimumEventLevel = value!.Value);
+        SetIfNotNull(minimumBreadcrumbLevel, value => sentrySerilogOptions.MinimumBreadcrumbLevel = value!.Value);
+        SetIfNotNull(formatProvider, value => sentrySerilogOptions.FormatProvider = value);
+        SetIfNotNull(textFormatter, value => sentrySerilogOptions.TextFormatter = value);
+        SetIfNotNull(sendDefaultPii, value => sentrySerilogOptions.SendDefaultPii = value!.Value);
+        SetIfNotNull(isEnvironmentUser, value => sentrySerilogOptions.IsEnvironmentUser = value!.Value);
+        SetIfNotNullOrWhitespace(serverName, value => sentrySerilogOptions.ServerName = value!);
+        SetIfNotNull(attachStackTrace, value => sentrySerilogOptions.AttachStacktrace = value!.Value);
+        SetIfNotNull(maxBreadcrumbs, value => sentrySerilogOptions.MaxBreadcrumbs = value!.Value);
+        SetIfNotNull(sampleRate, value => sentrySerilogOptions.SampleRate = value!);
+        SetIfNotNullOrWhitespace(release, value => sentrySerilogOptions.Release = value);
+        SetIfNotNullOrWhitespace(environment, value => sentrySerilogOptions.Environment = value);
+        SetIfNotNull(maxQueueItems, value => sentrySerilogOptions.MaxQueueItems = value!.Value);
+        SetIfNotNull(shutdownTimeout, value => sentrySerilogOptions.ShutdownTimeout = value!.Value);
+        SetIfNotNull(decompressionMethods, value => sentrySerilogOptions.DecompressionMethods = value!.Value);
+        SetIfNotNull(requestBodyCompressionLevel, value => sentrySerilogOptions.RequestBodyCompressionLevel = value!.Value);
+        SetIfNotNull(requestBodyCompressionBuffered, value => sentrySerilogOptions.RequestBodyCompressionBuffered = value!.Value);
+        SetIfNotNull(debug, value => sentrySerilogOptions.Debug = value!.Value);
+        SetIfNotNull(diagnosticLevel, value => sentrySerilogOptions.DiagnosticLevel = value!.Value);
+        SetIfNotNull(reportAssembliesMode, value => sentrySerilogOptions.ReportAssembliesMode = value!.Value);
+        SetIfNotNull(deduplicateMode, value => sentrySerilogOptions.DeduplicateMode = value!.Value);
 
         // Serilog-specific items
         sentrySerilogOptions.InitializeSdk = dsn is not null;  // Inferred from the Sentry overload that is used
@@ -324,6 +237,22 @@ public static class SentrySinkExtensions
             foreach (var tag in defaultTags)
             {
                 sentrySerilogOptions.DefaultTags.Add(tag.Key, tag.Value);
+            }
+        }
+
+        return;
+        static void SetIfNotNull<T>(T? value, Action<T> setter)
+        {
+            if (value is not null)
+            {
+                setter(value);
+            }
+        }
+        static void SetIfNotNullOrWhitespace(string? value, Action<string> setter)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                setter(value);
             }
         }
     }

--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -12,7 +12,7 @@ public static class SentrySinkExtensions
     /// Initialize Sentry and add the SentrySink for Serilog.
     /// </summary>
     /// <param name="loggerConfiguration">The logger configuration .<seealso cref="LoggerSinkConfiguration"/></param>
-    /// <param name="dsn">The Sentry DSN (required) <seealso cref="SentryOptions.Dsn"/></param>
+    /// <param name="dsn">The Sentry DSN (required). <seealso cref="SentryOptions.Dsn"/></param>
     /// <param name="minimumEventLevel">Minimum log level to send an event. <seealso cref="SentrySerilogOptions.MinimumEventLevel"/></param>
     /// <param name="minimumBreadcrumbLevel">Minimum log level to record a breadcrumb. <seealso cref="SentrySerilogOptions.MinimumBreadcrumbLevel"/></param>
     /// <param name="formatProvider">The Serilog format provider. <seealso cref="IFormatProvider"/></param>
@@ -214,12 +214,21 @@ public static class SentrySinkExtensions
         sentrySerilogOptions.TextFormatter = textFormatter ?? sentrySerilogOptions.TextFormatter;
         sentrySerilogOptions.SendDefaultPii = sendDefaultPii ?? sentrySerilogOptions.SendDefaultPii;
         sentrySerilogOptions.IsEnvironmentUser = isEnvironmentUser ?? sentrySerilogOptions.IsEnvironmentUser;
-        sentrySerilogOptions.ServerName = NonNullOrWhiteSpaceOrDefault(serverName, sentrySerilogOptions.ServerName);
+        if (!string.IsNullOrWhiteSpace(serverName))
+        {
+            sentrySerilogOptions.ServerName = serverName;
+        }
         sentrySerilogOptions.AttachStacktrace = attachStackTrace ?? sentrySerilogOptions.AttachStacktrace;
         sentrySerilogOptions.MaxBreadcrumbs = maxBreadcrumbs ?? sentrySerilogOptions.MaxBreadcrumbs;
         sentrySerilogOptions.SampleRate = sampleRate ?? sentrySerilogOptions.SampleRate;
-        sentrySerilogOptions.Release = NonNullOrWhiteSpaceOrDefault(release, sentrySerilogOptions.Release);
-        sentrySerilogOptions.Environment = NonNullOrWhiteSpaceOrDefault(environment, sentrySerilogOptions.Environment);
+        if (!string.IsNullOrWhiteSpace(release))
+        {
+            sentrySerilogOptions.Release = release;
+        }
+        if (!string.IsNullOrWhiteSpace(environment))
+        {
+            sentrySerilogOptions.Environment = environment;
+        }
         sentrySerilogOptions.MaxQueueItems = maxQueueItems ?? sentrySerilogOptions.MaxQueueItems;
         sentrySerilogOptions.ShutdownTimeout = shutdownTimeout ?? sentrySerilogOptions.ShutdownTimeout;
         sentrySerilogOptions.DecompressionMethods = decompressionMethods ?? sentrySerilogOptions.DecompressionMethods;
@@ -238,11 +247,6 @@ public static class SentrySinkExtensions
             {
                 sentrySerilogOptions.DefaultTags.Add(tag.Key, tag.Value);
             }
-        }
-
-        string? NonNullOrWhiteSpaceOrDefault(string? value, string? defaultValue)
-        {
-            return string.IsNullOrWhiteSpace(value) ? defaultValue : value;
         }
     }
 

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -5,6 +5,7 @@ namespace Sentry.Serilog
     {
         public SentrySerilogOptions() { }
         public System.IFormatProvider? FormatProvider { get; set; }
+        public bool InitializeSdk { get; set; }
         public Serilog.Events.LogEventLevel MinimumBreadcrumbLevel { get; set; }
         public Serilog.Events.LogEventLevel MinimumEventLevel { get; set; }
         public Serilog.Formatting.ITextFormatter? TextFormatter { get; set; }
@@ -15,7 +16,7 @@ namespace Serilog
     public static class SentrySinkExtensions
     {
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel, System.IFormatProvider? formatProvider, Serilog.Formatting.ITextFormatter? textFormatter) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,
                     string dsn,

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -5,7 +5,6 @@ namespace Sentry.Serilog
     {
         public SentrySerilogOptions() { }
         public System.IFormatProvider? FormatProvider { get; set; }
-        public bool InitializeSdk { get; set; }
         public Serilog.Events.LogEventLevel MinimumBreadcrumbLevel { get; set; }
         public Serilog.Events.LogEventLevel MinimumEventLevel { get; set; }
         public Serilog.Formatting.ITextFormatter? TextFormatter { get; set; }
@@ -16,11 +15,12 @@ namespace Serilog
     public static class SentrySinkExtensions
     {
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel, System.IFormatProvider? formatProvider, Serilog.Formatting.ITextFormatter? textFormatter) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,
-                    string? dsn = null,
-                    Serilog.Events.LogEventLevel minimumBreadcrumbLevel = 2,
-                    Serilog.Events.LogEventLevel minimumEventLevel = 4,
+                    string dsn,
+                    Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default,
+                    Serilog.Events.LogEventLevel? minimumEventLevel = default,
                     System.IFormatProvider? formatProvider = null,
                     Serilog.Formatting.ITextFormatter? textFormatter = null,
                     bool? sendDefaultPii = default,
@@ -40,7 +40,6 @@ namespace Serilog
                     Sentry.SentryLevel? diagnosticLevel = default,
                     Sentry.ReportAssembliesMode? reportAssembliesMode = default,
                     Sentry.DeduplicateMode? deduplicateMode = default,
-                    bool? initializeSdk = default,
                     System.Collections.Generic.Dictionary<string, string>? defaultTags = null) { }
     }
 }

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -5,6 +5,7 @@ namespace Sentry.Serilog
     {
         public SentrySerilogOptions() { }
         public System.IFormatProvider? FormatProvider { get; set; }
+        public bool InitializeSdk { get; set; }
         public Serilog.Events.LogEventLevel MinimumBreadcrumbLevel { get; set; }
         public Serilog.Events.LogEventLevel MinimumEventLevel { get; set; }
         public Serilog.Formatting.ITextFormatter? TextFormatter { get; set; }
@@ -15,7 +16,7 @@ namespace Serilog
     public static class SentrySinkExtensions
     {
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel, System.IFormatProvider? formatProvider, Serilog.Formatting.ITextFormatter? textFormatter) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,
                     string dsn,

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -5,7 +5,6 @@ namespace Sentry.Serilog
     {
         public SentrySerilogOptions() { }
         public System.IFormatProvider? FormatProvider { get; set; }
-        public bool InitializeSdk { get; set; }
         public Serilog.Events.LogEventLevel MinimumBreadcrumbLevel { get; set; }
         public Serilog.Events.LogEventLevel MinimumEventLevel { get; set; }
         public Serilog.Formatting.ITextFormatter? TextFormatter { get; set; }
@@ -16,11 +15,12 @@ namespace Serilog
     public static class SentrySinkExtensions
     {
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel, System.IFormatProvider? formatProvider, Serilog.Formatting.ITextFormatter? textFormatter) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,
-                    string? dsn = null,
-                    Serilog.Events.LogEventLevel minimumBreadcrumbLevel = 2,
-                    Serilog.Events.LogEventLevel minimumEventLevel = 4,
+                    string dsn,
+                    Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default,
+                    Serilog.Events.LogEventLevel? minimumEventLevel = default,
                     System.IFormatProvider? formatProvider = null,
                     Serilog.Formatting.ITextFormatter? textFormatter = null,
                     bool? sendDefaultPii = default,
@@ -40,7 +40,6 @@ namespace Serilog
                     Sentry.SentryLevel? diagnosticLevel = default,
                     Sentry.ReportAssembliesMode? reportAssembliesMode = default,
                     Sentry.DeduplicateMode? deduplicateMode = default,
-                    bool? initializeSdk = default,
                     System.Collections.Generic.Dictionary<string, string>? defaultTags = null) { }
     }
 }

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -5,6 +5,7 @@ namespace Sentry.Serilog
     {
         public SentrySerilogOptions() { }
         public System.IFormatProvider? FormatProvider { get; set; }
+        public bool InitializeSdk { get; set; }
         public Serilog.Events.LogEventLevel MinimumBreadcrumbLevel { get; set; }
         public Serilog.Events.LogEventLevel MinimumEventLevel { get; set; }
         public Serilog.Formatting.ITextFormatter? TextFormatter { get; set; }
@@ -15,7 +16,7 @@ namespace Serilog
     public static class SentrySinkExtensions
     {
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel, System.IFormatProvider? formatProvider, Serilog.Formatting.ITextFormatter? textFormatter) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,
                     string dsn,

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -5,7 +5,6 @@ namespace Sentry.Serilog
     {
         public SentrySerilogOptions() { }
         public System.IFormatProvider? FormatProvider { get; set; }
-        public bool InitializeSdk { get; set; }
         public Serilog.Events.LogEventLevel MinimumBreadcrumbLevel { get; set; }
         public Serilog.Events.LogEventLevel MinimumEventLevel { get; set; }
         public Serilog.Formatting.ITextFormatter? TextFormatter { get; set; }
@@ -16,11 +15,12 @@ namespace Serilog
     public static class SentrySinkExtensions
     {
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel, System.IFormatProvider? formatProvider, Serilog.Formatting.ITextFormatter? textFormatter) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,
-                    string? dsn = null,
-                    Serilog.Events.LogEventLevel minimumBreadcrumbLevel = 2,
-                    Serilog.Events.LogEventLevel minimumEventLevel = 4,
+                    string dsn,
+                    Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default,
+                    Serilog.Events.LogEventLevel? minimumEventLevel = default,
                     System.IFormatProvider? formatProvider = null,
                     Serilog.Formatting.ITextFormatter? textFormatter = null,
                     bool? sendDefaultPii = default,
@@ -40,7 +40,6 @@ namespace Serilog
                     Sentry.SentryLevel? diagnosticLevel = default,
                     Sentry.ReportAssembliesMode? reportAssembliesMode = default,
                     Sentry.DeduplicateMode? deduplicateMode = default,
-                    bool? initializeSdk = default,
                     System.Collections.Generic.Dictionary<string, string>? defaultTags = null) { }
     }
 }

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -5,6 +5,7 @@ namespace Sentry.Serilog
     {
         public SentrySerilogOptions() { }
         public System.IFormatProvider? FormatProvider { get; set; }
+        public bool InitializeSdk { get; set; }
         public Serilog.Events.LogEventLevel MinimumBreadcrumbLevel { get; set; }
         public Serilog.Events.LogEventLevel MinimumEventLevel { get; set; }
         public Serilog.Formatting.ITextFormatter? TextFormatter { get; set; }
@@ -15,7 +16,7 @@ namespace Serilog
     public static class SentrySinkExtensions
     {
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel, System.IFormatProvider? formatProvider, Serilog.Formatting.ITextFormatter? textFormatter) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,
                     string dsn,

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -5,7 +5,6 @@ namespace Sentry.Serilog
     {
         public SentrySerilogOptions() { }
         public System.IFormatProvider? FormatProvider { get; set; }
-        public bool InitializeSdk { get; set; }
         public Serilog.Events.LogEventLevel MinimumBreadcrumbLevel { get; set; }
         public Serilog.Events.LogEventLevel MinimumEventLevel { get; set; }
         public Serilog.Formatting.ITextFormatter? TextFormatter { get; set; }
@@ -16,11 +15,12 @@ namespace Serilog
     public static class SentrySinkExtensions
     {
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel, System.IFormatProvider? formatProvider, Serilog.Formatting.ITextFormatter? textFormatter) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,
-                    string? dsn = null,
-                    Serilog.Events.LogEventLevel minimumBreadcrumbLevel = 2,
-                    Serilog.Events.LogEventLevel minimumEventLevel = 4,
+                    string dsn,
+                    Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default,
+                    Serilog.Events.LogEventLevel? minimumEventLevel = default,
                     System.IFormatProvider? formatProvider = null,
                     Serilog.Formatting.ITextFormatter? textFormatter = null,
                     bool? sendDefaultPii = default,
@@ -40,7 +40,6 @@ namespace Serilog
                     Sentry.SentryLevel? diagnosticLevel = default,
                     Sentry.ReportAssembliesMode? reportAssembliesMode = default,
                     Sentry.DeduplicateMode? deduplicateMode = default,
-                    bool? initializeSdk = default,
                     System.Collections.Generic.Dictionary<string, string>? defaultTags = null) { }
     }
 }

--- a/test/Sentry.Serilog.Tests/SentrySerilogSinkExtensionsTests.cs
+++ b/test/Sentry.Serilog.Tests/SentrySerilogSinkExtensionsTests.cs
@@ -62,6 +62,7 @@ public class SentrySerilogSinkExtensionsTests
         // Compare. I'm not sure how to deep compare--I don't see a nuget ref to that type
         // of functionality and I'm hesitant to introduce new technologies with such a
         // small commit.
+        _fixture.Options.InitializeSdk = false; // Since we're not passing in a DSN... would use a different overload otherwise
         _fixture.Options.MinimumEventLevel = _fixture.MinimumEventLevel;
         _fixture.Options.MinimumBreadcrumbLevel = _fixture.MinimumBreadcrumbLevel;
         AssertEqualDeep(_fixture.Options, sut);


### PR DESCRIPTION
#skip-changelog

Potential refactor of `ConfigureSentrySerilogOptions` for discussion. 

I pulled this out of [simplify_serilog_2884](https://github.com/getsentry/sentry-dotnet/tree/simplify_serilog_2884) to keep the refactoring separate from the change. Not sure if it's worth it. It does make the code way more compact. (takes ~150 lines and makes it about ~50 lines)... on the flip side, it's a little bit more complex. 🤷🏻 