### PR TITLE
GitHubActions(build job): relax branch restrictions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ name: build
 on:
   push:
     branches:
-      - main
-      - release/*
+      - '**'
   pull_request:
     paths-ignore:
       - "**.md"


### PR DESCRIPTION
Restricting CI to certain branch prevents contributors to know the CI status of their contributions (e.g. the result from building and running unit tests after pushing their work to their fork) before they propose a PullRequest; because normally people create branches when they want to start to work on something (instead of having to use the 'main' branch of their fork).

#skip-changelog