### PR TITLE
Added OpenTelemetry.Instrumentation.Runtime metrics to built in metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Added OpenTelemetry.Instrumentation.Runtime to built in metrics ([#3133](https://github.com/getsentry/sentry-dotnet/pull/3133))
+- The SDK now automatically collects metrics coming from `OpenTelemetry.Instrumentation.Runtime` ([#3133](https://github.com/getsentry/sentry-dotnet/pull/3133))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Added OpenTelemetry.Instrumentation.Runtime to built in metrics ([#3133](https://github.com/getsentry/sentry-dotnet/pull/3133))
+
 ### Fixes
 
 - "No service for type 'Sentry.IHub' has been registered" exception when using OpenTelemetry and initializing Sentry via `SentrySdk.Init` ([#3129](https://github.com/getsentry/sentry-dotnet/pull/3129))

--- a/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Program.cs
+++ b/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Program.cs
@@ -14,7 +14,8 @@ builder.Services.AddOpenTelemetry()
     .WithMetrics(metrics =>
     {
         metrics
-            .AddRuntimeInstrumentation()
+            .AddRuntimeInstrumentation() // <-- Requires the OpenTelemetry.Instrumentation.Runtime package
+            // Collect some of the built-in ASP.NET Core metrics
             .AddMeter(
                 "Microsoft.AspNetCore.Hosting",
                 "Microsoft.AspNetCore.Server.Kestrel",
@@ -35,6 +36,7 @@ builder.WebHost.UseSentry(options =>
     options.Debug = builder.Environment.IsDevelopment();
     options.SendDefaultPii = true;
     options.TracesSampleRate = 1.0;
+    // This shows experimental support for capturing OpenTelemetry metrics with Sentry
     options.ExperimentalMetrics = new ExperimentalMetricsOptions()
     {
         CaptureSystemDiagnosticsMeters = BuiltInSystemDiagnosticsMeters.All

--- a/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Program.cs
+++ b/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Program.cs
@@ -15,7 +15,7 @@ builder.Services.AddOpenTelemetry()
     {
         metrics
             .AddRuntimeInstrumentation() // <-- Requires the OpenTelemetry.Instrumentation.Runtime package
-            // Collect some of the built-in ASP.NET Core metrics
+                                         // Collect some of the built-in ASP.NET Core metrics
             .AddMeter(
                 "Microsoft.AspNetCore.Hosting",
                 "Microsoft.AspNetCore.Server.Kestrel",

--- a/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Program.cs
+++ b/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Program.cs
@@ -32,7 +32,7 @@ builder.Services.AddOpenTelemetry()
 
 builder.WebHost.UseSentry(options =>
 {
-    options.Dsn = "...Your DSN...";
+    // options.Dsn = "...Your DSN...";
     options.Debug = builder.Environment.IsDevelopment();
     options.SendDefaultPii = true;
     options.TracesSampleRate = 1.0;

--- a/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Program.cs
+++ b/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Program.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Microsoft.AspNetCore.Authentication;
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Sentry.OpenTelemetry;
@@ -10,6 +11,15 @@ var builder = WebApplication.CreateBuilder(args);
 // OpenTelemetry Configuration
 // See https://opentelemetry.io/docs/instrumentation/net/getting-started/
 builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics =>
+    {
+        metrics
+            .AddRuntimeInstrumentation()
+            .AddMeter(
+                "Microsoft.AspNetCore.Hosting",
+                "Microsoft.AspNetCore.Server.Kestrel",
+                "System.Net.Http");
+    })
     .WithTracing(tracerProviderBuilder =>
         tracerProviderBuilder
             .AddSource(Telemetry.ActivitySource.Name)
@@ -21,10 +31,14 @@ builder.Services.AddOpenTelemetry()
 
 builder.WebHost.UseSentry(options =>
 {
-    //options.Dsn = "...Your DSN...";
+    options.Dsn = "...Your DSN...";
     options.Debug = builder.Environment.IsDevelopment();
     options.SendDefaultPii = true;
     options.TracesSampleRate = 1.0;
+    options.ExperimentalMetrics = new ExperimentalMetricsOptions()
+    {
+        CaptureSystemDiagnosticsMeters = BuiltInSystemDiagnosticsMeters.All
+    };
     options.UseOpenTelemetry(); // <-- Configure Sentry to use OpenTelemetry trace information
 });
 

--- a/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Sentry.Samples.OpenTelemetry.AspNetCore.csproj
+++ b/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Sentry.Samples.OpenTelemetry.AspNetCore.csproj
@@ -7,9 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.5.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sentry.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/ApplicationBuilderExtensions.cs
@@ -39,7 +39,6 @@ internal static class ApplicationBuilderExtensions
             {
                 o.UseStackTraceFactory(stackTraceFactory);
             }
-
         }
 
         var lifetime = app.ApplicationServices.GetService<IHostApplicationLifetime>();

--- a/src/Sentry/BuiltInSystemDiagnosticsMeters.cs
+++ b/src/Sentry/BuiltInSystemDiagnosticsMeters.cs
@@ -15,6 +15,7 @@ public static partial class BuiltInSystemDiagnosticsMeters
     private const string MicrosoftAspNetCoreHttpConnectionsPattern = @"^Microsoft\.AspNetCore\.Http\.Connections$";
     private const string MicrosoftExtensionsDiagnosticsHealthChecksPattern = @"^Microsoft\.Extensions\.Diagnostics\.HealthChecks$";
     private const string MicrosoftExtensionsDiagnosticsResourceMonitoringPattern = @"^Microsoft\.Extensions\.Diagnostics\.ResourceMonitoring$";
+    private const string OpenTelemetryInstrumentationRuntimePattern = @"^OpenTelemetry\.Instrumentation\.Runtime$";
     private const string SystemNetNameResolutionPattern = @"^System\.Net\.NameResolution$";
     private const string SystemNetHttpPattern = @"^System\.Net\.Http$";
 
@@ -130,6 +131,18 @@ public static partial class BuiltInSystemDiagnosticsMeters
     /// Matches the built in System.Net.NameResolution metrics
     /// </summary>
 #if NET8_0_OR_GREATER
+    public static readonly SubstringOrRegexPattern OpenTelemetryInstrumentationRuntime = OpenTelemetryInstrumentationRuntimeRegex();
+
+    [GeneratedRegex(OpenTelemetryInstrumentationRuntimePattern, RegexOptions.Compiled)]
+    private static partial Regex OpenTelemetryInstrumentationRuntimeRegex();
+#else
+    public static readonly SubstringOrRegexPattern OpenTelemetryInstrumentationRuntime = new Regex(OpenTelemetryInstrumentationRuntimePattern, RegexOptions.Compiled);
+#endif
+
+    /// <summary>
+    /// Matches the built in System.Net.NameResolution metrics
+    /// </summary>
+#if NET8_0_OR_GREATER
     public static readonly SubstringOrRegexPattern SystemNetNameResolution = SystemNetNameResolutionRegex();
 
     [GeneratedRegex(SystemNetNameResolutionPattern, RegexOptions.Compiled)]
@@ -159,10 +172,11 @@ public static partial class BuiltInSystemDiagnosticsMeters
         MicrosoftAspNetCoreHeaderParsing,
         MicrosoftAspNetCoreServerKestrel,
         MicrosoftAspNetCoreHttpConnections,
+        MicrosoftExtensionsDiagnosticsHealthChecks,
+        MicrosoftExtensionsDiagnosticsResourceMonitoring,
+        OpenTelemetryInstrumentationRuntime,
         SystemNetNameResolution,
         SystemNetHttp,
-        MicrosoftExtensionsDiagnosticsHealthChecks,
-        MicrosoftExtensionsDiagnosticsResourceMonitoring
     });
 
     /// <summary>

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -51,6 +51,7 @@ namespace Sentry
         public static readonly Sentry.SubstringOrRegexPattern MicrosoftAspNetCoreServerKestrel;
         public static readonly Sentry.SubstringOrRegexPattern MicrosoftExtensionsDiagnosticsHealthChecks;
         public static readonly Sentry.SubstringOrRegexPattern MicrosoftExtensionsDiagnosticsResourceMonitoring;
+        public static readonly Sentry.SubstringOrRegexPattern OpenTelemetryInstrumentationRuntime;
         public static readonly Sentry.SubstringOrRegexPattern SystemNetHttp;
         public static readonly Sentry.SubstringOrRegexPattern SystemNetNameResolution;
         public static System.Collections.Generic.IList<Sentry.SubstringOrRegexPattern> All { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -51,6 +51,7 @@ namespace Sentry
         public static readonly Sentry.SubstringOrRegexPattern MicrosoftAspNetCoreServerKestrel;
         public static readonly Sentry.SubstringOrRegexPattern MicrosoftExtensionsDiagnosticsHealthChecks;
         public static readonly Sentry.SubstringOrRegexPattern MicrosoftExtensionsDiagnosticsResourceMonitoring;
+        public static readonly Sentry.SubstringOrRegexPattern OpenTelemetryInstrumentationRuntime;
         public static readonly Sentry.SubstringOrRegexPattern SystemNetHttp;
         public static readonly Sentry.SubstringOrRegexPattern SystemNetNameResolution;
         public static System.Collections.Generic.IList<Sentry.SubstringOrRegexPattern> All { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -51,6 +51,7 @@ namespace Sentry
         public static readonly Sentry.SubstringOrRegexPattern MicrosoftAspNetCoreServerKestrel;
         public static readonly Sentry.SubstringOrRegexPattern MicrosoftExtensionsDiagnosticsHealthChecks;
         public static readonly Sentry.SubstringOrRegexPattern MicrosoftExtensionsDiagnosticsResourceMonitoring;
+        public static readonly Sentry.SubstringOrRegexPattern OpenTelemetryInstrumentationRuntime;
         public static readonly Sentry.SubstringOrRegexPattern SystemNetHttp;
         public static readonly Sentry.SubstringOrRegexPattern SystemNetNameResolution;
         public static System.Collections.Generic.IList<Sentry.SubstringOrRegexPattern> All { get; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -51,6 +51,7 @@ namespace Sentry
         public static readonly Sentry.SubstringOrRegexPattern MicrosoftAspNetCoreServerKestrel;
         public static readonly Sentry.SubstringOrRegexPattern MicrosoftExtensionsDiagnosticsHealthChecks;
         public static readonly Sentry.SubstringOrRegexPattern MicrosoftExtensionsDiagnosticsResourceMonitoring;
+        public static readonly Sentry.SubstringOrRegexPattern OpenTelemetryInstrumentationRuntime;
         public static readonly Sentry.SubstringOrRegexPattern SystemNetHttp;
         public static readonly Sentry.SubstringOrRegexPattern SystemNetNameResolution;
         public static System.Collections.Generic.IList<Sentry.SubstringOrRegexPattern> All { get; }


### PR DESCRIPTION
I noticed the Aspire starter template includes these metrics so we should probably make them part of our built in metrics also.

There is a bit of [documentation available for these here](https://opentelemetry.io/docs/languages/net/automatic/instrumentations/#metrics-instrumentations). 