### PR TITLE
Replaced ConcurrentDictionary with ReaderWriterLockSlim in MetricAggregator

### DIFF
--- a/src/Sentry/MetricAggregator.cs
+++ b/src/Sentry/MetricAggregator.cs
@@ -14,6 +14,7 @@ internal class MetricAggregator : IMetricAggregator
     private readonly TimeSpan _flushInterval;
 
     private readonly SemaphoreSlim _codeLocationLock = new(1,1);
+    private readonly ReaderWriterLockSlim _bucketsLock = new ReaderWriterLockSlim();
 
     private readonly CancellationTokenSource _shutdownSource;
     private volatile bool _disposed;
@@ -21,10 +22,10 @@ internal class MetricAggregator : IMetricAggregator
     // The key for this dictionary is the Timestamp for the bucket, rounded down to the nearest RollupInSeconds... so it
     // aggregates all of the metrics data for a particular time period. The Value is a dictionary for the metrics,
     // each of which has a key that uniquely identifies it within the time period
-    internal ConcurrentDictionary<long, ConcurrentDictionary<string, Metric>> Buckets => _buckets.Value;
+    internal Dictionary<long, ConcurrentDictionary<string, Metric>> Buckets => _buckets.Value;
 
-    private readonly Lazy<ConcurrentDictionary<long, ConcurrentDictionary<string, Metric>>> _buckets
-        = new(() => new ConcurrentDictionary<long, ConcurrentDictionary<string, Metric>>());
+    private readonly Lazy<Dictionary<long, ConcurrentDictionary<string, Metric>>> _buckets
+        = new(() => new Dictionary<long, ConcurrentDictionary<string, Metric>>());
 
     private long _lastClearedStaleLocations = DateTimeOffset.UtcNow.GetDayBucketKey();
     private readonly ConcurrentDictionary<long, HashSet<MetricResourceIdentifier>> _seenLocations = new();
@@ -183,10 +184,7 @@ internal class MetricAggregator : IMetricAggregator
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unknown MetricType")
         };
 
-        var timeBucket = Buckets.GetOrAdd(
-            timestamp.Value.GetTimeBucketKey(),
-            _ => new ConcurrentDictionary<string, Metric>()
-        );
+        var timeBucket = GetOrAddTimeBucket(timestamp.Value.GetTimeBucketKey());
 
         timeBucket.AddOrUpdate(
             GetMetricBucketKey(type, key, unit.Value, tags),
@@ -213,6 +211,44 @@ internal class MetricAggregator : IMetricAggregator
         if (_options.ExperimentalMetrics is { EnableCodeLocations: true })
         {
             RecordCodeLocation(type, key, unit.Value, stackLevel + 1, timestamp.Value);
+        }
+    }
+
+    private ConcurrentDictionary<string, Metric> GetOrAddTimeBucket(long bucketKey)
+    {
+        _bucketsLock.EnterUpgradeableReadLock();
+        try
+        {
+            if (Buckets.TryGetValue(bucketKey, out var existingBucket))
+            {
+                return existingBucket;
+            }
+            else
+            {
+                _bucketsLock.EnterWriteLock();
+                try
+                {
+                    // Check again in case another thread added the bucket while we were waiting for the write lock
+                    if (Buckets.TryGetValue(bucketKey, out existingBucket))
+                    {
+                        return existingBucket;
+                    }
+                    else
+                    {
+                        var timeBucket = new ConcurrentDictionary<string, Metric>();
+                        Buckets[bucketKey] = timeBucket;
+                        return timeBucket;
+                    }
+                }
+                finally
+                {
+                    _bucketsLock.ExitWriteLock();
+                }
+            }
+        }
+        finally
+        {
+            _bucketsLock.ExitUpgradeableReadLock();
         }
     }
 
@@ -334,9 +370,27 @@ internal class MetricAggregator : IMetricAggregator
                 cancellationToken.ThrowIfCancellationRequested();
 
                 _options.LogDebug("Flushing metrics for bucket {0}", key);
-                if (!Buckets.TryRemove(key, out var bucket))
+                ConcurrentDictionary<string, Metric>? bucket;
+                _bucketsLock.EnterWriteLock();
+                try
                 {
-                    continue;
+#if NETSTANDARD2_1_OR_GREATER
+                    if (!Buckets.Remove(key, out bucket))
+                    {
+                        continue;
+                    }
+#else
+                    if (!Buckets.ContainsKey(key))
+                    {
+                        continue;
+                    }
+                    bucket = Buckets[key];
+                    Buckets.Remove(key);
+#endif
+                }
+                finally
+                {
+                    _bucketsLock.ExitWriteLock();
                 }
 
                 _captureMetrics(bucket.Values);
@@ -383,10 +437,20 @@ internal class MetricAggregator : IMetricAggregator
             yield break;
         }
 
+        long[] keys;
+        _bucketsLock.EnterReadLock();
+        try
+        {
+            keys = Buckets.Keys.ToArray();
+        }
+        finally
+        {
+            _bucketsLock.ExitReadLock();
+        }
         if (force)
         {
             // Return all the buckets in this case
-            foreach (var key in Buckets.Keys)
+            foreach (var key in keys)
             {
                 yield return key;
             }
@@ -394,7 +458,7 @@ internal class MetricAggregator : IMetricAggregator
         else
         {
             var cutoff = MetricHelper.GetCutoff();
-            foreach (var key in Buckets.Keys)
+            foreach (var key in keys)
             {
                 var bucketTime = DateTimeOffset.FromUnixTimeSeconds(key);
                 if (bucketTime < cutoff)


### PR DESCRIPTION
#skip-changelog

Checking to see if this helps with https://github.com/getsentry/sentry-dotnet/issues/3033... I think we merge this in, once reviewed, and monitor to see if we have any more test failures over the next couple of weeks before resolving the original issue.