### PR TITLE
WIP: Added StartTimer extension method to IMetricAggregator

### DIFF
--- a/samples/Sentry.Samples.Console.Metrics/Program.cs
+++ b/samples/Sentry.Samples.Console.Metrics/Program.cs
@@ -60,9 +60,10 @@ internal static class Program
     {
         var solution = new[] { 3, 5, 7, 11, 13, 17 };
 
-        // The Timing class creates a distribution that is designed to measure the amount of time it takes to run code
+        // StartTimer creates a distribution that is designed to measure the amount of time it takes to run code
         // blocks. By default it will use a unit of Seconds - we're configuring it to use milliseconds here though.
-        using (new Timing("bingo", MeasurementUnit.Duration.Millisecond))
+        // The return value is an IDisposable and the timer will stop when the timer is disposed of.
+        using (SentrySdk.Metrics.StartTimer("bingo", MeasurementUnit.Duration.Millisecond))
         {
             for (var i = 0; i < attempts; i++)
             {
@@ -78,7 +79,7 @@ internal static class Program
 
     private static void CreateRevenueGauge(int sampleCount)
     {
-        using (new Timing(nameof(CreateRevenueGauge), MeasurementUnit.Duration.Millisecond))
+        using (SentrySdk.Metrics.StartTimer(nameof(CreateRevenueGauge), MeasurementUnit.Duration.Millisecond))
         {
             for (var i = 0; i < sampleCount; i++)
             {
@@ -92,7 +93,7 @@ internal static class Program
 
     private static void MeasureShrimp(int sampleCount)
     {
-        using (new Timing(nameof(MeasureShrimp), MeasurementUnit.Duration.Millisecond))
+        using (SentrySdk.Metrics.StartTimer(nameof(MeasureShrimp), MeasurementUnit.Duration.Millisecond))
         {
             for (var i = 0; i < sampleCount; i++)
             {

--- a/src/Sentry/IMetricAggregator.cs
+++ b/src/Sentry/IMetricAggregator.cs
@@ -105,3 +105,23 @@ public interface IMetricAggregator: IDisposable
     /// <returns>False if a shutdown is requested during flush, true otherwise</returns>
     Task FlushAsync(bool force = true, CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// Extension methods for <see cref="IMetricAggregator"/>.
+/// </summary>
+public static class MetricsAggregatorExtensions
+{
+    /// <summary>
+    /// Measures the time it takes to run a given code block and emits this as a metric.
+    /// </summary>
+    /// <example>
+    /// using (SentrySdk.Metrics.StartTimer("my-operation"))
+    /// {
+    ///     ...
+    /// }
+    /// </example>
+    public static IDisposable StartTimer(this IMetricAggregator aggregator, string key,
+        MeasurementUnit.Duration unit = MeasurementUnit.Duration.Second, IDictionary<string, string>? tags = null,
+        int stackLevel = 1)
+        => new Timing(SentrySdk.CurrentHub, key, unit, tags, stackLevel + 1);
+}

--- a/src/Sentry/Timing.cs
+++ b/src/Sentry/Timing.cs
@@ -4,8 +4,7 @@ using Sentry.Protocol.Metrics;
 namespace Sentry;
 
 /// <summary>
-/// Measures the time it takes to run a given code block and emits this as a metric. The <see cref="Timing"/> class is
-/// designed to be used in a <c>using</c> statement.
+/// Measures the time it takes to run a given code block and emits this as a metric.
 /// </summary>
 /// <example>
 /// using (var timing = new Timing("my-operation"))


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3074

This is a simple way to enable something like `SentrySdk.Metrics.StartTimer()`

One thing that bugs me a bit is that, unlike other instruments, `Timing` creates a span/transaction... and to do that it needs an `IHub`. The `MetricAggregator` can't supply that dependency so under the hood this extension method uses `SentrySdk.CurrentHub` to create spans/transactions for Timings. 

It would be possible to create an internal overload of the extension method that accepts an IHub instance as a parameter, for testing purpose... which is pretty much how the existing/previous `Timing` constructor worked, so I guess it holds together.

We've discussed previously the possibility of putting the MetricAggregator on `IHub` rather than on `ISentryClient`. I think that would make the code significantly more complex. It would couple the MetricAggregator with the Hub (where currently those things are decoupled) and add another layer of indirection for simple things like capturing metric events and transmitting them to Sentry. So I'm not a fan of that solution.

In any event, this solution enables the API interface we discussed. The only other thing we might want to do is make the `Timing` class internal so that people can't instanciate that directly (they have to use the `IMetricAggregator.StartTimer()` syntax). 