### PR TITLE
fix: MAUI eventbinding moved to `FinishedLaunching`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ If you have conflicts, you can opt-out by adding the following to your `csproj`:
 </PropertyGroup>
 ```
 
+### Fixes
+
+- Moved the binding to MAUI events for breadcrumb creation from `WillFinishLaunching` to `FinishedLaunching`. This delays the initial instantiation of `app`. ([#3057](https://github.com/getsentry/sentry-dotnet/pull/3057))
+
 ### Dependencies
 
 - Bump Java SDK from v7.1.0 to v7.2.0 ([#3049](https://github.com/getsentry/sentry-dotnet/pull/3049))

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -79,7 +79,7 @@ public static class SentryMauiAppBuilderExtensions
 #if __IOS__
             events.AddiOS(lifecycle =>
             {
-                lifecycle.WillFinishLaunching((application, launchOptions) =>
+                lifecycle.FinishedLaunching((application, launchOptions) =>
                 {
                     // A bit of hackery here, because we can't mock UIKit.UIApplication in tests.
                     var platformApplication = application != null!
@@ -100,7 +100,7 @@ public static class SentryMauiAppBuilderExtensions
                     platformApplication?.HandleMauiEvents(bind: false);
 
                     //According to https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623111-applicationwillterminate#discussion
-                    //WillTerminate is called: in situations where the app is running in the background (not suspended) and the system needs to terminate it for some reason. 
+                    //WillTerminate is called: in situations where the app is running in the background (not suspended) and the system needs to terminate it for some reason.
                     SentryMauiEventProcessor.InForeground = false;
                 });
 

--- a/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.Cocoa.cs
+++ b/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.Cocoa.cs
@@ -27,7 +27,7 @@ public partial class SentryMauiAppBuilderExtensionsTests
 
         // Act
         var lifecycleEventService = app.Services.GetRequiredService<ILifecycleEventService>();
-        lifecycleEventService.InvokeEvents<iOSLifecycle.WillFinishLaunching>
+        lifecycleEventService.InvokeEvents<iOSLifecycle.FinishedLaunching>
             (nameof(iOSLifecycle.FinishedLaunching), del =>
                 del.Invoke(null!, launchOptions));
 

--- a/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.Cocoa.cs
+++ b/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.Cocoa.cs
@@ -28,7 +28,7 @@ public partial class SentryMauiAppBuilderExtensionsTests
         // Act
         var lifecycleEventService = app.Services.GetRequiredService<ILifecycleEventService>();
         lifecycleEventService.InvokeEvents<iOSLifecycle.WillFinishLaunching>
-            (nameof(iOSLifecycle.WillFinishLaunching), del =>
+            (nameof(iOSLifecycle.FinishedLaunching), del =>
                 del.Invoke(null!, launchOptions));
 
         // Assert


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/2898

So there is nothing really "fixed" here. Putting it in `bitwarden` just highlighted a potential issue with the SDK. 
There the `app` relies on the `FinishedLaunching` callback to setup their own service container before instantiating the `app`. The SDK's call into `services` causes the app to be instantiated first.
Considering that other applications might be doing the same I think it's fair to move the binding to the `FinishedLaunching` as well.