### PR TITLE
Proguard upload test

### DIFF
--- a/integration-test/cli.Tests.ps1
+++ b/integration-test/cli.Tests.ps1
@@ -156,6 +156,7 @@ Describe 'MAUI' -ForEach @(
             'maui-app.pdb'
         )
         $result.ScriptOutput | Should -AnyElementMatch 'Found 1 debug information file \(1 with embedded sources\)'
+        $result.ScriptOutput | Should -AnyElementMatch 'Uploaded a total of 1 new mapping files'
     }
 
     It "uploads symbols and sources for an iOS build" -Skip:(!$IsMacOS) {

--- a/integration-test/common.ps1
+++ b/integration-test/common.ps1
@@ -181,6 +181,19 @@ BeforeAll {
             throw "Failed to create the test app '$name' from template '$type'."
         }
 
+        if ($type -eq 'maui')
+        {
+                            @"
+<Project>
+  <PropertyGroup>
+      <SentryUploadAndroidProguardMapping>true</SentryUploadAndroidProguardMapping>
+      <AndroidLinkTool Condition=`" '`$(AndroidLinkTool)' == '' `">r8</AndroidLinkTool>
+      <AndroidDexTool Condition=`" '`$(AndroidDexTool)' == '' `">d8</AndroidDexTool>
+  </PropertyGroup>
+</Project>
+"@ | Out-File $name/Directory.Build.props
+        }
+
         if ($type -eq 'console')
         {
             AddPackageReference $name 'Sentry'


### PR DESCRIPTION
Verify that the test server receives proguard mapping file. Fixes https://github.com/getsentry/sentry-dotnet/issues/2575

#skip-changelog