### PR TITLE
Use xcodebuild archive to build sentry-cocoa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Stop Sentry for MacCatalyst from creating `default.profraw` in the app bundle using xcodebuild archive to build sentry-cocoa ([#2960](https://github.com/getsentry/sentry-dotnet/pull/2960))
+
 ### Dependencies
 
 - Bump CLI from v2.22.3 to v2.23.0 ([#2956](https://github.com/getsentry/sentry-dotnet/pull/2956))

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -43,7 +43,7 @@ echo "::group::Building sentry-cocoa for Mac Catalyst"
 xcodebuild archive -project Sentry.xcodeproj \
     -scheme Sentry \
     -configuration Release \
-    -destination 'platform=macOS,variant=Mac Catalyst' \
+    -destination 'generic/platform=macOS,variant=Mac Catalyst' \
     -archivePath ./Carthage/output-maccatalyst.xcarchive \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -18,31 +18,37 @@ ios_simulator_sdk=$(echo "$sdks" | awk '/iOS Simulator SDKs/{getline; print $NF}
 
 # Build for iOS and iOS simulator.
 echo "::group::Building sentry-cocoa for iOS and iOS simulator"
-xcodebuild -project Sentry.xcodeproj \
+xcodebuild archive -project Sentry.xcodeproj \
     -scheme Sentry \
     -configuration Release \
     -sdk "$ios_sdk" \
-    -derivedDataPath ./Carthage/output-ios
-xcodebuild -project Sentry.xcodeproj \
+    -archivePath ./Carthage/output-ios.xcarchive \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+xcodebuild archive -project Sentry.xcodeproj \
     -scheme Sentry \
     -configuration Release \
     -sdk "$ios_simulator_sdk" \
-    -derivedDataPath ./Carthage/output-ios
+    -archivePath ./Carthage/output-iossimulator.xcarchive \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 xcodebuild -create-xcframework \
-    -framework ./Carthage/output-ios/Build/Products/Release-iphoneos/Sentry.framework \
-    -framework ./Carthage/output-ios/Build/Products/Release-iphonesimulator/Sentry.framework \
+    -framework ./Carthage/output-ios.xcarchive/Products/Library/Frameworks/Sentry.framework \
+    -framework ./Carthage/output-iossimulator.xcarchive/Products/Library/Frameworks/Sentry.framework \
     -output ./Carthage/Build-ios/Sentry.xcframework
 echo "::endgroup::"
 
 # Separately, build for Mac Catalyst
 echo "::group::Building sentry-cocoa for Mac Catalyst"
-xcodebuild -project Sentry.xcodeproj \
+xcodebuild archive -project Sentry.xcodeproj \
     -scheme Sentry \
     -configuration Release \
     -destination 'platform=macOS,variant=Mac Catalyst' \
-    -derivedDataPath ./Carthage/output-maccatalyst
+    -archivePath ./Carthage/output-maccatalyst.xcarchive \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 xcodebuild -create-xcframework \
-    -framework ./Carthage/output-maccatalyst/Build/Products/Release-maccatalyst/Sentry.framework \
+    -framework ./Carthage/output-maccatalyst.xcarchive/Products/Library/Frameworks/Sentry.framework \
     -output ./Carthage/Build-maccatalyst/Sentry.xcframework
 echo "::endgroup::"
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/2954

Without the "archive" command xcodebuild will build with code coverage enabled (`-fprofile-instr-generate` is passed to clang) and that links in the compiler profiling runtime. This is evidenced by the `__llvm_profile_runtime` symbol being present in the `Sentry` binary with `nm`. The static initializer will hook up profiling and we get a `default.profraw` file when the app exits.

The fix is to use the "archive" command instead, similar to how upstream sentry-cocoa uses it here: https://github.com/getsentry/sentry-cocoa/blob/ddb47781bffd76406f31ab43e66760362585fcd7/Makefile#L82-L83