### PR TITLE
chore: update internal dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -73,7 +73,7 @@
 
   <ItemGroup>
     <PackageReference Include="UnoptimizedAssemblyDetector" Version="0.1.1" PrivateAssets="All" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.3.0" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.9.0" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Import the root global usings, except for samples. -->

--- a/benchmarks/Sentry.Benchmarks/Sentry.Benchmarks.csproj
+++ b/benchmarks/Sentry.Benchmarks/Sentry.Benchmarks.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
-    <PackageReference Include="NSubstitute" Version="5.0.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.12" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -56,7 +56,7 @@
 
   <!-- only non-platform-specific projects should include these packages -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)'==''">
-    <PackageReference Include="Verify.Xunit" Version="22.11.5" />
+    <PackageReference Include="Verify.Xunit" Version="22.11.4" />
     <PackageReference Include="Verify.DiffPlex" Version="2.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" PrivateAssets="All" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -59,7 +59,7 @@
     <PackageReference Include="Verify.Xunit" Version="22.11.4" />
     <PackageReference Include="Verify.DiffPlex" Version="2.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -46,20 +46,20 @@
     <Using Include="Xunit" />
     <Using Include="Xunit.Abstractions" />
 
-    <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="xunit" Version="2.6.5" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.2" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="19.2.29" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="20.0.4" />
   </ItemGroup>
 
   <!-- only non-platform-specific projects should include these packages -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)'==''">
-    <PackageReference Include="Verify.Xunit" Version="20.0.0" />
-    <PackageReference Include="Verify.DiffPlex" Version="2.2.1" />
-    <PackageReference Include="PublicApiGenerator" Version="11.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="All" />
+    <PackageReference Include="Verify.Xunit" Version="22.11.5" />
+    <PackageReference Include="Verify.DiffPlex" Version="2.3.0" />
+    <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>

--- a/test/MauiTestUtils/DeviceTests.Runners.SourceGen/TestUtils.DeviceTests.Runners.SourceGen.csproj
+++ b/test/MauiTestUtils/DeviceTests.Runners.SourceGen/TestUtils.DeviceTests.Runners.SourceGen.csproj
@@ -6,10 +6,11 @@
     <RootNamespace>Microsoft.Maui.TestUtils</RootNamespace>
     <AssemblyName>Microsoft.Maui.TestUtils.DeviceTests.Runners.SourceGen</AssemblyName>
     <IsPackable>false</IsPackable>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MauiTestUtils/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/test/MauiTestUtils/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.utility" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.6.5" />
+    <PackageReference Include="xunit.runner.utility" Version="2.6.5" />
     <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.23252.4" />
   </ItemGroup>
 

--- a/test/MauiTestUtils/DeviceTests/AssertionExtensions.Android.cs
+++ b/test/MauiTestUtils/DeviceTests/AssertionExtensions.Android.cs
@@ -223,7 +223,7 @@ public static partial class AssertionExtensions
             }
         }
 
-        Assert.True(false, CreateColorError(bitmap, $"Color {expectedColor} not found."));
+        Assert.Fail(CreateColorError(bitmap, $"Color {expectedColor} not found."));
         return bitmap;
     }
 

--- a/test/MauiTestUtils/DeviceTests/AssertionExtensions.Windows.cs
+++ b/test/MauiTestUtils/DeviceTests/AssertionExtensions.Windows.cs
@@ -205,7 +205,7 @@ public static partial class AssertionExtensions
             }
         }
 
-        Assert.True(false, await CreateColorError(bitmap, $"Color {expectedColor} not found."));
+        Assert.Fail(await CreateColorError(bitmap, $"Color {expectedColor} not found."));
         return bitmap;
     }
 

