### PR TITLE
Repository Relative Filenames in Stack Frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### API breaking Changes
+
+- Filenames in stack traces are now stored as full paths relative to the repository root, when Git is being used for source control ([#2980](https://github.com/getsentry/sentry-dotnet/pull/2980))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.17.1 to v8.17.2 ([#2972](https://github.com/getsentry/sentry-dotnet/pull/2972))

--- a/src/Sentry/AttributeReader.cs
+++ b/src/Sentry/AttributeReader.cs
@@ -4,4 +4,6 @@ internal static class AttributeReader
 {
     public static string? TryGetProjectDirectory(Assembly assembly) =>
         assembly.GetCustomAttributes<AssemblyMetadataAttribute>().FirstOrDefault(x => x.Key == "Sentry.ProjectDirectory")?.Value;
+    public static string? TryGetRepositoryRoot(Assembly assembly) =>
+        assembly.GetCustomAttributes<AssemblyMetadataAttribute>().FirstOrDefault(x => x.Key == "Sentry.RepositoryRoot")?.Value;
 }

--- a/src/Sentry/Internal/DebugStackTrace.cs
+++ b/src/Sentry/Internal/DebugStackTrace.cs
@@ -349,13 +349,26 @@ internal class DebugStackTrace : SentryStackTrace
             if (AttributeReader.TryGetProjectDirectory(method.Module.Assembly) is { } projectPath
                 && frameFileName.StartsWith(projectPath, StringComparison.OrdinalIgnoreCase))
             {
-                frame.AbsolutePath = frameFileName;
+                frame.AbsolutePath = GetRepositoryRelativePath(method.Module.Assembly, frameFileName);
                 frameFileName = frameFileName[projectPath.Length..];
             }
             frame.FileName = frameFileName;
         }
 
         return frame;
+    }
+
+    internal static string GetRepositoryRelativePath(Assembly moduleAssembly, string frameFileName)
+    {
+        if (AttributeReader.TryGetProjectDirectory(moduleAssembly) is { } projectDirectory && frameFileName.StartsWith(projectDirectory))
+        {
+            frameFileName = frameFileName.Substring(projectDirectory.Length);
+            if (frameFileName.StartsWith("/"))
+            {
+                frameFileName = frameFileName.Substring(1);
+            }
+        }
+        return frameFileName;
     }
 
     /// <summary>

--- a/src/Sentry/Internal/DebugStackTrace.cs
+++ b/src/Sentry/Internal/DebugStackTrace.cs
@@ -360,7 +360,7 @@ internal class DebugStackTrace : SentryStackTrace
         return frame;
     }
 
