### PR TITLE
Removed `alpha` suffix from `Profiling`

### DIFF
--- a/src/Sentry.Profiling/Sentry.Profiling.csproj
+++ b/src/Sentry.Profiling/Sentry.Profiling.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <!-- TODO check and update the list of supported frameworks. -->
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
-    <VersionSuffix>-alpha.0</VersionSuffix>
     <PackageTags>$(PackageTags);Profiling;Diagnostic</PackageTags>
     <Description>Performance profiling support for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
   </PropertyGroup>


### PR DESCRIPTION
As said in https://github.com/getsentry/sentry-dotnet/pull/2881
To avoid `4.0.0-beta.2-alpha.0` let's wait until we GA this thing (release 4.0.0 without suffix) before adding the suffix.

#skip-changelog