--- a/test/MauiTestUtils/DeviceTests/AssertionExtensions.cs
+++ b/test/MauiTestUtils/DeviceTests/AssertionExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.DeviceTests;
 
 public static partial class AssertionExtensions
 {
-    static readonly Random rnd = new Random();
+    static private readonly Random rnd = new Random();
 
     public static async Task<bool> Wait(Func<bool> exitCondition, int timeout = 1000)
     {
@@ -22,14 +22,6 @@ public static partial class AssertionExtensions
         return exitCondition.Invoke();
     }
 
-    public static void AssertHasFlag(this Enum self, Enum flag)
-    {
-        var hasFlag = self.HasFlag(flag);
-
-        if (!hasFlag)
-            throw new ContainsException(flag, self);
-    }
-
     public static void AssertWithMessage(Action assertion, string message)
     {
         try
@@ -38,7 +30,7 @@ public static partial class AssertionExtensions
         }
         catch (Exception e)
         {
-            Assert.True(false, $"Message: {message} Failure: {e}");
+            Assert.Fail($"Message: {message} Failure: {e}");
         }
     }
 

--- a/test/MauiTestUtils/DeviceTests/TestUtils.DeviceTests.csproj
+++ b/test/MauiTestUtils/DeviceTests/TestUtils.DeviceTests.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.utility" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.6.5" />
+    <PackageReference Include="xunit.runner.utility" Version="2.6.5" />
     <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.23252.4" />
   </ItemGroup>
 

--- a/test/Sentry.Google.Cloud.Functions.Tests/IntegrationTests.cs
+++ b/test/Sentry.Google.Cloud.Functions.Tests/IntegrationTests.cs
@@ -67,7 +67,7 @@ public class IntegrationTests
                 "Expected SDK name to be in the payload");
             return; // pass
         }
-        Assert.False(true, "Exception should bubble from Middleware");
+        Assert.Fail("Exception should bubble from Middleware");
     }
 
     public class FailingFunction : IHttpFunction

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.Application.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.Application.cs
@@ -41,7 +41,7 @@ public partial class MauiEventsBinderTests
 
         var element = Substitute.For<Element>();
         application.RaiseEvent(eventName, new ElementEventArgs(element));
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleApplicationEvents(application, bind: false);
 
@@ -50,7 +50,7 @@ public partial class MauiEventsBinderTests
 
         // Assert
         application.RaiseEvent(eventName, new ElementEventArgs(element));
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 
     [Theory]
@@ -93,7 +93,7 @@ public partial class MauiEventsBinderTests
         };
 
         application.RaiseEvent(eventName, page);
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleApplicationEvents(application, bind: false);
 
@@ -101,7 +101,7 @@ public partial class MauiEventsBinderTests
         application.RaiseEvent(eventName, page);
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 
     [Theory]
@@ -134,7 +134,7 @@ public partial class MauiEventsBinderTests
         _fixture.Binder.HandleApplicationEvents(application);
 
         application.RaiseEvent(eventName, eventArgs);
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleApplicationEvents(application, bind: false);
 
@@ -142,7 +142,7 @@ public partial class MauiEventsBinderTests
         application.RaiseEvent(eventName, eventArgs);
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 
     public static IEnumerable<object[]> ApplicationModalEventsData
@@ -192,7 +192,7 @@ public partial class MauiEventsBinderTests
         _fixture.Binder.HandleApplicationEvents(application);
 
         application.UserAppTheme = AppTheme.Dark;
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleApplicationEvents(application, bind: false);
 
@@ -200,6 +200,6 @@ public partial class MauiEventsBinderTests
         application.UserAppTheme = AppTheme.Light;
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 }

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.Button.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.Button.cs
@@ -42,7 +42,7 @@ public partial class MauiEventsBinderTests
         };
         _fixture.Binder.HandleButtonEvents(button);
         button.RaiseEvent(eventName, EventArgs.Empty);
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleButtonEvents(button, bind: false);
 
@@ -50,6 +50,6 @@ public partial class MauiEventsBinderTests
         button.RaiseEvent(eventName, EventArgs.Empty);
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 }

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.Element.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.Element.cs
@@ -42,7 +42,7 @@ public partial class MauiEventsBinderTests
         var child = new MockElement("child");
 
         parent.RaiseEvent(eventName, new ElementEventArgs(child));
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleElementEvents(parent, bind: false);
 
