### PR TITLE
chore: make use of the new NSMutableDictionary return type in iOS profiler

### DIFF
--- a/src/Sentry/Platforms/Cocoa/CocoaProfiler.cs
+++ b/src/Sentry/Platforms/Cocoa/CocoaProfiler.cs
@@ -36,8 +36,7 @@ internal class CocoaProfiler : ITransactionProfiler
 
     public ISerializable? Collect(Transaction transaction)
     {
-        // TODO change return type of CocoaSDKs CollectProfileBetween to NSMutableDictionary
-        var payload = SentryCocoaHybridSdk.CollectProfileBetween(_startTimeNs, _endTimeNs, _cocoaTraceId)?.MutableCopy() as NSMutableDictionary;
+        var payload = SentryCocoaHybridSdk.CollectProfileBetween(_startTimeNs, _endTimeNs, _cocoaTraceId) as NSMutableDictionary;
         if (payload is null)
         {
             _options.LogWarning("Trace {0} collected profile payload is null", _traceId);

--- a/src/Sentry/Platforms/Cocoa/CocoaProfiler.cs
+++ b/src/Sentry/Platforms/Cocoa/CocoaProfiler.cs
@@ -36,7 +36,7 @@ internal class CocoaProfiler : ITransactionProfiler
 
     public ISerializable? Collect(Transaction transaction)
     {
-        var payload = SentryCocoaHybridSdk.CollectProfileBetween(_startTimeNs, _endTimeNs, _cocoaTraceId) as NSMutableDictionary;
+        var payload = SentryCocoaHybridSdk.CollectProfileBetween(_startTimeNs, _endTimeNs, _cocoaTraceId);
         if (payload is null)
         {
             _options.LogWarning("Trace {0} collected profile payload is null", _traceId);


### PR DESCRIPTION
Follow up on changes from the latest Cocoa SDK update.

#skip-changelog
