### PR TITLE
chore: update artifact actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Upload build and test outputs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: verify-test-results
           path: "**/*.received.*"
@@ -130,7 +130,7 @@ jobs:
 
       - name: Archive Nuget Packages
         if: env.CI_PUBLISHING_BUILD == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           if-no-files-found: error
@@ -158,7 +158,7 @@ jobs:
             integration-test
 
       - name: Fetch Nuget Packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ github.sha }}
           path: src

--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -7,7 +7,7 @@ on:
       - release/*
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
   build:
@@ -41,7 +41,7 @@ jobs:
         run: pwsh ./scripts/device-test.ps1 android -Build
 
       - name: Upload Android Test App
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: device-test-android
           if-no-files-found: error
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download test app artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: device-test-android
           path: bin
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload results
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: device-test-android-${{ matrix.api-level }}-results
           path: test_output

--- a/.github/workflows/device-tests-ios.yml
+++ b/.github/workflows/device-tests-ios.yml
@@ -38,7 +38,7 @@ jobs:
         run: pwsh ./scripts/device-test.ps1 ios -Build
 
       - name: Upload iOS Test App
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: device-test-ios
           if-no-files-found: error
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download test app artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: device-test-ios
           path: bin/Sentry.Maui.Device.TestApp.app
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload results
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: device-test-ios-results
           path: test_output

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: API Docs
 on:
   create:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   docs:
@@ -22,7 +22,7 @@ jobs:
           publish_dir: docs/_site
           force_orphan: true
       - name: Archive Docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/_site


### PR DESCRIPTION
#skip-changelog

combines #2974  and #2976 because they can't be done separately.