@@ -50,7 +50,7 @@ public partial class MauiEventsBinderTests
         parent.RaiseEvent(eventName, new ElementEventArgs(child));
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 
     [Fact]
@@ -88,7 +88,7 @@ public partial class MauiEventsBinderTests
         _fixture.Binder.HandleElementEvents(element);
 
         element.RaiseEvent(nameof(Application.ParentChanged), EventArgs.Empty);
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleElementEvents(element, bind: false);
 
@@ -96,7 +96,7 @@ public partial class MauiEventsBinderTests
         element.RaiseEvent(nameof(Application.ParentChanged), EventArgs.Empty);
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 
     [Fact]
@@ -132,7 +132,7 @@ public partial class MauiEventsBinderTests
         var otherBindingContext = Substitute.For<object>();
 
         element.BindingContext = bindingContext;
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleElementEvents(element, bind: false);
 
@@ -140,6 +140,6 @@ public partial class MauiEventsBinderTests
         element.BindingContext = otherBindingContext;
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 }

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.Page.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.Page.cs
@@ -41,7 +41,7 @@ public partial class MauiEventsBinderTests
         _fixture.Binder.HandlePageEvents(page);
 
         page.RaiseEvent(eventName, EventArgs.Empty);
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandlePageEvents(page, bind: false);
 
@@ -49,7 +49,7 @@ public partial class MauiEventsBinderTests
         page.RaiseEvent(eventName, EventArgs.Empty);
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public partial class MauiEventsBinderTests
                 .Invoke(new object[] {otherPage});
 
         page.RaiseEvent(nameof(Page.NavigatedTo), navigatedToEventArgs);
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandlePageEvents(page, bind: false);
 
@@ -113,7 +113,7 @@ public partial class MauiEventsBinderTests
         page.RaiseEvent(nameof(Page.NavigatedTo), navigatedToEventArgs);
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 
     [Fact]

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.Shell.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.Shell.cs
@@ -48,7 +48,7 @@ public partial class MauiEventsBinderTests
         const ShellNavigationSource source = ShellNavigationSource.Push;
 
         shell.RaiseEvent(nameof(Shell.Navigating), new ShellNavigatingEventArgs(current, target, source, false));
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleShellEvents(shell, bind: false);
 
@@ -56,7 +56,7 @@ public partial class MauiEventsBinderTests
         shell.RaiseEvent(nameof(Shell.Navigating), new ShellNavigatingEventArgs(target, current, source, false));
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public partial class MauiEventsBinderTests
         const ShellNavigationSource source = ShellNavigationSource.Push;
 
         shell.RaiseEvent(nameof(Shell.Navigated), new ShellNavigatedEventArgs(previous, current, source));
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleShellEvents(shell, bind: false);
 
@@ -111,6 +111,6 @@ public partial class MauiEventsBinderTests
         shell.RaiseEvent(nameof(Shell.Navigated), new ShellNavigatedEventArgs(current, previous, source));
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 }

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.VisualElement.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.VisualElement.cs
@@ -36,7 +36,7 @@ public partial class MauiEventsBinderTests
         _fixture.Binder.HandleVisualElementEvents(element);
 
         element.RaiseEvent(eventName, new FocusEventArgs(element, isFocused));
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleVisualElementEvents(element, bind: false);
 
@@ -44,6 +44,6 @@ public partial class MauiEventsBinderTests
         element.RaiseEvent(eventName, new FocusEventArgs(element, isFocused));
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 }

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.Window.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.Window.cs
@@ -49,7 +49,7 @@ public partial class MauiEventsBinderTests
         _fixture.Binder.HandleWindowEvents(window);
 
         window.RaiseEvent(eventName, EventArgs.Empty);
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleWindowEvents(window, bind: false);
 
@@ -57,7 +57,7 @@ public partial class MauiEventsBinderTests
         window.RaiseEvent(eventName, EventArgs.Empty);
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 
     [Theory]
