### PR TITLE
fix: remove aot warn

### DIFF
--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -12,7 +12,7 @@ ios_sdk=$(echo "$sdks" | awk '/iOS SDKs/{getline; print $NF}')
 ios_simulator_sdk=$(echo "$sdks" | awk '/iOS Simulator SDKs/{getline; print $NF}')
 
 # Note - We keep the build output in separate directories so that .NET
-# bundles iOS with net6.0-ios and Mac Catalyst with net6.0-maccatalyst.
+# bundles iOS with netX.0-ios and Mac Catalyst with netX.0-maccatalyst.
 # The lack of symlinks in the ios builds, means we should also be able
 # to use the package on Windows with "Pair to Mac".
 

--- a/src/Sentry/Internal/DebugStackTrace.cs
+++ b/src/Sentry/Internal/DebugStackTrace.cs
@@ -499,6 +499,7 @@ internal class DebugStackTrace : SentryStackTrace
     {
 #if !NET8_0_OR_GREATER
 #pragma warning disable 0162
+#endif
         if (AotHelper.IsNativeAot)
         {
             // Only unreachable outside NET8_0_OR_GREATER
@@ -506,6 +507,7 @@ internal class DebugStackTrace : SentryStackTrace
             assemblyName = null;
             return null;
         }
+#if !NET8_0_OR_GREATER
 #pragma warning restore 0162
 #endif
         assemblyName = module.FullyQualifiedName;

--- a/src/Sentry/Internal/DebugStackTrace.cs
+++ b/src/Sentry/Internal/DebugStackTrace.cs
@@ -497,14 +497,17 @@ internal class DebugStackTrace : SentryStackTrace
     [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = AotHelper.SuppressionJustification)]
     private static PEReader? TryReadAssemblyFromDisk(Module module, SentryOptions options, out string? assemblyName)
     {
+#if !NET8_0_OR_GREATER
+#pragma warning disable 0162
         if (AotHelper.IsNativeAot)
         {
-            #pragma warning disable 0162 // Unreachable code on old .NET frameworks
+            // Only unreachable outside NET8_0_OR_GREATER
+            // ReSharper disable once HeuristicUnreachableCode
             assemblyName = null;
             return null;
-            #pragma warning restore 0162
         }
-
+#pragma warning restore 0162
+#endif
         assemblyName = module.FullyQualifiedName;
         if (options.AssemblyReader is { } reader)
         {

--- a/src/Sentry/Internal/StackFrame.cs
+++ b/src/Sentry/Internal/StackFrame.cs
@@ -116,9 +116,11 @@ internal class RealStackFrame : IStackFrame
     public MethodBase? GetMethod() => AotHelper.IsNativeAot
 #if !NET8_0_OR_GREATER
 #pragma warning disable CS0162 // Unreachable code detected
+#endif
         // Only unreachable outside NET8_0_OR_GREATER
         // ReSharper disable once HeuristicUnreachableCode
         ? null
+#if !NET8_0_OR_GREATER
 #pragma warning restore CS0162 // Unreachable code detected
 #endif
         : _frame.GetMethod();

--- a/src/Sentry/Internal/StackFrame.cs
+++ b/src/Sentry/Internal/StackFrame.cs
@@ -114,7 +114,13 @@ internal class RealStackFrame : IStackFrame
 
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = AotHelper.SuppressionJustification)]
     public MethodBase? GetMethod() => AotHelper.IsNativeAot
+#if !NET8_0_OR_GREATER
+#pragma warning disable CS0162 // Unreachable code detected
+        // Only unreachable outside NET8_0_OR_GREATER
+        // ReSharper disable once HeuristicUnreachableCode
         ? null
+#pragma warning restore CS0162 // Unreachable code detected
+#endif
         : _frame.GetMethod();
 
 #if NET5_0_OR_GREATER


### PR DESCRIPTION
This will stop the warning but raises the question: Why do we have a const? 
Might `#ifdef` everywhere NET8 or newer at the callsite?

#skip-changelog