### PR TITLE
fix: Log warning in case of `debug` in `production`

### DIFF
--- a/src/Sentry/SentryOptionsExtensions.cs
+++ b/src/Sentry/SentryOptionsExtensions.cs
@@ -373,9 +373,8 @@ public static class SentryOptionsExtensions
 
             if (options.SettingLocator.GetEnvironment().Equals("production", StringComparison.OrdinalIgnoreCase))
             {
-                options.DiagnosticLogger.LogWarning("The DiagnosticLogger, specifically on the diagnostic level " +
-                                                    "`debug` (default) can cause performance degradations. " +
-                                                    "Many allocations, and printing to console can slow down your app." +
+                options.DiagnosticLogger.LogWarning("Sentry option 'Debug' is set to true while Environment is production. " +
+                                                    "Be aware this can cause performance degradation and is not advised. " +
                                                     "See https://docs.sentry.io/platforms/dotnet/configuration/diagnostic-logger " +
                                                     "for more information");
             }

--- a/src/Sentry/SentryOptionsExtensions.cs
+++ b/src/Sentry/SentryOptionsExtensions.cs
@@ -370,6 +370,15 @@ public static class SentryOptionsExtensions
                 options.DiagnosticLogger.LogDebug("Logging enabled with ConsoleDiagnosticLogger and min level: {0}",
                     options.DiagnosticLevel);
             }
+
+            if (options.SettingLocator.GetEnvironment().Equals("production", StringComparison.OrdinalIgnoreCase))
+            {
+                options.DiagnosticLogger.LogWarning("The DiagnosticLogger, specifically on the diagnostic level " +
+                                                    "`debug` (default) can cause performance degradations. " +
+                                                    "Many allocations, and printing to console can slow down your app." +
+                                                    "See https://docs.sentry.io/platforms/dotnet/configuration/diagnostic-logger " +
+                                                    "for more information");
+            }
         }
         else
         {

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -721,6 +721,33 @@ public class SentrySdkTests : IDisposable
         hub.ScopeManager.ScopeStackContainer.Should().BeOfType<GlobalScopeStackContainer>();
     }
 
+    [Fact]
+    public void InitHub_DebugInProductionEnvironment_LogsWarning()
+    {
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            DiagnosticLogger = _logger,
+            IsGlobalModeEnabled = true,
+            AutoSessionTracking = false,
+            BackgroundWorker = Substitute.For<IBackgroundWorker>(),
+            InitNativeSdks = false,
+            Debug = true,
+            Environment = "production"
+        };
+
+        SentrySdk.InitHub(options);
+
+        _logger.Received().Log(
+            SentryLevel.Warning,
+            "Sentry option 'Debug' is set to true while Environment is production. " +
+            "Be aware this can cause performance degradation and is not advised. " +
+            "See https://docs.sentry.io/platforms/dotnet/configuration/diagnostic-logger " +
+            "for more information",
+            Arg.Any<Exception>(),
+            Arg.Any<object[]>());
+    }
+
 #if !__MOBILE__ // On mobile, we'll always have logs from the Android/iOS SDK, so we can't reliably test for silence.
     [Fact]
     public void InitHub_GlobalModeOn_NoWarningOrErrorLogged()
@@ -730,7 +757,6 @@ public class SentrySdkTests : IDisposable
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             IsGlobalModeEnabled = true,
-            Debug = true,
             AutoSessionTracking = false,
             BackgroundWorker = Substitute.For<IBackgroundWorker>(),
             InitNativeSdks = false
@@ -759,7 +785,6 @@ public class SentrySdkTests : IDisposable
             Dsn = ValidDsn,
             DiagnosticLogger = _logger,
             IsGlobalModeEnabled = false,
-            Debug = true,
             AutoSessionTracking = false,
             BackgroundWorker = Substitute.For<IBackgroundWorker>(),
             InitNativeSdks = false


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/3027

#skip-changelog