### PR TITLE
add sentry to global usings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@
 
 ### Significant change in behavior
 
-- Added `Sentry` namespace to global usings when `ImplicitUsings is enabled ([#3043](https://github.com/getsentry/sentry-dotnet/pull/3043))
-  - To opt-out, use `<SentryImplicitUsings>false</SentryImplicitUsings>` to your project.
+- Added `Sentry` namespace to global usings when `ImplicitUsings` is enabled ([#3043](https://github.com/getsentry/sentry-dotnet/pull/3043))
+If you have conflicts, you can opt-out by adding the following to your `csproj`:
+```
+<ItemGroup>
+  <Using Remove="Sentry" />
+</ItemGroup>
+```
 
 ## 4.0.0-beta.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
 - Added `Sentry` namespace to global usings when `ImplicitUsings` is enabled ([#3043](https://github.com/getsentry/sentry-dotnet/pull/3043))
 If you have conflicts, you can opt-out by adding the following to your `csproj`:
 ```
-<ItemGroup>
-  <Using Remove="Sentry" />
-</ItemGroup>
+<PropertyGroup>
+  <SentryImplicitUsings>false</SentryImplicitUsings>
+</PropertyGroup>
 ```
 
 ## 4.0.0-beta.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Significant change in behavior
+
+- Added `Sentry` namespace to global usings when `ImplicitUsings is enabled ([#3043](https://github.com/getsentry/sentry-dotnet/pull/3043))
+  - To opt-out, use `<SentryImplicitUsings>false</SentryImplicitUsings>` to your project.
+
 ## 4.0.0-beta.8
 
 ### Features

--- a/benchmarks/Sentry.Benchmarks/LastActiveSpanBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/LastActiveSpanBenchmarks.cs
@@ -1,5 +1,4 @@
 using BenchmarkDotNet.Attributes;
-using Perfolizer.Mathematics.Randomization;
 
 namespace Sentry.Benchmarks;
 

--- a/benchmarks/Sentry.Benchmarks/StackFrameBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/StackFrameBenchmarks.cs
@@ -1,5 +1,4 @@
 using BenchmarkDotNet.Attributes;
-using Sentry.Extensibility;
 
 namespace Sentry.Benchmarks;
 

--- a/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Program.cs
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Program.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
-using Sentry;
 using Sentry.Samples.AspNetCore.Blazor.Wasm;
 
 // Capture blazor bootstrapping errors

--- a/samples/Sentry.Samples.AspNetCore.Mvc/Controllers/HomeController.cs
+++ b/samples/Sentry.Samples.AspNetCore.Mvc/Controllers/HomeController.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Samples.AspNetCore.Mvc.Models;
-using Sentry;
 
 namespace Samples.AspNetCore.Mvc.Controllers;
 

--- a/samples/Sentry.Samples.AspNetCore.Mvc/ExampleEventProcessor.cs
+++ b/samples/Sentry.Samples.AspNetCore.Mvc/ExampleEventProcessor.cs
@@ -1,4 +1,3 @@
-using Sentry;
 using Sentry.Extensibility;
 
 namespace Samples.AspNetCore.Mvc;

--- a/samples/Sentry.Samples.AspNetCore.Mvc/SpecialExceptionProcessor.cs
+++ b/samples/Sentry.Samples.AspNetCore.Mvc/SpecialExceptionProcessor.cs
@@ -1,4 +1,3 @@
-using Sentry;
 using Sentry.Extensibility;
 
 namespace Samples.AspNetCore.Mvc;

--- a/samples/Sentry.Samples.Console.Basic/Program.cs
+++ b/samples/Sentry.Samples.Console.Basic/Program.cs
@@ -8,7 +8,7 @@
  * For more advanced features of the SDK, see Sentry.Samples.Console.Customized.
  */
 
-using Sentry;
+
 
 // Initialize the Sentry SDK.  (It is not necessary to dispose it.)
 SentrySdk.Init(options =>

--- a/samples/Sentry.Samples.Console.Basic/Program.cs
+++ b/samples/Sentry.Samples.Console.Basic/Program.cs
@@ -8,8 +8,6 @@
  * For more advanced features of the SDK, see Sentry.Samples.Console.Customized.
  */
 
-
-
 // Initialize the Sentry SDK.  (It is not necessary to dispose it.)
 SentrySdk.Init(options =>
 {

--- a/samples/Sentry.Samples.Console.Customized/Program.cs
+++ b/samples/Sentry.Samples.Console.Customized/Program.cs
@@ -1,6 +1,4 @@
-using System.Reflection;
 using System.Xml.Xsl;
-using Sentry;
 using Sentry.Extensibility;
 
 internal static class Program

--- a/samples/Sentry.Samples.Console.Metrics/Program.cs
+++ b/samples/Sentry.Samples.Console.Metrics/Program.cs
@@ -1,6 +1,4 @@
-﻿using System.Numerics;
-
-namespace Sentry.Samples.Console.Metrics;
+﻿namespace Sentry.Samples.Console.Metrics;
 
 internal static class Program
 {

--- a/samples/Sentry.Samples.Console.Native/Program.cs
+++ b/samples/Sentry.Samples.Console.Native/Program.cs
@@ -1,7 +1,8 @@
 /*
  * This sample demonstrates a native crash handling in a NativeAOT published application.
  */
-using Sentry;
+
+
 
 // Initialize the Sentry SDK.  (It is not necessary to dispose it.)
 SentrySdk.Init(options =>

--- a/samples/Sentry.Samples.Console.Native/Program.cs
+++ b/samples/Sentry.Samples.Console.Native/Program.cs
@@ -2,8 +2,6 @@
  * This sample demonstrates a native crash handling in a NativeAOT published application.
  */
 
-
-
 // Initialize the Sentry SDK.  (It is not necessary to dispose it.)
 SentrySdk.Init(options =>
 {

--- a/samples/Sentry.Samples.Console.Profiling/Program.cs
+++ b/samples/Sentry.Samples.Console.Profiling/Program.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using Sentry;
 using Sentry.Profiling;
 
 internal static class Program

--- a/samples/Sentry.Samples.EntityFramework/Program.cs
+++ b/samples/Sentry.Samples.EntityFramework/Program.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Data.Common;
 using System.Data.Entity;
-using Sentry;
 
 using var _ = SentrySdk.Init(o =>
 {

--- a/samples/Sentry.Samples.GenericHost/SampleHostedService.cs
+++ b/samples/Sentry.Samples.GenericHost/SampleHostedService.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Sentry;
 
 internal class SampleHostedService : IHostedService
 {

--- a/samples/Sentry.Samples.GraphQL.Client.Http/Program.cs
+++ b/samples/Sentry.Samples.GraphQL.Client.Http/Program.cs
@@ -8,7 +8,6 @@ using System.Text.Json;
 using GraphQL;
 using GraphQL.Client.Http;
 using GraphQL.Client.Serializer.SystemTextJson;
-using Sentry;
 
 SentrySdk.Init(options =>
 {

--- a/samples/Sentry.Samples.GraphQL.Server/Notes/NotesData.cs
+++ b/samples/Sentry.Samples.GraphQL.Server/Notes/NotesData.cs
@@ -1,5 +1,3 @@
-using System.Collections.Concurrent;
-
 namespace Sentry.Samples.GraphQL.Server.Notes;
 
 public class NotesData

--- a/samples/Sentry.Samples.OpenTelemetry.Console/Program.cs
+++ b/samples/Sentry.Samples.OpenTelemetry.Console/Program.cs
@@ -8,7 +8,6 @@
 using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using Sentry;
 using Sentry.OpenTelemetry;
 
 var serviceName = "Sentry.Samples.OpenTelemetry.Console";

--- a/src/Sentry.AspNet/SentryHttpServerUtilityExtensions.cs
+++ b/src/Sentry.AspNet/SentryHttpServerUtilityExtensions.cs
@@ -1,5 +1,4 @@
 using Sentry.Extensibility;
-using Sentry.Protocol;
 
 namespace Sentry.AspNet;
 

--- a/src/Sentry.AspNetCore/BindableSentryAspNetCoreOptions.cs
+++ b/src/Sentry.AspNetCore/BindableSentryAspNetCoreOptions.cs
@@ -1,12 +1,9 @@
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Sentry.Extensibility;
 using Sentry.Extensions.Logging;
 
 #if NETSTANDARD2_0
 using IWebHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
 #else
-using Microsoft.Extensions.Hosting;
 #endif
 
 namespace Sentry.AspNetCore;

--- a/src/Sentry.AspNetCore/BindableSentryAspNetCoreOptions.cs
+++ b/src/Sentry.AspNetCore/BindableSentryAspNetCoreOptions.cs
@@ -3,7 +3,6 @@ using Sentry.Extensions.Logging;
 
 #if NETSTANDARD2_0
 using IWebHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
-#else
 #endif
 
 namespace Sentry.AspNetCore;

--- a/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
+++ b/src/Sentry.AspNetCore/SentryAspNetCoreOptionsSetup.cs
@@ -3,8 +3,6 @@ using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Options;
 using Sentry.Extensions.Logging;
 
-using IHostingEnvironment = Microsoft.AspNetCore.Hosting.IWebHostEnvironment;
-
 namespace Sentry.AspNetCore;
 
 /// <summary>

--- a/src/Sentry.AspNetCore/SentryTracingBuilder.cs
+++ b/src/Sentry.AspNetCore/SentryTracingBuilder.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Sentry.AspNetCore;

--- a/src/Sentry.AspNetCore/SentryTracingMiddlewareExtensions.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddlewareExtensions.cs
@@ -1,8 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Sentry;
 using Sentry.AspNetCore;
-using Sentry.Extensibility;
 using Sentry.Internal.Extensions;
 
 // ReSharper disable once CheckNamespace

--- a/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Configuration;

--- a/src/Sentry.Azure.Functions.Worker/SentryFunctionsWorkerMiddleware.cs
+++ b/src/Sentry.Azure.Functions.Worker/SentryFunctionsWorkerMiddleware.cs
@@ -1,5 +1,4 @@
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.Middleware;
 using Sentry.Extensibility;
 using Sentry.Internal;

--- a/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/EFConnectionDiagnosticSourceHelper.cs
+++ b/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/EFConnectionDiagnosticSourceHelper.cs
@@ -1,5 +1,4 @@
 using Sentry.Extensibility;
-using Sentry.Internal.Extensions;
 
 namespace Sentry.Internal.DiagnosticSource;
 

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/src/Sentry.Profiling/Downsampler.cs
+++ b/src/Sentry.Profiling/Downsampler.cs
@@ -1,6 +1,3 @@
-using Microsoft.Diagnostics.Tracing;
-using Microsoft.Diagnostics.Tracing.EventPipe;
-
 /// <summary>
 /// Reduce sampling rate from 1 Hz that is the default for the provider to the configured SamplingRateMs.
 /// </summary>

--- a/src/Sentry.Profiling/SampleProfileBuilder.cs
+++ b/src/Sentry.Profiling/SampleProfileBuilder.cs
@@ -1,7 +1,6 @@
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Etlx;
 using Sentry.Extensibility;
-using Sentry.Internal;
 using Sentry.Protocol;
 
 namespace Sentry.Profiling;

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -1,5 +1,4 @@
 using Sentry.Infrastructure;
-using Sentry.Internal;
 
 namespace Sentry.Extensibility;
 

--- a/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs
@@ -1,6 +1,5 @@
 using Sentry.Extensibility;
 using Sentry.Internal;
-using Sentry.Protocol;
 
 namespace Sentry.Integrations;
 

--- a/src/Sentry/Integrations/UnobservedTaskExceptionIntegration.cs
+++ b/src/Sentry/Integrations/UnobservedTaskExceptionIntegration.cs
@@ -1,5 +1,4 @@
 using Sentry.Internal;
-using Sentry.Protocol;
 
 namespace Sentry.Integrations;
 

--- a/src/Sentry/Internal/Extensions/PEReaderExtensions.cs
+++ b/src/Sentry/Internal/Extensions/PEReaderExtensions.cs
@@ -1,4 +1,3 @@
-using Sentry.Extensibility;
 using Sentry.Protocol;
 
 namespace Sentry.Internal.Extensions;

--- a/src/Sentry/Internal/ITransactionProfiler.cs
+++ b/src/Sentry/Internal/ITransactionProfiler.cs
@@ -1,5 +1,3 @@
-using Sentry.Protocol;
-
 namespace Sentry.Internal;
 
 /// <summary>

--- a/src/Sentry/Internal/MainSentryEventProcessor.cs
+++ b/src/Sentry/Internal/MainSentryEventProcessor.cs
@@ -1,5 +1,4 @@
 using Sentry.Extensibility;
-using Sentry.Internal.Extensions;
 using Sentry.Reflection;
 
 namespace Sentry.Internal;

--- a/src/Sentry/Internal/NoOpTransaction.cs
+++ b/src/Sentry/Internal/NoOpTransaction.cs
@@ -1,5 +1,3 @@
-using Sentry.Protocol;
-
 namespace Sentry.Internal;
 
 /// <summary>

--- a/src/Sentry/Internal/ScopeObserver.cs
+++ b/src/Sentry/Internal/ScopeObserver.cs
@@ -1,4 +1,3 @@
-using Sentry.Extensibility;
 using Sentry.Internal.Extensions;
 
 namespace Sentry.Internal;

--- a/src/Sentry/Internal/StackFrame.cs
+++ b/src/Sentry/Internal/StackFrame.cs
@@ -1,6 +1,3 @@
-using Sentry.Internal.Extensions;
-using Sentry.Extensibility;
-
 namespace Sentry.Internal;
 
 /// <summary>

--- a/src/Sentry/MetricAggregator.cs
+++ b/src/Sentry/MetricAggregator.cs
@@ -1,4 +1,3 @@
-using System;
 using Sentry.Extensibility;
 using Sentry.Internal;
 using Sentry.Internal.Extensions;

--- a/src/Sentry/PlatformAbstractions/RuntimeInfo.cs
+++ b/src/Sentry/PlatformAbstractions/RuntimeInfo.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Sentry.PlatformAbstractions;
 
 // https://github.com/dotnet/corefx/issues/17452

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -3,7 +3,6 @@ using Android.OS;
 using Sentry.Android;
 using Sentry.Android.Callbacks;
 using Sentry.Android.Extensions;
-using Sentry.Internal;
 using Sentry.JavaSdk.Android.Core;
 
 // Don't let the Sentry Android SDK auto-init, as we do that manually in SentrySdk.Init

--- a/src/Sentry/Platforms/Cocoa/CFunctions.cs
+++ b/src/Sentry/Platforms/Cocoa/CFunctions.cs
@@ -1,4 +1,5 @@
 using Sentry.Extensibility;
+using Sentry.Internal.Extensions;
 using Sentry.Protocol;
 
 namespace Sentry.Cocoa;

--- a/src/Sentry/Platforms/Cocoa/CFunctions.cs
+++ b/src/Sentry/Platforms/Cocoa/CFunctions.cs
@@ -1,5 +1,4 @@
 using Sentry.Extensibility;
-using Sentry.Internal.Extensions;
 using Sentry.Protocol;
 
 namespace Sentry.Cocoa;

--- a/src/Sentry/Platforms/Cocoa/CocoaEventProcessor.cs
+++ b/src/Sentry/Platforms/Cocoa/CocoaEventProcessor.cs
@@ -1,4 +1,5 @@
 using Sentry.Extensibility;
+using Sentry.Cocoa.Extensions;
 
 namespace Sentry.Cocoa;
 

--- a/src/Sentry/Platforms/Cocoa/CocoaEventProcessor.cs
+++ b/src/Sentry/Platforms/Cocoa/CocoaEventProcessor.cs
@@ -1,5 +1,4 @@
 using Sentry.Extensibility;
-using Sentry.Cocoa.Extensions;
 
 namespace Sentry.Cocoa;
 

--- a/src/Sentry/Platforms/Cocoa/Facades/SerializableNSObject.cs
+++ b/src/Sentry/Platforms/Cocoa/Facades/SerializableNSObject.cs
@@ -1,5 +1,4 @@
 using Sentry.Extensibility;
-using Sentry.Internal;
 
 namespace Sentry.Cocoa.Facades;
 

--- a/src/Sentry/Platforms/Cocoa/Facades/TransactionContextFacade.cs
+++ b/src/Sentry/Platforms/Cocoa/Facades/TransactionContextFacade.cs
@@ -1,3 +1,5 @@
+using Sentry.Cocoa.Extensions;
+
 namespace Sentry.Cocoa.Facades;
 
 internal class TransactionContextFacade : ITransactionContext

--- a/src/Sentry/Platforms/Cocoa/Facades/TransactionContextFacade.cs
+++ b/src/Sentry/Platforms/Cocoa/Facades/TransactionContextFacade.cs
@@ -1,5 +1,3 @@
-using Sentry.Cocoa.Extensions;
-
 namespace Sentry.Cocoa.Facades;
 
 internal class TransactionContextFacade : ITransactionContext

--- a/src/Sentry/Platforms/Native/NativeScopeObserver.cs
+++ b/src/Sentry/Platforms/Native/NativeScopeObserver.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Runtime.InteropServices;
-using Sentry.Extensibility;
 using Sentry.Internal;
 
 namespace Sentry.Native;

--- a/src/Sentry/Protocol/ProfileInfo.cs
+++ b/src/Sentry/Protocol/ProfileInfo.cs
@@ -1,5 +1,4 @@
 using Sentry.Extensibility;
-using Sentry.Internal;
 using Sentry.Internal.Extensions;
 
 namespace Sentry.Protocol;

--- a/src/Sentry/Protocol/SampleProfile.cs
+++ b/src/Sentry/Protocol/SampleProfile.cs
@@ -1,5 +1,4 @@
 using Sentry.Extensibility;
-using Sentry.Internal;
 using Sentry.Internal.Extensions;
 
 #if NETFRAMEWORK

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -1,8 +1,5 @@
 using Sentry.Extensibility;
-using Sentry.Internal;
 using Sentry.Internal.Extensions;
-using Sentry.Internal.OpenTelemetry;
-using Sentry.Protocol;
 
 namespace Sentry;
 

--- a/src/Sentry/SentryEvent.cs
+++ b/src/Sentry/SentryEvent.cs
@@ -1,6 +1,5 @@
 using Sentry.Extensibility;
 using Sentry.Integrations;
-using Sentry.Internal;
 using Sentry.Internal.Extensions;
 using Sentry.Protocol;
 

--- a/src/Sentry/SentryHttpFailedRequestHandler.cs
+++ b/src/Sentry/SentryHttpFailedRequestHandler.cs
@@ -1,4 +1,3 @@
-using Sentry.Internal;
 using Sentry.Protocol;
 
 namespace Sentry;

--- a/src/Sentry/SentryHttpMessageHandler.cs
+++ b/src/Sentry/SentryHttpMessageHandler.cs
@@ -1,6 +1,4 @@
 using Sentry.Extensibility;
-using Sentry.Internal;
-using Sentry.Internal.Extensions;
 using Sentry.Internal.OpenTelemetry;
 
 namespace Sentry;

--- a/src/Sentry/SentryMessageHandler.cs
+++ b/src/Sentry/SentryMessageHandler.cs
@@ -1,7 +1,5 @@
 using Sentry.Extensibility;
-using Sentry.Internal;
 using Sentry.Internal.Extensions;
-using Sentry.Internal.OpenTelemetry;
 
 namespace Sentry;
 

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -1,6 +1,5 @@
 using Sentry.Extensibility;
 using Sentry.Internal;
-using Sentry.Internal.ScopeStack;
 using Sentry.Protocol;
 
 namespace Sentry;

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <ItemGroup Condition="$(Language) == 'C#' and $(SentryImplicitUsings) != 'false' and ($(ImplicitUsings) == 'enable' or $(ImplicitUsings) == 'true')">
+    <!-- If the project has ImplicitUsings enabled, and SentryImplicitUsings is not false, auto import Sentry -->
+    <Using Include="Sentry" />
+  </ItemGroup>
+
   <PropertyGroup>
     <SentryAttributesFile>Sentry.Attributes$(MSBuildProjectExtension.Replace('proj', ''))</SentryAttributesFile>
   </PropertyGroup>

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <ItemGroup Condition="$(Language) == 'C#' and ($(ImplicitUsings) == 'enable' or $(ImplicitUsings) == 'true')">
+  <ItemGroup Condition="$(Language) == 'C#' and $(SentryImplicitUsings) != 'false' and ($(ImplicitUsings) == 'enable' or $(ImplicitUsings) == 'true')">
     <Using Include="Sentry" />
   </ItemGroup>
 

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -2,7 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup Condition="$(Language) == 'C#' and ($(ImplicitUsings) == 'enable' or $(ImplicitUsings) == 'true')">
-    <!-- If the project has ImplicitUsings enabled, and SentryImplicitUsings is not false, auto import Sentry -->
     <Using Include="Sentry" />
   </ItemGroup>
 

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <ItemGroup Condition="$(Language) == 'C#' and $(SentryImplicitUsings) != 'false' and ($(ImplicitUsings) == 'enable' or $(ImplicitUsings) == 'true')">
+  <ItemGroup Condition="$(Language) == 'C#' and ($(ImplicitUsings) == 'enable' or $(ImplicitUsings) == 'true')">
     <!-- If the project has ImplicitUsings enabled, and SentryImplicitUsings is not false, auto import Sentry -->
     <Using Include="Sentry" />
   </ItemGroup>

--- a/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
-using Sentry.AspNetCore.Extensions;
 
 #if NETCOREAPP3_1_OR_GREATER
 using IHostingEnvironment = Microsoft.AspNetCore.Hosting.IWebHostEnvironment;

--- a/test/Sentry.DiagnosticSource.Tests/SentrySqlListenerTests.cs
+++ b/test/Sentry.DiagnosticSource.Tests/SentrySqlListenerTests.cs
@@ -1,6 +1,4 @@
-using Microsoft.EntityFrameworkCore.Storage;
 using Sentry.Internal.DiagnosticSource;
-using Sentry.Internal.Extensions;
 using static Sentry.Internal.DiagnosticSource.SentrySqlListener;
 
 namespace Sentry.DiagnosticSource.Tests;

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Options;
 using Sentry.Maui.Internal;
 
 namespace Sentry.Maui.Tests;

--- a/test/Sentry.Maui.Tests/SentryMauiScreenshotTests.cs
+++ b/test/Sentry.Maui.Tests/SentryMauiScreenshotTests.cs
@@ -1,6 +1,4 @@
 using Microsoft.Extensions.Options;
-using Sentry.Internal.Http;
-using Sentry.Maui.Internal;
 
 namespace Sentry.Maui.Tests;
 

--- a/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
@@ -1,7 +1,4 @@
-using OpenTelemetry;
-using OpenTelemetry.Trace;
 using Sentry.Internal.OpenTelemetry;
-using Sentry.PlatformAbstractions;
 
 namespace Sentry.OpenTelemetry.Tests;
 

--- a/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs
+++ b/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs
@@ -1,5 +1,4 @@
 using Sentry.Internal.Http;
-using Xunit.Sdk;
 
 namespace Sentry.Profiling.Tests;
 

--- a/test/Sentry.Profiling.Tests/TraceLogProcessorTests.verify.cs
+++ b/test/Sentry.Profiling.Tests/TraceLogProcessorTests.verify.cs
@@ -1,9 +1,6 @@
-using System.Diagnostics.Tracing;
-using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Etlx;
 using Microsoft.Diagnostics.Tracing.EventPipe;
-using Microsoft.Diagnostics.Tracing.Parsers;
 
 namespace Sentry.Profiling.Tests;
 

--- a/test/Sentry.Tests/DynamicSamplingContextTests.cs
+++ b/test/Sentry.Tests/DynamicSamplingContextTests.cs
@@ -1,5 +1,3 @@
-using Xunit.Sdk;
-
 namespace Sentry.Tests;
 
 public class DynamicSamplingContextTests

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1,5 +1,4 @@
 using Sentry.Internal.Http;
-using Sentry.Internal.OpenTelemetry;
 
 namespace Sentry.Tests;
 

--- a/test/Sentry.Tests/HubTests.verify.cs
+++ b/test/Sentry.Tests/HubTests.verify.cs
@@ -1,5 +1,3 @@
-using Sentry.PlatformAbstractions;
-
 namespace Sentry.Tests;
 
 [UsesVerify]

--- a/test/Sentry.Tests/MetricBucketHelperTests.cs
+++ b/test/Sentry.Tests/MetricBucketHelperTests.cs
@@ -1,5 +1,3 @@
-using Sentry.Protocol.Metrics;
-
 namespace Sentry.Tests;
 
 public class MetricBucketHelperTests

--- a/test/SingleFileTestApp/SingleFileTestApp.csproj
+++ b/test/SingleFileTestApp/SingleFileTestApp.csproj
@@ -8,6 +8,7 @@
     <ImplicitUsings>true</ImplicitUsings>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
+    <SentryImplicitUsings>false</SentryImplicitUsings>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/SingleFileTestApp/SingleFileTestApp.csproj
+++ b/test/SingleFileTestApp/SingleFileTestApp.csproj
@@ -8,11 +8,8 @@
     <ImplicitUsings>true</ImplicitUsings>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
+    <SentryImplicitUsings>false</SentryImplicitUsings>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Using Remove="Sentry" />
-  </ItemGroup>
 
   <PropertyGroup>
     <_OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</_OSArchitecture>

--- a/test/SingleFileTestApp/SingleFileTestApp.csproj
+++ b/test/SingleFileTestApp/SingleFileTestApp.csproj
@@ -8,8 +8,11 @@
     <ImplicitUsings>true</ImplicitUsings>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <SentryImplicitUsings>false</SentryImplicitUsings>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Using Remove="Sentry" />
+  </ItemGroup>
 
   <PropertyGroup>
     <_OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</_OSArchitecture>


### PR DESCRIPTION
Now that this is complete:
* https://github.com/getsentry/sentry-dotnet/issues/1491

We can enable namespace `Sentry` by default