### PR TITLE
fix: Renamed `Contexts`, `Request`, and `Package`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixes
+
+- To resolve conflicting types due to the SDK adding itself to the global usings: 
+ - The class `Sentry.Context` has been renamed to `Sentry.SentryContext` ([#3121](https://github.com/getsentry/sentry-dotnet/pull/3121))
+ - The class `Sentry.Package` has been renamed to `Sentry.SentryPackage` ([#3121](https://github.com/getsentry/sentry-dotnet/pull/3121))
+ - The class `Sentry.Request` has been renamed to `Sentry.SentryRequest` ([#3121](https://github.com/getsentry/sentry-dotnet/pull/3121))
+
 ### Dependencies
 
 - Bump CLI from v2.27.0 to v2.28.0 ([#3119](https://github.com/getsentry/sentry-dotnet/pull/3119))
@@ -16,8 +23,8 @@
  - The interface `Sentry.ISession` has been renamed to `Sentry.ISentrySession` ([#3110](https://github.com/getsentry/sentry-dotnet/pull/3110))
  - The interface `Sentry.IJsonSerializable` has been renamed to `Sentry.ISentryJsonSerializable` ([#3116](https://github.com/getsentry/sentry-dotnet/pull/3116))
  - The class `Sentry.Session` has been renamed to `Sentry.SentrySession` ([#3110](https://github.com/getsentry/sentry-dotnet/pull/3110))
-- The class `Sentry.Attachment` has been renamed to `Sentry.SentryAttachment` ([#3116](https://github.com/getsentry/sentry-dotnet/pull/3116))
-- The class `Sentry.Hint` has been renamed to `Sentry.SentryHint` ([#3116](https://github.com/getsentry/sentry-dotnet/pull/3116))
+ - The class `Sentry.Attachment` has been renamed to `Sentry.SentryAttachment` ([#3116](https://github.com/getsentry/sentry-dotnet/pull/3116))
+ - The class `Sentry.Hint` has been renamed to `Sentry.SentryHint` ([#3116](https://github.com/getsentry/sentry-dotnet/pull/3116))
 
 ### Dependencies
 

--- a/src/Sentry/IEventLike.cs
+++ b/src/Sentry/IEventLike.cs
@@ -32,7 +32,7 @@ public interface IEventLike : IHasTags, IHasExtra
     /// <value>
     /// The HTTP.
     /// </value>
-    Request Request { get; set; }
+    SentryRequest Request { get; set; }
 
     /// <summary>
     /// Gets the structured Sentry context.
@@ -40,7 +40,7 @@ public interface IEventLike : IHasTags, IHasExtra
     /// <value>
     /// The contexts.
     /// </value>
-    Contexts Contexts { get; set; }
+    SentryContexts Contexts { get; set; }
 
     /// <summary>
     /// Gets the user information.

--- a/src/Sentry/Internal/MainSentryEventProcessor.cs
+++ b/src/Sentry/Internal/MainSentryEventProcessor.cs
@@ -158,7 +158,7 @@ internal class MainSentryEventProcessor : ISentryEventProcessor
         return @event;
     }
 
-    private static void AddMemoryInfo(Contexts contexts)
+    private static void AddMemoryInfo(SentryContexts contexts)
     {
 #if NETCOREAPP3_0_OR_GREATER
         var memory = GC.GetGCMemoryInfo();
@@ -192,7 +192,7 @@ internal class MainSentryEventProcessor : ISentryEventProcessor
 #endif
     }
 
-    private static void AddThreadPoolInfo(Contexts contexts)
+    private static void AddThreadPoolInfo(SentryContexts contexts)
     {
         ThreadPool.GetMinThreads(out var minWorkerThreads, out var minCompletionPortThreads);
         ThreadPool.GetMaxThreads(out var maxWorkerThreads, out var maxCompletionPortThreads);

--- a/src/Sentry/Internal/NoOpTransaction.cs
+++ b/src/Sentry/Internal/NoOpTransaction.cs
@@ -39,13 +39,13 @@ internal class NoOpTransaction : NoOpSpan, ITransactionTracer
         set { }
     }
 
-    public Request Request
+    public SentryRequest Request
     {
         get => new();
         set { }
     }
 
-    public Contexts Contexts
+    public SentryContexts Contexts
     {
         get => new();
         set { }

--- a/src/Sentry/Platforms/Cocoa/CocoaEventProcessor.cs
+++ b/src/Sentry/Platforms/Cocoa/CocoaEventProcessor.cs
@@ -16,7 +16,7 @@ internal class CocoaEventProcessor : ISentryEventProcessor, IDisposable
         if (json != null)
         {
             var jsonDoc = JsonDocument.Parse(json);
-            var contexts = Contexts.FromJson(jsonDoc.RootElement);
+            var contexts = SentryContexts.FromJson(jsonDoc.RootElement);
             contexts.CopyTo(@event.Contexts);
         }
 

--- a/src/Sentry/Protocol/ProfileInfo.cs
+++ b/src/Sentry/Protocol/ProfileInfo.cs
@@ -15,10 +15,10 @@ internal sealed class ProfileInfo : ISentryJsonSerializable
 
     public DebugMeta DebugMeta { get; set; } = new() { Images = new() };
 
-    private readonly Contexts _contexts = new();
+    private readonly SentryContexts _contexts = new();
 
     /// <inheritdoc />
-    public Contexts Contexts
+    public SentryContexts Contexts
     {
         get => _contexts;
         set => _contexts.ReplaceWith(value);

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -85,19 +85,19 @@ public class Scope : IEventLike
     /// <inheritdoc />
     public SentryLevel? Level { get; set; }
 
-    private Request? _request;
+    private SentryRequest? _request;
 
     /// <inheritdoc />
-    public Request Request
+    public SentryRequest Request
     {
-        get => _request ??= new Request();
+        get => _request ??= new SentryRequest();
         set => _request = value;
     }
 
-    private readonly Contexts _contexts = new();
+    private readonly SentryContexts _contexts = new();
 
     /// <inheritdoc />
-    public Contexts Contexts
+    public SentryContexts Contexts
     {
         get => _contexts;
         set => _contexts.ReplaceWith(value);

--- a/src/Sentry/SdkVersion.cs
+++ b/src/Sentry/SdkVersion.cs
@@ -19,14 +19,14 @@ public sealed class SdkVersion : ISentryJsonSerializable
 
     internal static SdkVersion Instance => InstanceLazy.Value;
 
-    internal ConcurrentBag<Package> InternalPackages { get; set; } = new();
+    internal ConcurrentBag<SentryPackage> InternalPackages { get; set; } = new();
     internal ConcurrentBag<string> Integrations { get; set; } = new();
 
     /// <summary>
     /// SDK packages.
     /// </summary>
     /// <remarks>This property is not required.</remarks>
-    public IEnumerable<Package> Packages => InternalPackages;
+    public IEnumerable<SentryPackage> Packages => InternalPackages;
 
     /// <summary>
     /// SDK name.
@@ -56,9 +56,9 @@ public sealed class SdkVersion : ISentryJsonSerializable
     /// <param name="name">The package name.</param>
     /// <param name="version">The package version.</param>
     public void AddPackage(string name, string version)
-        => AddPackage(new Package(name, version));
+        => AddPackage(new SentryPackage(name, version));
 
-    internal void AddPackage(Package package)
+    internal void AddPackage(SentryPackage package)
         => InternalPackages.Add(package);
 
     /// <summary>
@@ -88,8 +88,8 @@ public sealed class SdkVersion : ISentryJsonSerializable
     {
         // Packages
         var packages =
-            json.GetPropertyOrNull("packages")?.EnumerateArray().Select(Package.FromJson).ToArray()
-            ?? Array.Empty<Package>();
+            json.GetPropertyOrNull("packages")?.EnumerateArray().Select(SentryPackage.FromJson).ToArray()
+            ?? Array.Empty<SentryPackage>();
 
         // Integrations
         var integrations =
@@ -104,7 +104,7 @@ public sealed class SdkVersion : ISentryJsonSerializable
 
         return new SdkVersion
         {
-            InternalPackages = new ConcurrentBag<Package>(packages),
+            InternalPackages = new ConcurrentBag<SentryPackage>(packages),
             Integrations = new ConcurrentBag<string>(integrations),
             Name = name,
             Version = version

--- a/src/Sentry/SentryContexts.cs
+++ b/src/Sentry/SentryContexts.cs
@@ -11,7 +11,7 @@ namespace Sentry;
 /// Represents Sentry's structured Context.
 /// </summary>
 /// <seealso href="https://develop.sentry.dev/sdk/event-payloads/contexts/" />
-public sealed class Contexts : IDictionary<string, object>, ISentryJsonSerializable
+public sealed class SentryContexts : IDictionary<string, object>, ISentryJsonSerializable
 {
     private readonly ConcurrentDictionary<string, object> _innerDictionary = new(StringComparer.Ordinal);
 
@@ -59,16 +59,16 @@ public sealed class Contexts : IDictionary<string, object>, ISentryJsonSerializa
     public Trace Trace => _innerDictionary.GetOrCreate<Trace>(Trace.Type);
 
     /// <summary>
-    /// Initializes an instance of <see cref="Contexts"/>.
+    /// Initializes an instance of <see cref="SentryContexts"/>.
     /// </summary>
-    public Contexts() { }
+    public SentryContexts() { }
 
     /// <summary>
     /// Creates a deep clone of this context.
     /// </summary>
-    internal Contexts Clone()
+    internal SentryContexts Clone()
     {
-        var context = new Contexts();
+        var context = new SentryContexts();
 
         CopyTo(context);
 
@@ -78,7 +78,7 @@ public sealed class Contexts : IDictionary<string, object>, ISentryJsonSerializa
     /// <summary>
     /// Copies the items of the context while cloning the known types.
     /// </summary>
-    internal void CopyTo(Contexts to)
+    internal void CopyTo(SentryContexts to)
     {
         foreach (var kv in this)
         {
@@ -126,9 +126,9 @@ public sealed class Contexts : IDictionary<string, object>, ISentryJsonSerializa
     /// <summary>
     /// Parses from JSON.
     /// </summary>
-    public static Contexts FromJson(JsonElement json)
+    public static SentryContexts FromJson(JsonElement json)
     {
-        var result = new Contexts();
+        var result = new SentryContexts();
 
         foreach (var (name, value) in json.EnumerateObject())
         {
@@ -181,7 +181,7 @@ public sealed class Contexts : IDictionary<string, object>, ISentryJsonSerializa
         return result;
     }
 
-    internal void ReplaceWith(Contexts? contexts)
+    internal void ReplaceWith(SentryContexts? contexts)
     {
         Clear();
 
@@ -196,7 +196,7 @@ public sealed class Contexts : IDictionary<string, object>, ISentryJsonSerializa
         }
     }
 
-    internal Contexts? NullIfEmpty() => _innerDictionary.IsEmpty ? null : this;
+    internal SentryContexts? NullIfEmpty() => _innerDictionary.IsEmpty ? null : this;
 
     /// <inheritdoc/>
     public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => _innerDictionary.GetEnumerator();

--- a/src/Sentry/SentryEvent.cs
+++ b/src/Sentry/SentryEvent.cs
@@ -120,19 +120,19 @@ public sealed class SentryEvent : IEventLike, ISentryJsonSerializable
     /// <inheritdoc />
     public string? TransactionName { get; set; }
 
-    private Request? _request;
+    private SentryRequest? _request;
 
     /// <inheritdoc />
-    public Request Request
+    public SentryRequest Request
     {
-        get => _request ??= new Request();
+        get => _request ??= new SentryRequest();
         set => _request = value;
     }
 
-    private readonly Contexts _contexts = new();
+    private readonly SentryContexts _contexts = new();
 
     /// <inheritdoc />
-    public Contexts Contexts
+    public SentryContexts Contexts
     {
         get => _contexts;
         set => _contexts.ReplaceWith(value);
@@ -301,8 +301,8 @@ public sealed class SentryEvent : IEventLike, ISentryJsonSerializable
         var threadValues = json.GetPropertyOrNull("threads")?.GetPropertyOrNull("values")?.EnumerateArray().Select(SentryThread.FromJson).ToList().Pipe(v => new SentryValues<SentryThread>(v));
         var level = json.GetPropertyOrNull("level")?.GetString()?.ParseEnum<SentryLevel>();
         var transaction = json.GetPropertyOrNull("transaction")?.GetString();
-        var request = json.GetPropertyOrNull("request")?.Pipe(Request.FromJson);
-        var contexts = json.GetPropertyOrNull("contexts")?.Pipe(Contexts.FromJson);
+        var request = json.GetPropertyOrNull("request")?.Pipe(SentryRequest.FromJson);
+        var contexts = json.GetPropertyOrNull("contexts")?.Pipe(SentryContexts.FromJson);
         var user = json.GetPropertyOrNull("user")?.Pipe(SentryUser.FromJson);
         var environment = json.GetPropertyOrNull("environment")?.GetString();
         var sdk = json.GetPropertyOrNull("sdk")?.Pipe(SdkVersion.FromJson) ?? new SdkVersion();

--- a/src/Sentry/SentryGraphQLHttpFailedRequestHandler.cs
+++ b/src/Sentry/SentryGraphQLHttpFailedRequestHandler.cs
@@ -44,7 +44,7 @@ internal class SentryGraphQLHttpFailedRequestHandler : SentryFailedRequestHandle
             var @event = new SentryEvent(exception);
             var hint = new SentryHint(HintTypes.HttpResponseMessage, response);
 
-            var sentryRequest = new Request
+            var sentryRequest = new SentryRequest
             {
                 QueryString = request.RequestUri?.Query,
                 Method = request.Method.Method.ToUpperInvariant(),

--- a/src/Sentry/SentryHttpFailedRequestHandler.cs
+++ b/src/Sentry/SentryHttpFailedRequestHandler.cs
@@ -45,7 +45,7 @@ internal class SentryHttpFailedRequestHandler : SentryFailedRequestHandler
             var hint = new SentryHint(HintTypes.HttpResponseMessage, response);
 
             var uri = response.RequestMessage?.RequestUri;
-            var sentryRequest = new Request
+            var sentryRequest = new SentryRequest
             {
                 QueryString = uri?.Query,
                 Method = response.RequestMessage?.Method.Method.ToUpperInvariant()

--- a/src/Sentry/SentryPackage.cs
+++ b/src/Sentry/SentryPackage.cs
@@ -6,7 +6,7 @@ namespace Sentry;
 /// <summary>
 /// Represents a package used to compose the SDK.
 /// </summary>
-public sealed class Package : ISentryJsonSerializable
+public sealed class SentryPackage : ISentryJsonSerializable
 {
     /// <summary>
     /// The name of the package.
@@ -26,11 +26,11 @@ public sealed class Package : ISentryJsonSerializable
     public string Version { get; }
 
     /// <summary>
-    /// Creates a new instance of a <see cref="Package"/>.
+    /// Creates a new instance of a <see cref="SentryPackage"/>.
     /// </summary>
     /// <param name="name">The package name.</param>
     /// <param name="version">The package version.</param>
-    public Package(string name, string version)
+    public SentryPackage(string name, string version)
     {
         Name = name;
         Version = version;
@@ -50,12 +50,12 @@ public sealed class Package : ISentryJsonSerializable
     /// <summary>
     /// Parses from JSON.
     /// </summary>
-    public static Package FromJson(JsonElement json)
+    public static SentryPackage FromJson(JsonElement json)
     {
         var name = json.GetProperty("name").GetStringOrThrow();
         var version = json.GetProperty("version").GetStringOrThrow();
 
-        return new Package(name, version);
+        return new SentryPackage(name, version);
     }
 
     /// <inheritdoc />
@@ -75,7 +75,7 @@ public sealed class Package : ISentryJsonSerializable
             return true;
         }
 
-        if (obj is Package package)
+        if (obj is SentryPackage package)
         {
             return Name == package.Name && Version == package.Version;
         }

--- a/src/Sentry/SentryRequest.cs
+++ b/src/Sentry/SentryRequest.cs
@@ -25,7 +25,7 @@ namespace Sentry;
 /// }
 /// </example>
 /// <see href="https://develop.sentry.dev/sdk/event-payloads/request/"/>
-public sealed class Request : ISentryJsonSerializable
+public sealed class SentryRequest : ISentryJsonSerializable
 {
     internal Dictionary<string, string>? InternalEnv { get; private set; }
 
@@ -113,16 +113,16 @@ public sealed class Request : ISentryJsonSerializable
     /// This is a shallow copy.
     /// References like <see cref="Data"/> could hold a mutable, non-thread-safe object.
     /// </remarks>
-    public Request Clone()
+    public SentryRequest Clone()
     {
-        var request = new Request();
+        var request = new SentryRequest();
 
         CopyTo(request);
 
         return request;
     }
 
-    internal void CopyTo(Request? request)
+    internal void CopyTo(SentryRequest? request)
     {
         if (request == null)
         {
@@ -161,7 +161,7 @@ public sealed class Request : ISentryJsonSerializable
     /// <summary>
     /// Parses from JSON.
     /// </summary>
-    public static Request FromJson(JsonElement json)
+    public static SentryRequest FromJson(JsonElement json)
     {
         var env = json.GetPropertyOrNull("env")?.GetStringDictionaryOrNull();
         var other = json.GetPropertyOrNull("other")?.GetStringDictionaryOrNull();
@@ -172,7 +172,7 @@ public sealed class Request : ISentryJsonSerializable
         var query = json.GetPropertyOrNull("query_string")?.GetString();
         var cookies = json.GetPropertyOrNull("cookies")?.GetString();
 
-        return new Request
+        return new SentryRequest
         {
             InternalEnv = env?.WhereNotNullValue().ToDict(),
             InternalOther = other?.WhereNotNullValue().ToDict(),

--- a/src/Sentry/SentryTransaction.cs
+++ b/src/Sentry/SentryTransaction.cs
@@ -116,19 +116,19 @@ public class SentryTransaction : ITransactionData, ISentryJsonSerializable
     /// <inheritdoc />
     public SentryLevel? Level { get; set; }
 
-    private Request? _request;
+    private SentryRequest? _request;
 
     /// <inheritdoc />
-    public Request Request
+    public SentryRequest Request
     {
-        get => _request ??= new Request();
+        get => _request ??= new SentryRequest();
         set => _request = value;
     }
 
-    private readonly Contexts _contexts = new();
+    private readonly SentryContexts _contexts = new();
 
     /// <inheritdoc />
-    public Contexts Contexts
+    public SentryContexts Contexts
     {
         get => _contexts;
         set => _contexts.ReplaceWith(value);
@@ -367,8 +367,8 @@ public class SentryTransaction : ITransactionData, ISentryJsonSerializable
         var platform = json.GetPropertyOrNull("platform")?.GetString();
         var release = json.GetPropertyOrNull("release")?.GetString();
         var distribution = json.GetPropertyOrNull("dist")?.GetString();
-        var request = json.GetPropertyOrNull("request")?.Pipe(Request.FromJson);
-        var contexts = json.GetPropertyOrNull("contexts")?.Pipe(Contexts.FromJson) ?? new();
+        var request = json.GetPropertyOrNull("request")?.Pipe(SentryRequest.FromJson);
+        var contexts = json.GetPropertyOrNull("contexts")?.Pipe(SentryContexts.FromJson) ?? new();
         var user = json.GetPropertyOrNull("user")?.Pipe(SentryUser.FromJson);
         var environment = json.GetPropertyOrNull("environment")?.GetString();
         var sdk = json.GetPropertyOrNull("sdk")?.Pipe(SdkVersion.FromJson) ?? new SdkVersion();

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -100,19 +100,19 @@ public class TransactionTracer : ITransactionTracer
     /// <inheritdoc />
     public SentryLevel? Level { get; set; }
 
-    private Request? _request;
+    private SentryRequest? _request;
 
     /// <inheritdoc />
-    public Request Request
+    public SentryRequest Request
     {
-        get => _request ??= new Request();
+        get => _request ??= new SentryRequest();
         set => _request = value;
     }
 
-    private readonly Contexts _contexts = new();
+    private readonly SentryContexts _contexts = new();
 
     /// <inheritdoc />
-    public Contexts Contexts
+    public SentryContexts Contexts
     {
         get => _contexts;
         set => _contexts.ReplaceWith(value);

--- a/test/Sentry.Testing/VerifyExtensions.cs
+++ b/test/Sentry.Testing/VerifyExtensions.cs
@@ -26,7 +26,7 @@ public static class VerifyExtensions
             .IgnoreMembers<SentryEvent>(
                 _ => _.Modules,
                 _ => _.Release)
-            .IgnoreMembers<Request>(
+            .IgnoreMembers<SentryRequest>(
                 _ => _.Env,
                 _ => _.Url,
                 _ => _.Headers)
@@ -60,9 +60,9 @@ public static class VerifyExtensions
         }
     }
 
-    private class ContextsConverter : WriteOnlyJsonConverter<Contexts>
+    private class ContextsConverter : WriteOnlyJsonConverter<SentryContexts>
     {
-        public override void Write(VerifyJsonWriter writer, Contexts contexts)
+        public override void Write(VerifyJsonWriter writer, SentryContexts contexts)
         {
             var items = contexts
                 .Where(_ => _.Key != "os" &&

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -67,35 +67,6 @@ namespace Sentry
         public const string Platform = "csharp";
         public const int ProtocolVersion = 7;
     }
-    public sealed class Contexts : Sentry.ISentryJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
-    {
-        public Contexts() { }
-        public Sentry.Protocol.App App { get; }
-        public Sentry.Protocol.Browser Browser { get; }
-        public int Count { get; }
-        public Sentry.Protocol.Device Device { get; }
-        public Sentry.Protocol.Gpu Gpu { get; }
-        public bool IsReadOnly { get; }
-        public object this[string key] { get; set; }
-        public System.Collections.Generic.ICollection<string> Keys { get; }
-        public Sentry.Protocol.OperatingSystem OperatingSystem { get; }
-        public Sentry.Protocol.Response Response { get; }
-        public Sentry.Protocol.Runtime Runtime { get; }
-        public Sentry.Protocol.Trace Trace { get; }
-        public System.Collections.Generic.ICollection<object> Values { get; }
-        public void Add(System.Collections.Generic.KeyValuePair<string, object> item) { }
-        public void Add(string key, object value) { }
-        public void Clear() { }
-        public bool Contains(System.Collections.Generic.KeyValuePair<string, object> item) { }
-        public bool ContainsKey(string key) { }
-        public void CopyTo(System.Collections.Generic.KeyValuePair<string, object>[] array, int arrayIndex) { }
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() { }
-        public bool Remove(System.Collections.Generic.KeyValuePair<string, object> item) { }
-        public bool Remove(string key) { }
-        public bool TryGetValue(string key, out object value) { }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.Contexts FromJson(System.Text.Json.JsonElement json) { }
-    }
     [System.Obsolete("WARNING: This method deliberately causes a crash, and should not be used in a rea" +
         "l application.")]
     public enum CrashType
@@ -196,13 +167,13 @@ namespace Sentry
     public interface IEventLike : Sentry.IHasExtra, Sentry.IHasTags
     {
         System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        Sentry.Contexts Contexts { get; set; }
+        Sentry.SentryContexts Contexts { get; set; }
         string? Distribution { get; set; }
         string? Environment { get; set; }
         System.Collections.Generic.IReadOnlyList<string> Fingerprint { get; set; }
         Sentry.SentryLevel? Level { get; set; }
         string? Release { get; set; }
-        Sentry.Request Request { get; set; }
+        Sentry.SentryRequest Request { get; set; }
         Sentry.SdkVersion Sdk { get; }
         string? TransactionName { get; set; }
         Sentry.SentryUser User { get; set; }
@@ -394,51 +365,25 @@ namespace Sentry
             Exbibyte = 13,
         }
     }
-    public sealed class Package : Sentry.ISentryJsonSerializable
-    {
-        public Package(string name, string version) { }
-        public string Name { get; }
-        public string Version { get; }
-        public override bool Equals(object? obj) { }
-        public override int GetHashCode() { }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.Package FromJson(System.Text.Json.JsonElement json) { }
-    }
     public enum ReportAssembliesMode
     {
         None = 0,
         Version = 1,
         InformationalVersion = 2,
     }
-    public sealed class Request : Sentry.ISentryJsonSerializable
-    {
-        public Request() { }
-        public string? ApiTarget { get; set; }
-        public string? Cookies { get; set; }
-        public object? Data { get; set; }
-        public System.Collections.Generic.IDictionary<string, string> Env { get; }
-        public System.Collections.Generic.IDictionary<string, string> Headers { get; }
-        public string? Method { get; set; }
-        public System.Collections.Generic.IDictionary<string, string> Other { get; }
-        public string? QueryString { get; set; }
-        public string? Url { get; set; }
-        public Sentry.Request Clone() { }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.Request FromJson(System.Text.Json.JsonElement json) { }
-    }
     public class Scope : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags
     {
         public Scope(Sentry.SentryOptions? options) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.SentryAttachment> Attachments { get; }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public string? Distribution { get; set; }
         public string? Environment { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Extra { get; }
         public System.Collections.Generic.IReadOnlyList<string> Fingerprint { get; set; }
         public Sentry.SentryLevel? Level { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public Sentry.SdkVersion Sdk { get; }
         public Sentry.ISpan? Span { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
@@ -480,7 +425,7 @@ namespace Sentry
     {
         public SdkVersion() { }
         public string? Name { get; set; }
-        public System.Collections.Generic.IEnumerable<Sentry.Package> Packages { get; }
+        public System.Collections.Generic.IEnumerable<Sentry.SentryPackage> Packages { get; }
         public string? Version { get; set; }
         public void AddIntegration(string integration) { }
         public void AddPackage(string name, string version) { }
@@ -518,13 +463,42 @@ namespace Sentry
         public static void Flush(this Sentry.ISentryClient client, System.TimeSpan timeout) { }
         public static System.Threading.Tasks.Task FlushAsync(this Sentry.ISentryClient client) { }
     }
+    public sealed class SentryContexts : Sentry.ISentryJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
+    {
+        public SentryContexts() { }
+        public Sentry.Protocol.App App { get; }
+        public Sentry.Protocol.Browser Browser { get; }
+        public int Count { get; }
+        public Sentry.Protocol.Device Device { get; }
+        public Sentry.Protocol.Gpu Gpu { get; }
+        public bool IsReadOnly { get; }
+        public object this[string key] { get; set; }
+        public System.Collections.Generic.ICollection<string> Keys { get; }
+        public Sentry.Protocol.OperatingSystem OperatingSystem { get; }
+        public Sentry.Protocol.Response Response { get; }
+        public Sentry.Protocol.Runtime Runtime { get; }
+        public Sentry.Protocol.Trace Trace { get; }
+        public System.Collections.Generic.ICollection<object> Values { get; }
+        public void Add(System.Collections.Generic.KeyValuePair<string, object> item) { }
+        public void Add(string key, object value) { }
+        public void Clear() { }
+        public bool Contains(System.Collections.Generic.KeyValuePair<string, object> item) { }
+        public bool ContainsKey(string key) { }
+        public void CopyTo(System.Collections.Generic.KeyValuePair<string, object>[] array, int arrayIndex) { }
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() { }
+        public bool Remove(System.Collections.Generic.KeyValuePair<string, object> item) { }
+        public bool Remove(string key) { }
+        public bool TryGetValue(string key, out object value) { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryContexts FromJson(System.Text.Json.JsonElement json) { }
+    }
     [System.Diagnostics.DebuggerDisplay("{GetType().Name,nq}: {EventId,nq}")]
     public sealed class SentryEvent : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable
     {
         public SentryEvent() { }
         public SentryEvent(System.Exception? exception) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public System.Collections.Generic.List<Sentry.Protocol.DebugImage>? DebugImages { get; set; }
         public string? Distribution { get; set; }
         public string? Environment { get; set; }
@@ -538,7 +512,7 @@ namespace Sentry
         public System.Collections.Generic.IDictionary<string, string> Modules { get; }
         public string? Platform { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public Sentry.SdkVersion Sdk { get; }
         public System.Collections.Generic.IEnumerable<Sentry.Protocol.SentryException>? SentryExceptions { get; set; }
         public System.Collections.Generic.IEnumerable<Sentry.SentryThread>? SentryThreads { get; set; }
@@ -738,6 +712,32 @@ namespace Sentry
             where TProcessor : Sentry.Extensibility.ISentryTransactionProcessor { }
         public static Sentry.SentryOptions UseStackTraceFactory(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryStackTraceFactory sentryStackTraceFactory) { }
     }
+    public sealed class SentryPackage : Sentry.ISentryJsonSerializable
+    {
+        public SentryPackage(string name, string version) { }
+        public string Name { get; }
+        public string Version { get; }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryPackage FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class SentryRequest : Sentry.ISentryJsonSerializable
+    {
+        public SentryRequest() { }
+        public string? ApiTarget { get; set; }
+        public string? Cookies { get; set; }
+        public object? Data { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Env { get; }
+        public System.Collections.Generic.IDictionary<string, string> Headers { get; }
+        public string? Method { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Other { get; }
+        public string? QueryString { get; set; }
+        public string? Url { get; set; }
+        public Sentry.SentryRequest Clone() { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryRequest FromJson(System.Text.Json.JsonElement json) { }
+    }
     public static class SentrySdk
     {
         public static bool IsEnabled { get; }
@@ -890,7 +890,7 @@ namespace Sentry
         public SentryTransaction(string name, string operation) { }
         public SentryTransaction(string name, string operation, Sentry.TransactionNameSource nameSource) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public string? Description { get; set; }
         public string? Distribution { get; set; }
         public System.DateTimeOffset? EndTimestamp { get; }
@@ -909,7 +909,7 @@ namespace Sentry
         public Sentry.SpanId? ParentSpanId { get; }
         public string? Platform { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public double? SampleRate { get; }
         public Sentry.SdkVersion Sdk { get; }
         public Sentry.SpanId SpanId { get; }
@@ -1111,7 +1111,7 @@ namespace Sentry
     {
         public TransactionTracer(Sentry.IHub hub, Sentry.ITransactionContext context) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public string? Description { get; set; }
         public string? Distribution { get; set; }
         public System.DateTimeOffset? EndTimestamp { get; }
@@ -1129,7 +1129,7 @@ namespace Sentry
         public Sentry.SpanId? ParentSpanId { get; }
         public string? Platform { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public double? SampleRate { get; }
         public Sentry.SdkVersion Sdk { get; }
         public Sentry.SpanId SpanId { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -67,35 +67,6 @@ namespace Sentry
         public const string Platform = "csharp";
         public const int ProtocolVersion = 7;
     }
-    public sealed class Contexts : Sentry.ISentryJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
-    {
-        public Contexts() { }
-        public Sentry.Protocol.App App { get; }
-        public Sentry.Protocol.Browser Browser { get; }
-        public int Count { get; }
-        public Sentry.Protocol.Device Device { get; }
-        public Sentry.Protocol.Gpu Gpu { get; }
-        public bool IsReadOnly { get; }
-        public object this[string key] { get; set; }
-        public System.Collections.Generic.ICollection<string> Keys { get; }
-        public Sentry.Protocol.OperatingSystem OperatingSystem { get; }
-        public Sentry.Protocol.Response Response { get; }
-        public Sentry.Protocol.Runtime Runtime { get; }
-        public Sentry.Protocol.Trace Trace { get; }
-        public System.Collections.Generic.ICollection<object> Values { get; }
-        public void Add(System.Collections.Generic.KeyValuePair<string, object> item) { }
-        public void Add(string key, object value) { }
-        public void Clear() { }
-        public bool Contains(System.Collections.Generic.KeyValuePair<string, object> item) { }
-        public bool ContainsKey(string key) { }
-        public void CopyTo(System.Collections.Generic.KeyValuePair<string, object>[] array, int arrayIndex) { }
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() { }
-        public bool Remove(System.Collections.Generic.KeyValuePair<string, object> item) { }
-        public bool Remove(string key) { }
-        public bool TryGetValue(string key, out object value) { }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.Contexts FromJson(System.Text.Json.JsonElement json) { }
-    }
     [System.Obsolete("WARNING: This method deliberately causes a crash, and should not be used in a rea" +
         "l application.")]
     public enum CrashType
@@ -196,13 +167,13 @@ namespace Sentry
     public interface IEventLike : Sentry.IHasExtra, Sentry.IHasTags
     {
         System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        Sentry.Contexts Contexts { get; set; }
+        Sentry.SentryContexts Contexts { get; set; }
         string? Distribution { get; set; }
         string? Environment { get; set; }
         System.Collections.Generic.IReadOnlyList<string> Fingerprint { get; set; }
         Sentry.SentryLevel? Level { get; set; }
         string? Release { get; set; }
-        Sentry.Request Request { get; set; }
+        Sentry.SentryRequest Request { get; set; }
         Sentry.SdkVersion Sdk { get; }
         string? TransactionName { get; set; }
         Sentry.SentryUser User { get; set; }
@@ -394,51 +365,25 @@ namespace Sentry
             Exbibyte = 13,
         }
     }
-    public sealed class Package : Sentry.ISentryJsonSerializable
-    {
-        public Package(string name, string version) { }
-        public string Name { get; }
-        public string Version { get; }
-        public override bool Equals(object? obj) { }
-        public override int GetHashCode() { }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.Package FromJson(System.Text.Json.JsonElement json) { }
-    }
     public enum ReportAssembliesMode
     {
         None = 0,
         Version = 1,
         InformationalVersion = 2,
     }
-    public sealed class Request : Sentry.ISentryJsonSerializable
-    {
-        public Request() { }
-        public string? ApiTarget { get; set; }
-        public string? Cookies { get; set; }
-        public object? Data { get; set; }
-        public System.Collections.Generic.IDictionary<string, string> Env { get; }
-        public System.Collections.Generic.IDictionary<string, string> Headers { get; }
-        public string? Method { get; set; }
-        public System.Collections.Generic.IDictionary<string, string> Other { get; }
-        public string? QueryString { get; set; }
-        public string? Url { get; set; }
-        public Sentry.Request Clone() { }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.Request FromJson(System.Text.Json.JsonElement json) { }
-    }
     public class Scope : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags
     {
         public Scope(Sentry.SentryOptions? options) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.SentryAttachment> Attachments { get; }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public string? Distribution { get; set; }
         public string? Environment { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Extra { get; }
         public System.Collections.Generic.IReadOnlyList<string> Fingerprint { get; set; }
         public Sentry.SentryLevel? Level { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public Sentry.SdkVersion Sdk { get; }
         public Sentry.ISpan? Span { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
@@ -480,7 +425,7 @@ namespace Sentry
     {
         public SdkVersion() { }
         public string? Name { get; set; }
-        public System.Collections.Generic.IEnumerable<Sentry.Package> Packages { get; }
+        public System.Collections.Generic.IEnumerable<Sentry.SentryPackage> Packages { get; }
         public string? Version { get; set; }
         public void AddIntegration(string integration) { }
         public void AddPackage(string name, string version) { }
@@ -518,13 +463,42 @@ namespace Sentry
         public static void Flush(this Sentry.ISentryClient client, System.TimeSpan timeout) { }
         public static System.Threading.Tasks.Task FlushAsync(this Sentry.ISentryClient client) { }
     }
+    public sealed class SentryContexts : Sentry.ISentryJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
+    {
+        public SentryContexts() { }
+        public Sentry.Protocol.App App { get; }
+        public Sentry.Protocol.Browser Browser { get; }
+        public int Count { get; }
+        public Sentry.Protocol.Device Device { get; }
+        public Sentry.Protocol.Gpu Gpu { get; }
+        public bool IsReadOnly { get; }
+        public object this[string key] { get; set; }
+        public System.Collections.Generic.ICollection<string> Keys { get; }
+        public Sentry.Protocol.OperatingSystem OperatingSystem { get; }
+        public Sentry.Protocol.Response Response { get; }
+        public Sentry.Protocol.Runtime Runtime { get; }
+        public Sentry.Protocol.Trace Trace { get; }
+        public System.Collections.Generic.ICollection<object> Values { get; }
+        public void Add(System.Collections.Generic.KeyValuePair<string, object> item) { }
+        public void Add(string key, object value) { }
+        public void Clear() { }
+        public bool Contains(System.Collections.Generic.KeyValuePair<string, object> item) { }
+        public bool ContainsKey(string key) { }
+        public void CopyTo(System.Collections.Generic.KeyValuePair<string, object>[] array, int arrayIndex) { }
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() { }
+        public bool Remove(System.Collections.Generic.KeyValuePair<string, object> item) { }
+        public bool Remove(string key) { }
+        public bool TryGetValue(string key, out object value) { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryContexts FromJson(System.Text.Json.JsonElement json) { }
+    }
     [System.Diagnostics.DebuggerDisplay("{GetType().Name,nq}: {EventId,nq}")]
     public sealed class SentryEvent : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable
     {
         public SentryEvent() { }
         public SentryEvent(System.Exception? exception) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public System.Collections.Generic.List<Sentry.Protocol.DebugImage>? DebugImages { get; set; }
         public string? Distribution { get; set; }
         public string? Environment { get; set; }
@@ -538,7 +512,7 @@ namespace Sentry
         public System.Collections.Generic.IDictionary<string, string> Modules { get; }
         public string? Platform { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public Sentry.SdkVersion Sdk { get; }
         public System.Collections.Generic.IEnumerable<Sentry.Protocol.SentryException>? SentryExceptions { get; set; }
         public System.Collections.Generic.IEnumerable<Sentry.SentryThread>? SentryThreads { get; set; }
@@ -738,6 +712,32 @@ namespace Sentry
             where TProcessor : Sentry.Extensibility.ISentryTransactionProcessor { }
         public static Sentry.SentryOptions UseStackTraceFactory(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryStackTraceFactory sentryStackTraceFactory) { }
     }
+    public sealed class SentryPackage : Sentry.ISentryJsonSerializable
+    {
+        public SentryPackage(string name, string version) { }
+        public string Name { get; }
+        public string Version { get; }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryPackage FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class SentryRequest : Sentry.ISentryJsonSerializable
+    {
+        public SentryRequest() { }
+        public string? ApiTarget { get; set; }
+        public string? Cookies { get; set; }
+        public object? Data { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Env { get; }
+        public System.Collections.Generic.IDictionary<string, string> Headers { get; }
+        public string? Method { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Other { get; }
+        public string? QueryString { get; set; }
+        public string? Url { get; set; }
+        public Sentry.SentryRequest Clone() { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryRequest FromJson(System.Text.Json.JsonElement json) { }
+    }
     public static class SentrySdk
     {
         public static bool IsEnabled { get; }
@@ -890,7 +890,7 @@ namespace Sentry
         public SentryTransaction(string name, string operation) { }
         public SentryTransaction(string name, string operation, Sentry.TransactionNameSource nameSource) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public string? Description { get; set; }
         public string? Distribution { get; set; }
         public System.DateTimeOffset? EndTimestamp { get; }
@@ -909,7 +909,7 @@ namespace Sentry
         public Sentry.SpanId? ParentSpanId { get; }
         public string? Platform { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public double? SampleRate { get; }
         public Sentry.SdkVersion Sdk { get; }
         public Sentry.SpanId SpanId { get; }
@@ -1111,7 +1111,7 @@ namespace Sentry
     {
         public TransactionTracer(Sentry.IHub hub, Sentry.ITransactionContext context) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public string? Description { get; set; }
         public string? Distribution { get; set; }
         public System.DateTimeOffset? EndTimestamp { get; }
@@ -1129,7 +1129,7 @@ namespace Sentry
         public Sentry.SpanId? ParentSpanId { get; }
         public string? Platform { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public double? SampleRate { get; }
         public Sentry.SdkVersion Sdk { get; }
         public Sentry.SpanId SpanId { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -67,35 +67,6 @@ namespace Sentry
         public const string Platform = "csharp";
         public const int ProtocolVersion = 7;
     }
-    public sealed class Contexts : Sentry.ISentryJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
-    {
-        public Contexts() { }
-        public Sentry.Protocol.App App { get; }
-        public Sentry.Protocol.Browser Browser { get; }
-        public int Count { get; }
-        public Sentry.Protocol.Device Device { get; }
-        public Sentry.Protocol.Gpu Gpu { get; }
-        public bool IsReadOnly { get; }
-        public object this[string key] { get; set; }
-        public System.Collections.Generic.ICollection<string> Keys { get; }
-        public Sentry.Protocol.OperatingSystem OperatingSystem { get; }
-        public Sentry.Protocol.Response Response { get; }
-        public Sentry.Protocol.Runtime Runtime { get; }
-        public Sentry.Protocol.Trace Trace { get; }
-        public System.Collections.Generic.ICollection<object> Values { get; }
-        public void Add(System.Collections.Generic.KeyValuePair<string, object> item) { }
-        public void Add(string key, object value) { }
-        public void Clear() { }
-        public bool Contains(System.Collections.Generic.KeyValuePair<string, object> item) { }
-        public bool ContainsKey(string key) { }
-        public void CopyTo(System.Collections.Generic.KeyValuePair<string, object>[] array, int arrayIndex) { }
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() { }
-        public bool Remove(System.Collections.Generic.KeyValuePair<string, object> item) { }
-        public bool Remove(string key) { }
-        public bool TryGetValue(string key, out object value) { }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.Contexts FromJson(System.Text.Json.JsonElement json) { }
-    }
     [System.Obsolete("WARNING: This method deliberately causes a crash, and should not be used in a rea" +
         "l application.")]
     public enum CrashType
@@ -197,13 +168,13 @@ namespace Sentry
     public interface IEventLike : Sentry.IHasExtra, Sentry.IHasTags
     {
         System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        Sentry.Contexts Contexts { get; set; }
+        Sentry.SentryContexts Contexts { get; set; }
         string? Distribution { get; set; }
         string? Environment { get; set; }
         System.Collections.Generic.IReadOnlyList<string> Fingerprint { get; set; }
         Sentry.SentryLevel? Level { get; set; }
         string? Release { get; set; }
-        Sentry.Request Request { get; set; }
+        Sentry.SentryRequest Request { get; set; }
         Sentry.SdkVersion Sdk { get; }
         string? TransactionName { get; set; }
         Sentry.SentryUser User { get; set; }
@@ -395,51 +366,25 @@ namespace Sentry
             Exbibyte = 13,
         }
     }
-    public sealed class Package : Sentry.ISentryJsonSerializable
-    {
-        public Package(string name, string version) { }
-        public string Name { get; }
-        public string Version { get; }
-        public override bool Equals(object? obj) { }
-        public override int GetHashCode() { }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.Package FromJson(System.Text.Json.JsonElement json) { }
-    }
     public enum ReportAssembliesMode
     {
         None = 0,
         Version = 1,
         InformationalVersion = 2,
     }
-    public sealed class Request : Sentry.ISentryJsonSerializable
-    {
-        public Request() { }
-        public string? ApiTarget { get; set; }
-        public string? Cookies { get; set; }
-        public object? Data { get; set; }
-        public System.Collections.Generic.IDictionary<string, string> Env { get; }
-        public System.Collections.Generic.IDictionary<string, string> Headers { get; }
-        public string? Method { get; set; }
-        public System.Collections.Generic.IDictionary<string, string> Other { get; }
-        public string? QueryString { get; set; }
-        public string? Url { get; set; }
-        public Sentry.Request Clone() { }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.Request FromJson(System.Text.Json.JsonElement json) { }
-    }
     public class Scope : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags
     {
         public Scope(Sentry.SentryOptions? options) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.SentryAttachment> Attachments { get; }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public string? Distribution { get; set; }
         public string? Environment { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Extra { get; }
         public System.Collections.Generic.IReadOnlyList<string> Fingerprint { get; set; }
         public Sentry.SentryLevel? Level { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public Sentry.SdkVersion Sdk { get; }
         public Sentry.ISpan? Span { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
@@ -481,7 +426,7 @@ namespace Sentry
     {
         public SdkVersion() { }
         public string? Name { get; set; }
-        public System.Collections.Generic.IEnumerable<Sentry.Package> Packages { get; }
+        public System.Collections.Generic.IEnumerable<Sentry.SentryPackage> Packages { get; }
         public string? Version { get; set; }
         public void AddIntegration(string integration) { }
         public void AddPackage(string name, string version) { }
@@ -519,13 +464,42 @@ namespace Sentry
         public static void Flush(this Sentry.ISentryClient client, System.TimeSpan timeout) { }
         public static System.Threading.Tasks.Task FlushAsync(this Sentry.ISentryClient client) { }
     }
+    public sealed class SentryContexts : Sentry.ISentryJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
+    {
+        public SentryContexts() { }
+        public Sentry.Protocol.App App { get; }
+        public Sentry.Protocol.Browser Browser { get; }
+        public int Count { get; }
+        public Sentry.Protocol.Device Device { get; }
+        public Sentry.Protocol.Gpu Gpu { get; }
+        public bool IsReadOnly { get; }
+        public object this[string key] { get; set; }
+        public System.Collections.Generic.ICollection<string> Keys { get; }
+        public Sentry.Protocol.OperatingSystem OperatingSystem { get; }
+        public Sentry.Protocol.Response Response { get; }
+        public Sentry.Protocol.Runtime Runtime { get; }
+        public Sentry.Protocol.Trace Trace { get; }
+        public System.Collections.Generic.ICollection<object> Values { get; }
+        public void Add(System.Collections.Generic.KeyValuePair<string, object> item) { }
+        public void Add(string key, object value) { }
+        public void Clear() { }
+        public bool Contains(System.Collections.Generic.KeyValuePair<string, object> item) { }
+        public bool ContainsKey(string key) { }
+        public void CopyTo(System.Collections.Generic.KeyValuePair<string, object>[] array, int arrayIndex) { }
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() { }
+        public bool Remove(System.Collections.Generic.KeyValuePair<string, object> item) { }
+        public bool Remove(string key) { }
+        public bool TryGetValue(string key, out object value) { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryContexts FromJson(System.Text.Json.JsonElement json) { }
+    }
     [System.Diagnostics.DebuggerDisplay("{GetType().Name,nq}: {EventId,nq}")]
     public sealed class SentryEvent : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable
     {
         public SentryEvent() { }
         public SentryEvent(System.Exception? exception) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public System.Collections.Generic.List<Sentry.Protocol.DebugImage>? DebugImages { get; set; }
         public string? Distribution { get; set; }
         public string? Environment { get; set; }
@@ -539,7 +513,7 @@ namespace Sentry
         public System.Collections.Generic.IDictionary<string, string> Modules { get; }
         public string? Platform { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public Sentry.SdkVersion Sdk { get; }
         public System.Collections.Generic.IEnumerable<Sentry.Protocol.SentryException>? SentryExceptions { get; set; }
         public System.Collections.Generic.IEnumerable<Sentry.SentryThread>? SentryThreads { get; set; }
@@ -740,6 +714,32 @@ namespace Sentry
             where TProcessor : Sentry.Extensibility.ISentryTransactionProcessor { }
         public static Sentry.SentryOptions UseStackTraceFactory(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryStackTraceFactory sentryStackTraceFactory) { }
     }
+    public sealed class SentryPackage : Sentry.ISentryJsonSerializable
+    {
+        public SentryPackage(string name, string version) { }
+        public string Name { get; }
+        public string Version { get; }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryPackage FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class SentryRequest : Sentry.ISentryJsonSerializable
+    {
+        public SentryRequest() { }
+        public string? ApiTarget { get; set; }
+        public string? Cookies { get; set; }
+        public object? Data { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Env { get; }
+        public System.Collections.Generic.IDictionary<string, string> Headers { get; }
+        public string? Method { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Other { get; }
+        public string? QueryString { get; set; }
+        public string? Url { get; set; }
+        public Sentry.SentryRequest Clone() { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryRequest FromJson(System.Text.Json.JsonElement json) { }
+    }
     public static class SentrySdk
     {
         public static bool IsEnabled { get; }
@@ -892,7 +892,7 @@ namespace Sentry
         public SentryTransaction(string name, string operation) { }
         public SentryTransaction(string name, string operation, Sentry.TransactionNameSource nameSource) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public string? Description { get; set; }
         public string? Distribution { get; set; }
         public System.DateTimeOffset? EndTimestamp { get; }
@@ -911,7 +911,7 @@ namespace Sentry
         public Sentry.SpanId? ParentSpanId { get; }
         public string? Platform { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public double? SampleRate { get; }
         public Sentry.SdkVersion Sdk { get; }
         public Sentry.SpanId SpanId { get; }
@@ -1113,7 +1113,7 @@ namespace Sentry
     {
         public TransactionTracer(Sentry.IHub hub, Sentry.ITransactionContext context) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public string? Description { get; set; }
         public string? Distribution { get; set; }
         public System.DateTimeOffset? EndTimestamp { get; }
@@ -1131,7 +1131,7 @@ namespace Sentry
         public Sentry.SpanId? ParentSpanId { get; }
         public string? Platform { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public double? SampleRate { get; }
         public Sentry.SdkVersion Sdk { get; }
         public Sentry.SpanId SpanId { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -67,35 +67,6 @@ namespace Sentry
         public const string Platform = "csharp";
         public const int ProtocolVersion = 7;
     }
-    public sealed class Contexts : Sentry.ISentryJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
-    {
-        public Contexts() { }
-        public Sentry.Protocol.App App { get; }
-        public Sentry.Protocol.Browser Browser { get; }
-        public int Count { get; }
-        public Sentry.Protocol.Device Device { get; }
-        public Sentry.Protocol.Gpu Gpu { get; }
-        public bool IsReadOnly { get; }
-        public object this[string key] { get; set; }
-        public System.Collections.Generic.ICollection<string> Keys { get; }
-        public Sentry.Protocol.OperatingSystem OperatingSystem { get; }
-        public Sentry.Protocol.Response Response { get; }
-        public Sentry.Protocol.Runtime Runtime { get; }
-        public Sentry.Protocol.Trace Trace { get; }
-        public System.Collections.Generic.ICollection<object> Values { get; }
-        public void Add(System.Collections.Generic.KeyValuePair<string, object> item) { }
-        public void Add(string key, object value) { }
-        public void Clear() { }
-        public bool Contains(System.Collections.Generic.KeyValuePair<string, object> item) { }
-        public bool ContainsKey(string key) { }
-        public void CopyTo(System.Collections.Generic.KeyValuePair<string, object>[] array, int arrayIndex) { }
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() { }
-        public bool Remove(System.Collections.Generic.KeyValuePair<string, object> item) { }
-        public bool Remove(string key) { }
-        public bool TryGetValue(string key, out object value) { }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.Contexts FromJson(System.Text.Json.JsonElement json) { }
-    }
     [System.Obsolete("WARNING: This method deliberately causes a crash, and should not be used in a rea" +
         "l application.")]
     public enum CrashType
@@ -195,13 +166,13 @@ namespace Sentry
     public interface IEventLike : Sentry.IHasExtra, Sentry.IHasTags
     {
         System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        Sentry.Contexts Contexts { get; set; }
+        Sentry.SentryContexts Contexts { get; set; }
         string? Distribution { get; set; }
         string? Environment { get; set; }
         System.Collections.Generic.IReadOnlyList<string> Fingerprint { get; set; }
         Sentry.SentryLevel? Level { get; set; }
         string? Release { get; set; }
-        Sentry.Request Request { get; set; }
+        Sentry.SentryRequest Request { get; set; }
         Sentry.SdkVersion Sdk { get; }
         string? TransactionName { get; set; }
         Sentry.SentryUser User { get; set; }
@@ -393,51 +364,25 @@ namespace Sentry
             Exbibyte = 13,
         }
     }
-    public sealed class Package : Sentry.ISentryJsonSerializable
-    {
-        public Package(string name, string version) { }
-        public string Name { get; }
-        public string Version { get; }
-        public override bool Equals(object? obj) { }
-        public override int GetHashCode() { }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.Package FromJson(System.Text.Json.JsonElement json) { }
-    }
     public enum ReportAssembliesMode
     {
         None = 0,
         Version = 1,
         InformationalVersion = 2,
     }
-    public sealed class Request : Sentry.ISentryJsonSerializable
-    {
-        public Request() { }
-        public string? ApiTarget { get; set; }
-        public string? Cookies { get; set; }
-        public object? Data { get; set; }
-        public System.Collections.Generic.IDictionary<string, string> Env { get; }
-        public System.Collections.Generic.IDictionary<string, string> Headers { get; }
-        public string? Method { get; set; }
-        public System.Collections.Generic.IDictionary<string, string> Other { get; }
-        public string? QueryString { get; set; }
-        public string? Url { get; set; }
-        public Sentry.Request Clone() { }
-        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
-        public static Sentry.Request FromJson(System.Text.Json.JsonElement json) { }
-    }
     public class Scope : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags
     {
         public Scope(Sentry.SentryOptions? options) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.SentryAttachment> Attachments { get; }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public string? Distribution { get; set; }
         public string? Environment { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Extra { get; }
         public System.Collections.Generic.IReadOnlyList<string> Fingerprint { get; set; }
         public Sentry.SentryLevel? Level { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public Sentry.SdkVersion Sdk { get; }
         public Sentry.ISpan? Span { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get; }
@@ -479,7 +424,7 @@ namespace Sentry
     {
         public SdkVersion() { }
         public string? Name { get; set; }
-        public System.Collections.Generic.IEnumerable<Sentry.Package> Packages { get; }
+        public System.Collections.Generic.IEnumerable<Sentry.SentryPackage> Packages { get; }
         public string? Version { get; set; }
         public void AddIntegration(string integration) { }
         public void AddPackage(string name, string version) { }
@@ -517,13 +462,42 @@ namespace Sentry
         public static void Flush(this Sentry.ISentryClient client, System.TimeSpan timeout) { }
         public static System.Threading.Tasks.Task FlushAsync(this Sentry.ISentryClient client) { }
     }
+    public sealed class SentryContexts : Sentry.ISentryJsonSerializable, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
+    {
+        public SentryContexts() { }
+        public Sentry.Protocol.App App { get; }
+        public Sentry.Protocol.Browser Browser { get; }
+        public int Count { get; }
+        public Sentry.Protocol.Device Device { get; }
+        public Sentry.Protocol.Gpu Gpu { get; }
+        public bool IsReadOnly { get; }
+        public object this[string key] { get; set; }
+        public System.Collections.Generic.ICollection<string> Keys { get; }
+        public Sentry.Protocol.OperatingSystem OperatingSystem { get; }
+        public Sentry.Protocol.Response Response { get; }
+        public Sentry.Protocol.Runtime Runtime { get; }
+        public Sentry.Protocol.Trace Trace { get; }
+        public System.Collections.Generic.ICollection<object> Values { get; }
+        public void Add(System.Collections.Generic.KeyValuePair<string, object> item) { }
+        public void Add(string key, object value) { }
+        public void Clear() { }
+        public bool Contains(System.Collections.Generic.KeyValuePair<string, object> item) { }
+        public bool ContainsKey(string key) { }
+        public void CopyTo(System.Collections.Generic.KeyValuePair<string, object>[] array, int arrayIndex) { }
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() { }
+        public bool Remove(System.Collections.Generic.KeyValuePair<string, object> item) { }
+        public bool Remove(string key) { }
+        public bool TryGetValue(string key, out object value) { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryContexts FromJson(System.Text.Json.JsonElement json) { }
+    }
     [System.Diagnostics.DebuggerDisplay("{GetType().Name,nq}: {EventId,nq}")]
     public sealed class SentryEvent : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable
     {
         public SentryEvent() { }
         public SentryEvent(System.Exception? exception) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public System.Collections.Generic.List<Sentry.Protocol.DebugImage>? DebugImages { get; set; }
         public string? Distribution { get; set; }
         public string? Environment { get; set; }
@@ -537,7 +511,7 @@ namespace Sentry
         public System.Collections.Generic.IDictionary<string, string> Modules { get; }
         public string? Platform { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public Sentry.SdkVersion Sdk { get; }
         public System.Collections.Generic.IEnumerable<Sentry.Protocol.SentryException>? SentryExceptions { get; set; }
         public System.Collections.Generic.IEnumerable<Sentry.SentryThread>? SentryThreads { get; set; }
@@ -735,6 +709,32 @@ namespace Sentry
             where TProcessor : Sentry.Extensibility.ISentryTransactionProcessor { }
         public static Sentry.SentryOptions UseStackTraceFactory(this Sentry.SentryOptions options, Sentry.Extensibility.ISentryStackTraceFactory sentryStackTraceFactory) { }
     }
+    public sealed class SentryPackage : Sentry.ISentryJsonSerializable
+    {
+        public SentryPackage(string name, string version) { }
+        public string Name { get; }
+        public string Version { get; }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryPackage FromJson(System.Text.Json.JsonElement json) { }
+    }
+    public sealed class SentryRequest : Sentry.ISentryJsonSerializable
+    {
+        public SentryRequest() { }
+        public string? ApiTarget { get; set; }
+        public string? Cookies { get; set; }
+        public object? Data { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Env { get; }
+        public System.Collections.Generic.IDictionary<string, string> Headers { get; }
+        public string? Method { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Other { get; }
+        public string? QueryString { get; set; }
+        public string? Url { get; set; }
+        public Sentry.SentryRequest Clone() { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
+        public static Sentry.SentryRequest FromJson(System.Text.Json.JsonElement json) { }
+    }
     public static class SentrySdk
     {
         public static bool IsEnabled { get; }
@@ -887,7 +887,7 @@ namespace Sentry
         public SentryTransaction(string name, string operation) { }
         public SentryTransaction(string name, string operation, Sentry.TransactionNameSource nameSource) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public string? Description { get; set; }
         public string? Distribution { get; set; }
         public System.DateTimeOffset? EndTimestamp { get; }
@@ -906,7 +906,7 @@ namespace Sentry
         public Sentry.SpanId? ParentSpanId { get; }
         public string? Platform { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public double? SampleRate { get; }
         public Sentry.SdkVersion Sdk { get; }
         public Sentry.SpanId SpanId { get; }
@@ -1108,7 +1108,7 @@ namespace Sentry
     {
         public TransactionTracer(Sentry.IHub hub, Sentry.ITransactionContext context) { }
         public System.Collections.Generic.IReadOnlyCollection<Sentry.Breadcrumb> Breadcrumbs { get; }
-        public Sentry.Contexts Contexts { get; set; }
+        public Sentry.SentryContexts Contexts { get; set; }
         public string? Description { get; set; }
         public string? Distribution { get; set; }
         public System.DateTimeOffset? EndTimestamp { get; }
@@ -1126,7 +1126,7 @@ namespace Sentry
         public Sentry.SpanId? ParentSpanId { get; }
         public string? Platform { get; set; }
         public string? Release { get; set; }
-        public Sentry.Request Request { get; set; }
+        public Sentry.SentryRequest Request { get; set; }
         public double? SampleRate { get; }
         public Sentry.SdkVersion Sdk { get; }
         public Sentry.SpanId SpanId { get; }

--- a/test/Sentry.Tests/Protocol/BaseScopeTests.cs
+++ b/test/Sentry.Tests/Protocol/BaseScopeTests.cs
@@ -53,7 +53,7 @@ public class BaseScopeTests
     {
         _sut.Contexts.App.Name = "Foo";
 
-        var expected = new Contexts
+        var expected = new SentryContexts
         {
             App =
             {
@@ -76,7 +76,7 @@ public class BaseScopeTests
     [Fact]
     public void Request_Settable()
     {
-        var expected = new Request();
+        var expected = new SentryRequest();
         _sut.Request = expected;
         Assert.Same(expected, _sut.Request);
     }

--- a/test/Sentry.Tests/Protocol/Context/ContextCopyTests.verify.cs
+++ b/test/Sentry.Tests/Protocol/Context/ContextCopyTests.verify.cs
@@ -6,9 +6,9 @@ public class ContextCopyTests
     [Fact]
     public async Task CopyTo_Basic()
     {
-        var target = new Contexts();
+        var target = new SentryContexts();
 
-        var source = new Contexts
+        var source = new SentryContexts
         {
             App = { Name = "Test", Version = "1.2.3" },
             OperatingSystem = { Name = "Android", Version = "999" },
@@ -23,13 +23,13 @@ public class ContextCopyTests
     [Fact]
     public async Task CopyTo_ExistingOtherContexts()
     {
-        var target = new Contexts
+        var target = new SentryContexts
         {
             App = { Name = "Test", Version = "1.2.3" },
             ["Custom1"] = new Dictionary<string, object> { ["A"] = "Foo1", ["B"] = "Bar1", ["C"] = "Baz1" }
         };
 
-        var source = new Contexts
+        var source = new SentryContexts
         {
             OperatingSystem = { Name = "Android", Version = "999" },
             ["Custom2"] = new Dictionary<string, object> { ["A"] = "Foo2", ["B"] = "Bar2", ["C"] = "Baz2" }
@@ -43,13 +43,13 @@ public class ContextCopyTests
     [Fact]
     public async Task CopyTo_ExistingSameContexts()
     {
-        var target = new Contexts
+        var target = new SentryContexts
         {
             App = { Name = "Test", Version = "1.2.3" },
             ["Custom"] = new Dictionary<string, object> { ["A"] = "Foo1", ["B"] = "Bar1" }
         };
 
-        var source = new Contexts
+        var source = new SentryContexts
         {
             App = { Name = "Something Else" },
             ["Custom"] = new Dictionary<string, object> { ["A"] = "Foo2", ["B"] = "Bar2", ["C"] = "Baz2" }
@@ -63,14 +63,14 @@ public class ContextCopyTests
     [Fact]
     public async Task CopyTo_ExistingMixedContexts()
     {
-        var target = new Contexts
+        var target = new SentryContexts
         {
             App = { Name = "Test", Version = "1.2.3" },
             OperatingSystem = { Name = "Android", Version = "999" },
             ["Custom"] = new Dictionary<string, object> { ["A"] = "Foo1", ["B"] = "Bar1" }
         };
 
-        var source = new Contexts
+        var source = new SentryContexts
         {
             App = { Name = "Something Else" },
             ["Custom"] = new Dictionary<string, object> { ["A"] = "Foo2" }

--- a/test/Sentry.Tests/Protocol/Context/ContextsTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/ContextsTests.cs
@@ -14,11 +14,11 @@ public class ContextsTests
     [Fact]
     public void SerializeObject_NoPropertyFilled_SerializesEmptyObject()
     {
-        var sut = new Contexts();
+        var sut = new SentryContexts();
 
         var actualString = sut.ToJsonString(_testOutputLogger);
 
-        var actual = Json.Parse(actualString, Contexts.FromJson);
+        var actual = Json.Parse(actualString, SentryContexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("{}", actualString);
@@ -29,14 +29,14 @@ public class ContextsTests
     {
         const string expectedKey = "server";
         var os = new OperatingSystem { Name = "Linux" };
-        var sut = new Contexts
+        var sut = new SentryContexts
         {
             [expectedKey] = os
         };
 
         var actualString = sut.ToJsonString(_testOutputLogger);
 
-        var actual = Json.Parse(actualString, Contexts.FromJson);
+        var actual = Json.Parse(actualString, SentryContexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("""{"server":{"type":"os","name":"Linux"}}""", actualString);
@@ -45,7 +45,7 @@ public class ContextsTests
     [Fact]
     public void SerializeObject_SingleDevicePropertySet_SerializeSingleProperty()
     {
-        var sut = new Contexts
+        var sut = new SentryContexts
         {
             Device =
             {
@@ -55,7 +55,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString(_testOutputLogger);
 
-        var actual = Json.Parse(actualString, Contexts.FromJson);
+        var actual = Json.Parse(actualString, SentryContexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("""{"device":{"type":"device","arch":"x86"}}""", actualString);
@@ -64,7 +64,7 @@ public class ContextsTests
     [Fact]
     public void SerializeObject_SingleAppPropertySet_SerializeSingleProperty()
     {
-        var sut = new Contexts
+        var sut = new SentryContexts
         {
             App =
             {
@@ -74,7 +74,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString(_testOutputLogger);
 
-        var actual = Json.Parse(actualString, Contexts.FromJson);
+        var actual = Json.Parse(actualString, SentryContexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("""{"app":{"type":"app","app_name":"My.App"}}""", actualString);
@@ -83,7 +83,7 @@ public class ContextsTests
     [Fact]
     public void SerializeObject_SingleGpuPropertySet_SerializeSingleProperty()
     {
-        var sut = new Contexts
+        var sut = new SentryContexts
         {
             Gpu =
             {
@@ -93,7 +93,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString(_testOutputLogger);
 
-        var actual = Json.Parse(actualString, Contexts.FromJson);
+        var actual = Json.Parse(actualString, SentryContexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("""{"gpu":{"type":"gpu","name":"My.Gpu"}}""", actualString);
@@ -102,7 +102,7 @@ public class ContextsTests
     [Fact]
     public void SerializeObject_SingleResponsePropertySet_SerializeSingleProperty()
     {
-        var sut = new Contexts
+        var sut = new SentryContexts
         {
             Response =
             {
@@ -112,7 +112,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString(_testOutputLogger);
 
-        var actual = Json.Parse(actualString, Contexts.FromJson);
+        var actual = Json.Parse(actualString, SentryContexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("""{"response":{"type":"response","status_code":200}}""", actualString);
@@ -121,7 +121,7 @@ public class ContextsTests
     [Fact]
     public void SerializeObject_SingleRuntimePropertySet_SerializeSingleProperty()
     {
-        var sut = new Contexts
+        var sut = new SentryContexts
         {
             Runtime =
             {
@@ -131,7 +131,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString(_testOutputLogger);
 
-        var actual = Json.Parse(actualString, Contexts.FromJson);
+        var actual = Json.Parse(actualString, SentryContexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("""{"runtime":{"type":"runtime","version":"2.1.1.100"}}""", actualString);
@@ -141,14 +141,14 @@ public class ContextsTests
     public void SerializeObject_AnonymousObject_SerializedCorrectly()
     {
         // Arrange
-        var contexts = new Contexts
+        var contexts = new SentryContexts
         {
             ["foo"] = new { Bar = 42, Baz = "kek" }
         };
 
         // Act
         var json = contexts.ToJsonString(_testOutputLogger);
-        var roundtrip = Json.Parse(json, Contexts.FromJson);
+        var roundtrip = Json.Parse(json, SentryContexts.FromJson);
 
         // Assert
         json.Should().Be("""{"foo":{"Bar":42,"Baz":"kek"}}""");
@@ -163,7 +163,7 @@ public class ContextsTests
     [Fact]
     public void SerializeObject_SortsContextKeys()
     {
-        var sut = new Contexts
+        var sut = new SentryContexts
         {
             ["c"] = "3",
             ["a"] = "1",
@@ -178,14 +178,14 @@ public class ContextsTests
     public void SerializeObject_Null_Should_Be_Ignored()
     {
         // Arrange
-        var contexts = new Contexts
+        var contexts = new SentryContexts
         {
             ["key"] = null
         };
 
         // Act
         var json = contexts.ToJsonString(_testOutputLogger);
-        var roundtrip = Json.Parse(json, Contexts.FromJson);
+        var roundtrip = Json.Parse(json, SentryContexts.FromJson);
 
         // Assert
         json.Should().Be("{}");
@@ -196,7 +196,7 @@ public class ContextsTests
     [Fact]
     public void Ctor_SingleBrowserPropertySet_SerializeSingleProperty()
     {
-        var sut = new Contexts
+        var sut = new SentryContexts
         {
             Browser =
             {
@@ -206,7 +206,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString(_testOutputLogger);
 
-        var actual = Json.Parse(actualString, Contexts.FromJson);
+        var actual = Json.Parse(actualString, SentryContexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("""{"browser":{"type":"browser","name":"Netscape 1"}}""", actualString);
@@ -215,7 +215,7 @@ public class ContextsTests
     [Fact]
     public void Ctor_SingleOperatingSystemPropertySet_SerializeSingleProperty()
     {
-        var sut = new Contexts
+        var sut = new SentryContexts
         {
             OperatingSystem =
             {
@@ -225,7 +225,7 @@ public class ContextsTests
 
         var actualString = sut.ToJsonString(_testOutputLogger);
 
-        var actual = Json.Parse(actualString, Contexts.FromJson);
+        var actual = Json.Parse(actualString, SentryContexts.FromJson);
         actual.Should().BeEquivalentTo(sut);
 
         Assert.Equal("""{"os":{"type":"os","name":"BeOS 1"}}""", actualString);
@@ -234,7 +234,7 @@ public class ContextsTests
     [Fact]
     public void Clone_CopyValues()
     {
-        var sut = new Contexts
+        var sut = new SentryContexts
         {
             App =
             {

--- a/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
@@ -629,8 +629,8 @@ public class EnvelopeTests
         var @event = new SentryEvent(ex, timestamp, id)
         {
             User = new SentryUser { Id = "user-id" },
-            Request = new Request { Method = "POST" },
-            Contexts = new Contexts
+            Request = new SentryRequest { Method = "POST" },
+            Contexts = new SentryContexts
             {
                 ["context_key"] = "context_value",
                 ["context_key_with_null_value"] = null

--- a/test/Sentry.Tests/Protocol/PackageTests.cs
+++ b/test/Sentry.Tests/Protocol/PackageTests.cs
@@ -12,7 +12,7 @@ public class PackageTests
     [Fact]
     public void SerializeObject_AllPropertiesSetToNonDefault_SerializesValidObject()
     {
-        var sut = new Package("nuget:Sentry", "1.0.0-preview");
+        var sut = new SentryPackage("nuget:Sentry", "1.0.0-preview");
 
         var actual = sut.ToJsonString(_testOutputLogger);
 
@@ -21,7 +21,7 @@ public class PackageTests
 
     [Theory]
     [MemberData(nameof(TestCases))]
-    public void SerializeObject_TestCase_SerializesAsExpected((Package msg, string serialized) @case)
+    public void SerializeObject_TestCase_SerializesAsExpected((SentryPackage msg, string serialized) @case)
     {
         var actual = @case.msg.ToJsonString(_testOutputLogger);
 
@@ -30,8 +30,8 @@ public class PackageTests
 
     public static IEnumerable<object[]> TestCases()
     {
-        yield return new object[] { (new Package(null, null), "{}") };
-        yield return new object[] { (new Package("nuget:Sentry", null), """{"name":"nuget:Sentry"}""") };
-        yield return new object[] { (new Package(null, "0.0.0-alpha"), """{"version":"0.0.0-alpha"}""") };
+        yield return new object[] { (new SentryPackage(null, null), "{}") };
+        yield return new object[] { (new SentryPackage("nuget:Sentry", null), """{"name":"nuget:Sentry"}""") };
+        yield return new object[] { (new SentryPackage(null, "0.0.0-alpha"), """{"version":"0.0.0-alpha"}""") };
     }
 }

--- a/test/Sentry.Tests/Protocol/RequestTests.cs
+++ b/test/Sentry.Tests/Protocol/RequestTests.cs
@@ -5,7 +5,7 @@ public class RequestTests
     [Fact]
     public void Clone_CopyValues()
     {
-        var sut = new Request
+        var sut = new SentryRequest
         {
             ApiTarget = "graphql",
             Url = "https://sentry.io",

--- a/test/Sentry.Tests/Protocol/ScopeExtensionsTests.cs
+++ b/test/Sentry.Tests/Protocol/ScopeExtensionsTests.cs
@@ -1155,7 +1155,7 @@ public class ScopeExtensionsTests
         var target = _fixture.GetSut();
 
         var sut = _fixture.GetSut();
-        sut.Request = new Request
+        sut.Request = new SentryRequest
         {
             Method = "method"
         };
@@ -1173,7 +1173,7 @@ public class ScopeExtensionsTests
         target.Request.Other.Add("InternalOther", "Other");
 
         var sut = _fixture.GetSut();
-        sut.Request = new Request
+        sut.Request = new SentryRequest
         {
             Env = { { "sut: InternalEnv", "Env" } },
             Headers = { { "sut: InternalHeaders", "Headers" } },
@@ -1191,7 +1191,7 @@ public class ScopeExtensionsTests
     public void Apply_Request_NotOnTarget_SetFromSource()
     {
         var sut = _fixture.GetSut();
-        sut.Request = new Request
+        sut.Request = new SentryRequest
         {
             Env = { { "sut: InternalEnv", "Env" } },
             Headers = { { "sut: InternalHeaders", "Headers" } },
@@ -1221,7 +1221,7 @@ public class ScopeExtensionsTests
     {
         var targetData = new object();
         var target = _fixture.GetSut();
-        var request = new Request
+        var request = new SentryRequest
         {
             Cookies = "cookies",
             Data = targetData,
@@ -1232,7 +1232,7 @@ public class ScopeExtensionsTests
         target.Request = request;
 
         var sut = _fixture.GetSut();
-        sut.Request = new Request
+        sut.Request = new SentryRequest
         {
             Cookies = "sut: cookies",
             Data = new object(),

--- a/test/Sentry.Tests/Protocol/SentryEventTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryEventTests.cs
@@ -114,7 +114,7 @@ public partial class SentryEventTests
             Release = release,
             Distribution = distribution,
             TransactionName = transactionName,
-            Request = new Request
+            Request = new SentryRequest
             {
                 Method = "GET",
                 Url = requestUrl

--- a/test/Sentry.Tests/Protocol/SentryEventTests.verify.cs
+++ b/test/Sentry.Tests/Protocol/SentryEventTests.verify.cs
@@ -12,8 +12,8 @@ public partial class SentryEventTests
         var sut = new SentryEvent(ex, timestamp, id)
         {
             User = new SentryUser { Id = "user-id" },
-            Request = new Request { Method = "POST" },
-            Contexts = new Contexts
+            Request = new SentryRequest { Method = "POST" },
+            Contexts = new SentryContexts
             {
                 ["context_key"] = "context_value",
                 [".NET Framework"] = new Dictionary<string, string>
@@ -49,7 +49,7 @@ public partial class SentryEventTests
             },
         };
 
-        sut.Sdk.AddPackage(new Package("name", "version"));
+        sut.Sdk.AddPackage(new SentryPackage("name", "version"));
         sut.Sdk.AddIntegration("integration");
         sut.AddBreadcrumb(new Breadcrumb(timestamp, "crumb"));
         sut.AddBreadcrumb(new Breadcrumb(

--- a/test/Sentry.Tests/Protocol/SentryTransactionTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryTransactionTests.cs
@@ -91,7 +91,7 @@ public class SentryTransactionTests
             // transaction in the SDK anyway (by default they don't get sent... but the user can always override this
             // behavior if they need)
             User = new SentryUser { Id = "user-id", Username = "username", Email = "bob@foo.com", IpAddress = "127.0.0.1" },
-            Request = new Request { Method = "POST", Url = "https://user@not.redacted" },
+            Request = new SentryRequest { Method = "POST", Url = "https://user@not.redacted" },
             Sdk = new SdkVersion { Name = "SDK-test", Version = "1.1.1" },
             Environment = environment,
             Level = SentryLevel.Fatal,
@@ -107,7 +107,7 @@ public class SentryTransactionTests
             }
         };
 
-        txTracer.Sdk.AddPackage(new Package("name", "version"));
+        txTracer.Sdk.AddPackage(new SentryPackage("name", "version"));
         txTracer.AddBreadcrumb(new Breadcrumb(timestamp, breadcrumbMessage));
         txTracer.AddBreadcrumb(new Breadcrumb(
             timestamp,
@@ -176,7 +176,7 @@ public class SentryTransactionTests
             Description = "desc123",
             Status = SpanStatus.Aborted,
             User = new SentryUser { Id = "user-id" },
-            Request = new Request { Method = "POST" },
+            Request = new SentryRequest { Method = "POST" },
             Sdk = new SdkVersion { Name = "SDK-test", Version = "1.1.1" },
             Environment = "environment",
             Level = SentryLevel.Fatal,
@@ -195,7 +195,7 @@ public class SentryTransactionTests
         // Don't overwrite the contexts object as it contains trace data.
         // See https://github.com/getsentry/sentry-dotnet/issues/752
 
-        transaction.Sdk.AddPackage(new Package("name", "version"));
+        transaction.Sdk.AddPackage(new SentryPackage("name", "version"));
         transaction.AddBreadcrumb(new Breadcrumb(timestamp, "crumb"));
         transaction.AddBreadcrumb(new Breadcrumb(
             timestamp,


### PR DESCRIPTION
Aim to resolve https://github.com/getsentry/sentry-dotnet/issues/3105
I missed the sealed classes when grepping.