@@ -122,7 +122,7 @@ public partial class MauiEventsBinderTests
         };
 
         window.RaiseEvent(nameof(Window.Backgrounding), new BackgroundingEventArgs(state));
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleWindowEvents(window, bind: false);
 
@@ -130,7 +130,7 @@ public partial class MauiEventsBinderTests
         window.RaiseEvent(nameof(Window.Backgrounding), new BackgroundingEventArgs(state));
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 
     [Fact]
@@ -167,7 +167,7 @@ public partial class MauiEventsBinderTests
         _fixture.Binder.HandleWindowEvents(window);
 
         window.RaiseEvent(nameof(Window.DisplayDensityChanged), new DisplayDensityChangedEventArgs(1.25f));
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleWindowEvents(window, bind: false);
 
@@ -175,7 +175,7 @@ public partial class MauiEventsBinderTests
         window.RaiseEvent(nameof(Window.DisplayDensityChanged), new DisplayDensityChangedEventArgs(1.0f));
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 
     [Fact]
@@ -211,7 +211,7 @@ public partial class MauiEventsBinderTests
         _fixture.Binder.HandleWindowEvents(window);
 
         window.RaiseEvent(nameof(Window.PopCanceled), EventArgs.Empty);
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleWindowEvents(window, bind: false);
 
@@ -219,7 +219,7 @@ public partial class MauiEventsBinderTests
         window.RaiseEvent(nameof(Window.PopCanceled), EventArgs.Empty);
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 
     [Theory]
@@ -259,7 +259,7 @@ public partial class MauiEventsBinderTests
         _fixture.Binder.HandleWindowEvents(window);
 
         window.RaiseEvent(eventName, eventArgs);
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count); // Sanity check
+        Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check
 
         _fixture.Binder.HandleWindowEvents(window, bind: false);
 
@@ -267,7 +267,7 @@ public partial class MauiEventsBinderTests
         window.RaiseEvent(eventName, eventArgs);
 
         // Assert
-        Assert.Equal(1, _fixture.Scope.Breadcrumbs.Count);
+        Assert.Single(_fixture.Scope.Breadcrumbs);
     }
 
     public static IEnumerable<object[]> WindowModalEventsData

--- a/test/Sentry.Testing/Sentry.Testing.csproj
+++ b/test/Sentry.Testing/Sentry.Testing.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Sentry.Tests/FailedRequestTargetsTests.cs
+++ b/test/Sentry.Tests/FailedRequestTargetsTests.cs
@@ -6,7 +6,7 @@ public class FailedRequestTargetsTests
     public void SentryOptions_FailedRequestTargets_DefaultAll()
     {
         var options = new SentryOptions();
-        Assert.Equal(1, options.FailedRequestTargets.Count);
+        Assert.Single(options.FailedRequestTargets);
         Assert.Equal(".*", options.FailedRequestTargets[0].ToString());
     }
 

--- a/test/Sentry.Tests/GlobalSessionManagerTests.cs
+++ b/test/Sentry.Tests/GlobalSessionManagerTests.cs
@@ -496,8 +496,7 @@ public class GlobalSessionManagerTests : IDisposable
         persistedSessionUpdate.Should().BeNull();
     }
 
-    [Fact]
-    public SessionUpdate TryRecoverPersistedSession_HasRecoveredUpdateAndCrashedLastRunFailed_RecoveredSessionCaptured()
+    public SessionUpdate TryRecoverPersistedSessionWithExceptionOnLastRun()
     {
         // Arrange
         var expectedCrashMessage = "Invoking CrashedLastRun failed.";
@@ -520,7 +519,11 @@ public class GlobalSessionManagerTests : IDisposable
         return persistedSessionUpdate;
     }
 
