### PR TITLE
Set the scope transaction for Otel transactions

### DIFF
--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -103,6 +103,7 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
                 transactionContext, new Dictionary<string, object?>(), dynamicSamplingContext
                 );
             transaction.StartTimestamp = data.StartTimeUtc;
+            _hub.ConfigureScope(scope => scope.Transaction = transaction);
             _map[data.SpanId] = transaction;
         }
     }

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -276,14 +276,6 @@ public class TransactionTracer : ITransactionTracer
     internal ISpan StartChild(SpanId? spanId, SpanId parentSpanId, string operation,
         Instrumenter instrumenter = Instrumenter.Sentry)
     {
-        if (instrumenter != _instrumenter)
-        {
-            _options?.LogWarning(
-                "Attempted to create a span via {0} instrumentation to a span or transaction" +
-                " originating from {1} instrumentation. The span will not be created.", instrumenter, _instrumenter);
-            return NoOpSpan.Instance;
-        }
-
         var span = new SpanTracer(_hub, this, parentSpanId, TraceId, operation);
         if (spanId is { } id)
         {

--- a/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
@@ -191,6 +191,7 @@ public class SentrySpanProcessorTests : ActivitySourceTests
     {
         // Arrange
         _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
+        _fixture.ScopeManager = Substitute.For<IInternalScopeManager>();
         var sut = _fixture.GetSut();
 
         var data = Tracer.StartActivity("test op");
@@ -215,6 +216,7 @@ public class SentrySpanProcessorTests : ActivitySourceTests
             transaction.Description.Should().Be(data.DisplayName);
             transaction.Status.Should().BeNull();
             transaction.StartTimestamp.Should().Be(data.StartTimeUtc);
+            _fixture.ScopeManager.Received(1).ConfigureScope(Arg.Any<Action<Scope>>());
         }
     }
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3061

## Problem Summary

When using OpenTelemetry this is returning null:
https://github.com/getsentry/sentry-dotnet/blob/84925a9da90197e88ef41013e80e028358b9951f/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentrySqlListener.cs#L75-L79

When instrumenting with OpenTelemetry, the `SentrySpanProcessor` wasn't assigning these to the `Scope.Transaction`... so the integrations weren't able to create DB Spans under the DB Root. 