### PR TITLE
fix: Add `WinUIUnhandledExceptionIntegration` on Windows only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ If you have conflicts, you can opt-out by adding the following to your `csproj`:
 
 ### Fixes
 
-- The SDK no longer adds the `WinUIUnhandledExceptionIntegration` on non Windows platforms ([#3043](https://github.com/getsentry/sentry-dotnet/pull/3043))
+- The SDK no longer adds the `WinUIUnhandledExceptionIntegration` on non Windows platforms ([#3055](https://github.com/getsentry/sentry-dotnet/pull/3055))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ If you have conflicts, you can opt-out by adding the following to your `csproj`:
 </PropertyGroup>
 ```
 
+### Fixes
+
+- The SDK no longer adds the `WinUIUnhandledExceptionIntegration` on non Windows platforms ([#3043](https://github.com/getsentry/sentry-dotnet/pull/3043))
+
 ### Dependencies
 
 - Bump Java SDK from v7.1.0 to v7.2.0 ([#3049](https://github.com/getsentry/sentry-dotnet/pull/3049))

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -186,7 +186,7 @@ public class SentryOptions
             }
 #endif
 
-#if NET5_0_OR_GREATER && !__MOBILE__
+#if NET5_0_OR_GREATER && WINDOWS
             if ((_defaultIntegrations & DefaultIntegrations.WinUiUnhandledExceptionIntegration) != 0)
             {
                 yield return new WinUIUnhandledExceptionIntegration();

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -186,8 +186,9 @@ public class SentryOptions
             }
 #endif
 
-#if NET5_0_OR_GREATER && WINDOWS
-            if ((_defaultIntegrations & DefaultIntegrations.WinUiUnhandledExceptionIntegration) != 0)
+#if NET5_0_OR_GREATER && !__MOBILE__
+            if ((_defaultIntegrations & DefaultIntegrations.WinUiUnhandledExceptionIntegration) != 0
+                && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 yield return new WinUIUnhandledExceptionIntegration();
             }

--- a/test/Sentry.Tests/SentryOptionsTests.Integrations_default_ones_are_properly_registered.DotNet.verified.txt
+++ b/test/Sentry.Tests/SentryOptionsTests.Integrations_default_ones_are_properly_registered.DotNet.verified.txt
@@ -34,11 +34,5 @@
     Args: [
       SentryDiagnosticListenerIntegration
     ]
-  },
-  {
-    Message: Registering integration: '{0}'.,
-    Args: [
-      WinUIUnhandledExceptionIntegration
-    ]
   }
 ]

--- a/test/Sentry.Tests/SentryOptionsTests.verify.cs
+++ b/test/Sentry.Tests/SentryOptionsTests.verify.cs
@@ -3,9 +3,12 @@ namespace Sentry.Tests;
 [UsesVerify]
 public partial class SentryOptionsTests
 {
-    [Fact]
+    [SkippableFact]
     public Task Integrations_default_ones_are_properly_registered()
     {
+        // Windows additionally adds `WinUIUnhandledExceptionIntegration`
+        Skip.If(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+
         InMemoryDiagnosticLogger logger = new();
         SentryOptions options = new()
         {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/3050