### PR TITLE
fix: Clean build warnings

### DIFF
--- a/test/MauiTestUtils/DeviceTests.Runners/VisualRunner/DeviceRunner.cs
+++ b/test/MauiTestUtils/DeviceTests.Runners/VisualRunner/DeviceRunner.cs
@@ -285,9 +285,15 @@ public class DeviceRunner : ITestListener, ITestRunner
 
         var deviceExecSink = new DeviceExecutionSink(xunitTestCases, this, context);
 
-        IExecutionSink resultsSink = new DelegatingExecutionSummarySink(deviceExecSink, () => cancelled);
+        var resultsSink = new ExecutionSink(deviceExecSink, new ExecutionSinkOptions { CancelThunk = () => cancelled });
         if (longRunningSeconds > 0)
-            resultsSink = new DelegatingLongRunningTestDetectionSink(resultsSink, TimeSpan.FromSeconds(longRunningSeconds), diagSink);
+        {
+            resultsSink = new ExecutionSink(resultsSink, new ExecutionSinkOptions
+            {
+                LongRunningTestTime = TimeSpan.FromSeconds(longRunningSeconds),
+                DiagnosticMessageSink = diagSink
+            });
+        }
 
         var assm = new XunitProjectAssembly() { AssemblyFilename = runInfo.AssemblyFileName };
         deviceExecSink.OnMessage(new TestAssemblyExecutionStarting(assm, executionOptions));

--- a/test/MauiTestUtils/DeviceTests.Runners/VisualRunner/Sinks/DiagnosticMessageSink.cs
+++ b/test/MauiTestUtils/DeviceTests.Runners/VisualRunner/Sinks/DiagnosticMessageSink.cs
@@ -1,16 +1,30 @@
 ﻿#nullable enable
 using System;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner;
 
-class DiagnosticMessageSink : DiagnosticEventSink
+internal class DiagnosticMessageSink : Xunit.Sdk.LongLivedMarshalByRefObject, IMessageSink
 {
+    private Action<string> _logger;
+    private string _assemblyDisplayName;
+    private bool _showDiagnostics;
+
     public DiagnosticMessageSink(Action<string> logger, string assemblyDisplayName, bool showDiagnostics)
     {
-        if (showDiagnostics && logger != null)
+        _logger = logger;
+        _assemblyDisplayName = assemblyDisplayName;
+        _showDiagnostics = showDiagnostics;
+    }
+
+    public bool OnMessage(IMessageSinkMessage message)
+    {
+        if (_showDiagnostics)
         {
-            DiagnosticMessageEvent += args => logger($"{assemblyDisplayName}: {args.Message.Message}");
+            _logger($"{_assemblyDisplayName}: {message}");
         }
+
+        return true;
     }
 }

--- a/test/MauiTestUtils/DeviceTests/AssertionExtensions.iOS.cs
+++ b/test/MauiTestUtils/DeviceTests/AssertionExtensions.iOS.cs
@@ -269,7 +269,7 @@ public static partial class AssertionExtensions
             }
         }
 
-        Assert.True(false, CreateColorError(bitmap, $"Color {expectedColor} not found."));
+        Assert.Fail(CreateColorError(bitmap, $"Color {expectedColor} not found."));
         return bitmap;
     }
 


### PR DESCRIPTION
Clean builds logged a whole bunch of warnings.

```
/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests/AssertionExtensions.iOS.cs(272,9): warning xUnit2020: Do not use Assert.True(false, message) to fail a test. Use Assert.Fail(message) instead. (https://xunit.net/xunit.analyzers/rules/xUnit2020) [/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests/TestUtils.DeviceTests.csproj::TargetFramework=net7.0-ios]
/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests/AssertionExtensions.iOS.cs(272,9): warning xUnit2020: Do not use Assert.True(false, message) to fail a test. Use Assert.Fail(message) instead. (https://xunit.net/xunit.analyzers/rules/xUnit2020) [/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests/TestUtils.DeviceTests.csproj::TargetFramework=net7.0-maccatalyst]
/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests.Runners/VisualRunner/DeviceRunner.cs(288,42): warning CS0618: 'DelegatingExecutionSummarySink' is obsolete: 'This class has been obsoleted; please use ExecutionSink instead' [/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj::TargetFramework=net7.0-android]
/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests.Runners/VisualRunner/DeviceRunner.cs(290,31): warning CS0618: 'DelegatingLongRunningTestDetectionSink' is obsolete: 'This class has been obsoleted; please use ExecutionSink instead' [/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj::TargetFramework=net7.0-android]
/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests.Runners/VisualRunner/DeviceRunner.cs(288,42): warning CS0618: 'DelegatingExecutionSummarySink' is obsolete: 'This class has been obsoleted; please use ExecutionSink instead' [/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj::TargetFramework=net7.0-ios]
/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests.Runners/VisualRunner/DeviceRunner.cs(290,31): warning CS0618: 'DelegatingLongRunningTestDetectionSink' is obsolete: 'This class has been obsoleted; please use ExecutionSink instead' [/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj::TargetFramework=net7.0-ios]
/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests.Runners/VisualRunner/DeviceRunner.cs(288,42): warning CS0618: 'DelegatingExecutionSummarySink' is obsolete: 'This class has been obsoleted; please use ExecutionSink instead' [/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj::TargetFramework=net7.0-maccatalyst]
/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests.Runners/VisualRunner/DeviceRunner.cs(290,31): warning CS0618: 'DelegatingLongRunningTestDetectionSink' is obsolete: 'This class has been obsoleted; please use ExecutionSink instead' [/Users/bitfox/Workspace/sentry-dotnet/test/MauiTestUtils/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj::TargetFramework=net7.0-maccatalyst]
```

#skip-changelog