### PR TITLE
Skip CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed on Mono

### DIFF
--- a/test/Sentry.Tests/HubTests.verify.cs
+++ b/test/Sentry.Tests/HubTests.verify.cs
@@ -3,9 +3,12 @@ namespace Sentry.Tests;
 [UsesVerify]
 public partial class HubTests
 {
-    [Fact]
+    [SkippableFact]
     public async Task CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed()
     {
+        // Flaky on Mono. See https://github.com/getsentry/sentry-dotnet/issues/2751#issuecomment-1863385480
+        Skip.If(RuntimeInformation.FrameworkDescription.StartsWith("Mono", StringComparison.OrdinalIgnoreCase));
+
         // Arrange
         var worker = new FakeBackgroundWorker();
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/2751

#skip-changelog