-    public SessionUpdate TryRecoverPersistedSessionWithExceptionOnLastRun() => TryRecoverPersistedSession_HasRecoveredUpdateAndCrashedLastRunFailed_RecoveredSessionCaptured();
+    [Fact]
+    public void TryRecoverPersistedSession_HasRecoveredUpdateAndCrashedLastRunFailed_RecoveredSessionCaptured()
+    {
+        TryRecoverPersistedSessionWithExceptionOnLastRun();
+    }
 
     // A session update (of which the state doesn't matter for the test):
     private static SessionUpdate AnySessionUpdate()

--- a/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
@@ -792,7 +792,7 @@ public partial class HttpTransportTests
         var processedEnvelope = httpTransport.ProcessEnvelope(envelope);
 
         // There should only be the one event in the envelope
-        Assert.Equal(1, processedEnvelope.Items.Count);
+        Assert.Single(processedEnvelope.Items);
         Assert.Equal("event", processedEnvelope.Items[0].TryGetType());
     }
 }

--- a/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
+++ b/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
@@ -23,8 +23,8 @@ public partial class SentryStackTraceFactoryTests
         Assert.Null(sut.Create());
     }
 
-// TODO: Create integration test to test this behaviour when publishing AOT apps
-// See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
+    // TODO: Create integration test to test this behaviour when publishing AOT apps
+    // See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
     [Fact]
     public void Create_NoExceptionAndAttachStackTraceOptionOnWithOriginalMode_CurrentStackTrace()
     {
@@ -47,19 +47,19 @@ public partial class SentryStackTraceFactoryTests
             ) == true);
     }
 
-// TODO: Create integration test to test this behaviour when publishing AOT apps
-// See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
+    // TODO: Create integration test to test this behaviour when publishing AOT apps
+    // See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
     [Theory]
     [InlineData(StackTraceMode.Original, "AsyncWithWait_StackTrace { <lambda> }")]
     [InlineData(StackTraceMode.Enhanced, "void SentryStackTraceFactoryTests.AsyncWithWait_StackTrace(StackTraceMode mode, string method)+() => { }")]
-    public void AsyncWithWait_StackTrace(StackTraceMode mode, string method)
+    public async void AsyncWithWait_StackTrace(StackTraceMode mode, string method)
     {
         _fixture.SentryOptions.StackTraceMode = mode;
         _fixture.SentryOptions.AttachStacktrace = true;
         var sut = _fixture.GetSut();
 
         SentryStackTrace stackTrace = null!;
-        Task.Run(() => stackTrace = sut.Create()).Wait();
+        await Task.Run(() => stackTrace = sut.Create());
 
         Assert.NotNull(stackTrace);
 
@@ -71,8 +71,8 @@ public partial class SentryStackTraceFactoryTests
         }
     }
 
-// TODO: Create integration test to test this behaviour when publishing AOT apps
-// See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
+    // TODO: Create integration test to test this behaviour when publishing AOT apps
+    // See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
     [Theory]
     [InlineData(StackTraceMode.Original, "MoveNext")] // Should be "AsyncWithAwait_StackTrace { <lambda> }", but see note in SentryStackTraceFactory
     [InlineData(StackTraceMode.Enhanced, "async Task SentryStackTraceFactoryTests.AsyncWithAwait_StackTrace(StackTraceMode mode, string method)+(?) => { }")]
@@ -93,8 +93,8 @@ public partial class SentryStackTraceFactoryTests
         Assert.Equal(method, stackTrace.Frames.Last().Function);
     }
 
-// TODO: Create integration test to test this behaviour when publishing AOT apps
-// See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
+    // TODO: Create integration test to test this behaviour when publishing AOT apps
+    // See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
     [Fact]
     public void Create_NoExceptionAndAttachStackTraceOptionOnWithEnhancedMode_CurrentStackTrace()
     {
@@ -117,8 +117,8 @@ public partial class SentryStackTraceFactoryTests
             ) == true);
     }
 
-// TODO: Create integration test to test this behaviour when publishing AOT apps
-// See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
+    // TODO: Create integration test to test this behaviour when publishing AOT apps
+    // See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
     [Fact]
     public void Create_WithExceptionAndDefaultAttachStackTraceOption_HasStackTrace()
     {
@@ -135,8 +135,8 @@ public partial class SentryStackTraceFactoryTests
         Assert.NotNull(sut.Create(exception));
     }
 
