### PR TITLE
install android SDK automatically in CI

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -11,6 +11,9 @@ runs:
         echo "DOTNET_CLI_TELEMETRY_OPTOUT=1" >> $GITHUB_ENV
         echo "DOTNET_NOLOGO=1" >> $GITHUB_ENV
 
+    - name: Install Android SDK
+      uses: android-actions/setup-android@v3
+
     - name: Set Java Version
       uses: actions/setup-java@v3
       with:

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -11,8 +11,8 @@ runs:
         echo "DOTNET_CLI_TELEMETRY_OPTOUT=1" >> $GITHUB_ENV
         echo "DOTNET_NOLOGO=1" >> $GITHUB_ENV
 
-    - name: Set Java Version
-      uses: actions/setup-java@v3
+    # Needed for Android SDK setup step
+    - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: '17'

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -17,8 +17,8 @@ runs:
         distribution: 'temurin'
         java-version: '17'
 
-    - name: Install Android SDK
-      uses: android-actions/setup-android@v3
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@07976c6290703d34c16d382cb36445f98bb43b1f # v3.2.0
 
     - name: Set Java Version
       uses: actions/setup-java@v3

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -11,6 +11,12 @@ runs:
         echo "DOTNET_CLI_TELEMETRY_OPTOUT=1" >> $GITHUB_ENV
         echo "DOTNET_NOLOGO=1" >> $GITHUB_ENV
 
+    - name: Set Java Version
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
     - name: Install Android SDK
       uses: android-actions/setup-android@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         run: dotnet restore Sentry-CI-Build-${{ runner.os }}.slnf --nologo
 
       - name: Install Android SDK
-        run: dotnet build -t:InstallAndroidDependencies -p:AcceptAndroidSDKLicenses=True -p:AndroidSdkPath="/usr/local/lib/android/sdk/"
+        run: dotnet build -t:InstallAndroidDependencies -p:AcceptAndroidSDKLicenses=True -p:AndroidSdkPath=${{ env.ANDROID_SDK_ROOT }}
         working-directory: samples/Sentry.Samples.Android
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,10 +110,6 @@ jobs:
       - name: Restore .NET Dependencies
         run: dotnet restore Sentry-CI-Build-${{ runner.os }}.slnf --nologo
 
-      - name: Install Android SDK
-        run: dotnet build -t:InstallAndroidDependencies -p:AcceptAndroidSDKLicenses=True -p:AndroidSdkPath=${{ env.ANDROID_SDK_ROOT }}
-        working-directory: samples/Sentry.Samples.Android
-
       - name: Build
         run: dotnet build Sentry-CI-Build-${{ runner.os }}.slnf -c Release --no-restore --nologo -flp:logfile=build.log -p:CopyLocalLockFileAssemblies=true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,10 @@ jobs:
       - name: Restore .NET Dependencies
         run: dotnet restore Sentry-CI-Build-${{ runner.os }}.slnf --nologo
 
+      - name: Install Android SDK
+        run: dotnet build -t:InstallAndroidDependencies -p:AcceptAndroidSDKLicenses=True -p:AndroidSdkPath="/usr/local/lib/android/sdk/"
+        working-directory: samples/Sentry.Samples.Android
+
       - name: Build
         run: dotnet build Sentry-CI-Build-${{ runner.os }}.slnf -c Release --no-restore --nologo -flp:logfile=build.log -p:CopyLocalLockFileAssemblies=true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,6 +180,15 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      # Needed for Android SDK setup step
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@07976c6290703d34c16d382cb36445f98bb43b1f # v3.2.0
+
       - run: dotnet workload install android maui-android
 
       - name: Test

--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -25,12 +25,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set Java Version
-        uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "11"
-
       - name: Setup Environment
         uses: ./.github/actions/environment
 

--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -73,27 +73,18 @@ try
                 throw 'xharness run failed with non-zero exit code'
                 Pop-Location
             }
