### PR TITLE
Add minimum powershell version requirements to Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ For big feature it's advised to raise an issue to discuss it first.
 
 * You'll need `CMake` somewhere on your PATH. If you don't already have this, one way to get it is to install the [C++ CMake tools for Windows](https://learn.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-170#installation)
 
-* You'll need [`pwsh`](https://github.com/PowerShell/PowerShell#get-powershell) on PATH.
+* You'll need [`pwsh`](https://github.com/PowerShell/PowerShell#get-powershell) Core version 6 or later on PATH.
 
 * On Windows:
   - [.NET Framework](https://dotnet.microsoft.com/download/dotnet-framework) 4.6.2 or higher.

--- a/scripts/build-sentry-native.ps1
+++ b/scripts/build-sentry-native.ps1
@@ -5,6 +5,19 @@ $ErrorActionPreference = "Stop"
 Push-Location $PSScriptRoot/..
 try
 {
+    if ($PSVersionTable.PSVersion.Major -ge 6) {
+        # PowerShell Core
+        $IsWindows = $PSVersionTable.OS -like "*Win*"
+        $IsLinux = $PSVersionTable.OS -like "*Linux*"
+        $IsMacOS = $PSVersionTable.OS -like "*Darwin*"
+    } else {
+        # Windows PowerShell
+        $os = [System.Environment]::OSVersion
+        $IsWindows = $os.Platform -eq [System.PlatformID]::Win32NT
+        $IsLinux = $os.Platform -eq [System.PlatformID]::Unix
+        $IsMacOS = $false  # macOS determination is complex in Windows PowerShell
+    }
+
     $submodule = 'modules/sentry-native'
     $outDir = 'src/Sentry/Platforms/Native/sentry-native'
     $buildDir = "$submodule/build"

--- a/scripts/build-sentry-native.ps1
+++ b/scripts/build-sentry-native.ps1
@@ -5,19 +5,6 @@ $ErrorActionPreference = "Stop"
 Push-Location $PSScriptRoot/..
 try
 {
-    if ($PSVersionTable.PSVersion.Major -ge 6) {
-        # PowerShell Core
-        $IsWindows = $PSVersionTable.OS -like "*Win*"
-        $IsLinux = $PSVersionTable.OS -like "*Linux*"
-        $IsMacOS = $PSVersionTable.OS -like "*Darwin*"
-    } else {
-        # Windows PowerShell
-        $os = [System.Environment]::OSVersion
-        $IsWindows = $os.Platform -eq [System.PlatformID]::Win32NT
-        $IsLinux = $os.Platform -eq [System.PlatformID]::Unix
-        $IsMacOS = $false  # macOS determination is complex in Windows PowerShell
-    }
-
     $submodule = 'modules/sentry-native'
     $outDir = 'src/Sentry/Platforms/Native/sentry-native'
     $buildDir = "$submodule/build"


### PR DESCRIPTION
#skip-changelog

Building the solution on machines with older versions of PowerShell installed results in an error:
```
The variable '$IsMacOS' cannot be retrieved because it has not been set.
```

This is because our scripts leverage some automatic variables that are only set in PS Core 6+. 