### PR TITLE
fix: Android binding warnings

### DIFF
--- a/src/Sentry.Bindings.Android/Transforms/Metadata.xml
+++ b/src/Sentry.Bindings.Android/Transforms/Metadata.xml
@@ -70,12 +70,6 @@
   </add-node>
 
   <!--
-    This API uses FrameMetrics, which requires Android >= 24.0.  We currently target Android >= 21.0 which is the minimum supported by MAUI.
-    TODO: If we need this, figure out how to multi-target or late bind.
-  -->
-  <remove-node path="/api/package[@name='io.sentry.android.core.internal.util']/*[starts-with(@name,'SentryFrameMetricsCollector')]" />
-
-  <!--
     The BackfillingEventProcessor interface creates a stack overflow during code generation, which appears as:
       error MSB6006: "dotnet" exited with code 134
     AnrV2EventProcessor is dependenant on BackfillingEventProcessor

--- a/src/Sentry.Bindings.Android/Transforms/Metadata.xml
+++ b/src/Sentry.Bindings.Android/Transforms/Metadata.xml
@@ -76,12 +76,6 @@
   <remove-node path="/api/package[@name='io.sentry.android.core.internal.util']/*[starts-with(@name,'SentryFrameMetricsCollector')]" />
 
   <!--
-    This is very strange, but this API causes the dotnet process to crash during the BindingsGenerator task when the interface containing it is marked internal.
-    Either removing this method or switching the interface back to public fixes the issue.  Since we don't need it in .NET, we can remove the method.
-  -->
-  <remove-node path="/api/package[@name='io.sentry']/interface[@name='IntegrationName']/method[@name='addIntegrationToSdkVersion']" />
-
-  <!--
     The BackfillingEventProcessor interface creates a stack overflow during code generation, which appears as:
       error MSB6006: "dotnet" exited with code 134
     AnrV2EventProcessor is dependenant on BackfillingEventProcessor

--- a/src/Sentry.Bindings.Android/Transforms/Metadata.xml
+++ b/src/Sentry.Bindings.Android/Transforms/Metadata.xml
@@ -70,15 +70,22 @@
   </add-node>
 
   <!--
+    TODO: If we need this, figure out how to multi-target or late bind.
+    This API uses FrameMetrics, which requires Android >= 24.0.  We currently target Android >= 21.0 which is the minimum supported by MAUI.
+    AndroidProfiler is dependant on SentryFrameMetricsCollector
+  -->
+  <remove-node path="/api/package[@name='io.sentry.android.core.internal.util']/*[starts-with(@name,'SentryFrameMetricsCollector')]" />
+  <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='AndroidProfiler']/*" />
+
+  <!--
     The BackfillingEventProcessor interface creates a stack overflow during code generation, which appears as:
       error MSB6006: "dotnet" exited with code 134
-    AnrV2EventProcessor is dependenant on BackfillingEventProcessor
+    AnrV2EventProcessor is dependant on BackfillingEventProcessor
     We currently don't need to use either of these via C# bindings.
   -->
   <remove-node path="/api/package[@name='io.sentry']/interface[@name='BackfillingEventProcessor']" />
   <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='AnrV2EventProcessor']" />
-
-
+    
   <!--
     SentryEvent.serialize() expects an parameter which implements ObjectWriter.
     JsonObjectWriter implements ObjectWriter in Java, but somehow this is not reflected in the generated binding.


### PR DESCRIPTION
Fixes:
```
Unknown parameter type 'io.sentry.android.core.internal.util.SentryFrameMetricsCollector' for member 'Sentry.JavaSdk.Android.Core.AndroidProfiler.AndroidProfiler (string, int, io.sentry.android.core.internal.util.SentryFrameMetricsCollector, io.sentry.ISentryExecutorService, io.sentry.ILogger, io.sentry.android.core.BuildInfoProvider)'.
```
Java SDK `7.0.0` made the `AndroidProfiler` dependant on `SentryFrameMetricsCollector` is it gets yeeted too. (together with its nested types)

```
Metadata.xml element '<remove-node path="/api/package[@name='io.sentry']/interface[@name='IntegrationName']/method[@name='addIntegrationToSdkVersion']" />' matched no nodes.
```
`IntegrationUtils.addIntegrationToSdkVersion` changed in `7.0.0` as well and no longer needs this workaround.

#skip-changelog