-
-            Remove-Item -Recurse -Force test_output -ErrorAction SilentlyContinue
-            try
+        }
+        finally
+        {
+            if ($CI)
             {
-                xharness $group test $arguments --output-directory=test_output
-                if ($LASTEXITCODE -ne 0)
-                {
-                    throw 'xharness run failed with non-zero exit code'
-                }
+                scripts/parse-xunit2-xml.ps1 (Get-Item ./test_output/*.xml).FullName | Out-File $env:GITHUB_STEP_SUMMARY
             }
-            finally
-            {
-                if ($CI)
-                {
-                    scripts/parse-xunit2-xml.ps1 (Get-Item ./test_output/*.xml).FullName | Out-File $env:GITHUB_STEP_SUMMARY
-                }
 
-            }
         }
     }
-    finally
-    {
-        Pop-Location
-    }
+}
+finally
+{
+    Pop-Location
+}

--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -71,7 +71,6 @@ try
             if ($LASTEXITCODE -ne 0)
             {
                 throw 'xharness run failed with non-zero exit code'
-                Pop-Location
             }
         }
         finally

--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -9,7 +9,7 @@ param(
 )
 
 Set-StrictMode -Version latest
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
 
 if (!$Build -and !$Run)
 {
@@ -32,6 +32,16 @@ try
             '--app', "$buildDir/io.sentry.dotnet.maui.device.testapp-Signed.apk",
             '--package-name', 'io.sentry.dotnet.maui.device.testapp'
         )
+
+        if ($Build -and $CI)
+        {
+            dotnet build -f $tfm -t:InstallAndroidDependencies -p:AcceptAndroidSDKLicenses=True -p:AndroidSdkPath="/usr/local/lib/android/sdk/" test/Sentry.Maui.Device.TestApp
+            if ($LASTEXITCODE -ne 0)
+            {
+                throw 'Failed to build Sentry.Maui.Device.TestApp'
+            }
+        }
+
     }
     elseif ($Platform -eq 'ios')
     {
@@ -50,7 +60,7 @@ try
         dotnet build -f $tfm -c Release test/Sentry.Maui.Device.TestApp
         if ($LASTEXITCODE -ne 0)
         {
-            throw "Failed to build Sentry.Maui.Device.TestApp"
+            throw 'Failed to build Sentry.Maui.Device.TestApp'
         }
     }
 
@@ -59,7 +69,7 @@ try
         if (!(Get-Command xharness -ErrorAction SilentlyContinue))
         {
             Push-Location ($CI ? $env:RUNNER_TEMP : $IsWindows ? $env:TMP : $IsMacos ? $env:TMPDIR : '/temp')
-            dotnet tool install Microsoft.DotNet.XHarness.CLI --global --version "1.*-*" `
+            dotnet tool install Microsoft.DotNet.XHarness.CLI --global --version '1.*-*' `
                 --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
             Pop-Location
         }
@@ -70,7 +80,7 @@ try
             xharness $group test $arguments --output-directory=test_output
             if ($LASTEXITCODE -ne 0)
             {
-                throw "xharness run failed with non-zero exit code"
+                throw 'xharness run failed with non-zero exit code'
             }
         }
         finally

--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -35,7 +35,7 @@ try
 
         if ($Build -and $CI)
         {
-            dotnet build -f $tfm -t:InstallAndroidDependencies -p:AcceptAndroidSDKLicenses=True -p:AndroidSdkPath="/usr/local/lib/android/sdk/" test/Sentry.Maui.Device.TestApp
+            dotnet build -f $tfm -t:InstallAndroidDependencies -p:AcceptAndroidSDKLicenses=True -p:AndroidSdkPath=$env:ANDROID_SDK_ROOT test/Sentry.Maui.Device.TestApp
             if ($LASTEXITCODE -ne 0)
             {
                 throw 'Failed to build Sentry.Maui.Device.TestApp'


### PR DESCRIPTION
Old Android SDKs have been removed from GH actions images (https://github.com/actions/runner-images/issues/8952), let's install them manually.

closes #3032 

#skip-changelog
