### PR TITLE
workaround .net nativeAOT crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Workaround a .NET 8 NativeAOT crash on transaction finish. ([#2943](https://github.com/getsentry/sentry-dotnet/pull/2943))
+
 ### API breaking Changes
 
 #### Changed APIs

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -165,7 +165,7 @@ public class TransactionTracer : ITransactionTracer
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string> Tags => _tags;
 
-    private readonly ConcurrentBag<SpanTracer> _spans = new();
+    private readonly ConcurrentBag<ISpan> _spans = new();
 
     /// <inheritdoc />
     public IReadOnlyCollection<ISpan> Spans => _spans;


### PR DESCRIPTION
fixes #2933

We don't need to keep the specific type here, changing to the same type as the intermediary collection works around the bug cleanly without any external APIs being affected (as long as we don't expect people casting stuff around)

Upstream issue: https://github.com/dotnet/runtime/issues/95574
