### PR TITLE
fix: Rename `IJsonSerializable`, `Hint`, and `Attachment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 ### Fixes 
 
 - To resolve conflicting types due to the SDK adding itself to the global usings: 
- - The interface `Sentry.ISession` has been renamed to `Sentry.ISentrySession`
+ - The interface `Sentry.ISession` has been renamed to `Sentry.ISentrySession` ([#3110](https://github.com/getsentry/sentry-dotnet/pull/3110))
+ - The interface `Sentry.IJsonSerializable` has been renamed to `Sentry.ISentryJsonSerializable` ([#3116](https://github.com/getsentry/sentry-dotnet/pull/3116))
  - The class `Sentry.Session` has been renamed to `Sentry.SentrySession` ([#3110](https://github.com/getsentry/sentry-dotnet/pull/3110))
+ - The class `Sentry.Attachment` has been renamed to `Sentry.SentryAttachment` ([#3116](https://github.com/getsentry/sentry-dotnet/pull/3116))
+ - The class `Sentry.Hint` has been renamed to `Sentry.SentryHint` ([#3116](https://github.com/getsentry/sentry-dotnet/pull/3116))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
  - The interface `Sentry.ISession` has been renamed to `Sentry.ISentrySession` ([#3110](https://github.com/getsentry/sentry-dotnet/pull/3110))
  - The interface `Sentry.IJsonSerializable` has been renamed to `Sentry.ISentryJsonSerializable` ([#3116](https://github.com/getsentry/sentry-dotnet/pull/3116))
  - The class `Sentry.Session` has been renamed to `Sentry.SentrySession` ([#3110](https://github.com/getsentry/sentry-dotnet/pull/3110))
- - The class `Sentry.Attachment` has been renamed to `Sentry.SentryAttachment` ([#3116](https://github.com/getsentry/sentry-dotnet/pull/3116))
- - The class `Sentry.Hint` has been renamed to `Sentry.SentryHint` ([#3116](https://github.com/getsentry/sentry-dotnet/pull/3116))
+- The class `Sentry.Attachment` has been renamed to `Sentry.SentryAttachment` ([#3116](https://github.com/getsentry/sentry-dotnet/pull/3116))
+- The class `Sentry.Hint` has been renamed to `Sentry.SentryHint` ([#3116](https://github.com/getsentry/sentry-dotnet/pull/3116))
 
 ### Dependencies
 

--- a/samples/Sentry.Samples.Console.Customized/Program.cs
+++ b/samples/Sentry.Samples.Console.Customized/Program.cs
@@ -110,7 +110,7 @@ internal static class Program
 
             SentrySdk.AddBreadcrumb(
                 new Breadcrumb("A breadcrumb that will be replaced by the 'BeforeBreadcrumb callback because of the hint", null),
-                new Hint("don't trust this breadcrumb", "trust this instead")
+                new SentryHint("don't trust this breadcrumb", "trust this instead")
                 );
 
             // Data added to the root scope (no PushScope called up to this point)

--- a/src/Sentry.Maui/Internal/ScreenshotAttachment.cs
+++ b/src/Sentry.Maui/Internal/ScreenshotAttachment.cs
@@ -2,7 +2,7 @@ using Sentry.Extensibility;
 
 namespace Sentry.Maui.Internal;
 
-internal class ScreenshotAttachment : Attachment
+internal class ScreenshotAttachment : SentryAttachment
 {
     public ScreenshotAttachment(SentryMauiOptions options)
         : this(

--- a/src/Sentry.Maui/Internal/SentryMauiScreenshotProcessor.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiScreenshotProcessor.cs
@@ -16,7 +16,7 @@ internal class SentryMauiScreenshotProcessor : ISentryEventProcessorWithHint
         return @event;
     }
 
-    public SentryEvent? Process(SentryEvent @event, Hint hint)
+    public SentryEvent? Process(SentryEvent @event, SentryHint hint)
     {
         hint.Attachments.Add(new ScreenshotAttachment(_options));
         return @event;

--- a/src/Sentry/Breadcrumb.cs
+++ b/src/Sentry/Breadcrumb.cs
@@ -8,7 +8,7 @@ namespace Sentry;
 /// Series of application events.
 /// </summary>
 [DebuggerDisplay("Message: {" + nameof(Message) + "}, Type: {" + nameof(Type) + "}")]
-public sealed class Breadcrumb : IJsonSerializable
+public sealed class Breadcrumb : ISentryJsonSerializable
 {
     private readonly IReadOnlyDictionary<string, string>? _data;
     private readonly string? _message;

--- a/src/Sentry/Contexts.cs
+++ b/src/Sentry/Contexts.cs
@@ -11,7 +11,7 @@ namespace Sentry;
 /// Represents Sentry's structured Context.
 /// </summary>
 /// <seealso href="https://develop.sentry.dev/sdk/event-payloads/contexts/" />
-public sealed class Contexts : IDictionary<string, object>, IJsonSerializable
+public sealed class Contexts : IDictionary<string, object>, ISentryJsonSerializable
 {
     private readonly ConcurrentDictionary<string, object> _innerDictionary = new(StringComparer.Ordinal);
 

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -147,7 +147,7 @@ public class DisabledHub : IHub, IDisposable
     /// <summary>
     /// No-Op.
     /// </summary>
-    public SentryId CaptureEvent(SentryEvent evt, Scope? scope = null, Hint? hint = null) => SentryId.Empty;
+    public SentryId CaptureEvent(SentryEvent evt, Scope? scope = null, SentryHint? hint = null) => SentryId.Empty;
 
     /// <summary>
     /// No-Op.
@@ -157,7 +157,7 @@ public class DisabledHub : IHub, IDisposable
     /// <summary>
     /// No-Op.
     /// </summary>
-    public SentryId CaptureEvent(SentryEvent evt, Hint? hint, Action<Scope> configureScope) => SentryId.Empty;
+    public SentryId CaptureEvent(SentryEvent evt, SentryHint? hint, Action<Scope> configureScope) => SentryId.Empty;
 
     /// <summary>
     /// No-Op.
@@ -169,7 +169,7 @@ public class DisabledHub : IHub, IDisposable
     /// <summary>
     /// No-Op.
     /// </summary>
-    public void CaptureTransaction(SentryTransaction transaction, Scope? scope, Hint? hint)
+    public void CaptureTransaction(SentryTransaction transaction, Scope? scope, SentryHint? hint)
     {
     }
 

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -219,7 +219,7 @@ public sealed class HubAdapter : IHub
     /// </summary>
     [DebuggerStepThrough]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public SentryId CaptureEvent(SentryEvent evt, Scope? scope, Hint? hint = null)
+    public SentryId CaptureEvent(SentryEvent evt, Scope? scope, SentryHint? hint = null)
         => SentrySdk.CaptureEvent(evt, scope, hint);
 
     /// <summary>
@@ -233,7 +233,7 @@ public sealed class HubAdapter : IHub
     /// <summary>
     /// Forwards the call to <see cref="SentrySdk"/>.
     /// </summary>
-    public SentryId CaptureEvent(SentryEvent evt, Hint? hint, Action<Scope> configureScope)
+    public SentryId CaptureEvent(SentryEvent evt, SentryHint? hint, Action<Scope> configureScope)
         => SentrySdk.CaptureEvent(evt, hint, configureScope);
 
     /// <summary>
@@ -256,7 +256,7 @@ public sealed class HubAdapter : IHub
     /// </summary>
     [DebuggerStepThrough]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void CaptureTransaction(SentryTransaction transaction, Scope? scope, Hint? hint)
+    public void CaptureTransaction(SentryTransaction transaction, Scope? scope, SentryHint? hint)
         => SentrySdk.CaptureTransaction(transaction, scope, hint);
 
     /// <summary>

--- a/src/Sentry/Extensibility/ISentryEventProcessor.cs
+++ b/src/Sentry/Extensibility/ISentryEventProcessor.cs
@@ -20,7 +20,7 @@ public interface ISentryEventProcessor
 
 internal static class ISentryEventProcessorExtensions
 {
-    internal static SentryEvent? DoProcessEvent(this ISentryEventProcessor processor, SentryEvent @event, Hint hint)
+    internal static SentryEvent? DoProcessEvent(this ISentryEventProcessor processor, SentryEvent @event, SentryHint hint)
     {
         return (processor is ISentryEventProcessorWithHint contextualProcessor)
             ? contextualProcessor.Process(@event, hint)

--- a/src/Sentry/Extensibility/ISentryEventProcessorWithHint.cs
+++ b/src/Sentry/Extensibility/ISentryEventProcessorWithHint.cs
@@ -9,13 +9,13 @@ public interface ISentryEventProcessorWithHint : ISentryEventProcessor
     /// Process the <see cref="SentryEvent"/>
     /// </summary>
     /// <param name="event">The event to process</param>
-    /// <param name="hint">A <see cref="Hint"/> with context that may be useful prior to sending the event</param>
+    /// <param name="hint">A <see cref="SentryHint"/> with context that may be useful prior to sending the event</param>
     /// <return>The processed event or <c>null</c> if the event was dropped.</return>
     /// <remarks>
     /// The event returned can be the same instance received or a new one.
     /// Returning null will stop the processing pipeline so that the event will neither be processed by
     /// additional event processors or sent to Sentry.
     /// </remarks>
-    SentryEvent? Process(SentryEvent @event, Hint hint);
+    SentryEvent? Process(SentryEvent @event, SentryHint hint);
 }
 

--- a/src/Sentry/Extensibility/ISentryTransactionProcessor.cs
+++ b/src/Sentry/Extensibility/ISentryTransactionProcessor.cs
@@ -19,7 +19,7 @@ public interface ISentryTransactionProcessor
 
 internal static class ISentryTransactionProcessorExtensions
 {
-    internal static SentryTransaction? DoProcessTransaction(this ISentryTransactionProcessor processor, SentryTransaction transaction, Hint hint)
+    internal static SentryTransaction? DoProcessTransaction(this ISentryTransactionProcessor processor, SentryTransaction transaction, SentryHint hint)
     {
         return (processor is ISentryTransactionProcessorWithHint contextualProcessor)
             ? contextualProcessor.Process(transaction, hint)

--- a/src/Sentry/Extensibility/ISentryTransactionProcessorWithHint.cs
+++ b/src/Sentry/Extensibility/ISentryTransactionProcessorWithHint.cs
@@ -9,11 +9,11 @@ public interface ISentryTransactionProcessorWithHint : ISentryTransactionProcess
     /// Process the <see cref="SentryTransaction"/>
     /// </summary>
     /// <param name="transaction">The Transaction to process</param>
-    /// <param name="hint">A <see cref="Hint"/> with context that may be useful prior to sending the transaction</param>
+    /// <param name="hint">A <see cref="SentryHint"/> with context that may be useful prior to sending the transaction</param>
     /// <remarks>
     /// The transaction returned can be the same instance received or a new one.
     /// Returning null will stop the processing pipeline.
     /// Meaning the transaction should no longer be processed nor send.
     /// </remarks>
-    SentryTransaction? Process(SentryTransaction transaction, Hint hint);
+    SentryTransaction? Process(SentryTransaction transaction, SentryHint hint);
 }

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -135,7 +135,7 @@ public static class HubExtensions
     public static void AddBreadcrumb(
         this IHub hub,
         Breadcrumb breadcrumb,
-        Hint? hint = null
+        SentryHint? hint = null
         )
     {
         // Not to throw on code that ignores nullability warnings.
@@ -145,7 +145,7 @@ public static class HubExtensions
         }
 
         hub.ConfigureScope(
-            s => s.AddBreadcrumb(breadcrumb, hint ?? new Hint())
+            s => s.AddBreadcrumb(breadcrumb, hint ?? new SentryHint())
             );
     }
 

--- a/src/Sentry/IHub.cs
+++ b/src/Sentry/IHub.cs
@@ -124,5 +124,5 @@ public interface IHub :
     /// <param name="hint">An optional hint to be provided with the event</param>
     /// <param name="configureScope">The callback to configure the scope.</param>
     /// <returns></returns>
-    public SentryId CaptureEvent(SentryEvent evt, Hint? hint, Action<Scope> configureScope);
+    public SentryId CaptureEvent(SentryEvent evt, SentryHint? hint, Action<Scope> configureScope);
 }

--- a/src/Sentry/ISentryClient.cs
+++ b/src/Sentry/ISentryClient.cs
@@ -27,7 +27,7 @@ public interface ISentryClient
     /// <param name="scope">An optional scope to be applied to the event.</param>
     /// <param name="hint">An optional hint providing high level context for the source of the event</param>
     /// <returns>The Id of the event.</returns>
-    SentryId CaptureEvent(SentryEvent evt, Scope? scope = null, Hint? hint = null);
+    SentryId CaptureEvent(SentryEvent evt, Scope? scope = null, SentryHint? hint = null);
 
     /// <summary>
     /// Captures a user feedback.
@@ -60,7 +60,7 @@ public interface ISentryClient
     /// This will be available in callbacks prior to processing the transaction.
     /// </param>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    void CaptureTransaction(SentryTransaction transaction, Scope? scope, Hint? hint);
+    void CaptureTransaction(SentryTransaction transaction, Scope? scope, SentryHint? hint);
 
     /// <summary>
     /// Captures a session update.

--- a/src/Sentry/ISentryJsonSerializable.cs
+++ b/src/Sentry/ISentryJsonSerializable.cs
@@ -5,7 +5,7 @@ namespace Sentry;
 /// <summary>
 /// Sentry JsonSerializable.
 /// </summary>
-public interface IJsonSerializable
+public interface ISentryJsonSerializable
 {
     /// <summary>
     /// Writes the object as JSON.
@@ -19,7 +19,7 @@ public interface IJsonSerializable
 
 internal static class JsonSerializableExtensions
 {
-    public static void WriteToFile(this IJsonSerializable serializable, string filePath, IDiagnosticLogger? logger)
+    public static void WriteToFile(this ISentryJsonSerializable serializable, string filePath, IDiagnosticLogger? logger)
     {
         using var file = File.Create(filePath);
         using var writer = new Utf8JsonWriter(file);

--- a/src/Sentry/Internal/ClientReport.cs
+++ b/src/Sentry/Internal/ClientReport.cs
@@ -3,7 +3,7 @@ using Sentry.Internal.Extensions;
 
 namespace Sentry.Internal;
 
-internal class ClientReport : IJsonSerializable
+internal class ClientReport : ISentryJsonSerializable
 {
     public DateTimeOffset Timestamp { get; }
     public IReadOnlyDictionary<DiscardReasonWithCategory, int> DiscardedEvents { get; }

--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -128,7 +128,7 @@ internal static class JsonExtensions
     public static Dictionary<string, TValue>? GetDictionaryOrNull<TValue>(
         this JsonElement json,
         Func<JsonElement, TValue> factory)
-        where TValue : IJsonSerializable?
+        where TValue : ISentryJsonSerializable?
     {
         if (json.ValueKind != JsonValueKind.Object)
         {
@@ -283,7 +283,7 @@ internal static class JsonExtensions
         IEnumerable<KeyValuePair<string, TValue>>? dic,
         IDiagnosticLogger? logger,
         bool includeNullValues = true)
-        where TValue : IJsonSerializable?
+        where TValue : ISentryJsonSerializable?
     {
         if (dic is not null)
         {
@@ -345,7 +345,7 @@ internal static class JsonExtensions
         string propertyName,
         IEnumerable<KeyValuePair<string, TValue>>? dic,
         IDiagnosticLogger? logger)
-        where TValue : IJsonSerializable?
+        where TValue : ISentryJsonSerializable?
     {
         writer.WritePropertyName(propertyName);
         writer.WriteDictionaryValue(dic, logger);
@@ -424,7 +424,7 @@ internal static class JsonExtensions
 
     public static void WriteSerializableValue(
         this Utf8JsonWriter writer,
-        IJsonSerializable value,
+        ISentryJsonSerializable value,
         IDiagnosticLogger? logger)
     {
         value.WriteTo(writer, logger);
@@ -433,7 +433,7 @@ internal static class JsonExtensions
     public static void WriteSerializable(
         this Utf8JsonWriter writer,
         string propertyName,
-        IJsonSerializable value,
+        ISentryJsonSerializable value,
         IDiagnosticLogger? logger)
     {
         writer.WritePropertyName(propertyName);
@@ -449,7 +449,7 @@ internal static class JsonExtensions
         {
             writer.WriteNullValue();
         }
-        else if (value is IJsonSerializable serializable)
+        else if (value is ISentryJsonSerializable serializable)
         {
             writer.WriteSerializableValue(serializable, logger);
         }
@@ -784,7 +784,7 @@ internal static class JsonExtensions
     public static void WriteSerializableIfNotNull(
         this Utf8JsonWriter writer,
         string propertyName,
-        IJsonSerializable? value,
+        ISentryJsonSerializable? value,
         IDiagnosticLogger? logger)
     {
         if (value is not null)
@@ -811,7 +811,7 @@ internal static class JsonExtensions
         string propertyName,
         IEnumerable<KeyValuePair<string, TValue>>? dic,
         IDiagnosticLogger? logger)
-        where TValue : IJsonSerializable?
+        where TValue : ISentryJsonSerializable?
     {
         var dictionary = dic as IReadOnlyDictionary<string, TValue> ?? dic?.ToDict();
         if (dictionary is not null && dictionary.Count > 0)

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -382,7 +382,7 @@ internal class Hub : IHub, IMetricHub, IDisposable
     public SentryId CaptureEvent(SentryEvent evt, Action<Scope> configureScope)
         => CaptureEvent(evt, null, configureScope);
 
-    public SentryId CaptureEvent(SentryEvent evt, Hint? hint, Action<Scope> configureScope)
+    public SentryId CaptureEvent(SentryEvent evt, SentryHint? hint, Action<Scope> configureScope)
     {
         if (!IsEnabled)
         {
@@ -405,7 +405,7 @@ internal class Hub : IHub, IMetricHub, IDisposable
 
     public bool CaptureEnvelope(Envelope envelope) => _ownedClient.CaptureEnvelope(envelope);
 
-    public SentryId CaptureEvent(SentryEvent evt, Scope? scope = null, Hint? hint = null)
+    public SentryId CaptureEvent(SentryEvent evt, Scope? scope = null, SentryHint? hint = null)
     {
         if (!IsEnabled)
         {
@@ -473,7 +473,7 @@ internal class Hub : IHub, IMetricHub, IDisposable
 
     public void CaptureTransaction(SentryTransaction transaction) => CaptureTransaction(transaction, null, null);
 
-    public void CaptureTransaction(SentryTransaction transaction, Scope? scope, Hint? hint)
+    public void CaptureTransaction(SentryTransaction transaction, Scope? scope, SentryHint? hint)
     {
         // Note: The hub should capture transactions even if it is disabled.
         // This allows transactions to be reported as failed when they encountered an unhandled exception,

--- a/src/Sentry/Internal/MemoryInfo.cs
+++ b/src/Sentry/Internal/MemoryInfo.cs
@@ -5,7 +5,7 @@ using Sentry.Internal.Extensions;
 
 namespace Sentry.Internal;
 
-internal sealed class MemoryInfo : IJsonSerializable
+internal sealed class MemoryInfo : ISentryJsonSerializable
 {
     public long AllocatedBytes { get; }
     public long FragmentedBytes { get; }

--- a/src/Sentry/Internal/ThreadPoolInfo.cs
+++ b/src/Sentry/Internal/ThreadPoolInfo.cs
@@ -2,7 +2,7 @@ using Sentry.Extensibility;
 
 namespace Sentry.Internal;
 
-internal sealed class ThreadPoolInfo : IJsonSerializable
+internal sealed class ThreadPoolInfo : ISentryJsonSerializable
 {
     public ThreadPoolInfo(
         int minWorkerThreads,

--- a/src/Sentry/Package.cs
+++ b/src/Sentry/Package.cs
@@ -6,7 +6,7 @@ namespace Sentry;
 /// <summary>
 /// Represents a package used to compose the SDK.
 /// </summary>
-public sealed class Package : IJsonSerializable
+public sealed class Package : ISentryJsonSerializable
 {
     /// <summary>
     /// The name of the package.

--- a/src/Sentry/PersistedSessionUpdate.cs
+++ b/src/Sentry/PersistedSessionUpdate.cs
@@ -3,7 +3,7 @@ using Sentry.Internal.Extensions;
 
 namespace Sentry;
 
-internal class PersistedSessionUpdate : IJsonSerializable
+internal class PersistedSessionUpdate : ISentryJsonSerializable
 {
     public SessionUpdate Update { get; }
 

--- a/src/Sentry/Platforms/Android/Callbacks/BeforeBreadcrumbCallback.cs
+++ b/src/Sentry/Platforms/Android/Callbacks/BeforeBreadcrumbCallback.cs
@@ -4,9 +4,9 @@ namespace Sentry.Android.Callbacks;
 
 internal class BeforeBreadcrumbCallback : JavaObject, JavaSdk.SentryOptions.IBeforeBreadcrumbCallback
 {
-    private readonly Func<Breadcrumb, Hint, Breadcrumb?> _beforeBreadcrumb;
+    private readonly Func<Breadcrumb, SentryHint, Breadcrumb?> _beforeBreadcrumb;
 
-    public BeforeBreadcrumbCallback(Func<Breadcrumb, Hint, Breadcrumb?> beforeBreadcrumb)
+    public BeforeBreadcrumbCallback(Func<Breadcrumb, SentryHint, Breadcrumb?> beforeBreadcrumb)
     {
         _beforeBreadcrumb = beforeBreadcrumb;
     }

--- a/src/Sentry/Platforms/Android/Callbacks/BeforeSendCallback.cs
+++ b/src/Sentry/Platforms/Android/Callbacks/BeforeSendCallback.cs
@@ -4,12 +4,12 @@ namespace Sentry.Android.Callbacks;
 
 internal class BeforeSendCallback : JavaObject, JavaSdk.SentryOptions.IBeforeSendCallback
 {
-    private readonly Func<SentryEvent, Hint, SentryEvent?> _beforeSend;
+    private readonly Func<SentryEvent, SentryHint, SentryEvent?> _beforeSend;
     private readonly SentryOptions _options;
     private readonly JavaSdk.SentryOptions _javaOptions;
 
     public BeforeSendCallback(
-        Func<SentryEvent, Hint, SentryEvent?> beforeSend,
+        Func<SentryEvent, SentryHint, SentryEvent?> beforeSend,
         SentryOptions options,
         JavaSdk.SentryOptions javaOptions)
     {

--- a/src/Sentry/Platforms/Android/Extensions/AttachmentExtensions.cs
+++ b/src/Sentry/Platforms/Android/Extensions/AttachmentExtensions.cs
@@ -2,7 +2,7 @@ namespace Sentry.Android.Extensions;
 
 internal static class AttachmentExtensions
 {
-    public static Attachment ToAttachment(this JavaSdk.Attachment attachment)
+    public static SentryAttachment ToAttachment(this JavaSdk.Attachment attachment)
     {
         // TODO: Convert JavaSdk.Attachment to Sentry.Attachment.
         // One way to do this might be to serialise the JavaSdk.Attachment as
@@ -14,7 +14,7 @@ internal static class AttachmentExtensions
         throw new NotImplementedException();
     }
 
-    public static JavaSdk.Attachment ToJavaAttachment(this Attachment attachment)
+    public static JavaSdk.Attachment ToJavaAttachment(this SentryAttachment attachment)
     {
         // TODO: Convert Sentry.Attachment to JavaSdk.Attachment.
         // Same problem as ToAttachment() above but in reverse.

--- a/src/Sentry/Platforms/Android/Extensions/HintExtensions.cs
+++ b/src/Sentry/Platforms/Android/Extensions/HintExtensions.cs
@@ -2,14 +2,14 @@ namespace Sentry.Android.Extensions;
 
 internal static class HintExtensions
 {
-    public static Hint ToHint(this JavaSdk.Hint javaHint)
+    public static SentryHint ToHint(this JavaSdk.Hint javaHint)
     {
         // Note the JavaSDK doesn't expose the internal hint storage in any way that is iterable,
         // so unless you know the key, you can't get the value. This prevents us from converting
         // anything in the JavaSdk.Hint except the explicitly named properties:
         //  Attachments, Screenshot and ViewHierarchy
 
-        var dotnetHint = new Hint();
+        var dotnetHint = new SentryHint();
         // TODO: Implement ToAttachment
         //dotnetHint.Screenshot = (javaHint.Screenshot is { } screenshot) ? screenshot.ToAttachment() : null;
         //dotnetHint.ViewHierarchy = (javaHint.ViewHierarchy is { } viewhierarchy) ? viewhierarchy.ToAttachment() : null;
@@ -18,7 +18,7 @@ internal static class HintExtensions
         return dotnetHint;
     }
 
-    public static JavaSdk.Hint ToJavaHint(this Hint dotnetHint)
+    public static JavaSdk.Hint ToJavaHint(this SentryHint dotnetHint)
     {
         var javaHint = new JavaSdk.Hint();
         // TODO: Implement ToJavaAttachment

--- a/src/Sentry/Platforms/Android/LogCatAttachmentEventProcessor.cs
+++ b/src/Sentry/Platforms/Android/LogCatAttachmentEventProcessor.cs
@@ -22,7 +22,7 @@ internal class LogCatAttachmentEventProcessor : ISentryEventProcessorWithHint
         _maxLines = maxLines;
     }
 
-    public SentryEvent Process(SentryEvent @event, Hint hint)
+    public SentryEvent Process(SentryEvent @event, SentryHint hint)
     {
         // If sending has failed once, we have to disable this feature to prevent infinite loops and to allow the SDK to work otherwise
         if (!SendLogcatLogs)
@@ -81,7 +81,7 @@ internal class LogCatAttachmentEventProcessor : ISentryEventProcessorWithHint
             output.Seek(0, SeekOrigin.Begin);
             var bytes = output.ToArray();
 
-            hint.Attachments.Add(new Attachment(AttachmentType.Default, new ByteAttachmentContent(bytes), "logcat.log", "text/logcat"));
+            hint.Attachments.Add(new SentryAttachment(AttachmentType.Default, new ByteAttachmentContent(bytes), "logcat.log", "text/logcat"));
 
             //hint.AddAttachment($"{filesDir.Path}/{fileName}", AttachmentType.Default, "text/logcat");
 
@@ -100,6 +100,6 @@ internal class LogCatAttachmentEventProcessor : ISentryEventProcessorWithHint
 
     public SentryEvent Process(SentryEvent @event)
     {
-        return Process(@event, new Hint());
+        return Process(@event, new SentryHint());
     }
 }

--- a/src/Sentry/Platforms/Cocoa/SentrySdk.cs
+++ b/src/Sentry/Platforms/Cocoa/SentrySdk.cs
@@ -62,7 +62,7 @@ public static partial class SentrySdk
             {
                 // Note: The Cocoa SDK doesn't yet support hints.
                 // See https://github.com/getsentry/sentry-cocoa/issues/2325
-                var hint = new Hint();
+                var hint = new SentryHint();
                 var breadcrumb = b.ToBreadcrumb(options.DiagnosticLogger);
                 var result = beforeBreadcrumb(breadcrumb, hint)?.ToCocoaBreadcrumb();
 

--- a/src/Sentry/Protocol/App.cs
+++ b/src/Sentry/Protocol/App.cs
@@ -12,7 +12,7 @@ namespace Sentry.Protocol;
 /// was running and carries meta data about the current session.
 /// </remarks>
 /// <seealso href="https://develop.sentry.dev/sdk/event-payloads/contexts/"/>
-public sealed class App : IJsonSerializable, ICloneable<App>, IUpdatable<App>
+public sealed class App : ISentryJsonSerializable, ICloneable<App>, IUpdatable<App>
 {
     /// <summary>
     /// Tells Sentry which type of context this is.

--- a/src/Sentry/Protocol/Browser.cs
+++ b/src/Sentry/Protocol/Browser.cs
@@ -10,7 +10,7 @@ namespace Sentry.Protocol;
 /// web request that triggered the event.
 /// </summary>
 /// <seealso href="https://develop.sentry.dev/sdk/event-payloads/contexts/"/>
-public sealed class Browser : IJsonSerializable, ICloneable<Browser>, IUpdatable<Browser>
+public sealed class Browser : ISentryJsonSerializable, ICloneable<Browser>, IUpdatable<Browser>
 {
     /// <summary>
     /// Tells Sentry which type of context this is.

--- a/src/Sentry/Protocol/DebugImage.cs
+++ b/src/Sentry/Protocol/DebugImage.cs
@@ -7,7 +7,7 @@ namespace Sentry.Protocol;
 /// The Sentry Debug Meta Images interface.
 /// </summary>
 /// <see href="https://develop.sentry.dev/sdk/event-payloads/debugmeta#debug-images"/>
-public sealed class DebugImage : IJsonSerializable
+public sealed class DebugImage : ISentryJsonSerializable
 {
     /// <summary>
     /// Type of the debug image.

--- a/src/Sentry/Protocol/DebugMeta.cs
+++ b/src/Sentry/Protocol/DebugMeta.cs
@@ -7,7 +7,7 @@ namespace Sentry.Protocol;
 /// The Sentry Debug Meta interface.
 /// </summary>
 /// <see href="https://develop.sentry.dev/sdk/event-payloads/debugmeta"/>
-internal sealed class DebugMeta : IJsonSerializable
+internal sealed class DebugMeta : ISentryJsonSerializable
 {
     public List<DebugImage>? Images { get; set; }
 

--- a/src/Sentry/Protocol/Device.cs
+++ b/src/Sentry/Protocol/Device.cs
@@ -8,7 +8,7 @@ namespace Sentry.Protocol;
 /// Describes the device that caused the event. This is most appropriate for mobile applications.
 /// </summary>
 /// <seealso href="https://develop.sentry.dev/sdk/event-payloads/contexts/"/>
-public sealed class Device : IJsonSerializable, ICloneable<Device>, IUpdatable<Device>
+public sealed class Device : ISentryJsonSerializable, ICloneable<Device>, IUpdatable<Device>
 {
     /// <summary>
     /// Tells Sentry which type of context this is.

--- a/src/Sentry/Protocol/Envelopes/AsyncJsonSerializable.cs
+++ b/src/Sentry/Protocol/Envelopes/AsyncJsonSerializable.cs
@@ -10,19 +10,19 @@ internal sealed class AsyncJsonSerializable : ISerializable
     /// <summary>
     /// Source object.
     /// </summary>
-    public Task<IJsonSerializable> Source { get; }
+    public Task<ISentryJsonSerializable> Source { get; }
 
     /// <summary>
     /// Initializes an instance of <see cref="AsyncJsonSerializable"/>.
     /// </summary>
     public static AsyncJsonSerializable CreateFrom<T>(Task<T> source)
-        where T : IJsonSerializable
+        where T : ISentryJsonSerializable
     {
-        var task = source.ContinueWith(t => t.Result as IJsonSerializable);
+        var task = source.ContinueWith(t => t.Result as ISentryJsonSerializable);
         return new AsyncJsonSerializable(task);
     }
 
-    private AsyncJsonSerializable(Task<IJsonSerializable> source) => Source = source;
+    private AsyncJsonSerializable(Task<ISentryJsonSerializable> source) => Source = source;
 
     /// <inheritdoc />
     public async Task SerializeAsync(Stream stream, IDiagnosticLogger? logger, CancellationToken cancellationToken = default)

--- a/src/Sentry/Protocol/Envelopes/Envelope.cs
+++ b/src/Sentry/Protocol/Envelopes/Envelope.cs
@@ -226,7 +226,7 @@ public sealed class Envelope : ISerializable, IDisposable
     public static Envelope FromEvent(
         SentryEvent @event,
         IDiagnosticLogger? logger = null,
-        IReadOnlyCollection<Attachment>? attachments = null,
+        IReadOnlyCollection<SentryAttachment>? attachments = null,
         SessionUpdate? sessionUpdate = null)
     {
         var eventId = @event.EventId;

--- a/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
@@ -281,13 +281,13 @@ public sealed class EnvelopeItem : ISerializable, IDisposable
     /// <summary>
     /// Creates an <see cref="EnvelopeItem"/> from <paramref name="attachment"/>.
     /// </summary>
-    public static EnvelopeItem FromAttachment(Attachment attachment)
+    public static EnvelopeItem FromAttachment(SentryAttachment attachment)
     {
         var stream = attachment.Content.GetStream();
         return FromAttachment(attachment, stream);
     }
 
-    internal static EnvelopeItem FromAttachment(Attachment attachment, Stream stream)
+    internal static EnvelopeItem FromAttachment(SentryAttachment attachment, Stream stream)
     {
         var attachmentType = attachment.Type switch
         {

--- a/src/Sentry/Protocol/Envelopes/JsonSerializable.cs
+++ b/src/Sentry/Protocol/Envelopes/JsonSerializable.cs
@@ -10,12 +10,12 @@ internal sealed class JsonSerializable : ISerializable
     /// <summary>
     /// Source object.
     /// </summary>
-    public IJsonSerializable Source { get; }
+    public ISentryJsonSerializable Source { get; }
 
     /// <summary>
     /// Initializes an instance of <see cref="JsonSerializable"/>.
     /// </summary>
-    public JsonSerializable(IJsonSerializable source) => Source = source;
+    public JsonSerializable(ISentryJsonSerializable source) => Source = source;
 
     /// <inheritdoc />
     public async Task SerializeAsync(Stream stream, IDiagnosticLogger? logger, CancellationToken cancellationToken = default)

--- a/src/Sentry/Protocol/Gpu.cs
+++ b/src/Sentry/Protocol/Gpu.cs
@@ -8,7 +8,7 @@ namespace Sentry.Protocol;
 /// Graphics device unit.
 /// </summary>
 /// <seealso href="https://develop.sentry.dev/sdk/event-payloads/contexts/#gpu-context"/>
-public sealed class Gpu : IJsonSerializable, ICloneable<Gpu>, IUpdatable<Gpu>
+public sealed class Gpu : ISentryJsonSerializable, ICloneable<Gpu>, IUpdatable<Gpu>
 {
     /// <summary>
     /// Tells Sentry which type of context this is.

--- a/src/Sentry/Protocol/Measurement.cs
+++ b/src/Sentry/Protocol/Measurement.cs
@@ -6,7 +6,7 @@ namespace Sentry.Protocol;
 /// <summary>
 /// A measurement, containing a numeric value and a unit.
 /// </summary>
-public sealed class Measurement : IJsonSerializable
+public sealed class Measurement : ISentryJsonSerializable
 {
     /// <summary>
     /// The numeric value of the measurement.

--- a/src/Sentry/Protocol/Mechanism.cs
+++ b/src/Sentry/Protocol/Mechanism.cs
@@ -12,7 +12,7 @@ namespace Sentry.Protocol;
 /// This includes general exception values obtained from operating system or runtime APIs, as well as mechanism-specific values.
 /// </remarks>
 /// <see href="https://develop.sentry.dev/sdk/event-payloads/exception/#exception-mechanism"/>
-public sealed class Mechanism : IJsonSerializable
+public sealed class Mechanism : ISentryJsonSerializable
 {
     /// <summary>
     /// Key found inside of <c>Exception.Data</c> to inform if the exception was handled.

--- a/src/Sentry/Protocol/Metrics/CodeLocations.cs
+++ b/src/Sentry/Protocol/Metrics/CodeLocations.cs
@@ -7,7 +7,7 @@ namespace Sentry.Protocol.Metrics;
 /// Represents a collection of code locations.
 /// </summary>
 internal class CodeLocations(long timestamp, IReadOnlyDictionary<MetricResourceIdentifier, SentryStackFrame> locations)
-    : IJsonSerializable
+    : ISentryJsonSerializable
 {
     /// <summary>
     /// Uniquely identifies a code location using the number of seconds since the UnixEpoch, as measured at the start
@@ -15,7 +15,7 @@ internal class CodeLocations(long timestamp, IReadOnlyDictionary<MetricResourceI
     /// </summary>
     public long Timestamp => timestamp;
 
-    /// <inheritdoc cref="IJsonSerializable.WriteTo"/>
+    /// <inheritdoc cref="ISentryJsonSerializable.WriteTo"/>
     public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? logger)
     {
         writer.WriteStartObject();

--- a/src/Sentry/Protocol/Metrics/Metric.cs
+++ b/src/Sentry/Protocol/Metrics/Metric.cs
@@ -7,7 +7,7 @@ namespace Sentry.Protocol.Metrics;
 /// <summary>
 /// Base class for metric instruments
 /// </summary>
-internal abstract class Metric : IJsonSerializable, ISentrySerializable
+internal abstract class Metric : ISentryJsonSerializable, ISentrySerializable
 {
     /// <summary>
     /// Creates a new instance of <see cref="Metric"/>.
@@ -75,7 +75,7 @@ internal abstract class Metric : IJsonSerializable, ISentrySerializable
     /// </summary>
     protected abstract void WriteValues(Utf8JsonWriter writer, IDiagnosticLogger? logger);
 
-    /// <inheritdoc cref="IJsonSerializable.WriteTo"/>
+    /// <inheritdoc cref="ISentryJsonSerializable.WriteTo"/>
     public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? logger)
     {
         writer.WriteStartObject();

--- a/src/Sentry/Protocol/OperatingSystem.cs
+++ b/src/Sentry/Protocol/OperatingSystem.cs
@@ -11,7 +11,7 @@ namespace Sentry.Protocol;
 /// Defines the operating system that caused the event. In web contexts, this is the operating system of the browser (normally pulled from the User-Agent string).
 /// </remarks>
 /// <seealso href="https://develop.sentry.dev/sdk/event-payloads/contexts/#os-context"/>
-public sealed class OperatingSystem : IJsonSerializable, ICloneable<OperatingSystem>, IUpdatable<OperatingSystem>
+public sealed class OperatingSystem : ISentryJsonSerializable, ICloneable<OperatingSystem>, IUpdatable<OperatingSystem>
 {
     /// <summary>
     /// Tells Sentry which type of context this is.

--- a/src/Sentry/Protocol/ProfileInfo.cs
+++ b/src/Sentry/Protocol/ProfileInfo.cs
@@ -6,7 +6,7 @@ namespace Sentry.Protocol;
 /// <summary>
 /// Profiling context information.
 /// </summary>
-internal sealed class ProfileInfo : IJsonSerializable
+internal sealed class ProfileInfo : ISentryJsonSerializable
 {
     /// <summary>
     /// Profile's event ID.

--- a/src/Sentry/Protocol/Response.cs
+++ b/src/Sentry/Protocol/Response.cs
@@ -23,7 +23,7 @@ namespace Sentry.Protocol;
 ///}
 /// </example>
 /// <see href="https://develop.sentry.dev/sdk/event-payloads/types/#responsecontext"/>
-public sealed class Response : IJsonSerializable, ICloneable<Response>, IUpdatable<Response>
+public sealed class Response : ISentryJsonSerializable, ICloneable<Response>, IUpdatable<Response>
 {
     /// <summary>
     /// Tells Sentry which type of context this is.

--- a/src/Sentry/Protocol/Runtime.cs
+++ b/src/Sentry/Protocol/Runtime.cs
@@ -11,7 +11,7 @@ namespace Sentry.Protocol;
 /// Typically this context is used multiple times if multiple runtimes are involved (for instance if you have a JavaScript application running on top of JVM)
 /// </remarks>
 /// <seealso href="https://develop.sentry.dev/sdk/event-payloads/contexts/"/>
-public sealed class Runtime : IJsonSerializable, ICloneable<Runtime>, IUpdatable<Runtime>
+public sealed class Runtime : ISentryJsonSerializable, ICloneable<Runtime>, IUpdatable<Runtime>
 {
     /// <summary>
     /// Tells Sentry which type of context this is.

--- a/src/Sentry/Protocol/SampleProfile.cs
+++ b/src/Sentry/Protocol/SampleProfile.cs
@@ -10,7 +10,7 @@ namespace Sentry.Protocol;
 /// <summary>
 /// Sentry sampling profiler output profile
 /// </summary>
-internal sealed class SampleProfile : IJsonSerializable
+internal sealed class SampleProfile : ISentryJsonSerializable
 {
     // Note: changing these to properties would break because GrowableArray is a struct.
     internal Internal.GrowableArray<Sample> Samples = new(10000);
@@ -52,7 +52,7 @@ internal sealed class SampleProfile : IJsonSerializable
         writer.WriteEndObject();
     }
 
-    public class Sample : IJsonSerializable
+    public class Sample : ISentryJsonSerializable
     {
         /// <summary>
         /// Timestamp in nanoseconds relative to the profile start.

--- a/src/Sentry/Protocol/SentryException.cs
+++ b/src/Sentry/Protocol/SentryException.cs
@@ -7,7 +7,7 @@ namespace Sentry.Protocol;
 /// Sentry Exception interface.
 /// </summary>
 /// <see href="https://develop.sentry.dev/sdk/event-payloads/exception"/>
-public sealed class SentryException : IJsonSerializable
+public sealed class SentryException : ISentryJsonSerializable
 {
     /// <summary>
     /// Exception Type.

--- a/src/Sentry/Protocol/Trace.cs
+++ b/src/Sentry/Protocol/Trace.cs
@@ -7,7 +7,7 @@ namespace Sentry.Protocol;
 /// <summary>
 /// Trace context data.
 /// </summary>
-public class Trace : ITraceContext, IJsonSerializable, ICloneable<Trace>, IUpdatable<Trace>
+public class Trace : ITraceContext, ISentryJsonSerializable, ICloneable<Trace>, IUpdatable<Trace>
 {
     /// <summary>
     /// Tells Sentry which type of context this is.

--- a/src/Sentry/Request.cs
+++ b/src/Sentry/Request.cs
@@ -25,7 +25,7 @@ namespace Sentry;
 /// }
 /// </example>
 /// <see href="https://develop.sentry.dev/sdk/event-payloads/request/"/>
-public sealed class Request : IJsonSerializable
+public sealed class Request : ISentryJsonSerializable
 {
     internal Dictionary<string, string>? InternalEnv { get; private set; }
 

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -220,15 +220,15 @@ public class Scope : IEventLike
     public IReadOnlyDictionary<string, string> Tags => _tags;
 
 #if NETSTANDARD2_0 || NETFRAMEWORK
-    private ConcurrentBag<Attachment> _attachments = new();
+    private ConcurrentBag<SentryAttachment> _attachments = new();
 #else
-    private readonly ConcurrentBag<Attachment> _attachments = new();
+    private readonly ConcurrentBag<SentryAttachment> _attachments = new();
 #endif
 
     /// <summary>
     /// Attachments.
     /// </summary>
-    public IReadOnlyCollection<Attachment> Attachments => _attachments;
+    public IReadOnlyCollection<SentryAttachment> Attachments => _attachments;
 
     /// <summary>
     /// Creates a scope with the specified options.
@@ -251,14 +251,14 @@ public class Scope : IEventLike
     }
 
     /// <inheritdoc />
-    public void AddBreadcrumb(Breadcrumb breadcrumb) => AddBreadcrumb(breadcrumb, new Hint());
+    public void AddBreadcrumb(Breadcrumb breadcrumb) => AddBreadcrumb(breadcrumb, new SentryHint());
 
     /// <summary>
     /// Adds a breadcrumb with a hint.
     /// </summary>
     /// <param name="breadcrumb">The breadcrumb</param>
     /// <param name="hint">A hint for use in the BeforeBreadcrumb callback</param>
-    public void AddBreadcrumb(Breadcrumb breadcrumb, Hint hint)
+    public void AddBreadcrumb(Breadcrumb breadcrumb, SentryHint hint)
     {
         if (Options.BeforeBreadcrumbInternal is { } beforeBreadcrumb)
         {
@@ -331,7 +331,7 @@ public class Scope : IEventLike
     /// <summary>
     /// Adds an attachment.
     /// </summary>
-    public void AddAttachment(Attachment attachment) => _attachments.Add(attachment);
+    public void AddAttachment(SentryAttachment attachment) => _attachments.Add(attachment);
 
     /// <summary>
     /// Resets all the properties and collections within the scope to their default values.

--- a/src/Sentry/ScopeExtensions.cs
+++ b/src/Sentry/ScopeExtensions.cs
@@ -166,7 +166,7 @@ public static class ScopeExtensions
         // TODO: Envelope spec allows the last item to not have a length.
         // So if we make sure there's only 1 item without length, we can support it.
         scope.AddAttachment(
-            new Attachment(
+            new SentryAttachment(
                 type,
                 new StreamAttachmentContent(stream),
                 fileName,
@@ -183,7 +183,7 @@ public static class ScopeExtensions
         AttachmentType type = AttachmentType.Default,
         string? contentType = null) =>
         scope.AddAttachment(
-            new Attachment(
+            new SentryAttachment(
                 type,
                 new ByteAttachmentContent(data),
                 fileName,
@@ -198,7 +198,7 @@ public static class ScopeExtensions
         AttachmentType type = AttachmentType.Default,
         string? contentType = null) =>
         scope.AddAttachment(
-            new Attachment(
+            new SentryAttachment(
                 type,
                 new FileAttachmentContent(filePath, scope.Options.UseAsyncFileIO),
                 Path.GetFileName(filePath),

--- a/src/Sentry/SdkVersion.cs
+++ b/src/Sentry/SdkVersion.cs
@@ -8,7 +8,7 @@ namespace Sentry;
 /// Information about the SDK to be sent with the SentryEvent.
 /// </summary>
 /// <remarks>Requires Sentry version 8.4 or higher.</remarks>
-public sealed class SdkVersion : IJsonSerializable
+public sealed class SdkVersion : ISentryJsonSerializable
 {
     private static readonly Lazy<SdkVersion> InstanceLazy = new(
         () => new SdkVersion

--- a/src/Sentry/SentryAttachment.cs
+++ b/src/Sentry/SentryAttachment.cs
@@ -43,7 +43,7 @@ public enum AttachmentType
 /// Sentry attachment.
 /// </summary>
 [DebuggerDisplay("{" + nameof(FileName) + "}")]
-public class Attachment
+public class SentryAttachment
 {
     /// <summary>
     /// Attachment type.
@@ -66,9 +66,9 @@ public class Attachment
     public string? ContentType { get; }
 
     /// <summary>
-    /// Initializes an instance of <see cref="Attachment"/>.
+    /// Initializes an instance of <see cref="SentryAttachment"/>.
     /// </summary>
-    public Attachment(
+    public SentryAttachment(
         AttachmentType type,
         IAttachmentContent content,
         string fileName,

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -77,7 +77,7 @@ public class SentryClient : ISentryClient, IDisposable
     }
 
     /// <inheritdoc />
-    public SentryId CaptureEvent(SentryEvent? @event, Scope? scope = null, Hint? hint = null)
+    public SentryId CaptureEvent(SentryEvent? @event, Scope? scope = null, SentryHint? hint = null)
     {
         if (@event == null)
         {
@@ -112,7 +112,7 @@ public class SentryClient : ISentryClient, IDisposable
     public void CaptureTransaction(SentryTransaction transaction) => CaptureTransaction(transaction, null, null);
 
     /// <inheritdoc />
-    public void CaptureTransaction(SentryTransaction transaction, Scope? scope, Hint? hint)
+    public void CaptureTransaction(SentryTransaction transaction, Scope? scope, SentryHint? hint)
     {
         if (transaction.SpanId.Equals(SpanId.Empty))
         {
@@ -148,7 +148,7 @@ public class SentryClient : ISentryClient, IDisposable
         }
 
         scope ??= new Scope(_options);
-        hint ??= new Hint();
+        hint ??= new SentryHint();
         hint.AddAttachmentsFromScope(scope);
 
         _options.LogInfo("Capturing transaction.");
@@ -186,7 +186,7 @@ public class SentryClient : ISentryClient, IDisposable
         CaptureEnvelope(Envelope.FromTransaction(processedTransaction));
     }
 
-    private SentryTransaction? BeforeSendTransaction(SentryTransaction transaction, Hint hint)
+    private SentryTransaction? BeforeSendTransaction(SentryTransaction transaction, SentryHint hint)
     {
         if (_options.BeforeSendTransactionInternal is null)
         {
@@ -243,7 +243,7 @@ public class SentryClient : ISentryClient, IDisposable
     public Task FlushAsync(TimeSpan timeout) => Worker.FlushAsync(timeout);
 
     // TODO: this method needs to be refactored, it's really hard to analyze nullability
-    private SentryId DoSendEvent(SentryEvent @event, Hint? hint, Scope? scope)
+    private SentryId DoSendEvent(SentryEvent @event, SentryHint? hint, Scope? scope)
     {
         var filteredExceptions = ApplyExceptionFilters(@event.Exception);
         if (filteredExceptions?.Count > 0)
@@ -255,7 +255,7 @@ public class SentryClient : ISentryClient, IDisposable
         }
 
         scope ??= new Scope(_options);
-        hint ??= new Hint();
+        hint ??= new SentryHint();
         hint.AddAttachmentsFromScope(scope);
 
         _options.LogInfo("Capturing event.");
@@ -389,7 +389,7 @@ public class SentryClient : ISentryClient, IDisposable
         return false;
     }
 
-    private SentryEvent? BeforeSend(SentryEvent? @event, Hint hint)
+    private SentryEvent? BeforeSend(SentryEvent? @event, SentryHint hint)
     {
         if (_options.BeforeSendInternal == null)
         {

--- a/src/Sentry/SentryEvent.cs
+++ b/src/Sentry/SentryEvent.cs
@@ -10,7 +10,7 @@ namespace Sentry;
 /// </summary>
 /// <seealso href="https://develop.sentry.dev/sdk/event-payloads/" />
 [DebuggerDisplay("{GetType().Name,nq}: {" + nameof(EventId) + ",nq}")]
-public sealed class SentryEvent : IEventLike, IJsonSerializable
+public sealed class SentryEvent : IEventLike, ISentryJsonSerializable
 {
     private IDictionary<string, string>? _modules;
 

--- a/src/Sentry/SentryGraphQLHttpFailedRequestHandler.cs
+++ b/src/Sentry/SentryGraphQLHttpFailedRequestHandler.cs
@@ -42,7 +42,7 @@ internal class SentryGraphQLHttpFailedRequestHandler : SentryFailedRequestHandle
             exception.SetSentryMechanism(MechanismType, "GraphQL Failed Request Handler", false);
 
             var @event = new SentryEvent(exception);
-            var hint = new Hint(HintTypes.HttpResponseMessage, response);
+            var hint = new SentryHint(HintTypes.HttpResponseMessage, response);
 
             var sentryRequest = new Request
             {

--- a/src/Sentry/SentryHint.cs
+++ b/src/Sentry/SentryHint.cs
@@ -4,20 +4,20 @@ namespace Sentry;
 /// A hint that can be provided when capturing a <see cref="SentryEvent"/> or when adding a <see cref="Breadcrumb"/>.
 /// Hints can be used to filter or modify events, transactions, or breadcrumbs before they are sent to Sentry.
 /// </summary>
-public class Hint
+public class SentryHint
 {
     private readonly SentryOptions? _options;
-    private readonly List<Attachment> _attachments = new();
+    private readonly List<SentryAttachment> _attachments = new();
     private Dictionary<string, object?>? _items;
 
     /// <summary>
-    /// Creates a new instance of <see cref="Hint"/>.
+    /// Creates a new instance of <see cref="SentryHint"/>.
     /// </summary>
-    public Hint() : this(SentrySdk.CurrentHub.GetSentryOptions())
+    public SentryHint() : this(SentrySdk.CurrentHub.GetSentryOptions())
     {
     }
 
-    internal Hint(SentryOptions? options)
+    internal SentryHint(SentryOptions? options)
     {
         _options = options;
     }
@@ -27,7 +27,7 @@ public class Hint
     /// </summary>
     /// <param name="key">The key of the hint item.</param>
     /// <param name="value">The value of the hint item.</param>
-    public Hint(string key, object? value)
+    public SentryHint(string key, object? value)
         : this()
     {
         Items[key] = value;
@@ -40,7 +40,7 @@ public class Hint
     /// This collection represents all of the attachments that will be sent to Sentry with the corresponding event.
     /// You can add or remove attachments from this collection as needed.
     /// </remarks>
-    public ICollection<Attachment> Attachments => _attachments;
+    public ICollection<SentryAttachment> Attachments => _attachments;
 
     /// <summary>
     /// A dictionary of arbitrary items provided with the Hint.
@@ -72,7 +72,7 @@ public class Hint
         if (_options is not null)
         {
             _attachments.Add(
-                new Attachment(
+                new SentryAttachment(
                     type,
                     new FileAttachmentContent(filePath, _options.UseAsyncFileIO),
                     Path.GetFileName(filePath),
@@ -85,16 +85,16 @@ public class Hint
     /// </summary>
     /// <param name="attachments">The attachment(s) to add.</param>
     /// <returns>A Hint having the attachment(s).</returns>
-    public static Hint WithAttachments(params Attachment[] attachments) => WithAttachments(attachments.AsEnumerable());
+    public static SentryHint WithAttachments(params SentryAttachment[] attachments) => WithAttachments(attachments.AsEnumerable());
 
     /// <summary>
     /// Creates a new Hint with attachments.
     /// </summary>
     /// <param name="attachments">The attachments to add.</param>
     /// <returns>A Hint having the attachments.</returns>
-    public static Hint WithAttachments(IEnumerable<Attachment> attachments)
+    public static SentryHint WithAttachments(IEnumerable<SentryAttachment> attachments)
     {
-        var hint = new Hint();
+        var hint = new SentryHint();
         hint._attachments.AddRange(attachments);
         return hint;
     }

--- a/src/Sentry/SentryHttpFailedRequestHandler.cs
+++ b/src/Sentry/SentryHttpFailedRequestHandler.cs
@@ -42,7 +42,7 @@ internal class SentryHttpFailedRequestHandler : SentryFailedRequestHandler
             exception.SetSentryMechanism(MechanismType);
 
             var @event = new SentryEvent(exception);
-            var hint = new Hint(HintTypes.HttpResponseMessage, response);
+            var hint = new SentryHint(HintTypes.HttpResponseMessage, response);
 
             var uri = response.RequestMessage?.RequestUri;
             var sentryRequest = new Request

--- a/src/Sentry/SentryId.cs
+++ b/src/Sentry/SentryId.cs
@@ -5,7 +5,7 @@ namespace Sentry;
 /// <summary>
 /// The identifier of an event in Sentry.
 /// </summary>
-public readonly struct SentryId : IEquatable<SentryId>, IJsonSerializable
+public readonly struct SentryId : IEquatable<SentryId>, ISentryJsonSerializable
 {
     private readonly Guid _guid;
 

--- a/src/Sentry/SentryMessage.cs
+++ b/src/Sentry/SentryMessage.cs
@@ -16,7 +16,7 @@ namespace Sentry;
 /// }
 /// </example>
 /// <seealso href="https://develop.sentry.dev/sdk/event-payloads/message/"/>
-public sealed class SentryMessage : IJsonSerializable
+public sealed class SentryMessage : ISentryJsonSerializable
 {
     /// <summary>
     /// The raw message string (un-interpolated).

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -1093,7 +1093,7 @@ public class SentryOptions
     /// </summary>
     /// <remarks>
     /// This option applies only to complex objects being added to Sentry events as contexts or extras, which do not
-    /// implement <see cref="IJsonSerializable"/>.
+    /// implement <see cref="ISentryJsonSerializable"/>.
     /// </remarks>
     public bool JsonPreserveReferences
     {

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -423,9 +423,9 @@ public class SentryOptions
         return string.Equals(requestBaseUrl, _sentryBaseUrl.Value, StringComparison.OrdinalIgnoreCase);
     }
 
-    private Func<SentryEvent, Hint, SentryEvent?>? _beforeSend;
+    private Func<SentryEvent, SentryHint, SentryEvent?>? _beforeSend;
 
-    internal Func<SentryEvent, Hint, SentryEvent?>? BeforeSendInternal => _beforeSend;
+    internal Func<SentryEvent, SentryHint, SentryEvent?>? BeforeSendInternal => _beforeSend;
 
     /// <summary>
     /// Configures a callback function to be invoked before sending an event to Sentry
@@ -435,7 +435,7 @@ public class SentryOptions
     /// application a chance to inspect and/or modify the event before it's sent. If the
     /// event should not be sent at all, return null from the callback.
     /// </remarks>
-    public void SetBeforeSend(Func<SentryEvent, Hint, SentryEvent?> beforeSend)
+    public void SetBeforeSend(Func<SentryEvent, SentryHint, SentryEvent?> beforeSend)
     {
         _beforeSend = beforeSend;
     }
@@ -453,15 +453,15 @@ public class SentryOptions
         _beforeSend = (@event, _) => beforeSend(@event);
     }
 
-    private Func<SentryTransaction, Hint, SentryTransaction?>? _beforeSendTransaction;
+    private Func<SentryTransaction, SentryHint, SentryTransaction?>? _beforeSendTransaction;
 
-    internal Func<SentryTransaction, Hint, SentryTransaction?>? BeforeSendTransactionInternal => _beforeSendTransaction;
+    internal Func<SentryTransaction, SentryHint, SentryTransaction?>? BeforeSendTransactionInternal => _beforeSendTransaction;
 
     /// <summary>
     /// Configures a callback to invoke before sending a transaction to Sentry
     /// </summary>
     /// <param name="beforeSendTransaction">The callback</param>
-    public void SetBeforeSendTransaction(Func<SentryTransaction, Hint, SentryTransaction?> beforeSendTransaction)
+    public void SetBeforeSendTransaction(Func<SentryTransaction, SentryHint, SentryTransaction?> beforeSendTransaction)
     {
         _beforeSendTransaction = beforeSendTransaction;
     }
@@ -475,9 +475,9 @@ public class SentryOptions
         _beforeSendTransaction = (transaction, _) => beforeSendTransaction(transaction);
     }
 
-    private Func<Breadcrumb, Hint, Breadcrumb?>? _beforeBreadcrumb;
+    private Func<Breadcrumb, SentryHint, Breadcrumb?>? _beforeBreadcrumb;
 
-    internal Func<Breadcrumb, Hint, Breadcrumb?>? BeforeBreadcrumbInternal => _beforeBreadcrumb;
+    internal Func<Breadcrumb, SentryHint, Breadcrumb?>? BeforeBreadcrumbInternal => _beforeBreadcrumb;
 
     /// <summary>
     /// Sets a callback function to be invoked when a breadcrumb is about to be stored.
@@ -486,7 +486,7 @@ public class SentryOptions
     /// Gives a chance to inspect and modify the breadcrumb. If null is returned, the
     /// breadcrumb will be discarded. Otherwise the result of the callback will be stored.
     /// </remarks>
-    public void SetBeforeBreadcrumb(Func<Breadcrumb, Hint, Breadcrumb?> beforeBreadcrumb)
+    public void SetBeforeBreadcrumb(Func<Breadcrumb, SentryHint, Breadcrumb?> beforeBreadcrumb)
     {
         _beforeBreadcrumb = beforeBreadcrumb;
     }

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -357,7 +357,7 @@ public static partial class SentrySdk
     /// <param name="hint">A hint providing additional context that can be used in the BeforeBreadcrumb callback</param>
     /// <see cref="AddBreadcrumb(string, string?, string?, IDictionary{string, string}?, BreadcrumbLevel)"/>
     [DebuggerStepThrough]
-    public static void AddBreadcrumb(Breadcrumb breadcrumb, Hint? hint = null)
+    public static void AddBreadcrumb(Breadcrumb breadcrumb, SentryHint? hint = null)
         => CurrentHub.AddBreadcrumb(breadcrumb, hint);
 
     /// <summary>
@@ -392,7 +392,7 @@ public static partial class SentrySdk
     /// <returns>The Id of the event.</returns>
     [DebuggerStepThrough]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static SentryId CaptureEvent(SentryEvent evt, Scope? scope = null, Hint? hint = null)
+    public static SentryId CaptureEvent(SentryEvent evt, Scope? scope = null, SentryHint? hint = null)
         => CurrentHub.CaptureEvent(evt, scope, hint);
 
     /// <summary>
@@ -421,7 +421,7 @@ public static partial class SentrySdk
     /// <returns>The Id of the event.</returns>
     [DebuggerStepThrough]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static SentryId CaptureEvent(SentryEvent evt, Hint? hint, Action<Scope> configureScope)
+    public static SentryId CaptureEvent(SentryEvent evt, SentryHint? hint, Action<Scope> configureScope)
         => CurrentHub.CaptureEvent(evt, hint, configureScope);
 
     /// <summary>
@@ -510,7 +510,7 @@ public static partial class SentrySdk
     /// </remarks>
     [DebuggerStepThrough]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static void CaptureTransaction(SentryTransaction transaction, Scope? scope, Hint? hint)
+    public static void CaptureTransaction(SentryTransaction transaction, Scope? scope, SentryHint? hint)
         => CurrentHub.CaptureTransaction(transaction, scope, hint);
 
     /// <summary>

--- a/src/Sentry/SentrySpan.cs
+++ b/src/Sentry/SentrySpan.cs
@@ -9,7 +9,7 @@ namespace Sentry;
 /// <summary>
 /// Transaction span.
 /// </summary>
-public class SentrySpan : ISpanData, IJsonSerializable
+public class SentrySpan : ISpanData, ISentryJsonSerializable
 {
     /// <inheritdoc />
     public SpanId SpanId { get; private set; }

--- a/src/Sentry/SentryStackFrame.cs
+++ b/src/Sentry/SentryStackFrame.cs
@@ -7,7 +7,7 @@ namespace Sentry;
 /// A frame of a stacktrace.
 /// </summary>
 /// <see href="https://develop.sentry.dev/sdk/event-payloads/stacktrace/"/>
-public sealed class SentryStackFrame : IJsonSerializable
+public sealed class SentryStackFrame : ISentryJsonSerializable
 {
     internal List<string>? InternalPreContext { get; private set; }
 

--- a/src/Sentry/SentryStackTrace.cs
+++ b/src/Sentry/SentryStackTrace.cs
@@ -40,7 +40,7 @@ public enum InstructionAddressAdjustment
 /// Frames should be sorted from oldest to newest.
 /// </remarks>
 /// <see href="https://develop.sentry.dev/sdk/event-payloads/stacktrace/"/>
-public class SentryStackTrace : IJsonSerializable
+public class SentryStackTrace : ISentryJsonSerializable
 {
     internal IList<SentryStackFrame>? InternalFrames { get; private set; }
 

--- a/src/Sentry/SentryThread.cs
+++ b/src/Sentry/SentryThread.cs
@@ -7,7 +7,7 @@ namespace Sentry;
 /// A thread running at the time of an event.
 /// </summary>
 /// <see href="https://develop.sentry.dev/sdk/event-payloads/threads/"/>
-public sealed class SentryThread : IJsonSerializable
+public sealed class SentryThread : ISentryJsonSerializable
 {
     /// <summary>
     /// The Id of the thread.

--- a/src/Sentry/SentryTransaction.cs
+++ b/src/Sentry/SentryTransaction.cs
@@ -9,7 +9,7 @@ namespace Sentry;
 /// <summary>
 /// Sentry performance transaction.
 /// </summary>
-public class SentryTransaction : ITransactionData, IJsonSerializable
+public class SentryTransaction : ITransactionData, ISentryJsonSerializable
 {
     /// <summary>
     /// Transaction's event ID.

--- a/src/Sentry/SentryUser.cs
+++ b/src/Sentry/SentryUser.cs
@@ -7,7 +7,7 @@ namespace Sentry;
 /// An interface which describes the authenticated User for a request.
 /// </summary>
 /// <see href="https://develop.sentry.dev/sdk/event-payloads/user/"/>
-public sealed class SentryUser : IJsonSerializable
+public sealed class SentryUser : ISentryJsonSerializable
 {
     internal Action<SentryUser>? PropertyChanged { get; set; }
 

--- a/src/Sentry/SentryValues.cs
+++ b/src/Sentry/SentryValues.cs
@@ -6,7 +6,7 @@ namespace Sentry;
 /// <summary>
 /// Helps serialization of Sentry protocol types which include a values property.
 /// </summary>
-internal sealed class SentryValues<T> : IJsonSerializable
+internal sealed class SentryValues<T> : ISentryJsonSerializable
 {
     /// <summary>
     /// The values.

--- a/src/Sentry/SessionUpdate.cs
+++ b/src/Sentry/SessionUpdate.cs
@@ -7,7 +7,7 @@ namespace Sentry;
 /// Session update.
 /// </summary>
 // https://develop.sentry.dev/sdk/sessions/#session-update-payload
-public class SessionUpdate : ISentrySession, IJsonSerializable
+public class SessionUpdate : ISentrySession, ISentryJsonSerializable
 {
     /// <inheritdoc />
     public SentryId Id { get; }

--- a/src/Sentry/SpanId.cs
+++ b/src/Sentry/SpanId.cs
@@ -6,7 +6,7 @@ namespace Sentry;
 /// <summary>
 /// Sentry span ID.
 /// </summary>
-public readonly struct SpanId : IEquatable<SpanId>, IJsonSerializable
+public readonly struct SpanId : IEquatable<SpanId>, ISentryJsonSerializable
 {
     private static readonly char[] HexChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
     private static readonly RandomValuesFactory Random = new SynchronizedRandomValuesFactory();

--- a/src/Sentry/UserFeedback.cs
+++ b/src/Sentry/UserFeedback.cs
@@ -6,7 +6,7 @@ namespace Sentry;
 /// <summary>
 /// Sentry User Feedback.
 /// </summary>
-public sealed class UserFeedback : IJsonSerializable
+public sealed class UserFeedback : ISentryJsonSerializable
 {
     /// <summary>
     /// The eventId of the event to which the user feedback is associated.

--- a/src/Sentry/ViewHierarchy.cs
+++ b/src/Sentry/ViewHierarchy.cs
@@ -6,7 +6,7 @@ namespace Sentry
     /// <summary>
     /// Sentry View Hierarchy.
     /// </summary>
-    public sealed class ViewHierarchy : IJsonSerializable
+    public sealed class ViewHierarchy : ISentryJsonSerializable
     {
         /// <summary>
         /// The rendering system this view hierarchy is capturing.

--- a/src/Sentry/ViewHierarchyAttachment.cs
+++ b/src/Sentry/ViewHierarchyAttachment.cs
@@ -3,7 +3,7 @@ namespace Sentry;
 /// <summary>
 /// Sentry View Hierarchy attachment.
 /// </summary>
-public class ViewHierarchyAttachment : Attachment
+public class ViewHierarchyAttachment : SentryAttachment
 {
     /// <summary>
     /// Initializes an instance of <see cref="ViewHierarchyAttachment"/>.

--- a/src/Sentry/ViewHierarchyNode.cs
+++ b/src/Sentry/ViewHierarchyNode.cs
@@ -5,7 +5,7 @@ namespace Sentry;
 /// <summary>
 /// Sentry View Hierarchy Node
 /// </summary>
-public abstract class ViewHierarchyNode : IJsonSerializable
+public abstract class ViewHierarchyNode : ISentryJsonSerializable
 {
     private List<ViewHierarchyNode>? _children;
 

--- a/test/Sentry.AspNetCore.Tests/MiddlewareLoggerIntegration.cs
+++ b/test/Sentry.AspNetCore.Tests/MiddlewareLoggerIntegration.cs
@@ -41,7 +41,7 @@ public class MiddlewareLoggerIntegration : IDisposable
             };
             loggingOptions.InitializeSdk = false;
 
-            Client.When(client => client.CaptureEvent(Arg.Any<SentryEvent>(), Arg.Any<Scope>(), Arg.Any<Hint>()))
+            Client.When(client => client.CaptureEvent(Arg.Any<SentryEvent>(), Arg.Any<Scope>(), Arg.Any<SentryHint>()))
                 .Do(callback => callback.Arg<Scope>().Evaluate());
 
             var hub = new Hub(new SentryOptions { Dsn = ValidDsn });
@@ -83,7 +83,7 @@ public class MiddlewareLoggerIntegration : IDisposable
 
         _ = _fixture.Client.Received(1).CaptureEvent(
             Arg.Any<SentryEvent>(),
-            Arg.Is<Scope>(e => e.Breadcrumbs.Any(b => b.Message == expectedCrumb)), Arg.Any<Hint>());
+            Arg.Is<Scope>(e => e.Breadcrumbs.Any(b => b.Message == expectedCrumb)), Arg.Any<SentryHint>());
     }
 
     [Fact]
@@ -104,7 +104,7 @@ public class MiddlewareLoggerIntegration : IDisposable
 
         _ = _fixture.Client.Received(1).CaptureEvent(
             Arg.Any<SentryEvent>(),
-            Arg.Is<Scope>(e => e.Breadcrumbs.Any(b => b.Message == expectedCrumb)), Arg.Any<Hint>());
+            Arg.Is<Scope>(e => e.Breadcrumbs.Any(b => b.Message == expectedCrumb)), Arg.Any<SentryHint>());
     }
 
     [Fact]
@@ -119,7 +119,7 @@ public class MiddlewareLoggerIntegration : IDisposable
 
         _ = _fixture.Client.Received(1).CaptureEvent(
             Arg.Any<SentryEvent>(),
-            Arg.Is<Scope>(e => e.Level == expected), Arg.Any<Hint>());
+            Arg.Is<Scope>(e => e.Level == expected), Arg.Any<SentryHint>());
     }
 
     public void Dispose() => _fixture.Dispose();

--- a/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryTracingMiddlewareTests.cs
@@ -57,7 +57,7 @@ public class SentryTracingMiddlewareTests
                 transaction.Name == "GET /person/{id}" &&
                 transaction.NameSource == TransactionNameSource.Route),
             Arg.Any<Scope>(),
-            Arg.Any<Hint>()
+            Arg.Any<SentryHint>()
             );
     }
 
@@ -153,7 +153,7 @@ public class SentryTracingMiddlewareTests
             t.IsSampled == false
         ),
         Arg.Any<Scope>(),
-        Arg.Any<Hint>()
+        Arg.Any<SentryHint>()
         );
     }
 
@@ -187,7 +187,7 @@ public class SentryTracingMiddlewareTests
         sentryClient.CaptureTransaction(
             Arg.Do<SentryTransaction>(t => transaction = t),
             Arg.Any<Scope>(),
-            Arg.Any<Hint>()
+            Arg.Any<SentryHint>()
             );
 
         // Act
@@ -599,7 +599,7 @@ public class SentryTracingMiddlewareTests
         var expectedName = "My custom name";
 
         var sentryClient = Substitute.For<ISentryClient>();
-        sentryClient.When(x => x.CaptureTransaction(Arg.Any<SentryTransaction>(), Arg.Any<Scope>(), Arg.Any<Hint>()))
+        sentryClient.When(x => x.CaptureTransaction(Arg.Any<SentryTransaction>(), Arg.Any<Scope>(), Arg.Any<SentryHint>()))
             .Do(callback => transaction = callback.Arg<SentryTransaction>());
         var options = new SentryAspNetCoreOptions
         {
@@ -641,7 +641,7 @@ public class SentryTracingMiddlewareTests
         SentryTransaction transaction = null;
 
         var sentryClient = Substitute.For<ISentryClient>();
-        sentryClient.When(x => x.CaptureTransaction(Arg.Any<SentryTransaction>(), Arg.Any<Scope>(), Arg.Any<Hint>()))
+        sentryClient.When(x => x.CaptureTransaction(Arg.Any<SentryTransaction>(), Arg.Any<Scope>(), Arg.Any<SentryHint>()))
             .Do(callback => transaction = callback.Arg<SentryTransaction>());
         var options = new SentryAspNetCoreOptions
         {

--- a/test/Sentry.Azure.Functions.Worker.Tests/SentryFunctionsWorkerMiddlewareTests.cs
+++ b/test/Sentry.Azure.Functions.Worker.Tests/SentryFunctionsWorkerMiddlewareTests.cs
@@ -22,7 +22,7 @@ public class SentryFunctionsWorkerMiddlewareTests
             var client = Substitute.For<ISentryClient>();
             var sessionManager = Substitute.For<ISessionManager>();
 
-            client.When(x => x.CaptureTransaction(Arg.Any<SentryTransaction>(), Arg.Any<Scope>(), Arg.Any<Hint>()))
+            client.When(x => x.CaptureTransaction(Arg.Any<SentryTransaction>(), Arg.Any<Scope>(), Arg.Any<SentryHint>()))
                 .Do(callback => Transaction = callback.Arg<SentryTransaction>());
 
             ScopeManager = new SentryScopeManager(options, client);

--- a/test/Sentry.Testing/JsonSerializableExtensions.cs
+++ b/test/Sentry.Testing/JsonSerializableExtensions.cs
@@ -4,7 +4,7 @@ internal static class JsonSerializableExtensions
 {
     private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
-    public static string ToJsonString(this IJsonSerializable serializable, IDiagnosticLogger logger = null, bool indented = false) =>
+    public static string ToJsonString(this ISentryJsonSerializable serializable, IDiagnosticLogger logger = null, bool indented = false) =>
         WriteToJsonString(writer => writer.WriteSerializableValue(serializable, logger), indented);
 
     public static string ToJsonString(this object @object, IDiagnosticLogger logger = null, bool indented = false) =>

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -1,15 +1,6 @@
 ﻿[assembly: System.CLSCompliant(true)]
 namespace Sentry
 {
-    [System.Diagnostics.DebuggerDisplay("{FileName}")]
-    public class Attachment
-    {
-        public Attachment(Sentry.AttachmentType type, Sentry.IAttachmentContent content, string fileName, string? contentType) { }
-        public Sentry.IAttachmentContent Content { get; }
-        public string? ContentType { get; }
-        public string FileName { get; }
-        public Sentry.AttachmentType Type { get; }
-    }
     public enum AttachmentType
     {
         Default = 0,
@@ -162,16 +153,6 @@ namespace Sentry
     {
         public static void SetTags(this Sentry.IHasTags hasTags, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> tags) { }
     }
-    public class Hint
-    {
-        public Hint() { }
-        public Hint(string key, object? value) { }
-        public System.Collections.Generic.ICollection<Sentry.Attachment> Attachments { get; }
-        public System.Collections.Generic.IDictionary<string, object?> Items { get; }
-        public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
-        public static Sentry.Hint WithAttachments(params Sentry.Attachment[] attachments) { }
-        public static Sentry.Hint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.Attachment> attachments) { }
-    }
     public static class HintTypes
     {
         public const string HttpResponseMessage = "http-response-message";
@@ -195,7 +176,7 @@ namespace Sentry
     }
     public static class HubExtensions
     {
-        public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Breadcrumb breadcrumb, Sentry.Hint? hint = null) { }
+        public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
@@ -244,7 +225,7 @@ namespace Sentry
         Sentry.IMetricAggregator Metrics { get; }
         void BindException(System.Exception exception, Sentry.ISpan span);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope);
-        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope);
+        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope);
         Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null);
         Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null);
         void EndSession(Sentry.SessionEndStatus status = 0);
@@ -279,10 +260,10 @@ namespace Sentry
     {
         bool IsEnabled { get; }
         bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
-        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.Hint? hint = null);
+        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null);
         void CaptureSession(Sentry.SessionUpdate sessionUpdate);
         void CaptureTransaction(Sentry.SentryTransaction transaction);
-        void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint);
+        void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint);
         void CaptureUserFeedback(Sentry.UserFeedback userFeedback);
         System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
     }
@@ -448,7 +429,7 @@ namespace Sentry
     public class Scope : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags
     {
         public Scope(Sentry.SentryOptions? options) { }
-        public System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment> Attachments { get; }
+        public System.Collections.Generic.IReadOnlyCollection<Sentry.SentryAttachment> Attachments { get; }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
         public Sentry.Contexts Contexts { get; set; }
         public string? Distribution { get; set; }
@@ -464,9 +445,9 @@ namespace Sentry
         public Sentry.ITransactionTracer? Transaction { get; set; }
         public string? TransactionName { get; set; }
         public Sentry.SentryUser User { get; set; }
-        public void AddAttachment(Sentry.Attachment attachment) { }
+        public void AddAttachment(Sentry.SentryAttachment attachment) { }
         public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb) { }
-        public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.Hint hint) { }
+        public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.SentryHint hint) { }
         public void Apply(Sentry.IEventLike other) { }
         public void Apply(Sentry.Scope other) { }
         public void Apply(object state) { }
@@ -506,15 +487,24 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SdkVersion FromJson(System.Text.Json.JsonElement json) { }
     }
+    [System.Diagnostics.DebuggerDisplay("{FileName}")]
+    public class SentryAttachment
+    {
+        public SentryAttachment(Sentry.AttachmentType type, Sentry.IAttachmentContent content, string fileName, string? contentType) { }
+        public Sentry.IAttachmentContent Content { get; }
+        public string? ContentType { get; }
+        public string FileName { get; }
+        public Sentry.AttachmentType Type { get; }
+    }
     public class SentryClient : Sentry.ISentryClient, System.IDisposable
     {
         public SentryClient(Sentry.SentryOptions options) { }
         public bool IsEnabled { get; }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.Hint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
         public void Dispose() { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
@@ -569,6 +559,16 @@ namespace Sentry
         public SentryGraphQLHttpMessageHandler(System.Net.Http.HttpMessageHandler? innerHandler = null, Sentry.IHub? hub = null) { }
         protected override void HandleResponse(System.Net.Http.HttpResponseMessage response, Sentry.ISpan? span, string method, string url) { }
         protected override Sentry.ISpan? ProcessRequest(System.Net.Http.HttpRequestMessage request, string method, string url) { }
+    }
+    public class SentryHint
+    {
+        public SentryHint() { }
+        public SentryHint(string key, object? value) { }
+        public System.Collections.Generic.ICollection<Sentry.SentryAttachment> Attachments { get; }
+        public System.Collections.Generic.IDictionary<string, object?> Items { get; }
+        public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
+        public static Sentry.SentryHint WithAttachments(params Sentry.SentryAttachment[] attachments) { }
+        public static Sentry.SentryHint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.SentryAttachment> attachments) { }
     }
     public class SentryHttpMessageHandler : Sentry.SentryMessageHandler
     {
@@ -695,11 +695,11 @@ namespace Sentry
         public void AddJsonSerializerContext<T>(System.Func<System.Text.Json.JsonSerializerOptions, T> contextBuilder)
             where T : System.Text.Json.Serialization.JsonSerializerContext { }
         public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?> beforeBreadcrumb) { }
-        public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.Hint, Sentry.Breadcrumb?> beforeBreadcrumb) { }
+        public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.SentryHint, Sentry.Breadcrumb?> beforeBreadcrumb) { }
         public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryEvent?> beforeSend) { }
-        public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.Hint, Sentry.SentryEvent?> beforeSend) { }
+        public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryHint, Sentry.SentryEvent?> beforeSend) { }
         public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.SentryTransaction?> beforeSendTransaction) { }
-        public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.Hint, Sentry.SentryTransaction?> beforeSendTransaction) { }
+        public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.SentryHint, Sentry.SentryTransaction?> beforeSendTransaction) { }
     }
     public static class SentryOptionsExtensions
     {
@@ -743,22 +743,22 @@ namespace Sentry
         public static bool IsEnabled { get; }
         public static Sentry.SentryId LastEventId { get; }
         public static Sentry.IMetricAggregator Metrics { get; }
-        public static void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.Hint? hint = null) { }
+        public static void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void BindClient(Sentry.ISentryClient client) { }
         public static void BindException(System.Exception exception, Sentry.ISpan span) { }
         public static bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.Hint? hint = null) { }
+        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
+        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureMessage(string message, Sentry.SentryLevel level = 1) { }
         public static Sentry.SentryId CaptureMessage(string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public static void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public static void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public static void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public static void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
         public static void CaptureUserFeedback(Sentry.SentryId eventId, string email, string comments, string? name = null) { }
         [System.Obsolete("WARNING: This method deliberately causes a crash, and should not be used in a rea" +
@@ -1169,7 +1169,7 @@ namespace Sentry
         public System.Collections.Generic.List<Sentry.ViewHierarchyNode> Windows { get; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
     }
-    public class ViewHierarchyAttachment : Sentry.Attachment
+    public class ViewHierarchyAttachment : Sentry.SentryAttachment
     {
         public ViewHierarchyAttachment(Sentry.IAttachmentContent content) { }
     }
@@ -1229,11 +1229,11 @@ namespace Sentry.Extensibility
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.Hint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
@@ -1272,12 +1272,12 @@ namespace Sentry.Extensibility
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope, Sentry.Hint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope, Sentry.SentryHint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public Sentry.SentryId CaptureException(System.Exception exception) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public void CaptureUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
@@ -1336,7 +1336,7 @@ namespace Sentry.Extensibility
     }
     public interface ISentryEventProcessorWithHint : Sentry.Extensibility.ISentryEventProcessor
     {
-        Sentry.SentryEvent? Process(Sentry.SentryEvent @event, Sentry.Hint hint);
+        Sentry.SentryEvent? Process(Sentry.SentryEvent @event, Sentry.SentryHint hint);
     }
     public interface ISentryStackTraceFactory
     {
@@ -1348,7 +1348,7 @@ namespace Sentry.Extensibility
     }
     public interface ISentryTransactionProcessorWithHint : Sentry.Extensibility.ISentryTransactionProcessor
     {
-        Sentry.SentryTransaction? Process(Sentry.SentryTransaction transaction, Sentry.Hint hint);
+        Sentry.SentryTransaction? Process(Sentry.SentryTransaction transaction, Sentry.SentryHint hint);
     }
     public interface ITransport
     {
@@ -1708,7 +1708,7 @@ namespace Sentry.Protocol.Envelopes
         public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
         public Sentry.SentryId? TryGetEventId() { }
         public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.Envelope> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
-        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.SentryAttachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
         public static Sentry.Protocol.Envelopes.Envelope FromSession(Sentry.SessionUpdate sessionUpdate) { }
         public static Sentry.Protocol.Envelopes.Envelope FromTransaction(Sentry.SentryTransaction transaction) { }
         public static Sentry.Protocol.Envelopes.Envelope FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
@@ -1725,7 +1725,7 @@ namespace Sentry.Protocol.Envelopes
         public long? TryGetLength() { }
         public string? TryGetType() { }
         public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.EnvelopeItem> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
-        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.Attachment attachment) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.SentryAttachment attachment) { }
         public static Sentry.Protocol.Envelopes.EnvelopeItem FromEvent(Sentry.SentryEvent @event) { }
         public static Sentry.Protocol.Envelopes.EnvelopeItem FromSession(Sentry.SessionUpdate sessionUpdate) { }
         public static Sentry.Protocol.Envelopes.EnvelopeItem FromTransaction(Sentry.SentryTransaction transaction) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -24,7 +24,7 @@ namespace Sentry
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("Message: {Message}, Type: {Type}")]
-    public sealed class Breadcrumb : Sentry.IJsonSerializable
+    public sealed class Breadcrumb : Sentry.ISentryJsonSerializable
     {
         public Breadcrumb(string message, string type, System.Collections.Generic.IReadOnlyDictionary<string, string>? data = null, string? category = null, Sentry.BreadcrumbLevel level = 0) { }
         public string? Category { get; }
@@ -76,7 +76,7 @@ namespace Sentry
         public const string Platform = "csharp";
         public const int ProtocolVersion = 7;
     }
-    public sealed class Contexts : Sentry.IJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
+    public sealed class Contexts : Sentry.ISentryJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
     {
         public Contexts() { }
         public Sentry.Protocol.App App { get; }
@@ -256,10 +256,6 @@ namespace Sentry
         void StartSession();
         Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext);
     }
-    public interface IJsonSerializable
-    {
-        void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger);
-    }
     public interface IMetricAggregator : System.IDisposable
     {
         void Distribution(string key, double value = 1, Sentry.MeasurementUnit? unit = default, System.Collections.Generic.IDictionary<string, string>? tags = null, System.DateTimeOffset? timestamp = default, int stackLevel = 1);
@@ -289,6 +285,10 @@ namespace Sentry
         void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint);
         void CaptureUserFeedback(Sentry.UserFeedback userFeedback);
         System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
+    public interface ISentryJsonSerializable
+    {
+        void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger);
     }
     public interface ISentryScopeManager
     {
@@ -413,7 +413,7 @@ namespace Sentry
             Exbibyte = 13,
         }
     }
-    public sealed class Package : Sentry.IJsonSerializable
+    public sealed class Package : Sentry.ISentryJsonSerializable
     {
         public Package(string name, string version) { }
         public string Name { get; }
@@ -429,7 +429,7 @@ namespace Sentry
         Version = 1,
         InformationalVersion = 2,
     }
-    public sealed class Request : Sentry.IJsonSerializable
+    public sealed class Request : Sentry.ISentryJsonSerializable
     {
         public Request() { }
         public string? ApiTarget { get; set; }
@@ -495,7 +495,7 @@ namespace Sentry
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventExceptionProcessor> GetAllExceptionProcessors(this Sentry.Scope scope) { }
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryTransactionProcessor> GetAllTransactionProcessors(this Sentry.Scope scope) { }
     }
-    public sealed class SdkVersion : Sentry.IJsonSerializable
+    public sealed class SdkVersion : Sentry.ISentryJsonSerializable
     {
         public SdkVersion() { }
         public string? Name { get; set; }
@@ -529,7 +529,7 @@ namespace Sentry
         public static System.Threading.Tasks.Task FlushAsync(this Sentry.ISentryClient client) { }
     }
     [System.Diagnostics.DebuggerDisplay("{GetType().Name,nq}: {EventId,nq}")]
-    public sealed class SentryEvent : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.IJsonSerializable
+    public sealed class SentryEvent : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable
     {
         public SentryEvent() { }
         public SentryEvent(System.Exception? exception) { }
@@ -579,7 +579,7 @@ namespace Sentry
         protected override void HandleResponse(System.Net.Http.HttpResponseMessage response, Sentry.ISpan? span, string method, string url) { }
         protected override Sentry.ISpan? ProcessRequest(System.Net.Http.HttpRequestMessage request, string method, string url) { }
     }
-    public readonly struct SentryId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SentryId>
+    public readonly struct SentryId : Sentry.ISentryJsonSerializable, System.IEquatable<Sentry.SentryId>
     {
         public static readonly Sentry.SentryId Empty;
         public SentryId(System.Guid guid) { }
@@ -609,7 +609,7 @@ namespace Sentry
         [System.Runtime.Serialization.EnumMember(Value="fatal")]
         Fatal = 4,
     }
-    public sealed class SentryMessage : Sentry.IJsonSerializable
+    public sealed class SentryMessage : Sentry.ISentryJsonSerializable
     {
         public SentryMessage() { }
         public string? Formatted { get; set; }
@@ -805,7 +805,7 @@ namespace Sentry
         public string? UserAgent { get; }
         public void ReportError() { }
     }
-    public class SentrySpan : Sentry.IHasExtra, Sentry.IHasTags, Sentry.IJsonSerializable, Sentry.ISpanData, Sentry.Protocol.ITraceContext
+    public class SentrySpan : Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable, Sentry.ISpanData, Sentry.Protocol.ITraceContext
     {
         public SentrySpan(Sentry.ISpan tracer) { }
         public SentrySpan(Sentry.SpanId? parentSpanId, string operation) { }
@@ -830,7 +830,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentrySpan FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryStackFrame : Sentry.IJsonSerializable
+    public sealed class SentryStackFrame : Sentry.ISentryJsonSerializable
     {
         public SentryStackFrame() { }
         public string? AbsolutePath { get; set; }
@@ -856,7 +856,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackFrame FromJson(System.Text.Json.JsonElement json) { }
     }
-    public class SentryStackTrace : Sentry.IJsonSerializable
+    public class SentryStackTrace : Sentry.ISentryJsonSerializable
     {
         public SentryStackTrace() { }
         public Sentry.InstructionAddressAdjustment? AddressAdjustment { get; set; }
@@ -864,7 +864,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackTrace FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryThread : Sentry.IJsonSerializable
+    public sealed class SentryThread : Sentry.ISentryJsonSerializable
     {
         public SentryThread() { }
         public bool? Crashed { get; set; }
@@ -884,7 +884,7 @@ namespace Sentry
         public override string ToString() { }
         public static Sentry.SentryTraceHeader Parse(string value) { }
     }
-    public class SentryTransaction : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.IJsonSerializable, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
+    public class SentryTransaction : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
     {
         public SentryTransaction(Sentry.ITransactionTracer tracer) { }
         public SentryTransaction(string name, string operation) { }
@@ -928,7 +928,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryTransaction FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryUser : Sentry.IJsonSerializable
+    public sealed class SentryUser : Sentry.ISentryJsonSerializable
     {
         public SentryUser() { }
         public string? Email { get; set; }
@@ -947,7 +947,7 @@ namespace Sentry
         Crashed = 1,
         Abnormal = 2,
     }
-    public class SessionUpdate : Sentry.IJsonSerializable, Sentry.ISentrySession
+    public class SessionUpdate : Sentry.ISentryJsonSerializable, Sentry.ISentrySession
     {
         public SessionUpdate(Sentry.SessionUpdate sessionUpdate, bool isInitial) { }
         public SessionUpdate(Sentry.SessionUpdate sessionUpdate, bool isInitial, Sentry.SessionEndStatus? endStatus) { }
@@ -994,7 +994,7 @@ namespace Sentry
         public static Sentry.ITransactionTracer GetTransaction(this Sentry.ISpan span) { }
         public static Sentry.ISpan StartChild(this Sentry.ISpan span, string operation, string? description) { }
     }
-    public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>
+    public readonly struct SpanId : Sentry.ISentryJsonSerializable, System.IEquatable<Sentry.SpanId>
     {
         public static readonly Sentry.SpanId Empty;
         public SpanId(long value) { }
@@ -1152,7 +1152,7 @@ namespace Sentry
         public Sentry.ISpan StartChild(string operation) { }
         public void UnsetTag(string key) { }
     }
-    public sealed class UserFeedback : Sentry.IJsonSerializable
+    public sealed class UserFeedback : Sentry.ISentryJsonSerializable
     {
         public UserFeedback(Sentry.SentryId eventId, string? name, string? email, string? comments) { }
         public string? Comments { get; }
@@ -1162,7 +1162,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.UserFeedback FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class ViewHierarchy : Sentry.IJsonSerializable
+    public sealed class ViewHierarchy : Sentry.ISentryJsonSerializable
     {
         public ViewHierarchy(string renderingSystem) { }
         public string RenderingSystem { get; set; }
@@ -1173,7 +1173,7 @@ namespace Sentry
     {
         public ViewHierarchyAttachment(Sentry.IAttachmentContent content) { }
     }
-    public abstract class ViewHierarchyNode : Sentry.IJsonSerializable
+    public abstract class ViewHierarchyNode : Sentry.ISentryJsonSerializable
     {
         protected ViewHierarchyNode(string type) { }
         public System.Collections.Generic.List<Sentry.ViewHierarchyNode> Children { get; set; }
@@ -1482,7 +1482,7 @@ namespace Sentry.PlatformAbstractions
 }
 namespace Sentry.Protocol
 {
-    public sealed class App : Sentry.IJsonSerializable
+    public sealed class App : Sentry.ISentryJsonSerializable
     {
         public const string Type = "app";
         public App() { }
@@ -1497,7 +1497,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.App FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Browser : Sentry.IJsonSerializable
+    public sealed class Browser : Sentry.ISentryJsonSerializable
     {
         public const string Type = "browser";
         public Browser() { }
@@ -1506,7 +1506,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.Browser FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class DebugImage : Sentry.IJsonSerializable
+    public sealed class DebugImage : Sentry.ISentryJsonSerializable
     {
         public DebugImage() { }
         public string? CodeFile { get; set; }
@@ -1520,7 +1520,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.DebugImage FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Device : Sentry.IJsonSerializable
+    public sealed class Device : Sentry.ISentryJsonSerializable
     {
         public const string Type = "device";
         public Device() { }
@@ -1570,7 +1570,7 @@ namespace Sentry.Protocol
         [System.Runtime.Serialization.EnumMember(Value="landscape")]
         Landscape = 1,
     }
-    public sealed class Gpu : Sentry.IJsonSerializable
+    public sealed class Gpu : Sentry.ISentryJsonSerializable
     {
         public const string Type = "gpu";
         public Gpu() { }
@@ -1602,14 +1602,14 @@ namespace Sentry.Protocol
         Sentry.SpanStatus? Status { get; }
         Sentry.SentryId TraceId { get; }
     }
-    public sealed class Measurement : Sentry.IJsonSerializable
+    public sealed class Measurement : Sentry.ISentryJsonSerializable
     {
         public Sentry.MeasurementUnit Unit { get; }
         public object Value { get; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Measurement FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Mechanism : Sentry.IJsonSerializable
+    public sealed class Mechanism : Sentry.ISentryJsonSerializable
     {
         public static readonly string DescriptionKey;
         public static readonly string HandledKey;
@@ -1629,7 +1629,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Mechanism FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class OperatingSystem : Sentry.IJsonSerializable
+    public sealed class OperatingSystem : Sentry.ISentryJsonSerializable
     {
         public const string Type = "os";
         public OperatingSystem() { }
@@ -1642,7 +1642,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.OperatingSystem FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Response : Sentry.IJsonSerializable
+    public sealed class Response : Sentry.ISentryJsonSerializable
     {
         public const string Type = "response";
         public Response() { }
@@ -1657,7 +1657,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Response FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Runtime : Sentry.IJsonSerializable
+    public sealed class Runtime : Sentry.ISentryJsonSerializable
     {
         public const string Type = "runtime";
         public Runtime() { }
@@ -1669,7 +1669,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.Runtime FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryException : Sentry.IJsonSerializable
+    public sealed class SentryException : Sentry.ISentryJsonSerializable
     {
         public SentryException() { }
         public Sentry.Protocol.Mechanism? Mechanism { get; set; }
@@ -1681,7 +1681,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.SentryException FromJson(System.Text.Json.JsonElement json) { }
     }
-    public class Trace : Sentry.IJsonSerializable, Sentry.Protocol.ITraceContext
+    public class Trace : Sentry.ISentryJsonSerializable, Sentry.Protocol.ITraceContext
     {
         public const string Type = "trace";
         public Trace() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -1,15 +1,6 @@
 ﻿[assembly: System.CLSCompliant(true)]
 namespace Sentry
 {
-    [System.Diagnostics.DebuggerDisplay("{FileName}")]
-    public class Attachment
-    {
-        public Attachment(Sentry.AttachmentType type, Sentry.IAttachmentContent content, string fileName, string? contentType) { }
-        public Sentry.IAttachmentContent Content { get; }
-        public string? ContentType { get; }
-        public string FileName { get; }
-        public Sentry.AttachmentType Type { get; }
-    }
     public enum AttachmentType
     {
         Default = 0,
@@ -162,16 +153,6 @@ namespace Sentry
     {
         public static void SetTags(this Sentry.IHasTags hasTags, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> tags) { }
     }
-    public class Hint
-    {
-        public Hint() { }
-        public Hint(string key, object? value) { }
-        public System.Collections.Generic.ICollection<Sentry.Attachment> Attachments { get; }
-        public System.Collections.Generic.IDictionary<string, object?> Items { get; }
-        public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
-        public static Sentry.Hint WithAttachments(params Sentry.Attachment[] attachments) { }
-        public static Sentry.Hint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.Attachment> attachments) { }
-    }
     public static class HintTypes
     {
         public const string HttpResponseMessage = "http-response-message";
@@ -195,7 +176,7 @@ namespace Sentry
     }
     public static class HubExtensions
     {
-        public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Breadcrumb breadcrumb, Sentry.Hint? hint = null) { }
+        public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
@@ -244,7 +225,7 @@ namespace Sentry
         Sentry.IMetricAggregator Metrics { get; }
         void BindException(System.Exception exception, Sentry.ISpan span);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope);
-        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope);
+        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope);
         Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null);
         Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null);
         void EndSession(Sentry.SessionEndStatus status = 0);
@@ -279,10 +260,10 @@ namespace Sentry
     {
         bool IsEnabled { get; }
         bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
-        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.Hint? hint = null);
+        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null);
         void CaptureSession(Sentry.SessionUpdate sessionUpdate);
         void CaptureTransaction(Sentry.SentryTransaction transaction);
-        void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint);
+        void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint);
         void CaptureUserFeedback(Sentry.UserFeedback userFeedback);
         System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
     }
@@ -448,7 +429,7 @@ namespace Sentry
     public class Scope : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags
     {
         public Scope(Sentry.SentryOptions? options) { }
-        public System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment> Attachments { get; }
+        public System.Collections.Generic.IReadOnlyCollection<Sentry.SentryAttachment> Attachments { get; }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
         public Sentry.Contexts Contexts { get; set; }
         public string? Distribution { get; set; }
@@ -464,9 +445,9 @@ namespace Sentry
         public Sentry.ITransactionTracer? Transaction { get; set; }
         public string? TransactionName { get; set; }
         public Sentry.SentryUser User { get; set; }
-        public void AddAttachment(Sentry.Attachment attachment) { }
+        public void AddAttachment(Sentry.SentryAttachment attachment) { }
         public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb) { }
-        public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.Hint hint) { }
+        public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.SentryHint hint) { }
         public void Apply(Sentry.IEventLike other) { }
         public void Apply(Sentry.Scope other) { }
         public void Apply(object state) { }
@@ -506,15 +487,24 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SdkVersion FromJson(System.Text.Json.JsonElement json) { }
     }
+    [System.Diagnostics.DebuggerDisplay("{FileName}")]
+    public class SentryAttachment
+    {
+        public SentryAttachment(Sentry.AttachmentType type, Sentry.IAttachmentContent content, string fileName, string? contentType) { }
+        public Sentry.IAttachmentContent Content { get; }
+        public string? ContentType { get; }
+        public string FileName { get; }
+        public Sentry.AttachmentType Type { get; }
+    }
     public class SentryClient : Sentry.ISentryClient, System.IDisposable
     {
         public SentryClient(Sentry.SentryOptions options) { }
         public bool IsEnabled { get; }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.Hint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
         public void Dispose() { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
@@ -569,6 +559,16 @@ namespace Sentry
         public SentryGraphQLHttpMessageHandler(System.Net.Http.HttpMessageHandler? innerHandler = null, Sentry.IHub? hub = null) { }
         protected override void HandleResponse(System.Net.Http.HttpResponseMessage response, Sentry.ISpan? span, string method, string url) { }
         protected override Sentry.ISpan? ProcessRequest(System.Net.Http.HttpRequestMessage request, string method, string url) { }
+    }
+    public class SentryHint
+    {
+        public SentryHint() { }
+        public SentryHint(string key, object? value) { }
+        public System.Collections.Generic.ICollection<Sentry.SentryAttachment> Attachments { get; }
+        public System.Collections.Generic.IDictionary<string, object?> Items { get; }
+        public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
+        public static Sentry.SentryHint WithAttachments(params Sentry.SentryAttachment[] attachments) { }
+        public static Sentry.SentryHint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.SentryAttachment> attachments) { }
     }
     public class SentryHttpMessageHandler : Sentry.SentryMessageHandler
     {
@@ -695,11 +695,11 @@ namespace Sentry
         public void AddJsonSerializerContext<T>(System.Func<System.Text.Json.JsonSerializerOptions, T> contextBuilder)
             where T : System.Text.Json.Serialization.JsonSerializerContext { }
         public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?> beforeBreadcrumb) { }
-        public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.Hint, Sentry.Breadcrumb?> beforeBreadcrumb) { }
+        public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.SentryHint, Sentry.Breadcrumb?> beforeBreadcrumb) { }
         public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryEvent?> beforeSend) { }
-        public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.Hint, Sentry.SentryEvent?> beforeSend) { }
+        public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryHint, Sentry.SentryEvent?> beforeSend) { }
         public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.SentryTransaction?> beforeSendTransaction) { }
-        public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.Hint, Sentry.SentryTransaction?> beforeSendTransaction) { }
+        public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.SentryHint, Sentry.SentryTransaction?> beforeSendTransaction) { }
     }
     public static class SentryOptionsExtensions
     {
@@ -743,22 +743,22 @@ namespace Sentry
         public static bool IsEnabled { get; }
         public static Sentry.SentryId LastEventId { get; }
         public static Sentry.IMetricAggregator Metrics { get; }
-        public static void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.Hint? hint = null) { }
+        public static void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void BindClient(Sentry.ISentryClient client) { }
         public static void BindException(System.Exception exception, Sentry.ISpan span) { }
         public static bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.Hint? hint = null) { }
+        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
+        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureMessage(string message, Sentry.SentryLevel level = 1) { }
         public static Sentry.SentryId CaptureMessage(string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public static void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public static void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public static void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public static void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
         public static void CaptureUserFeedback(Sentry.SentryId eventId, string email, string comments, string? name = null) { }
         [System.Obsolete("WARNING: This method deliberately causes a crash, and should not be used in a rea" +
@@ -1169,7 +1169,7 @@ namespace Sentry
         public System.Collections.Generic.List<Sentry.ViewHierarchyNode> Windows { get; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
     }
-    public class ViewHierarchyAttachment : Sentry.Attachment
+    public class ViewHierarchyAttachment : Sentry.SentryAttachment
     {
         public ViewHierarchyAttachment(Sentry.IAttachmentContent content) { }
     }
@@ -1229,11 +1229,11 @@ namespace Sentry.Extensibility
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.Hint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
@@ -1272,12 +1272,12 @@ namespace Sentry.Extensibility
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope, Sentry.Hint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope, Sentry.SentryHint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public Sentry.SentryId CaptureException(System.Exception exception) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public void CaptureUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
@@ -1336,7 +1336,7 @@ namespace Sentry.Extensibility
     }
     public interface ISentryEventProcessorWithHint : Sentry.Extensibility.ISentryEventProcessor
     {
-        Sentry.SentryEvent? Process(Sentry.SentryEvent @event, Sentry.Hint hint);
+        Sentry.SentryEvent? Process(Sentry.SentryEvent @event, Sentry.SentryHint hint);
     }
     public interface ISentryStackTraceFactory
     {
@@ -1348,7 +1348,7 @@ namespace Sentry.Extensibility
     }
     public interface ISentryTransactionProcessorWithHint : Sentry.Extensibility.ISentryTransactionProcessor
     {
-        Sentry.SentryTransaction? Process(Sentry.SentryTransaction transaction, Sentry.Hint hint);
+        Sentry.SentryTransaction? Process(Sentry.SentryTransaction transaction, Sentry.SentryHint hint);
     }
     public interface ITransport
     {
@@ -1708,7 +1708,7 @@ namespace Sentry.Protocol.Envelopes
         public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
         public Sentry.SentryId? TryGetEventId() { }
         public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.Envelope> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
-        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.SentryAttachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
         public static Sentry.Protocol.Envelopes.Envelope FromSession(Sentry.SessionUpdate sessionUpdate) { }
         public static Sentry.Protocol.Envelopes.Envelope FromTransaction(Sentry.SentryTransaction transaction) { }
         public static Sentry.Protocol.Envelopes.Envelope FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
@@ -1725,7 +1725,7 @@ namespace Sentry.Protocol.Envelopes
         public long? TryGetLength() { }
         public string? TryGetType() { }
         public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.EnvelopeItem> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
-        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.Attachment attachment) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.SentryAttachment attachment) { }
         public static Sentry.Protocol.Envelopes.EnvelopeItem FromEvent(Sentry.SentryEvent @event) { }
         public static Sentry.Protocol.Envelopes.EnvelopeItem FromSession(Sentry.SessionUpdate sessionUpdate) { }
         public static Sentry.Protocol.Envelopes.EnvelopeItem FromTransaction(Sentry.SentryTransaction transaction) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -24,7 +24,7 @@ namespace Sentry
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("Message: {Message}, Type: {Type}")]
-    public sealed class Breadcrumb : Sentry.IJsonSerializable
+    public sealed class Breadcrumb : Sentry.ISentryJsonSerializable
     {
         public Breadcrumb(string message, string type, System.Collections.Generic.IReadOnlyDictionary<string, string>? data = null, string? category = null, Sentry.BreadcrumbLevel level = 0) { }
         public string? Category { get; }
@@ -76,7 +76,7 @@ namespace Sentry
         public const string Platform = "csharp";
         public const int ProtocolVersion = 7;
     }
-    public sealed class Contexts : Sentry.IJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
+    public sealed class Contexts : Sentry.ISentryJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
     {
         public Contexts() { }
         public Sentry.Protocol.App App { get; }
@@ -256,10 +256,6 @@ namespace Sentry
         void StartSession();
         Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext);
     }
-    public interface IJsonSerializable
-    {
-        void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger);
-    }
     public interface IMetricAggregator : System.IDisposable
     {
         void Distribution(string key, double value = 1, Sentry.MeasurementUnit? unit = default, System.Collections.Generic.IDictionary<string, string>? tags = null, System.DateTimeOffset? timestamp = default, int stackLevel = 1);
@@ -289,6 +285,10 @@ namespace Sentry
         void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint);
         void CaptureUserFeedback(Sentry.UserFeedback userFeedback);
         System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
+    public interface ISentryJsonSerializable
+    {
+        void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger);
     }
     public interface ISentryScopeManager
     {
@@ -413,7 +413,7 @@ namespace Sentry
             Exbibyte = 13,
         }
     }
-    public sealed class Package : Sentry.IJsonSerializable
+    public sealed class Package : Sentry.ISentryJsonSerializable
     {
         public Package(string name, string version) { }
         public string Name { get; }
@@ -429,7 +429,7 @@ namespace Sentry
         Version = 1,
         InformationalVersion = 2,
     }
-    public sealed class Request : Sentry.IJsonSerializable
+    public sealed class Request : Sentry.ISentryJsonSerializable
     {
         public Request() { }
         public string? ApiTarget { get; set; }
@@ -495,7 +495,7 @@ namespace Sentry
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventExceptionProcessor> GetAllExceptionProcessors(this Sentry.Scope scope) { }
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryTransactionProcessor> GetAllTransactionProcessors(this Sentry.Scope scope) { }
     }
-    public sealed class SdkVersion : Sentry.IJsonSerializable
+    public sealed class SdkVersion : Sentry.ISentryJsonSerializable
     {
         public SdkVersion() { }
         public string? Name { get; set; }
@@ -529,7 +529,7 @@ namespace Sentry
         public static System.Threading.Tasks.Task FlushAsync(this Sentry.ISentryClient client) { }
     }
     [System.Diagnostics.DebuggerDisplay("{GetType().Name,nq}: {EventId,nq}")]
-    public sealed class SentryEvent : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.IJsonSerializable
+    public sealed class SentryEvent : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable
     {
         public SentryEvent() { }
         public SentryEvent(System.Exception? exception) { }
@@ -579,7 +579,7 @@ namespace Sentry
         protected override void HandleResponse(System.Net.Http.HttpResponseMessage response, Sentry.ISpan? span, string method, string url) { }
         protected override Sentry.ISpan? ProcessRequest(System.Net.Http.HttpRequestMessage request, string method, string url) { }
     }
-    public readonly struct SentryId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SentryId>
+    public readonly struct SentryId : Sentry.ISentryJsonSerializable, System.IEquatable<Sentry.SentryId>
     {
         public static readonly Sentry.SentryId Empty;
         public SentryId(System.Guid guid) { }
@@ -609,7 +609,7 @@ namespace Sentry
         [System.Runtime.Serialization.EnumMember(Value="fatal")]
         Fatal = 4,
     }
-    public sealed class SentryMessage : Sentry.IJsonSerializable
+    public sealed class SentryMessage : Sentry.ISentryJsonSerializable
     {
         public SentryMessage() { }
         public string? Formatted { get; set; }
@@ -805,7 +805,7 @@ namespace Sentry
         public string? UserAgent { get; }
         public void ReportError() { }
     }
-    public class SentrySpan : Sentry.IHasExtra, Sentry.IHasTags, Sentry.IJsonSerializable, Sentry.ISpanData, Sentry.Protocol.ITraceContext
+    public class SentrySpan : Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable, Sentry.ISpanData, Sentry.Protocol.ITraceContext
     {
         public SentrySpan(Sentry.ISpan tracer) { }
         public SentrySpan(Sentry.SpanId? parentSpanId, string operation) { }
@@ -830,7 +830,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentrySpan FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryStackFrame : Sentry.IJsonSerializable
+    public sealed class SentryStackFrame : Sentry.ISentryJsonSerializable
     {
         public SentryStackFrame() { }
         public string? AbsolutePath { get; set; }
@@ -856,7 +856,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackFrame FromJson(System.Text.Json.JsonElement json) { }
     }
-    public class SentryStackTrace : Sentry.IJsonSerializable
+    public class SentryStackTrace : Sentry.ISentryJsonSerializable
     {
         public SentryStackTrace() { }
         public Sentry.InstructionAddressAdjustment? AddressAdjustment { get; set; }
@@ -864,7 +864,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackTrace FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryThread : Sentry.IJsonSerializable
+    public sealed class SentryThread : Sentry.ISentryJsonSerializable
     {
         public SentryThread() { }
         public bool? Crashed { get; set; }
@@ -884,7 +884,7 @@ namespace Sentry
         public override string ToString() { }
         public static Sentry.SentryTraceHeader Parse(string value) { }
     }
-    public class SentryTransaction : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.IJsonSerializable, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
+    public class SentryTransaction : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
     {
         public SentryTransaction(Sentry.ITransactionTracer tracer) { }
         public SentryTransaction(string name, string operation) { }
@@ -928,7 +928,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryTransaction FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryUser : Sentry.IJsonSerializable
+    public sealed class SentryUser : Sentry.ISentryJsonSerializable
     {
         public SentryUser() { }
         public string? Email { get; set; }
@@ -947,7 +947,7 @@ namespace Sentry
         Crashed = 1,
         Abnormal = 2,
     }
-    public class SessionUpdate : Sentry.IJsonSerializable, Sentry.ISentrySession
+    public class SessionUpdate : Sentry.ISentryJsonSerializable, Sentry.ISentrySession
     {
         public SessionUpdate(Sentry.SessionUpdate sessionUpdate, bool isInitial) { }
         public SessionUpdate(Sentry.SessionUpdate sessionUpdate, bool isInitial, Sentry.SessionEndStatus? endStatus) { }
@@ -994,7 +994,7 @@ namespace Sentry
         public static Sentry.ITransactionTracer GetTransaction(this Sentry.ISpan span) { }
         public static Sentry.ISpan StartChild(this Sentry.ISpan span, string operation, string? description) { }
     }
-    public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>
+    public readonly struct SpanId : Sentry.ISentryJsonSerializable, System.IEquatable<Sentry.SpanId>
     {
         public static readonly Sentry.SpanId Empty;
         public SpanId(long value) { }
@@ -1152,7 +1152,7 @@ namespace Sentry
         public Sentry.ISpan StartChild(string operation) { }
         public void UnsetTag(string key) { }
     }
-    public sealed class UserFeedback : Sentry.IJsonSerializable
+    public sealed class UserFeedback : Sentry.ISentryJsonSerializable
     {
         public UserFeedback(Sentry.SentryId eventId, string? name, string? email, string? comments) { }
         public string? Comments { get; }
@@ -1162,7 +1162,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.UserFeedback FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class ViewHierarchy : Sentry.IJsonSerializable
+    public sealed class ViewHierarchy : Sentry.ISentryJsonSerializable
     {
         public ViewHierarchy(string renderingSystem) { }
         public string RenderingSystem { get; set; }
@@ -1173,7 +1173,7 @@ namespace Sentry
     {
         public ViewHierarchyAttachment(Sentry.IAttachmentContent content) { }
     }
-    public abstract class ViewHierarchyNode : Sentry.IJsonSerializable
+    public abstract class ViewHierarchyNode : Sentry.ISentryJsonSerializable
     {
         protected ViewHierarchyNode(string type) { }
         public System.Collections.Generic.List<Sentry.ViewHierarchyNode> Children { get; set; }
@@ -1482,7 +1482,7 @@ namespace Sentry.PlatformAbstractions
 }
 namespace Sentry.Protocol
 {
-    public sealed class App : Sentry.IJsonSerializable
+    public sealed class App : Sentry.ISentryJsonSerializable
     {
         public const string Type = "app";
         public App() { }
@@ -1497,7 +1497,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.App FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Browser : Sentry.IJsonSerializable
+    public sealed class Browser : Sentry.ISentryJsonSerializable
     {
         public const string Type = "browser";
         public Browser() { }
@@ -1506,7 +1506,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.Browser FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class DebugImage : Sentry.IJsonSerializable
+    public sealed class DebugImage : Sentry.ISentryJsonSerializable
     {
         public DebugImage() { }
         public string? CodeFile { get; set; }
@@ -1520,7 +1520,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.DebugImage FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Device : Sentry.IJsonSerializable
+    public sealed class Device : Sentry.ISentryJsonSerializable
     {
         public const string Type = "device";
         public Device() { }
@@ -1570,7 +1570,7 @@ namespace Sentry.Protocol
         [System.Runtime.Serialization.EnumMember(Value="landscape")]
         Landscape = 1,
     }
-    public sealed class Gpu : Sentry.IJsonSerializable
+    public sealed class Gpu : Sentry.ISentryJsonSerializable
     {
         public const string Type = "gpu";
         public Gpu() { }
@@ -1602,14 +1602,14 @@ namespace Sentry.Protocol
         Sentry.SpanStatus? Status { get; }
         Sentry.SentryId TraceId { get; }
     }
-    public sealed class Measurement : Sentry.IJsonSerializable
+    public sealed class Measurement : Sentry.ISentryJsonSerializable
     {
         public Sentry.MeasurementUnit Unit { get; }
         public object Value { get; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Measurement FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Mechanism : Sentry.IJsonSerializable
+    public sealed class Mechanism : Sentry.ISentryJsonSerializable
     {
         public static readonly string DescriptionKey;
         public static readonly string HandledKey;
@@ -1629,7 +1629,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Mechanism FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class OperatingSystem : Sentry.IJsonSerializable
+    public sealed class OperatingSystem : Sentry.ISentryJsonSerializable
     {
         public const string Type = "os";
         public OperatingSystem() { }
@@ -1642,7 +1642,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.OperatingSystem FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Response : Sentry.IJsonSerializable
+    public sealed class Response : Sentry.ISentryJsonSerializable
     {
         public const string Type = "response";
         public Response() { }
@@ -1657,7 +1657,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Response FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Runtime : Sentry.IJsonSerializable
+    public sealed class Runtime : Sentry.ISentryJsonSerializable
     {
         public const string Type = "runtime";
         public Runtime() { }
@@ -1669,7 +1669,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.Runtime FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryException : Sentry.IJsonSerializable
+    public sealed class SentryException : Sentry.ISentryJsonSerializable
     {
         public SentryException() { }
         public Sentry.Protocol.Mechanism? Mechanism { get; set; }
@@ -1681,7 +1681,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.SentryException FromJson(System.Text.Json.JsonElement json) { }
     }
-    public class Trace : Sentry.IJsonSerializable, Sentry.Protocol.ITraceContext
+    public class Trace : Sentry.ISentryJsonSerializable, Sentry.Protocol.ITraceContext
     {
         public const string Type = "trace";
         public Trace() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -24,7 +24,7 @@ namespace Sentry
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("Message: {Message}, Type: {Type}")]
-    public sealed class Breadcrumb : Sentry.IJsonSerializable
+    public sealed class Breadcrumb : Sentry.ISentryJsonSerializable
     {
         public Breadcrumb(string message, string type, System.Collections.Generic.IReadOnlyDictionary<string, string>? data = null, string? category = null, Sentry.BreadcrumbLevel level = 0) { }
         public string? Category { get; }
@@ -76,7 +76,7 @@ namespace Sentry
         public const string Platform = "csharp";
         public const int ProtocolVersion = 7;
     }
-    public sealed class Contexts : Sentry.IJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
+    public sealed class Contexts : Sentry.ISentryJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
     {
         public Contexts() { }
         public Sentry.Protocol.App App { get; }
@@ -257,10 +257,6 @@ namespace Sentry
         void StartSession();
         Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext);
     }
-    public interface IJsonSerializable
-    {
-        void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger);
-    }
     public interface IMetricAggregator : System.IDisposable
     {
         void Distribution(string key, double value = 1, Sentry.MeasurementUnit? unit = default, System.Collections.Generic.IDictionary<string, string>? tags = null, System.DateTimeOffset? timestamp = default, int stackLevel = 1);
@@ -290,6 +286,10 @@ namespace Sentry
         void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint);
         void CaptureUserFeedback(Sentry.UserFeedback userFeedback);
         System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
+    public interface ISentryJsonSerializable
+    {
+        void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger);
     }
     public interface ISentryScopeManager
     {
@@ -414,7 +414,7 @@ namespace Sentry
             Exbibyte = 13,
         }
     }
-    public sealed class Package : Sentry.IJsonSerializable
+    public sealed class Package : Sentry.ISentryJsonSerializable
     {
         public Package(string name, string version) { }
         public string Name { get; }
@@ -430,7 +430,7 @@ namespace Sentry
         Version = 1,
         InformationalVersion = 2,
     }
-    public sealed class Request : Sentry.IJsonSerializable
+    public sealed class Request : Sentry.ISentryJsonSerializable
     {
         public Request() { }
         public string? ApiTarget { get; set; }
@@ -496,7 +496,7 @@ namespace Sentry
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventExceptionProcessor> GetAllExceptionProcessors(this Sentry.Scope scope) { }
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryTransactionProcessor> GetAllTransactionProcessors(this Sentry.Scope scope) { }
     }
-    public sealed class SdkVersion : Sentry.IJsonSerializable
+    public sealed class SdkVersion : Sentry.ISentryJsonSerializable
     {
         public SdkVersion() { }
         public string? Name { get; set; }
@@ -530,7 +530,7 @@ namespace Sentry
         public static System.Threading.Tasks.Task FlushAsync(this Sentry.ISentryClient client) { }
     }
     [System.Diagnostics.DebuggerDisplay("{GetType().Name,nq}: {EventId,nq}")]
-    public sealed class SentryEvent : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.IJsonSerializable
+    public sealed class SentryEvent : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable
     {
         public SentryEvent() { }
         public SentryEvent(System.Exception? exception) { }
@@ -580,7 +580,7 @@ namespace Sentry
         protected override void HandleResponse(System.Net.Http.HttpResponseMessage response, Sentry.ISpan? span, string method, string url) { }
         protected override Sentry.ISpan? ProcessRequest(System.Net.Http.HttpRequestMessage request, string method, string url) { }
     }
-    public readonly struct SentryId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SentryId>
+    public readonly struct SentryId : Sentry.ISentryJsonSerializable, System.IEquatable<Sentry.SentryId>
     {
         public static readonly Sentry.SentryId Empty;
         public SentryId(System.Guid guid) { }
@@ -610,7 +610,7 @@ namespace Sentry
         [System.Runtime.Serialization.EnumMember(Value="fatal")]
         Fatal = 4,
     }
-    public sealed class SentryMessage : Sentry.IJsonSerializable
+    public sealed class SentryMessage : Sentry.ISentryJsonSerializable
     {
         public SentryMessage() { }
         public string? Formatted { get; set; }
@@ -807,7 +807,7 @@ namespace Sentry
         public string? UserAgent { get; }
         public void ReportError() { }
     }
-    public class SentrySpan : Sentry.IHasExtra, Sentry.IHasTags, Sentry.IJsonSerializable, Sentry.ISpanData, Sentry.Protocol.ITraceContext
+    public class SentrySpan : Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable, Sentry.ISpanData, Sentry.Protocol.ITraceContext
     {
         public SentrySpan(Sentry.ISpan tracer) { }
         public SentrySpan(Sentry.SpanId? parentSpanId, string operation) { }
@@ -832,7 +832,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentrySpan FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryStackFrame : Sentry.IJsonSerializable
+    public sealed class SentryStackFrame : Sentry.ISentryJsonSerializable
     {
         public SentryStackFrame() { }
         public string? AbsolutePath { get; set; }
@@ -858,7 +858,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackFrame FromJson(System.Text.Json.JsonElement json) { }
     }
-    public class SentryStackTrace : Sentry.IJsonSerializable
+    public class SentryStackTrace : Sentry.ISentryJsonSerializable
     {
         public SentryStackTrace() { }
         public Sentry.InstructionAddressAdjustment? AddressAdjustment { get; set; }
@@ -866,7 +866,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackTrace FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryThread : Sentry.IJsonSerializable
+    public sealed class SentryThread : Sentry.ISentryJsonSerializable
     {
         public SentryThread() { }
         public bool? Crashed { get; set; }
@@ -886,7 +886,7 @@ namespace Sentry
         public override string ToString() { }
         public static Sentry.SentryTraceHeader Parse(string value) { }
     }
-    public class SentryTransaction : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.IJsonSerializable, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
+    public class SentryTransaction : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
     {
         public SentryTransaction(Sentry.ITransactionTracer tracer) { }
         public SentryTransaction(string name, string operation) { }
@@ -930,7 +930,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryTransaction FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryUser : Sentry.IJsonSerializable
+    public sealed class SentryUser : Sentry.ISentryJsonSerializable
     {
         public SentryUser() { }
         public string? Email { get; set; }
@@ -949,7 +949,7 @@ namespace Sentry
         Crashed = 1,
         Abnormal = 2,
     }
-    public class SessionUpdate : Sentry.IJsonSerializable, Sentry.ISentrySession
+    public class SessionUpdate : Sentry.ISentryJsonSerializable, Sentry.ISentrySession
     {
         public SessionUpdate(Sentry.SessionUpdate sessionUpdate, bool isInitial) { }
         public SessionUpdate(Sentry.SessionUpdate sessionUpdate, bool isInitial, Sentry.SessionEndStatus? endStatus) { }
@@ -996,7 +996,7 @@ namespace Sentry
         public static Sentry.ITransactionTracer GetTransaction(this Sentry.ISpan span) { }
         public static Sentry.ISpan StartChild(this Sentry.ISpan span, string operation, string? description) { }
     }
-    public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>
+    public readonly struct SpanId : Sentry.ISentryJsonSerializable, System.IEquatable<Sentry.SpanId>
     {
         public static readonly Sentry.SpanId Empty;
         public SpanId(long value) { }
@@ -1154,7 +1154,7 @@ namespace Sentry
         public Sentry.ISpan StartChild(string operation) { }
         public void UnsetTag(string key) { }
     }
-    public sealed class UserFeedback : Sentry.IJsonSerializable
+    public sealed class UserFeedback : Sentry.ISentryJsonSerializable
     {
         public UserFeedback(Sentry.SentryId eventId, string? name, string? email, string? comments) { }
         public string? Comments { get; }
@@ -1164,7 +1164,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.UserFeedback FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class ViewHierarchy : Sentry.IJsonSerializable
+    public sealed class ViewHierarchy : Sentry.ISentryJsonSerializable
     {
         public ViewHierarchy(string renderingSystem) { }
         public string RenderingSystem { get; set; }
@@ -1175,7 +1175,7 @@ namespace Sentry
     {
         public ViewHierarchyAttachment(Sentry.IAttachmentContent content) { }
     }
-    public abstract class ViewHierarchyNode : Sentry.IJsonSerializable
+    public abstract class ViewHierarchyNode : Sentry.ISentryJsonSerializable
     {
         protected ViewHierarchyNode(string type) { }
         public System.Collections.Generic.List<Sentry.ViewHierarchyNode> Children { get; set; }
@@ -1484,7 +1484,7 @@ namespace Sentry.PlatformAbstractions
 }
 namespace Sentry.Protocol
 {
-    public sealed class App : Sentry.IJsonSerializable
+    public sealed class App : Sentry.ISentryJsonSerializable
     {
         public const string Type = "app";
         public App() { }
@@ -1499,7 +1499,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.App FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Browser : Sentry.IJsonSerializable
+    public sealed class Browser : Sentry.ISentryJsonSerializable
     {
         public const string Type = "browser";
         public Browser() { }
@@ -1508,7 +1508,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.Browser FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class DebugImage : Sentry.IJsonSerializable
+    public sealed class DebugImage : Sentry.ISentryJsonSerializable
     {
         public DebugImage() { }
         public string? CodeFile { get; set; }
@@ -1522,7 +1522,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.DebugImage FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Device : Sentry.IJsonSerializable
+    public sealed class Device : Sentry.ISentryJsonSerializable
     {
         public const string Type = "device";
         public Device() { }
@@ -1572,7 +1572,7 @@ namespace Sentry.Protocol
         [System.Runtime.Serialization.EnumMember(Value="landscape")]
         Landscape = 1,
     }
-    public sealed class Gpu : Sentry.IJsonSerializable
+    public sealed class Gpu : Sentry.ISentryJsonSerializable
     {
         public const string Type = "gpu";
         public Gpu() { }
@@ -1604,14 +1604,14 @@ namespace Sentry.Protocol
         Sentry.SpanStatus? Status { get; }
         Sentry.SentryId TraceId { get; }
     }
-    public sealed class Measurement : Sentry.IJsonSerializable
+    public sealed class Measurement : Sentry.ISentryJsonSerializable
     {
         public Sentry.MeasurementUnit Unit { get; }
         public object Value { get; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Measurement FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Mechanism : Sentry.IJsonSerializable
+    public sealed class Mechanism : Sentry.ISentryJsonSerializable
     {
         public static readonly string DescriptionKey;
         public static readonly string HandledKey;
@@ -1631,7 +1631,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Mechanism FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class OperatingSystem : Sentry.IJsonSerializable
+    public sealed class OperatingSystem : Sentry.ISentryJsonSerializable
     {
         public const string Type = "os";
         public OperatingSystem() { }
@@ -1644,7 +1644,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.OperatingSystem FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Response : Sentry.IJsonSerializable
+    public sealed class Response : Sentry.ISentryJsonSerializable
     {
         public const string Type = "response";
         public Response() { }
@@ -1659,7 +1659,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Response FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Runtime : Sentry.IJsonSerializable
+    public sealed class Runtime : Sentry.ISentryJsonSerializable
     {
         public const string Type = "runtime";
         public Runtime() { }
@@ -1671,7 +1671,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.Runtime FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryException : Sentry.IJsonSerializable
+    public sealed class SentryException : Sentry.ISentryJsonSerializable
     {
         public SentryException() { }
         public Sentry.Protocol.Mechanism? Mechanism { get; set; }
@@ -1683,7 +1683,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.SentryException FromJson(System.Text.Json.JsonElement json) { }
     }
-    public class Trace : Sentry.IJsonSerializable, Sentry.Protocol.ITraceContext
+    public class Trace : Sentry.ISentryJsonSerializable, Sentry.Protocol.ITraceContext
     {
         public const string Type = "trace";
         public Trace() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -1,15 +1,6 @@
 ﻿[assembly: System.CLSCompliant(true)]
 namespace Sentry
 {
-    [System.Diagnostics.DebuggerDisplay("{FileName}")]
-    public class Attachment
-    {
-        public Attachment(Sentry.AttachmentType type, Sentry.IAttachmentContent content, string fileName, string? contentType) { }
-        public Sentry.IAttachmentContent Content { get; }
-        public string? ContentType { get; }
-        public string FileName { get; }
-        public Sentry.AttachmentType Type { get; }
-    }
     public enum AttachmentType
     {
         Default = 0,
@@ -163,16 +154,6 @@ namespace Sentry
     {
         public static void SetTags(this Sentry.IHasTags hasTags, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> tags) { }
     }
-    public class Hint
-    {
-        public Hint() { }
-        public Hint(string key, object? value) { }
-        public System.Collections.Generic.ICollection<Sentry.Attachment> Attachments { get; }
-        public System.Collections.Generic.IDictionary<string, object?> Items { get; }
-        public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
-        public static Sentry.Hint WithAttachments(params Sentry.Attachment[] attachments) { }
-        public static Sentry.Hint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.Attachment> attachments) { }
-    }
     public static class HintTypes
     {
         public const string HttpResponseMessage = "http-response-message";
@@ -196,7 +177,7 @@ namespace Sentry
     }
     public static class HubExtensions
     {
-        public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Breadcrumb breadcrumb, Sentry.Hint? hint = null) { }
+        public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
@@ -245,7 +226,7 @@ namespace Sentry
         Sentry.IMetricAggregator Metrics { get; }
         void BindException(System.Exception exception, Sentry.ISpan span);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope);
-        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope);
+        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope);
         Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null);
         Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null);
         void EndSession(Sentry.SessionEndStatus status = 0);
@@ -280,10 +261,10 @@ namespace Sentry
     {
         bool IsEnabled { get; }
         bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
-        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.Hint? hint = null);
+        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null);
         void CaptureSession(Sentry.SessionUpdate sessionUpdate);
         void CaptureTransaction(Sentry.SentryTransaction transaction);
-        void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint);
+        void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint);
         void CaptureUserFeedback(Sentry.UserFeedback userFeedback);
         System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
     }
@@ -449,7 +430,7 @@ namespace Sentry
     public class Scope : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags
     {
         public Scope(Sentry.SentryOptions? options) { }
-        public System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment> Attachments { get; }
+        public System.Collections.Generic.IReadOnlyCollection<Sentry.SentryAttachment> Attachments { get; }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
         public Sentry.Contexts Contexts { get; set; }
         public string? Distribution { get; set; }
@@ -465,9 +446,9 @@ namespace Sentry
         public Sentry.ITransactionTracer? Transaction { get; set; }
         public string? TransactionName { get; set; }
         public Sentry.SentryUser User { get; set; }
-        public void AddAttachment(Sentry.Attachment attachment) { }
+        public void AddAttachment(Sentry.SentryAttachment attachment) { }
         public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb) { }
-        public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.Hint hint) { }
+        public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.SentryHint hint) { }
         public void Apply(Sentry.IEventLike other) { }
         public void Apply(Sentry.Scope other) { }
         public void Apply(object state) { }
@@ -507,15 +488,24 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SdkVersion FromJson(System.Text.Json.JsonElement json) { }
     }
+    [System.Diagnostics.DebuggerDisplay("{FileName}")]
+    public class SentryAttachment
+    {
+        public SentryAttachment(Sentry.AttachmentType type, Sentry.IAttachmentContent content, string fileName, string? contentType) { }
+        public Sentry.IAttachmentContent Content { get; }
+        public string? ContentType { get; }
+        public string FileName { get; }
+        public Sentry.AttachmentType Type { get; }
+    }
     public class SentryClient : Sentry.ISentryClient, System.IDisposable
     {
         public SentryClient(Sentry.SentryOptions options) { }
         public bool IsEnabled { get; }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.Hint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
         public void Dispose() { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
@@ -570,6 +560,16 @@ namespace Sentry
         public SentryGraphQLHttpMessageHandler(System.Net.Http.HttpMessageHandler? innerHandler = null, Sentry.IHub? hub = null) { }
         protected override void HandleResponse(System.Net.Http.HttpResponseMessage response, Sentry.ISpan? span, string method, string url) { }
         protected override Sentry.ISpan? ProcessRequest(System.Net.Http.HttpRequestMessage request, string method, string url) { }
+    }
+    public class SentryHint
+    {
+        public SentryHint() { }
+        public SentryHint(string key, object? value) { }
+        public System.Collections.Generic.ICollection<Sentry.SentryAttachment> Attachments { get; }
+        public System.Collections.Generic.IDictionary<string, object?> Items { get; }
+        public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
+        public static Sentry.SentryHint WithAttachments(params Sentry.SentryAttachment[] attachments) { }
+        public static Sentry.SentryHint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.SentryAttachment> attachments) { }
     }
     public class SentryHttpMessageHandler : Sentry.SentryMessageHandler
     {
@@ -696,11 +696,11 @@ namespace Sentry
         public void AddJsonSerializerContext<T>(System.Func<System.Text.Json.JsonSerializerOptions, T> contextBuilder)
             where T : System.Text.Json.Serialization.JsonSerializerContext { }
         public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?> beforeBreadcrumb) { }
-        public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.Hint, Sentry.Breadcrumb?> beforeBreadcrumb) { }
+        public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.SentryHint, Sentry.Breadcrumb?> beforeBreadcrumb) { }
         public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryEvent?> beforeSend) { }
-        public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.Hint, Sentry.SentryEvent?> beforeSend) { }
+        public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryHint, Sentry.SentryEvent?> beforeSend) { }
         public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.SentryTransaction?> beforeSendTransaction) { }
-        public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.Hint, Sentry.SentryTransaction?> beforeSendTransaction) { }
+        public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.SentryHint, Sentry.SentryTransaction?> beforeSendTransaction) { }
     }
     public static class SentryOptionsExtensions
     {
@@ -745,22 +745,22 @@ namespace Sentry
         public static bool IsEnabled { get; }
         public static Sentry.SentryId LastEventId { get; }
         public static Sentry.IMetricAggregator Metrics { get; }
-        public static void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.Hint? hint = null) { }
+        public static void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void BindClient(Sentry.ISentryClient client) { }
         public static void BindException(System.Exception exception, Sentry.ISpan span) { }
         public static bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.Hint? hint = null) { }
+        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
+        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureMessage(string message, Sentry.SentryLevel level = 1) { }
         public static Sentry.SentryId CaptureMessage(string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public static void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public static void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public static void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public static void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
         public static void CaptureUserFeedback(Sentry.SentryId eventId, string email, string comments, string? name = null) { }
         [System.Obsolete("WARNING: This method deliberately causes a crash, and should not be used in a rea" +
@@ -1171,7 +1171,7 @@ namespace Sentry
         public System.Collections.Generic.List<Sentry.ViewHierarchyNode> Windows { get; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
     }
-    public class ViewHierarchyAttachment : Sentry.Attachment
+    public class ViewHierarchyAttachment : Sentry.SentryAttachment
     {
         public ViewHierarchyAttachment(Sentry.IAttachmentContent content) { }
     }
@@ -1231,11 +1231,11 @@ namespace Sentry.Extensibility
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.Hint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
@@ -1274,12 +1274,12 @@ namespace Sentry.Extensibility
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope, Sentry.Hint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope, Sentry.SentryHint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public Sentry.SentryId CaptureException(System.Exception exception) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public void CaptureUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
@@ -1338,7 +1338,7 @@ namespace Sentry.Extensibility
     }
     public interface ISentryEventProcessorWithHint : Sentry.Extensibility.ISentryEventProcessor
     {
-        Sentry.SentryEvent? Process(Sentry.SentryEvent @event, Sentry.Hint hint);
+        Sentry.SentryEvent? Process(Sentry.SentryEvent @event, Sentry.SentryHint hint);
     }
     public interface ISentryStackTraceFactory
     {
@@ -1350,7 +1350,7 @@ namespace Sentry.Extensibility
     }
     public interface ISentryTransactionProcessorWithHint : Sentry.Extensibility.ISentryTransactionProcessor
     {
-        Sentry.SentryTransaction? Process(Sentry.SentryTransaction transaction, Sentry.Hint hint);
+        Sentry.SentryTransaction? Process(Sentry.SentryTransaction transaction, Sentry.SentryHint hint);
     }
     public interface ITransport
     {
@@ -1710,7 +1710,7 @@ namespace Sentry.Protocol.Envelopes
         public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
         public Sentry.SentryId? TryGetEventId() { }
         public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.Envelope> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
-        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.SentryAttachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
         public static Sentry.Protocol.Envelopes.Envelope FromSession(Sentry.SessionUpdate sessionUpdate) { }
         public static Sentry.Protocol.Envelopes.Envelope FromTransaction(Sentry.SentryTransaction transaction) { }
         public static Sentry.Protocol.Envelopes.Envelope FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
@@ -1727,7 +1727,7 @@ namespace Sentry.Protocol.Envelopes
         public long? TryGetLength() { }
         public string? TryGetType() { }
         public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.EnvelopeItem> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
-        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.Attachment attachment) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.SentryAttachment attachment) { }
         public static Sentry.Protocol.Envelopes.EnvelopeItem FromEvent(Sentry.SentryEvent @event) { }
         public static Sentry.Protocol.Envelopes.EnvelopeItem FromSession(Sentry.SessionUpdate sessionUpdate) { }
         public static Sentry.Protocol.Envelopes.EnvelopeItem FromTransaction(Sentry.SentryTransaction transaction) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -24,7 +24,7 @@ namespace Sentry
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("Message: {Message}, Type: {Type}")]
-    public sealed class Breadcrumb : Sentry.IJsonSerializable
+    public sealed class Breadcrumb : Sentry.ISentryJsonSerializable
     {
         public Breadcrumb(string message, string type, System.Collections.Generic.IReadOnlyDictionary<string, string>? data = null, string? category = null, Sentry.BreadcrumbLevel level = 0) { }
         public string? Category { get; }
@@ -76,7 +76,7 @@ namespace Sentry
         public const string Platform = "csharp";
         public const int ProtocolVersion = 7;
     }
-    public sealed class Contexts : Sentry.IJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
+    public sealed class Contexts : Sentry.ISentryJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
     {
         public Contexts() { }
         public Sentry.Protocol.App App { get; }
@@ -255,10 +255,6 @@ namespace Sentry
         void StartSession();
         Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext);
     }
-    public interface IJsonSerializable
-    {
-        void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger);
-    }
     public interface IMetricAggregator : System.IDisposable
     {
         void Distribution(string key, double value = 1, Sentry.MeasurementUnit? unit = default, System.Collections.Generic.IDictionary<string, string>? tags = null, System.DateTimeOffset? timestamp = default, int stackLevel = 1);
@@ -288,6 +284,10 @@ namespace Sentry
         void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint);
         void CaptureUserFeedback(Sentry.UserFeedback userFeedback);
         System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
+    }
+    public interface ISentryJsonSerializable
+    {
+        void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger);
     }
     public interface ISentryScopeManager
     {
@@ -412,7 +412,7 @@ namespace Sentry
             Exbibyte = 13,
         }
     }
-    public sealed class Package : Sentry.IJsonSerializable
+    public sealed class Package : Sentry.ISentryJsonSerializable
     {
         public Package(string name, string version) { }
         public string Name { get; }
@@ -428,7 +428,7 @@ namespace Sentry
         Version = 1,
         InformationalVersion = 2,
     }
-    public sealed class Request : Sentry.IJsonSerializable
+    public sealed class Request : Sentry.ISentryJsonSerializable
     {
         public Request() { }
         public string? ApiTarget { get; set; }
@@ -494,7 +494,7 @@ namespace Sentry
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryEventExceptionProcessor> GetAllExceptionProcessors(this Sentry.Scope scope) { }
         public static System.Collections.Generic.IEnumerable<Sentry.Extensibility.ISentryTransactionProcessor> GetAllTransactionProcessors(this Sentry.Scope scope) { }
     }
-    public sealed class SdkVersion : Sentry.IJsonSerializable
+    public sealed class SdkVersion : Sentry.ISentryJsonSerializable
     {
         public SdkVersion() { }
         public string? Name { get; set; }
@@ -528,7 +528,7 @@ namespace Sentry
         public static System.Threading.Tasks.Task FlushAsync(this Sentry.ISentryClient client) { }
     }
     [System.Diagnostics.DebuggerDisplay("{GetType().Name,nq}: {EventId,nq}")]
-    public sealed class SentryEvent : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.IJsonSerializable
+    public sealed class SentryEvent : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable
     {
         public SentryEvent() { }
         public SentryEvent(System.Exception? exception) { }
@@ -578,7 +578,7 @@ namespace Sentry
         protected override void HandleResponse(System.Net.Http.HttpResponseMessage response, Sentry.ISpan? span, string method, string url) { }
         protected override Sentry.ISpan? ProcessRequest(System.Net.Http.HttpRequestMessage request, string method, string url) { }
     }
-    public readonly struct SentryId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SentryId>
+    public readonly struct SentryId : Sentry.ISentryJsonSerializable, System.IEquatable<Sentry.SentryId>
     {
         public static readonly Sentry.SentryId Empty;
         public SentryId(System.Guid guid) { }
@@ -608,7 +608,7 @@ namespace Sentry
         [System.Runtime.Serialization.EnumMember(Value="fatal")]
         Fatal = 4,
     }
-    public sealed class SentryMessage : Sentry.IJsonSerializable
+    public sealed class SentryMessage : Sentry.ISentryJsonSerializable
     {
         public SentryMessage() { }
         public string? Formatted { get; set; }
@@ -802,7 +802,7 @@ namespace Sentry
         public string? UserAgent { get; }
         public void ReportError() { }
     }
-    public class SentrySpan : Sentry.IHasExtra, Sentry.IHasTags, Sentry.IJsonSerializable, Sentry.ISpanData, Sentry.Protocol.ITraceContext
+    public class SentrySpan : Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable, Sentry.ISpanData, Sentry.Protocol.ITraceContext
     {
         public SentrySpan(Sentry.ISpan tracer) { }
         public SentrySpan(Sentry.SpanId? parentSpanId, string operation) { }
@@ -827,7 +827,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentrySpan FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryStackFrame : Sentry.IJsonSerializable
+    public sealed class SentryStackFrame : Sentry.ISentryJsonSerializable
     {
         public SentryStackFrame() { }
         public string? AbsolutePath { get; set; }
@@ -853,7 +853,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackFrame FromJson(System.Text.Json.JsonElement json) { }
     }
-    public class SentryStackTrace : Sentry.IJsonSerializable
+    public class SentryStackTrace : Sentry.ISentryJsonSerializable
     {
         public SentryStackTrace() { }
         public Sentry.InstructionAddressAdjustment? AddressAdjustment { get; set; }
@@ -861,7 +861,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryStackTrace FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryThread : Sentry.IJsonSerializable
+    public sealed class SentryThread : Sentry.ISentryJsonSerializable
     {
         public SentryThread() { }
         public bool? Crashed { get; set; }
@@ -881,7 +881,7 @@ namespace Sentry
         public override string ToString() { }
         public static Sentry.SentryTraceHeader Parse(string value) { }
     }
-    public class SentryTransaction : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.IJsonSerializable, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
+    public class SentryTransaction : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
     {
         public SentryTransaction(Sentry.ITransactionTracer tracer) { }
         public SentryTransaction(string name, string operation) { }
@@ -925,7 +925,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SentryTransaction FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryUser : Sentry.IJsonSerializable
+    public sealed class SentryUser : Sentry.ISentryJsonSerializable
     {
         public SentryUser() { }
         public string? Email { get; set; }
@@ -944,7 +944,7 @@ namespace Sentry
         Crashed = 1,
         Abnormal = 2,
     }
-    public class SessionUpdate : Sentry.IJsonSerializable, Sentry.ISentrySession
+    public class SessionUpdate : Sentry.ISentryJsonSerializable, Sentry.ISentrySession
     {
         public SessionUpdate(Sentry.SessionUpdate sessionUpdate, bool isInitial) { }
         public SessionUpdate(Sentry.SessionUpdate sessionUpdate, bool isInitial, Sentry.SessionEndStatus? endStatus) { }
@@ -991,7 +991,7 @@ namespace Sentry
         public static Sentry.ITransactionTracer GetTransaction(this Sentry.ISpan span) { }
         public static Sentry.ISpan StartChild(this Sentry.ISpan span, string operation, string? description) { }
     }
-    public readonly struct SpanId : Sentry.IJsonSerializable, System.IEquatable<Sentry.SpanId>
+    public readonly struct SpanId : Sentry.ISentryJsonSerializable, System.IEquatable<Sentry.SpanId>
     {
         public static readonly Sentry.SpanId Empty;
         public SpanId(long value) { }
@@ -1149,7 +1149,7 @@ namespace Sentry
         public Sentry.ISpan StartChild(string operation) { }
         public void UnsetTag(string key) { }
     }
-    public sealed class UserFeedback : Sentry.IJsonSerializable
+    public sealed class UserFeedback : Sentry.ISentryJsonSerializable
     {
         public UserFeedback(Sentry.SentryId eventId, string? name, string? email, string? comments) { }
         public string? Comments { get; }
@@ -1159,7 +1159,7 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.UserFeedback FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class ViewHierarchy : Sentry.IJsonSerializable
+    public sealed class ViewHierarchy : Sentry.ISentryJsonSerializable
     {
         public ViewHierarchy(string renderingSystem) { }
         public string RenderingSystem { get; set; }
@@ -1170,7 +1170,7 @@ namespace Sentry
     {
         public ViewHierarchyAttachment(Sentry.IAttachmentContent content) { }
     }
-    public abstract class ViewHierarchyNode : Sentry.IJsonSerializable
+    public abstract class ViewHierarchyNode : Sentry.ISentryJsonSerializable
     {
         protected ViewHierarchyNode(string type) { }
         public System.Collections.Generic.List<Sentry.ViewHierarchyNode> Children { get; set; }
@@ -1480,7 +1480,7 @@ namespace Sentry.PlatformAbstractions
 }
 namespace Sentry.Protocol
 {
-    public sealed class App : Sentry.IJsonSerializable
+    public sealed class App : Sentry.ISentryJsonSerializable
     {
         public const string Type = "app";
         public App() { }
@@ -1495,7 +1495,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.App FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Browser : Sentry.IJsonSerializable
+    public sealed class Browser : Sentry.ISentryJsonSerializable
     {
         public const string Type = "browser";
         public Browser() { }
@@ -1504,7 +1504,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.Browser FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class DebugImage : Sentry.IJsonSerializable
+    public sealed class DebugImage : Sentry.ISentryJsonSerializable
     {
         public DebugImage() { }
         public string? CodeFile { get; set; }
@@ -1518,7 +1518,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.DebugImage FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Device : Sentry.IJsonSerializable
+    public sealed class Device : Sentry.ISentryJsonSerializable
     {
         public const string Type = "device";
         public Device() { }
@@ -1568,7 +1568,7 @@ namespace Sentry.Protocol
         [System.Runtime.Serialization.EnumMember(Value="landscape")]
         Landscape = 1,
     }
-    public sealed class Gpu : Sentry.IJsonSerializable
+    public sealed class Gpu : Sentry.ISentryJsonSerializable
     {
         public const string Type = "gpu";
         public Gpu() { }
@@ -1600,14 +1600,14 @@ namespace Sentry.Protocol
         Sentry.SpanStatus? Status { get; }
         Sentry.SentryId TraceId { get; }
     }
-    public sealed class Measurement : Sentry.IJsonSerializable
+    public sealed class Measurement : Sentry.ISentryJsonSerializable
     {
         public Sentry.MeasurementUnit Unit { get; }
         public object Value { get; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Measurement FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Mechanism : Sentry.IJsonSerializable
+    public sealed class Mechanism : Sentry.ISentryJsonSerializable
     {
         public static readonly string DescriptionKey;
         public static readonly string HandledKey;
@@ -1627,7 +1627,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Mechanism FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class OperatingSystem : Sentry.IJsonSerializable
+    public sealed class OperatingSystem : Sentry.ISentryJsonSerializable
     {
         public const string Type = "os";
         public OperatingSystem() { }
@@ -1640,7 +1640,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.OperatingSystem FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Response : Sentry.IJsonSerializable
+    public sealed class Response : Sentry.ISentryJsonSerializable
     {
         public const string Type = "response";
         public Response() { }
@@ -1655,7 +1655,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.Response FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class Runtime : Sentry.IJsonSerializable
+    public sealed class Runtime : Sentry.ISentryJsonSerializable
     {
         public const string Type = "runtime";
         public Runtime() { }
@@ -1667,7 +1667,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? _) { }
         public static Sentry.Protocol.Runtime FromJson(System.Text.Json.JsonElement json) { }
     }
-    public sealed class SentryException : Sentry.IJsonSerializable
+    public sealed class SentryException : Sentry.ISentryJsonSerializable
     {
         public SentryException() { }
         public Sentry.Protocol.Mechanism? Mechanism { get; set; }
@@ -1679,7 +1679,7 @@ namespace Sentry.Protocol
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.Protocol.SentryException FromJson(System.Text.Json.JsonElement json) { }
     }
-    public class Trace : Sentry.IJsonSerializable, Sentry.Protocol.ITraceContext
+    public class Trace : Sentry.ISentryJsonSerializable, Sentry.Protocol.ITraceContext
     {
         public const string Type = "trace";
         public Trace() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -1,15 +1,6 @@
 ﻿[assembly: System.CLSCompliant(true)]
 namespace Sentry
 {
-    [System.Diagnostics.DebuggerDisplay("{FileName}")]
-    public class Attachment
-    {
-        public Attachment(Sentry.AttachmentType type, Sentry.IAttachmentContent content, string fileName, string? contentType) { }
-        public Sentry.IAttachmentContent Content { get; }
-        public string? ContentType { get; }
-        public string FileName { get; }
-        public Sentry.AttachmentType Type { get; }
-    }
     public enum AttachmentType
     {
         Default = 0,
@@ -161,16 +152,6 @@ namespace Sentry
     {
         public static void SetTags(this Sentry.IHasTags hasTags, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> tags) { }
     }
-    public class Hint
-    {
-        public Hint() { }
-        public Hint(string key, object? value) { }
-        public System.Collections.Generic.ICollection<Sentry.Attachment> Attachments { get; }
-        public System.Collections.Generic.IDictionary<string, object?> Items { get; }
-        public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
-        public static Sentry.Hint WithAttachments(params Sentry.Attachment[] attachments) { }
-        public static Sentry.Hint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.Attachment> attachments) { }
-    }
     public static class HintTypes
     {
         public const string HttpResponseMessage = "http-response-message";
@@ -194,7 +175,7 @@ namespace Sentry
     }
     public static class HubExtensions
     {
-        public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Breadcrumb breadcrumb, Sentry.Hint? hint = null) { }
+        public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
@@ -243,7 +224,7 @@ namespace Sentry
         Sentry.IMetricAggregator Metrics { get; }
         void BindException(System.Exception exception, Sentry.ISpan span);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope);
-        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope);
+        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope);
         Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null);
         Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null);
         void EndSession(Sentry.SessionEndStatus status = 0);
@@ -278,10 +259,10 @@ namespace Sentry
     {
         bool IsEnabled { get; }
         bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
-        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.Hint? hint = null);
+        Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null);
         void CaptureSession(Sentry.SessionUpdate sessionUpdate);
         void CaptureTransaction(Sentry.SentryTransaction transaction);
-        void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint);
+        void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint);
         void CaptureUserFeedback(Sentry.UserFeedback userFeedback);
         System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout);
     }
@@ -447,7 +428,7 @@ namespace Sentry
     public class Scope : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags
     {
         public Scope(Sentry.SentryOptions? options) { }
-        public System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment> Attachments { get; }
+        public System.Collections.Generic.IReadOnlyCollection<Sentry.SentryAttachment> Attachments { get; }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
         public Sentry.Contexts Contexts { get; set; }
         public string? Distribution { get; set; }
@@ -463,9 +444,9 @@ namespace Sentry
         public Sentry.ITransactionTracer? Transaction { get; set; }
         public string? TransactionName { get; set; }
         public Sentry.SentryUser User { get; set; }
-        public void AddAttachment(Sentry.Attachment attachment) { }
+        public void AddAttachment(Sentry.SentryAttachment attachment) { }
         public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb) { }
-        public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.Hint hint) { }
+        public void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.SentryHint hint) { }
         public void Apply(Sentry.IEventLike other) { }
         public void Apply(Sentry.Scope other) { }
         public void Apply(object state) { }
@@ -505,15 +486,24 @@ namespace Sentry
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
         public static Sentry.SdkVersion FromJson(System.Text.Json.JsonElement json) { }
     }
+    [System.Diagnostics.DebuggerDisplay("{FileName}")]
+    public class SentryAttachment
+    {
+        public SentryAttachment(Sentry.AttachmentType type, Sentry.IAttachmentContent content, string fileName, string? contentType) { }
+        public Sentry.IAttachmentContent Content { get; }
+        public string? ContentType { get; }
+        public string FileName { get; }
+        public Sentry.AttachmentType Type { get; }
+    }
     public class SentryClient : Sentry.ISentryClient, System.IDisposable
     {
         public SentryClient(Sentry.SentryOptions options) { }
         public bool IsEnabled { get; }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.Hint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
         public void Dispose() { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
@@ -568,6 +558,16 @@ namespace Sentry
         public SentryGraphQLHttpMessageHandler(System.Net.Http.HttpMessageHandler? innerHandler = null, Sentry.IHub? hub = null) { }
         protected override void HandleResponse(System.Net.Http.HttpResponseMessage response, Sentry.ISpan? span, string method, string url) { }
         protected override Sentry.ISpan? ProcessRequest(System.Net.Http.HttpRequestMessage request, string method, string url) { }
+    }
+    public class SentryHint
+    {
+        public SentryHint() { }
+        public SentryHint(string key, object? value) { }
+        public System.Collections.Generic.ICollection<Sentry.SentryAttachment> Attachments { get; }
+        public System.Collections.Generic.IDictionary<string, object?> Items { get; }
+        public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
+        public static Sentry.SentryHint WithAttachments(params Sentry.SentryAttachment[] attachments) { }
+        public static Sentry.SentryHint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.SentryAttachment> attachments) { }
     }
     public class SentryHttpMessageHandler : Sentry.SentryMessageHandler
     {
@@ -693,11 +693,11 @@ namespace Sentry
         public void AddJsonSerializerContext<T>(System.Func<System.Text.Json.JsonSerializerOptions, T> contextBuilder)
             where T : System.Text.Json.Serialization.JsonSerializerContext { }
         public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.Breadcrumb?> beforeBreadcrumb) { }
-        public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.Hint, Sentry.Breadcrumb?> beforeBreadcrumb) { }
+        public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.SentryHint, Sentry.Breadcrumb?> beforeBreadcrumb) { }
         public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryEvent?> beforeSend) { }
-        public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.Hint, Sentry.SentryEvent?> beforeSend) { }
+        public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryHint, Sentry.SentryEvent?> beforeSend) { }
         public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.SentryTransaction?> beforeSendTransaction) { }
-        public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.Hint, Sentry.SentryTransaction?> beforeSendTransaction) { }
+        public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.SentryHint, Sentry.SentryTransaction?> beforeSendTransaction) { }
     }
     public static class SentryOptionsExtensions
     {
@@ -740,22 +740,22 @@ namespace Sentry
         public static bool IsEnabled { get; }
         public static Sentry.SentryId LastEventId { get; }
         public static Sentry.IMetricAggregator Metrics { get; }
-        public static void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.Hint? hint = null) { }
+        public static void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void BindClient(Sentry.ISentryClient client) { }
         public static void BindException(System.Exception exception, Sentry.ISpan span) { }
         public static bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.Hint? hint = null) { }
+        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
+        public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureMessage(string message, Sentry.SentryLevel level = 1) { }
         public static Sentry.SentryId CaptureMessage(string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public static void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public static void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public static void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public static void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
         public static void CaptureUserFeedback(Sentry.SentryId eventId, string email, string comments, string? name = null) { }
         [System.Obsolete("WARNING: This method deliberately causes a crash, and should not be used in a rea" +
@@ -1166,7 +1166,7 @@ namespace Sentry
         public System.Collections.Generic.List<Sentry.ViewHierarchyNode> Windows { get; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
     }
-    public class ViewHierarchyAttachment : Sentry.Attachment
+    public class ViewHierarchyAttachment : Sentry.SentryAttachment
     {
         public ViewHierarchyAttachment(Sentry.IAttachmentContent content) { }
     }
@@ -1226,11 +1226,11 @@ namespace Sentry.Extensibility
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.Hint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public void CaptureUserFeedback(Sentry.UserFeedback userFeedback) { }
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
@@ -1269,12 +1269,12 @@ namespace Sentry.Extensibility
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Hint? hint, System.Action<Sentry.Scope> configureScope) { }
-        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope, Sentry.Hint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope, Sentry.SentryHint? hint = null) { }
+        public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public Sentry.SentryId CaptureException(System.Exception exception) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
         public void CaptureTransaction(Sentry.SentryTransaction transaction) { }
-        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.Hint? hint) { }
+        public void CaptureTransaction(Sentry.SentryTransaction transaction, Sentry.Scope? scope, Sentry.SentryHint? hint) { }
         public void CaptureUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
         public void ConfigureScope(System.Action<Sentry.Scope> configureScope) { }
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
@@ -1333,7 +1333,7 @@ namespace Sentry.Extensibility
     }
     public interface ISentryEventProcessorWithHint : Sentry.Extensibility.ISentryEventProcessor
     {
-        Sentry.SentryEvent? Process(Sentry.SentryEvent @event, Sentry.Hint hint);
+        Sentry.SentryEvent? Process(Sentry.SentryEvent @event, Sentry.SentryHint hint);
     }
     public interface ISentryStackTraceFactory
     {
@@ -1345,7 +1345,7 @@ namespace Sentry.Extensibility
     }
     public interface ISentryTransactionProcessorWithHint : Sentry.Extensibility.ISentryTransactionProcessor
     {
-        Sentry.SentryTransaction? Process(Sentry.SentryTransaction transaction, Sentry.Hint hint);
+        Sentry.SentryTransaction? Process(Sentry.SentryTransaction transaction, Sentry.SentryHint hint);
     }
     public interface ITransport
     {
@@ -1706,7 +1706,7 @@ namespace Sentry.Protocol.Envelopes
         public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, Sentry.Extensibility.IDiagnosticLogger? logger, System.Threading.CancellationToken cancellationToken = default) { }
         public Sentry.SentryId? TryGetEventId() { }
         public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.Envelope> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
-        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.Attachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
+        public static Sentry.Protocol.Envelopes.Envelope FromEvent(Sentry.SentryEvent @event, Sentry.Extensibility.IDiagnosticLogger? logger = null, System.Collections.Generic.IReadOnlyCollection<Sentry.SentryAttachment>? attachments = null, Sentry.SessionUpdate? sessionUpdate = null) { }
         public static Sentry.Protocol.Envelopes.Envelope FromSession(Sentry.SessionUpdate sessionUpdate) { }
         public static Sentry.Protocol.Envelopes.Envelope FromTransaction(Sentry.SentryTransaction transaction) { }
         public static Sentry.Protocol.Envelopes.Envelope FromUserFeedback(Sentry.UserFeedback sentryUserFeedback) { }
@@ -1723,7 +1723,7 @@ namespace Sentry.Protocol.Envelopes
         public long? TryGetLength() { }
         public string? TryGetType() { }
         public static System.Threading.Tasks.Task<Sentry.Protocol.Envelopes.EnvelopeItem> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
-        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.Attachment attachment) { }
+        public static Sentry.Protocol.Envelopes.EnvelopeItem FromAttachment(Sentry.SentryAttachment attachment) { }
         public static Sentry.Protocol.Envelopes.EnvelopeItem FromEvent(Sentry.SentryEvent @event) { }
         public static Sentry.Protocol.Envelopes.EnvelopeItem FromSession(Sentry.SessionUpdate sessionUpdate) { }
         public static Sentry.Protocol.Envelopes.EnvelopeItem FromTransaction(Sentry.SentryTransaction transaction) { }

--- a/test/Sentry.Tests/AttachmentHelper.cs
+++ b/test/Sentry.Tests/AttachmentHelper.cs
@@ -2,7 +2,7 @@ namespace Sentry.Tests
 {
     internal static class AttachmentHelper
     {
-        internal static Attachment FakeAttachment(string name = "test.txt")
+        internal static SentryAttachment FakeAttachment(string name = "test.txt")
         => new(
             AttachmentType.Default,
             new StreamAttachmentContent(new MemoryStream(new byte[] { 1 })),

--- a/test/Sentry.Tests/HintTests.cs
+++ b/test/Sentry.Tests/HintTests.cs
@@ -19,7 +19,7 @@ public class HintTests : IDisposable
         File.Create(attachmentPath1);
         File.Create(attachmentPath2);
 
-        var hint = new Hint(new SentryOptions());
+        var hint = new SentryHint(new SentryOptions());
 
         // Act
         hint.AddAttachment(attachmentPath1);
@@ -33,7 +33,7 @@ public class HintTests : IDisposable
     public void Clear_WithEntries_ClearsHintEntries()
     {
         // Arrange
-        var hint = new Hint("key", "value");
+        var hint = new SentryHint("key", "value");
 
         // Act
         hint.Items.Clear();
@@ -46,7 +46,7 @@ public class HintTests : IDisposable
     public void ClearAttachments_WithAttachments_ClearsHintAttachments()
     {
         // Arrange
-        var hint = new Hint();
+        var hint = new SentryHint();
         var attachment1 = Path.Combine(_testDirectory, Path.GetTempFileName());
         hint.AddAttachment(attachment1);
 
@@ -61,7 +61,7 @@ public class HintTests : IDisposable
     public void ContainsKey_ExistingKey_ReturnsTrue()
     {
         // Arrange
-        var hint = new Hint("key", "value");
+        var hint = new SentryHint("key", "value");
 
         // Act
         var containsKey = hint.Items.ContainsKey("key");
@@ -74,7 +74,7 @@ public class HintTests : IDisposable
     public void ContainsKey_NonExistingKey_ReturnsFalse()
     {
         // Arrange
-        var hint = new Hint("key", "value");
+        var hint = new SentryHint("key", "value");
 
         // Act
         var containsKey = hint.Items.ContainsKey("nonExistingKey");
@@ -87,7 +87,7 @@ public class HintTests : IDisposable
     public void Count_ReturnsZero_WhenHintIsEmpty()
     {
         // Arrange
-        var hint = new Hint();
+        var hint = new SentryHint();
 
         // Act
         var count = hint.Items.Count;
@@ -100,7 +100,7 @@ public class HintTests : IDisposable
     public void Count_ReturnsCorrectValue_WhenHintHasItems()
     {
         // Arrange
-        var hint = new Hint();
+        var hint = new SentryHint();
         hint.Items["key1"] = "value1";
         hint.Items["key2"] = "value2";
 
@@ -115,7 +115,7 @@ public class HintTests : IDisposable
     public void Remove_WithExistingKey_RemovesEntry()
     {
         // Arrange
-        var hint = new Hint("key", "value");
+        var hint = new SentryHint("key", "value");
 
         // Act
         hint.Items.Remove("key");
@@ -132,7 +132,7 @@ public class HintTests : IDisposable
         var attachment2 = AttachmentHelper.FakeAttachment("attachment2");
 
         // Act
-        var hint = Hint.WithAttachments(attachment1, attachment2);
+        var hint = SentryHint.WithAttachments(attachment1, attachment2);
 
         // Assert
         hint.Attachments.Count.Should().Be(2);
@@ -146,10 +146,10 @@ public class HintTests : IDisposable
         // Arrange
         var attachment1 = AttachmentHelper.FakeAttachment("attachment1");
         var attachment2 = AttachmentHelper.FakeAttachment("attachment2");
-        var attachments = new List<Attachment> { attachment1, attachment2 };
+        var attachments = new List<SentryAttachment> { attachment1, attachment2 };
 
         // Act
-        var hint = Hint.WithAttachments(attachments);
+        var hint = SentryHint.WithAttachments(attachments);
 
         // Assert
         hint.Attachments.Count.Should().Be(2);

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -127,7 +127,7 @@ public partial class HubTests
             Arg.Is<SentryEvent>(evt =>
                 evt.Contexts.Trace.TraceId == transaction.TraceId &&
                 evt.Contexts.Trace.SpanId == transaction.SpanId),
-            Arg.Any<Scope>(), Arg.Any<Hint>());
+            Arg.Any<Scope>(), Arg.Any<SentryHint>());
     }
 
     [Fact]
@@ -149,7 +149,7 @@ public partial class HubTests
             Arg.Is<SentryEvent>(evt =>
                 evt.Contexts.Trace.TraceId == transaction.TraceId &&
                 evt.Contexts.Trace.SpanId == transaction.SpanId),
-            Arg.Any<Scope>(), Arg.Any<Hint>());
+            Arg.Any<Scope>(), Arg.Any<SentryHint>());
     }
 
     [Fact]
@@ -188,7 +188,7 @@ public partial class HubTests
         _fixture.Client.Received(1).CaptureEvent(
             Arg.Is<SentryEvent>(evt =>
                 evt.DynamicSamplingContext == dsc),
-            Arg.Any<Scope>(), Arg.Any<Hint>());
+            Arg.Any<Scope>(), Arg.Any<SentryHint>());
     }
 
     [Fact]
@@ -210,7 +210,7 @@ public partial class HubTests
             Arg.Is<SentryEvent>(evt =>
                 evt.Contexts.Trace.TraceId == default &&
                 evt.Contexts.Trace.SpanId == default),
-            Arg.Any<Scope>(), Arg.Any<Hint>());
+            Arg.Any<Scope>(), Arg.Any<SentryHint>());
     }
 
     [Fact]
@@ -229,7 +229,7 @@ public partial class HubTests
             Arg.Is<SentryEvent>(evt =>
                 evt.Contexts.Trace.TraceId == scope.PropagationContext.TraceId &&
                 evt.Contexts.Trace.SpanId == scope.PropagationContext.SpanId),
-            Arg.Any<Scope>(), Arg.Any<Hint>());
+            Arg.Any<Scope>(), Arg.Any<SentryHint>());
     }
 
     [Fact]
@@ -435,7 +435,7 @@ public partial class HubTests
     {
         // Arrange
         var @event = new SentryEvent();
-        var hint = new Hint();
+        var hint = new SentryHint();
         var hub = _fixture.GetSut();
 
         // Act
@@ -444,7 +444,7 @@ public partial class HubTests
         // Assert
         _fixture.Client.Received(1).CaptureEvent(
             Arg.Any<SentryEvent>(),
-            Arg.Any<Scope>(), Arg.Is<Hint>(h => h == hint));
+            Arg.Any<Scope>(), Arg.Is<SentryHint>(h => h == hint));
     }
 
     [Fact]
@@ -1391,7 +1391,7 @@ public partial class HubTests
         hub.CaptureEvent(evt);
 
         // Assert
-        _fixture.Client.Received(enabled ? 1 : 0).CaptureEvent(Arg.Any<SentryEvent>(), Arg.Any<Scope>(), Arg.Any<Hint>());
+        _fixture.Client.Received(enabled ? 1 : 0).CaptureEvent(Arg.Any<SentryEvent>(), Arg.Any<Scope>(), Arg.Any<SentryHint>());
     }
 
     [Theory]
@@ -1452,7 +1452,7 @@ public partial class HubTests
         transaction.Finish();
 
         // Assert
-        _fixture.Client.Received().CaptureTransaction(Arg.Is<SentryTransaction>(t => t.IsSampled == enabled), Arg.Any<Scope>(), Arg.Any<Hint>());
+        _fixture.Client.Received().CaptureTransaction(Arg.Is<SentryTransaction>(t => t.IsSampled == enabled), Arg.Any<Scope>(), Arg.Any<SentryHint>());
     }
 
     [Fact]
@@ -1466,7 +1466,7 @@ public partial class HubTests
         transaction.Finish();
 
         // Assert
-        _fixture.Client.Received().CaptureTransaction(Arg.Any<SentryTransaction>(), Arg.Any<Scope>(), Arg.Any<Hint>());
+        _fixture.Client.Received().CaptureTransaction(Arg.Any<SentryTransaction>(), Arg.Any<Scope>(), Arg.Any<SentryHint>());
     }
 
     [Theory]

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -53,7 +53,7 @@ public class CachingTransportTests
 
         try
         {
-            var attachment = new Attachment(AttachmentType.Default, new FileAttachmentContent(tempFile), "Attachment.txt", null);
+            var attachment = new SentryAttachment(AttachmentType.Default, new FileAttachmentContent(tempFile), "Attachment.txt", null);
             using var envelope = Envelope.FromEvent(new SentryEvent(), attachments: new[] { attachment });
 
             // Act

--- a/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
@@ -520,7 +520,7 @@ public partial class HttpTransportTests
             },
             new HttpClient(httpHandler));
 
-        var attachment = new Attachment(
+        var attachment = new SentryAttachment(
             AttachmentType.Default,
             new FileAttachmentContent("test1.txt"),
             "test1.txt",
@@ -566,13 +566,13 @@ public partial class HttpTransportTests
             },
             new HttpClient(httpHandler));
 
-        var attachmentNormal = new Attachment(
+        var attachmentNormal = new SentryAttachment(
             AttachmentType.Default,
             new StreamAttachmentContent(new MemoryStream(new byte[] { 1 })),
             "test1.txt",
             null);
 
-        var attachmentTooBig = new Attachment(
+        var attachmentTooBig = new SentryAttachment(
             AttachmentType.Default,
             new StreamAttachmentContent(new MemoryStream(new byte[] { 1, 2, 3, 4, 5 })),
             "test2.txt",

--- a/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
@@ -535,7 +535,7 @@ public class EnvelopeTests
             """);
     }
 
-    private class ThrowingSerializable : IJsonSerializable
+    private class ThrowingSerializable : ISentryJsonSerializable
     {
         public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger logger)
         {

--- a/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
@@ -726,7 +726,7 @@ public class EnvelopeTests
 
         using var attachmentStream = new MemoryStream(new byte[] { 1, 2, 3 });
 
-        var attachment = new Attachment(
+        var attachment = new SentryAttachment(
             AttachmentType.Default,
             new StreamAttachmentContent(attachmentStream),
             "file.txt",
@@ -763,7 +763,7 @@ public class EnvelopeTests
 
         using var attachmentStream = new MemoryStream(new byte[] { 1, 2, 3 });
 
-        var attachment = new Attachment(
+        var attachment = new SentryAttachment(
             AttachmentType.Default,
             new StreamAttachmentContent(attachmentStream),
             "file.txt",
@@ -893,14 +893,14 @@ public class EnvelopeTests
     public void FromEvent_EmptyAttachmentStream_DoesNotIncludeAttachment()
     {
         // Arrange
-        var attachment = new Attachment(
+        var attachment = new SentryAttachment(
             default,
             new StreamAttachmentContent(Stream.Null),
             "Screenshot.jpg",
             "image/jpg");
 
         // Act
-        var envelope = Envelope.FromEvent(new SentryEvent(), attachments: new List<Attachment> { attachment });
+        var envelope = Envelope.FromEvent(new SentryEvent(), attachments: new List<SentryAttachment> { attachment });
 
         // Assert
         envelope.Items.Should().HaveCount(1);
@@ -912,14 +912,14 @@ public class EnvelopeTests
         // Arrange
         var path = Path.GetTempFileName();
         using var stream = File.OpenRead(path);
-        var attachment = new Attachment(
+        var attachment = new SentryAttachment(
             default,
             new StreamAttachmentContent(stream),
             "Screenshot.jpg",
             "image/jpg");
 
         // Act
-        _ = Envelope.FromEvent(new SentryEvent(), attachments: new List<Attachment> { attachment });
+        _ = Envelope.FromEvent(new SentryEvent(), attachments: new List<SentryAttachment> { attachment });
 
         // Assert
         Assert.Throws<ObjectDisposedException>(() => stream.ReadByte());

--- a/test/Sentry.Tests/Protocol/MeasurementTests.cs
+++ b/test/Sentry.Tests/Protocol/MeasurementTests.cs
@@ -188,7 +188,7 @@ public partial class MeasurementTests
                 t.Measurements["foo"].Value.As<int>() == int.MaxValue &&
                 t.Measurements["foo"].Unit == EmptyUnit),
             Arg.Any<Scope>(),
-            Arg.Any<Hint>()
+            Arg.Any<SentryHint>()
             );
     }
 
@@ -216,7 +216,7 @@ public partial class MeasurementTests
                 t.Measurements["foo"].Value.As<long>() == long.MaxValue &&
                 t.Measurements["foo"].Unit == EmptyUnit),
             Arg.Any<Scope>(),
-            Arg.Any<Hint>()
+            Arg.Any<SentryHint>()
             );
     }
 
@@ -244,7 +244,7 @@ public partial class MeasurementTests
                 t.Measurements["foo"].Value.As<ulong>() == ulong.MaxValue &&
                 t.Measurements["foo"].Unit == EmptyUnit),
             Arg.Any<Scope>(),
-            Arg.Any<Hint>()
+            Arg.Any<SentryHint>()
             );
     }
 
@@ -272,7 +272,7 @@ public partial class MeasurementTests
                 Math.Abs(t.Measurements["foo"].Value.As<double>() - double.MaxValue) < double.Epsilon &&
                 t.Measurements["foo"].Unit == EmptyUnit),
             Arg.Any<Scope>(),
-            Arg.Any<Hint>()
+            Arg.Any<SentryHint>()
         );
     }
 
@@ -300,7 +300,7 @@ public partial class MeasurementTests
                 t.Measurements["foo"].Value.As<int>() == int.MaxValue &&
                 t.Measurements["foo"].Unit == MeasurementUnit.Duration.Nanosecond),
             Arg.Any<Scope>(),
-            Arg.Any<Hint>()
+            Arg.Any<SentryHint>()
             );
     }
 
@@ -328,7 +328,7 @@ public partial class MeasurementTests
                 t.Measurements["foo"].Value.As<long>() == long.MaxValue &&
                 t.Measurements["foo"].Unit == MeasurementUnit.Duration.Nanosecond),
             Arg.Any<Scope>(),
-            Arg.Any<Hint>()
+            Arg.Any<SentryHint>()
             );
     }
 
@@ -356,7 +356,7 @@ public partial class MeasurementTests
                 t.Measurements["foo"].Value.As<ulong>() == ulong.MaxValue &&
                 t.Measurements["foo"].Unit == MeasurementUnit.Duration.Nanosecond),
             Arg.Any<Scope>(),
-            Arg.Any<Hint>()
+            Arg.Any<SentryHint>()
             );
     }
 
@@ -384,7 +384,7 @@ public partial class MeasurementTests
                 Math.Abs(t.Measurements["foo"].Value.As<double>() - double.MaxValue) < double.Epsilon &&
                 t.Measurements["foo"].Unit == MeasurementUnit.Duration.Nanosecond),
             Arg.Any<Scope>(),
-            Arg.Any<Hint>()
+            Arg.Any<SentryHint>()
             );
     }
 }

--- a/test/Sentry.Tests/Protocol/SentryTransactionTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryTransactionTests.cs
@@ -449,7 +449,7 @@ public class SentryTransactionTests
         transaction.Finish();
 
         // Assert
-        client.Received(1).CaptureTransaction(Arg.Any<SentryTransaction>(), Arg.Any<Scope>(), Arg.Any<Hint>());
+        client.Received(1).CaptureTransaction(Arg.Any<SentryTransaction>(), Arg.Any<Scope>(), Arg.Any<SentryHint>());
     }
 
     [Fact]
@@ -478,7 +478,7 @@ public class SentryTransactionTests
                 e.Contexts.Trace.SpanId == transaction.SpanId &&
                 e.Contexts.Trace.ParentSpanId == transaction.ParentSpanId
             ),
-            Arg.Any<Scope>(), Arg.Any<Hint>());
+            Arg.Any<Scope>(), Arg.Any<SentryHint>());
     }
 
     [Fact]

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -295,8 +295,8 @@ public class ScopeTests
     {
         // Arrange
         var scope = new Scope();
-        var attachment = new Attachment(default, default, default, default);
-        var attachment2 = new Attachment(default, default, default, default);
+        var attachment = new SentryAttachment(default, default, default, default);
+        var attachment2 = new SentryAttachment(default, default, default, default);
 
         // Act
         scope.AddAttachment(attachment);
@@ -400,7 +400,7 @@ public class ScopeTests
     {
         // Arrange
         var options = new SentryOptions();
-        Hint receivedHint = null;
+        SentryHint receivedHint = null;
         options.SetBeforeBreadcrumb((breadcrumb, hint) =>
         {
             receivedHint = hint;
@@ -409,7 +409,7 @@ public class ScopeTests
         var scope = new Scope(options);
 
         // Act
-        var expectedHint = new Hint();
+        var expectedHint = new SentryHint();
         scope.AddBreadcrumb(new Breadcrumb(), expectedHint);
 
         // Assert
@@ -421,7 +421,7 @@ public class ScopeTests
     {
         // Arrange
         var options = new SentryOptions();
-        Hint hint = null;
+        SentryHint hint = null;
         options.SetBeforeBreadcrumb((b, h) =>
         {
             hint = h;
@@ -633,7 +633,7 @@ public static class ScopeTestExtensions
         scope.AddBreadcrumb(new(message: $"{salt} breadcrumb"));
         scope.SetExtra("extra", $"{salt} extra");
         scope.SetTag("tag", $"{salt} tag");
-        scope.AddAttachment(new Attachment(default, default, default, $"{salt} attachment"));
+        scope.AddAttachment(new SentryAttachment(default, default, default, $"{salt} attachment"));
     }
 
     public static void ShouldBeEquivalentTo(this Scope source, Scope target)

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -326,7 +326,7 @@ public partial class SentryClientTests
     [Fact]
     public void CaptureEvent_BeforeSend_GetsHint()
     {
-        Hint received = null;
+        SentryHint received = null;
         _fixture.SentryOptions.SetBeforeSend((e, h) =>
         {
             received = h;
@@ -334,7 +334,7 @@ public partial class SentryClientTests
         });
 
         var @event = new SentryEvent();
-        var hint = new Hint();
+        var hint = new SentryHint();
 
         var sut = _fixture.GetSut();
         _ = sut.CaptureEvent(@event, hint: hint);
@@ -346,7 +346,7 @@ public partial class SentryClientTests
     public void CaptureEvent_BeforeSend_Gets_ScopeAttachments()
     {
         // Arrange
-        Hint hint = null;
+        SentryHint hint = null;
         _fixture.SentryOptions.SetBeforeSend((e, h) =>
         {
             hint = h;
@@ -395,7 +395,7 @@ public partial class SentryClientTests
     {
         // Arrange
         var processor = Substitute.For<ISentryEventProcessorWithHint>();
-        processor.Process(Arg.Any<SentryEvent>(), Arg.Any<Hint>()).Returns(new SentryEvent());
+        processor.Process(Arg.Any<SentryEvent>(), Arg.Any<SentryHint>()).Returns(new SentryEvent());
         _fixture.SentryOptions.AddEventProcessor(processor);
 
         // Act
@@ -403,7 +403,7 @@ public partial class SentryClientTests
         _ = sut.CaptureEvent(new SentryEvent());
 
         // Assert
-        processor.Received(1).Process(Arg.Any<SentryEvent>(), Arg.Any<Hint>());
+        processor.Received(1).Process(Arg.Any<SentryEvent>(), Arg.Any<SentryHint>());
     }
 
     [Fact]
@@ -411,8 +411,8 @@ public partial class SentryClientTests
     {
         // Arrange
         var processor = Substitute.For<ISentryEventProcessorWithHint>();
-        Hint hint = null;
-        processor.Process(Arg.Any<SentryEvent>(), Arg.Do<Hint>(h => hint = h)).Returns(new SentryEvent());
+        SentryHint hint = null;
+        processor.Process(Arg.Any<SentryEvent>(), Arg.Do<SentryHint>(h => hint = h)).Returns(new SentryEvent());
         _fixture.SentryOptions.AddEventProcessor(processor);
 
         var scope = new Scope(_fixture.SentryOptions);
@@ -1038,7 +1038,7 @@ public partial class SentryClientTests
             IsSampled = true,
             EndTimestamp = DateTimeOffset.Now // finished
         };
-        var attachments = new List<Attachment> {
+        var attachments = new List<SentryAttachment> {
             AttachmentHelper.FakeAttachment("foo"),
             AttachmentHelper.FakeAttachment("bar")
         };
@@ -1046,7 +1046,7 @@ public partial class SentryClientTests
         scope.AddAttachment(attachments[0]);
         scope.AddAttachment(attachments[1]);
 
-        Hint hint = null;
+        SentryHint hint = null;
         _fixture.SentryOptions.SetBeforeSendTransaction((e, h) =>
         {
             hint = h;
@@ -1066,7 +1066,7 @@ public partial class SentryClientTests
     {
         // Arrange
         var processor = Substitute.For<ISentryTransactionProcessorWithHint>();
-        processor.Process(Arg.Any<SentryTransaction>(), Arg.Any<Hint>()).Returns(new SentryTransaction("name", "operation"));
+        processor.Process(Arg.Any<SentryTransaction>(), Arg.Any<SentryHint>()).Returns(new SentryTransaction("name", "operation"));
         _fixture.SentryOptions.AddTransactionProcessor(processor);
 
         var transaction = new SentryTransaction("name", "operation")
@@ -1079,7 +1079,7 @@ public partial class SentryClientTests
         _fixture.GetSut().CaptureTransaction(transaction);
 
         // Assert
-        processor.Received(1).Process(Arg.Any<SentryTransaction>(), Arg.Any<Hint>());
+        processor.Received(1).Process(Arg.Any<SentryTransaction>(), Arg.Any<SentryHint>());
     }
 
     [Fact]
@@ -1093,14 +1093,14 @@ public partial class SentryClientTests
         };
 
         var processor = Substitute.For<ISentryTransactionProcessorWithHint>();
-        Hint hint = null;
+        SentryHint hint = null;
         processor.Process(
             Arg.Any<SentryTransaction>(),
-            Arg.Do<Hint>(h => hint = h))
+            Arg.Do<SentryHint>(h => hint = h))
             .Returns(new SentryTransaction("name", "operation"));
         _fixture.SentryOptions.AddTransactionProcessor(processor);
 
-        var attachments = new List<Attachment> { AttachmentHelper.FakeAttachment("foo.txt") };
+        var attachments = new List<SentryAttachment> { AttachmentHelper.FakeAttachment("foo.txt") };
         var scope = new Scope(_fixture.SentryOptions);
         scope.AddAttachment(attachments[0]);
 
@@ -1116,7 +1116,7 @@ public partial class SentryClientTests
     [Fact]
     public void CaptureTransaction_BeforeSendTransaction_GetsHint()
     {
-        Hint received = null;
+        SentryHint received = null;
         _fixture.SentryOptions.SetBeforeSendTransaction((tx, h) =>
         {
             received = h;
@@ -1130,7 +1130,7 @@ public partial class SentryClientTests
         };
 
         var sut = _fixture.GetSut();
-        var hint = new Hint();
+        var hint = new SentryHint();
         sut.CaptureTransaction(transaction, null, hint);
 
         Assert.Same(hint, received);

--- a/test/Sentry.Tests/SentryGraphQlHttpFailedRequestHandlerTests.cs
+++ b/test/Sentry.Tests/SentryGraphQlHttpFailedRequestHandlerTests.cs
@@ -100,7 +100,7 @@ public class SentryGraphQlHttpFailedRequestHandlerTests
         // Assert
         hub.Received(1).CaptureEvent(
             Arg.Any<SentryEvent>(),
-            Arg.Any<Scope>(), Arg.Any<Hint>());
+            Arg.Any<Scope>(), Arg.Any<SentryHint>());
     }
 
     [Fact]
@@ -123,7 +123,7 @@ public class SentryGraphQlHttpFailedRequestHandlerTests
         // Assert
         hub.Received(1).CaptureEvent(
             Arg.Any<SentryEvent>(),
-            Arg.Any<Scope>(), Arg.Any<Hint>());
+            Arg.Any<Scope>(), Arg.Any<SentryHint>());
     }
 
     [Fact]
@@ -143,7 +143,7 @@ public class SentryGraphQlHttpFailedRequestHandlerTests
 
         // Act
         SentryEvent @event = null;
-        hub.CaptureEvent(Arg.Do<SentryEvent>(e => @event = e), hint: Arg.Any<Hint>());
+        hub.CaptureEvent(Arg.Do<SentryEvent>(e => @event = e), hint: Arg.Any<SentryHint>());
         sut.HandleResponse(response);
 
         // Assert
@@ -177,7 +177,7 @@ public class SentryGraphQlHttpFailedRequestHandlerTests
         SentryEvent @event = null;
         hub.CaptureEvent(
             Arg.Do<SentryEvent>(e => @event = e),
-            hint: Arg.Any<Hint>()
+            hint: Arg.Any<SentryHint>()
             );
 
         // Act
@@ -233,10 +233,10 @@ public class SentryGraphQlHttpFailedRequestHandlerTests
         response.RequestMessage = SentryGraphQlTestHelpers.GetRequestQuery(ValidQuery);
 
         // Act
-        Hint hint = null;
+        SentryHint hint = null;
         hub.CaptureEvent(
             Arg.Any<SentryEvent>(),
-            hint: Arg.Do<Hint>(h => hint = h)
+            hint: Arg.Do<SentryHint>(h => hint = h)
             );
         sut.HandleResponse(response);
 

--- a/test/Sentry.Tests/SentryHttpFailedRequestHandlerTests.cs
+++ b/test/Sentry.Tests/SentryHttpFailedRequestHandlerTests.cs
@@ -119,7 +119,7 @@ public class SentryHttpFailedRequestHandlerTests
         // Assert
         _hub.Received(1).CaptureEvent(
             Arg.Any<SentryEvent>(),
-            Arg.Any<Scope>(), Arg.Any<Hint>());
+            Arg.Any<Scope>(), Arg.Any<SentryHint>());
     }
 
     [Fact]
@@ -138,7 +138,7 @@ public class SentryHttpFailedRequestHandlerTests
 
         // Act
         SentryEvent @event = null;
-        ((ISentryClient)_hub).CaptureEvent(Arg.Do<SentryEvent>(e => @event = e), hint: Arg.Any<Hint>());
+        ((ISentryClient)_hub).CaptureEvent(Arg.Do<SentryEvent>(e => @event = e), hint: Arg.Any<SentryHint>());
         sut.HandleResponse(response);
 
         // Assert
@@ -170,7 +170,7 @@ public class SentryHttpFailedRequestHandlerTests
         SentryEvent @event = null;
         ((ISentryClient)_hub).CaptureEvent(
             Arg.Do<SentryEvent>(e => @event = e),
-            hint: Arg.Any<Hint>()
+            hint: Arg.Any<SentryHint>()
             );
         sut.HandleResponse(response);
 
@@ -220,7 +220,7 @@ public class SentryHttpFailedRequestHandlerTests
         SentryEvent @event = null;
         ((ISentryClient)_hub).CaptureEvent(
             Arg.Do<SentryEvent>(e => @event = e),
-            hint: Arg.Any<Hint>()
+            hint: Arg.Any<SentryHint>()
             );
         sut.HandleResponse(response);
 
@@ -249,10 +249,10 @@ public class SentryHttpFailedRequestHandlerTests
         response.RequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://foo/bar");
 
         // Act
-        Hint hint = null;
+        SentryHint hint = null;
         ((ISentryClient)_hub).CaptureEvent(
             Arg.Any<SentryEvent>(),
-            hint: Arg.Do<Hint>(h => hint = h)
+            hint: Arg.Do<SentryHint>(h => hint = h)
             );
         sut.HandleResponse(response);
 


### PR DESCRIPTION
Renamed types and interfaces on the root namespace most likely to cause conflicts.