-// TODO: Create integration test to test this behaviour when publishing AOT apps
-// See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
+    // TODO: Create integration test to test this behaviour when publishing AOT apps
+    // See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
     [Fact]
     public void Create_WithExceptionAndAttachStackTraceOptionOn_HasStackTrace()
     {
@@ -156,8 +156,8 @@ public partial class SentryStackTraceFactoryTests
         Assert.Equal(new StackTrace(exception, true).FrameCount, stackTrace?.Frames.Count);
     }
 
-// TODO: Create integration test to test this behaviour when publishing AOT apps
-// See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
+    // TODO: Create integration test to test this behaviour when publishing AOT apps
+    // See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
     [SkippableFact]
     public void FileNameShouldBeRelative()
     {
@@ -197,8 +197,8 @@ public partial class SentryStackTraceFactoryTests
 
     private static string GetThisFilePath([CallerFilePath] string path = null) => path;
 
-// TODO: Create integration test to test this behaviour when publishing AOT apps
-// See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
+    // TODO: Create integration test to test this behaviour when publishing AOT apps
+    // See https://github.com/getsentry/sentry-dotnet/pull/2732#discussion_r1371006441
     [Theory]
     [InlineData(StackTraceMode.Original, "ByRefMethodThatThrows")]
     [InlineData(StackTraceMode.Enhanced, "(Fixture f, int b) SentryStackTraceFactoryTests.ByRefMethodThatThrows(int value, in int valueIn, ref int valueRef, out int valueOut)")]

--- a/test/Sentry.Tests/ProfilerTests.cs
+++ b/test/Sentry.Tests/ProfilerTests.cs
@@ -53,9 +53,9 @@ public class ProfilerTests
             await hub.FlushAsync();
 
             // Asserts
-            var completedTask = await Task.WhenAny(tcs.Task, Task.Delay(1_000)).ConfigureAwait(false);
+            var completedTask = await Task.WhenAny(tcs.Task, Task.Delay(1_000));
             completedTask.Should().Be(tcs.Task);
-            var envelopeLines = tcs.Task.Result.Split('\n');
+            var envelopeLines = (await tcs.Task).Split('\n');
             envelopeLines.Length.Should().Be(6);
 
             // header rows before payloads

--- a/test/Sentry.Tests/Protocol/ScopeExtensionsTests.cs
+++ b/test/Sentry.Tests/Protocol/ScopeExtensionsTests.cs
@@ -1280,7 +1280,7 @@ public class ScopeExtensionsTests
         source.Apply(target);
 
         // Assert
-        Assert.Equal(1, target.Attachments.Count);
+        Assert.Single(target.Attachments);
     }
 
     [Fact]
@@ -1296,6 +1296,6 @@ public class ScopeExtensionsTests
         source.Apply(target);
 
         // Assert
-        Assert.Equal(1, target.Attachments.Count);
+        Assert.Single(target.Attachments);
     }
 }

--- a/test/Sentry.Tests/Sentry.Tests.csproj
+++ b/test/Sentry.Tests/Sentry.Tests.csproj
@@ -40,8 +40,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
   </ItemGroup>
 
 </Project>

--- a/test/Sentry.Tests/TracePropagationTargetTests.cs
+++ b/test/Sentry.Tests/TracePropagationTargetTests.cs
@@ -6,7 +6,7 @@ public class TracePropagationTargetTests
     public void SentryOptions_TracePropagationTargets_DefaultAll()
     {
         var options = new SentryOptions();
-        Assert.Equal(1, options.TracePropagationTargets.Count);
+        Assert.Single(options.TracePropagationTargets);
         Assert.Equal(".*", options.TracePropagationTargets[0].ToString());
     }
 


### PR DESCRIPTION
#skip-changelog

While trying to make .NET8 device tests work, I've noticed we have some outdated test dependencies.
This makes the changes in a self-contained PR.
