### PR TITLE
fix: OTel spans for Sentry requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
    - Supports Android and iOS only. Windows is not supported.
 - MAUI: App context has `in_foreground` indicating whether app was on the background or foreground. ([#2983](https://github.com/getsentry/sentry-dotnet/pull/2983))
 
+### Fixes
+
+- Fixed an issue when using the SDK together with Open Telemetry `1.5.0` and newer where the SDK would create transactions for itself. The fix is backwards compatible. ([#3001](https://github.com/getsentry/sentry-dotnet/pull/3001))
+
 ### Significant change in behavior
 
 - The User.IpAddress is now set to {{auto}} by default, even when sendDefaultPII is disabled ([#2981](https://github.com/getsentry/sentry-dotnet/pull/2981))

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -115,7 +115,7 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
 
         var url =
             attributes.TryGetTypedValue(OtelSemanticConventions.AttributeUrlFull, out string? tempUrl) ? tempUrl
-            : attributes.TryGetTypedValue("http.url", out string? fallbackUrl) ? fallbackUrl // Falling back to a convention from pre-1.5.0
+            : attributes.TryGetTypedValue(OtelSemanticConventions.AttributeHttpUrl, out string? fallbackUrl) ? fallbackUrl // Falling back to pre-1.5.0
             : null;
 
         if (!string.IsNullOrEmpty(url) && (_options?.IsSentryRequest(url) ?? false))

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -115,7 +115,7 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
 
         var url =
             attributes.TryGetTypedValue(OtelSemanticConventions.AttributeUrlFull, out string? tempUrl) ? tempUrl
-            : attributes.TryGetTypedValue("http.url", out string? fallbackUrl) ? fallbackUrl    // Falling back to a convention from pre-1.5.0
+            : attributes.TryGetTypedValue("http.url", out string? fallbackUrl) ? fallbackUrl // Falling back to a convention from pre-1.5.0
             : null;
 
         if (!string.IsNullOrEmpty(url) && (_options?.IsSentryRequest(url) ?? false))

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -113,7 +113,7 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
         // Make a dictionary of the attributes (aka "tags") for faster lookup when used throughout the processor.
         var attributes = data.TagObjects.ToDict();
 
-        if (attributes.TryGetTypedValue("http.url", out string? url) && (_options?.IsSentryRequest(url) ?? false))
+        if (attributes.TryGetTypedValue("url.full", out string? url) && (_options?.IsSentryRequest(url) ?? false))
         {
             _options?.DiagnosticLogger?.LogDebug($"Ignoring Activity {data.SpanId} for Sentry request.");
 

--- a/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
@@ -378,14 +378,16 @@ public class SentrySpanProcessorTests : ActivitySourceTests
         }
     }
 
-    [Fact]
-    public void OnEnd_IsSentryRequest_DoesNotFinishTransaction()
+    [Theory]
+    [InlineData(OtelSemanticConventions.AttributeUrlFull)]
+    [InlineData(OtelSemanticConventions.AttributeHttpUrl)]
+    public void OnEnd_IsSentryRequest_DoesNotFinishTransaction(string urlKey)
     {
         // Arrange
         _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
         var sut = _fixture.GetSut();
 
-        var tags = new Dictionary<string, object> { { "foo", "bar" }, { "http.url", _fixture.Options.Dsn } };
+        var tags = new Dictionary<string, object> { { "foo", "bar" }, { urlKey, _fixture.Options.Dsn } };
         var data = Tracer.StartActivity(name: "test operation", kind: ActivityKind.Internal, parentContext: default, tags)!;
         data.DisplayName = "test display name";
         sut.OnStart(data);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/2998

Looks like the key changed.