### PR TITLE
Bump from Xcode 15.0.1 to 15.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
         uses: ./.github/actions/buildcocoasdk
 
       # Only switch to newer xcode after building the Cocoa SDK so that it can keep IPHONEOS_DEPLOYMENT_TARGET=11.0
-      - run: sudo xcode-select -s /Applications/Xcode_15.0.1.app
+      - run: sudo xcode-select -s /Applications/Xcode_15.1.app
         if: runner.os == 'macOS'
 
       - name: Restore .NET Dependencies


### PR DESCRIPTION
We've started getting build errors in all our branches like [this](https://github.com/getsentry/sentry-dotnet/actions/runs/7547059918/job/20546201300):
> ILLINK : warning MT0079: The recommended Xcode version for Microsoft.MacCatalyst 17.2.8004 is Xcode 15.1 or later. The current Xcode version (found in /Applications/Xcode_15.0.1.app/Contents/Developer) is 15.0.1. [/Users/runner/work/sentry-dotnet/sentry-dotnet/samples/Sentry.Samples.MacCatalyst/Sentry.Samples.MacCatalyst.csproj]

This PR bumps the version of Xcode that we have pinned in our build.yaml file to 15.1

#skip-changelog