-    internal static string? TryGetRoot(Assembly moduleAssembly, string fileName, Func<Assembly, string?> resolveRoot)
+    private static string? TryGetRoot(Assembly moduleAssembly, string fileName, Func<Assembly, string?> resolveRoot)
     {
         var root = resolveRoot(moduleAssembly);
         return !string.IsNullOrEmpty(root) && fileName.StartsWith(root, StringComparison.OrdinalIgnoreCase)

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -12,11 +12,16 @@
           Outputs="$(IntermediateOutputPath)$(SentryAttributesFile)">
     <PropertyGroup>
       <SentryAttributesFilePath>$(IntermediateOutputPath)$(SentryAttributesFile)</SentryAttributesFilePath>
+      <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(ProjectDir)'))))</RepoRoot>
     </PropertyGroup>
     <ItemGroup>
       <SentryAttributes Include="System.Reflection.AssemblyMetadata">
         <_Parameter1>Sentry.ProjectDirectory</_Parameter1>
         <_Parameter2>$(ProjectDir)</_Parameter2>
+      </SentryAttributes>
+      <SentryAttributes Include="System.Reflection.AssemblyMetadata">
+        <_Parameter1>Sentry.RepositoryRoot</_Parameter1>
+        <_Parameter2>$(RepoRoot)</_Parameter2>
       </SentryAttributes>
       <!-- Ensure not part of Compile, as a workaround for https://github.com/dotnet/sdk/issues/114 -->
       <Compile Remove="$(SentryAttributesFilePath)" />

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
@@ -37,12 +37,12 @@
                 Stacktrace: {
                   Frames: [
                     {
-                      FileName: /test/Sentry.NLog.Tests/IntegrationTests.verify.cs,
+                      FileName: {TestDir}IntegrationTests.verify.cs,
                       Function: Task IntegrationTests.Simple(),
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
+                      AbsolutePath: {SolutionDirectory}{TestDir}IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.NLog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
@@ -37,12 +37,12 @@
                 Stacktrace: {
                   Frames: [
                     {
-                      FileName: IntegrationTests.verify.cs,
+                      FileName: /test/Sentry.NLog.Tests/IntegrationTests.verify.cs,
                       Function: Task IntegrationTests.Simple(),
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: test/Sentry.NLog.Tests/IntegrationTests.verify.cs,
+                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.NLog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
@@ -42,7 +42,7 @@
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
+                      AbsolutePath: test/Sentry.NLog.Tests/IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.NLog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
@@ -37,12 +37,12 @@
                 Stacktrace: {
                   Frames: [
                     {
-                      FileName: /test/Sentry.NLog.Tests/IntegrationTests.verify.cs,
+                      FileName: {TestDir}IntegrationTests.verify.cs,
                       Function: Task IntegrationTests.Simple(),
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
+                      AbsolutePath: {SolutionDirectory}{TestDir}IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.NLog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
@@ -37,12 +37,12 @@
                 Stacktrace: {
                   Frames: [
                     {
-                      FileName: IntegrationTests.verify.cs,
+                      FileName: /test/Sentry.NLog.Tests/IntegrationTests.verify.cs,
                       Function: Task IntegrationTests.Simple(),
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: test/Sentry.NLog.Tests/IntegrationTests.verify.cs,
+                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.NLog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
@@ -42,7 +42,7 @@
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
+                      AbsolutePath: test/Sentry.NLog.Tests/IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.NLog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
@@ -37,12 +37,12 @@
                 Stacktrace: {
                   Frames: [
                     {
-                      FileName: /test/Sentry.NLog.Tests/IntegrationTests.verify.cs,
+                      FileName: {TestDir}IntegrationTests.verify.cs,
                       Function: Task IntegrationTests.Simple(),
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
+                      AbsolutePath: {SolutionDirectory}{TestDir}IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.NLog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
@@ -37,12 +37,12 @@
                 Stacktrace: {
                   Frames: [
                     {
-                      FileName: IntegrationTests.verify.cs,
+                      FileName: /test/Sentry.NLog.Tests/IntegrationTests.verify.cs,
                       Function: Task IntegrationTests.Simple(),
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: test/Sentry.NLog.Tests/IntegrationTests.verify.cs,
+                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.NLog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
@@ -42,7 +42,7 @@
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
+                      AbsolutePath: test/Sentry.NLog.Tests/IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.NLog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.Net4_8.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.Net4_8.verified.txt
@@ -37,12 +37,12 @@
                 Stacktrace: {
                   Frames: [
                     {
-                      FileName: IntegrationTests.verify.cs,
+                      FileName: {TestDir}IntegrationTests.verify.cs,
                       Function: Task IntegrationTests.Simple(),
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
+                      AbsolutePath: {SolutionDirectory}{TestDir}IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.NLog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.NLog.Tests/IntegrationTests.verify.cs
+++ b/test/Sentry.NLog.Tests/IntegrationTests.verify.cs
@@ -57,6 +57,8 @@ public class IntegrationTests
 
         return Verify(transport.Envelopes)
             .UniqueForRuntimeAndVersion()
+            .AddScrubber(x => x.Replace(@"/test/Sentry.NLog.Tests/", @"{TestDir}"))
+            .AddScrubber(x => x.Replace(@"\test\Sentry.NLog.Tests\", @"{TestDir}"))
             .IgnoreStandardSentryMembers();
     }
 

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
@@ -202,7 +202,7 @@
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
+                      AbsolutePath: test/Sentry.Serilog.Tests/IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.Serilog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
@@ -197,12 +197,12 @@
                 Stacktrace: {
                   Frames: [
                     {
-                      FileName: IntegrationTests.verify.cs,
+                      FileName: /test/Sentry.Serilog.Tests/IntegrationTests.verify.cs,
                       Function: Task IntegrationTests.Simple(),
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: test/Sentry.Serilog.Tests/IntegrationTests.verify.cs,
+                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.Serilog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
@@ -197,12 +197,12 @@
                 Stacktrace: {
                   Frames: [
                     {
-                      FileName: /test/Sentry.Serilog.Tests/IntegrationTests.verify.cs,
+                      FileName: {TestDir}IntegrationTests.verify.cs,
                       Function: Task IntegrationTests.Simple(),
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
+                      AbsolutePath: {SolutionDirectory}{TestDir}IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.Serilog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
@@ -202,7 +202,7 @@
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
+                      AbsolutePath: test/Sentry.Serilog.Tests/IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.Serilog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
@@ -197,12 +197,12 @@
                 Stacktrace: {
                   Frames: [
                     {
-                      FileName: IntegrationTests.verify.cs,
+                      FileName: /test/Sentry.Serilog.Tests/IntegrationTests.verify.cs,
                       Function: Task IntegrationTests.Simple(),
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: test/Sentry.Serilog.Tests/IntegrationTests.verify.cs,
+                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.Serilog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
@@ -197,12 +197,12 @@
                 Stacktrace: {
                   Frames: [
                     {
-                      FileName: /test/Sentry.Serilog.Tests/IntegrationTests.verify.cs,
+                      FileName: {TestDir}IntegrationTests.verify.cs,
                       Function: Task IntegrationTests.Simple(),
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
+                      AbsolutePath: {SolutionDirectory}{TestDir}IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.Serilog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
@@ -202,7 +202,7 @@
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
+                      AbsolutePath: test/Sentry.Serilog.Tests/IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.Serilog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
@@ -197,12 +197,12 @@
                 Stacktrace: {
                   Frames: [
                     {
-                      FileName: IntegrationTests.verify.cs,
+                      FileName: /test/Sentry.Serilog.Tests/IntegrationTests.verify.cs,
                       Function: Task IntegrationTests.Simple(),
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: test/Sentry.Serilog.Tests/IntegrationTests.verify.cs,
+                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.Serilog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
@@ -197,12 +197,12 @@
                 Stacktrace: {
                   Frames: [
                     {
-                      FileName: /test/Sentry.Serilog.Tests/IntegrationTests.verify.cs,
+                      FileName: {TestDir}IntegrationTests.verify.cs,
                       Function: Task IntegrationTests.Simple(),
                       Module: null,
                       LineNumber: 48,
                       ColumnNumber: 17,
-                      AbsolutePath: {ProjectDirectory}IntegrationTests.verify.cs,
+                      AbsolutePath: {SolutionDirectory}{TestDir}IntegrationTests.verify.cs,
                       ContextLine: null,
                       InApp: false,
                       Package: Sentry.Serilog.Tests, Version=SCRUBBED, Culture=SCRUBBED, PublicKeyToken=SCRUBBED,

--- a/test/Sentry.Serilog.Tests/IntegrationTests.verify.cs
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.verify.cs
@@ -58,6 +58,8 @@ public class IntegrationTests
 
         return Verify(transport.Envelopes)
             .UniqueForRuntimeAndVersion()
+            .AddScrubber(x => x.Replace(@"/test/Sentry.Serilog.Tests/", @"{TestDir}"))
+            .AddScrubber(x => x.Replace(@"\test\Sentry.Serilog.Tests\", @"{TestDir}"))
             .IgnoreStandardSentryMembers();
     }
 

--- a/test/Sentry.Tests/Internals/DebugStackTraceTests.verify.cs
+++ b/test/Sentry.Tests/Internals/DebugStackTraceTests.verify.cs
@@ -111,7 +111,7 @@ public class DebugStackTraceTests
 // TODO: Create integration test to test this behaviour when publishing AOT apps
 // See https://github.com/getsentry/sentry-dotnet/issues/2772
     [Fact]
-    public void CreateSentryStackFrame_AbsolutePath_StripProjectRoot()
+    public void CreateSentryStackFrame_FileName_RepositoryRelativePath()
     {
         var stackTrace = new StackTrace(true);
         var frame = stackTrace.GetFrames().First(f => !string.IsNullOrEmpty(f.GetFileName()));
@@ -119,7 +119,8 @@ public class DebugStackTraceTests
 
         var actual = sut.CreateFrame(new RealStackFrame(frame));
 
-        actual?.AbsolutePath.Should().Be("test/Sentry.Tests/Internals/DebugStackTraceTests.verify.cs");
+        var expected = Path.DirectorySeparatorChar + Path.Combine("test", "Sentry.Tests", "Internals", "DebugStackTraceTests.verify.cs");
+        actual?.FileName.Should().Be(expected);
     }
 
     [Fact]

--- a/test/Sentry.Tests/Internals/DebugStackTraceTests.verify.cs
+++ b/test/Sentry.Tests/Internals/DebugStackTraceTests.verify.cs
@@ -108,21 +108,6 @@ public class DebugStackTraceTests
         Assert.Null(stackFrame.Module);
     }
 
-// TODO: Create integration test to test this behaviour when publishing AOT apps
-// See https://github.com/getsentry/sentry-dotnet/issues/2772
-    [Fact]
-    public void CreateSentryStackFrame_FileName_RepositoryRelativePath()
-    {
-        var stackTrace = new StackTrace(true);
-        var frame = stackTrace.GetFrames().First(f => !string.IsNullOrEmpty(f.GetFileName()));
-        var sut = _fixture.GetSut();
-
-        var actual = sut.CreateFrame(new RealStackFrame(frame));
-
-        var expected = Path.DirectorySeparatorChar + Path.Combine("test", "Sentry.Tests", "Internals", "DebugStackTraceTests.verify.cs");
-        actual?.FileName.Should().Be(expected);
-    }
-
     [Fact]
     public void MergeDebugImages_Empty()
     {

--- a/test/Sentry.Tests/Internals/DebugStackTraceTests.verify.cs
+++ b/test/Sentry.Tests/Internals/DebugStackTraceTests.verify.cs
@@ -108,6 +108,20 @@ public class DebugStackTraceTests
         Assert.Null(stackFrame.Module);
     }
 
+// TODO: Create integration test to test this behaviour when publishing AOT apps
+// See https://github.com/getsentry/sentry-dotnet/issues/2772
+    [Fact]
+    public void CreateSentryStackFrame_AbsolutePath_StripProjectRoot()
+    {
+        var stackTrace = new StackTrace(true);
+        var frame = stackTrace.GetFrames().First(f => !string.IsNullOrEmpty(f.GetFileName()));
+        var sut = _fixture.GetSut();
+
+        var actual = sut.CreateFrame(new RealStackFrame(frame));
+
+        actual?.AbsolutePath.Should().Be("test/Sentry.Tests/Internals/DebugStackTraceTests.verify.cs");
+    }
+
     [Fact]
     public void MergeDebugImages_Empty()
     {

--- a/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.MethodGeneric_mode=Enhanced.verified.txt
+++ b/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.MethodGeneric_mode=Enhanced.verified.txt
@@ -1,7 +1,7 @@
 ﻿{
   FileName: Internals/SentryStackTraceFactoryTests.cs,
   Function: void SentryStackTraceFactoryTests.GenericMethodThatThrows<T>(T value),
-  AbsolutePath: {ProjectDirectory}Internals/SentryStackTraceFactoryTests.cs,
+  AbsolutePath: test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs,
   InApp: true,
   AddressMode: rel:0
 }

--- a/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.MethodGeneric_mode=Enhanced.verified.txt
+++ b/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.MethodGeneric_mode=Enhanced.verified.txt
@@ -1,7 +1,7 @@
 ﻿{
-  FileName: Internals/SentryStackTraceFactoryTests.cs,
+  FileName: /test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs,
   Function: void SentryStackTraceFactoryTests.GenericMethodThatThrows<T>(T value),
-  AbsolutePath: test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs,
+  AbsolutePath: {ProjectDirectory}Internals/SentryStackTraceFactoryTests.cs,
   InApp: true,
   AddressMode: rel:0
 }

--- a/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.MethodGeneric_mode=Original.verified.txt
+++ b/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.MethodGeneric_mode=Original.verified.txt
@@ -1,8 +1,8 @@
 ﻿{
-  FileName: Internals/SentryStackTraceFactoryTests.cs,
+  FileName: /test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs,
   Function: GenericMethodThatThrows,
   Module: Other.Tests.Internals.SentryStackTraceFactoryTests,
-  AbsolutePath: test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs,
+  AbsolutePath: {ProjectDirectory}Internals/SentryStackTraceFactoryTests.cs,
   InApp: true,
   AddressMode: rel:0
 }

--- a/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.MethodGeneric_mode=Original.verified.txt
+++ b/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.MethodGeneric_mode=Original.verified.txt
@@ -2,7 +2,7 @@
   FileName: Internals/SentryStackTraceFactoryTests.cs,
   Function: GenericMethodThatThrows,
   Module: Other.Tests.Internals.SentryStackTraceFactoryTests,
-  AbsolutePath: {ProjectDirectory}Internals/SentryStackTraceFactoryTests.cs,
+  AbsolutePath: test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs,
   InApp: true,
   AddressMode: rel:0
 }

--- a/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
+++ b/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
@@ -191,7 +191,7 @@ public partial class SentryStackTraceFactoryTests
         var path = Path.Combine("Internals", "SentryStackTraceFactoryTests.cs");
         Assert.Equal(path, frame.FileName);
 
-        var fullPath = GetThisFilePath();
+        var fullPath = "test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs";
         Assert.Equal(fullPath, frame.AbsolutePath);
     }
 

--- a/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
+++ b/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
@@ -188,11 +188,12 @@ public partial class SentryStackTraceFactoryTests
         Skip.If(string.IsNullOrEmpty(frame.FileName));
 #endif
 
-        var path = Path.Combine("Internals", "SentryStackTraceFactoryTests.cs");
+        var path = Path.DirectorySeparatorChar + Path.Combine("test", "Sentry.Tests", "Internals", "SentryStackTraceFactoryTests.cs");
         Assert.Equal(path, frame.FileName);
 
-        var fullPath = "test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs";
+        var fullPath = GetThisFilePath();
         Assert.Equal(fullPath, frame.AbsolutePath);
+        return;
     }
 
     private static string GetThisFilePath([CallerFilePath] string path = null) => path;


### PR DESCRIPTION
Resolves to https://github.com/getsentry/sentry-dotnet/issues/2978

The idea is to strip everything above the repository root from the absolute path that we report in stack traces... so if someone has a git repo for their project in `/Users/Bobby/code/myPetProject/` the filename paths would be reported as:
- `/Users/Bobby/code/myPetProject/readme.md` -> `readme.md`
- `/Users/Bobby/code/myPetProject/src/Program.cs` -> `src/Program.cs`

Combining that with a remote URL (via source link) and a commit hash, we'd be able to take people directly to the source code.