### PR TITLE
fix: Allow a DSN `string.Empty` to be overwritten by the environment

### DIFF
--- a/src/Sentry/Internal/SettingLocator.cs
+++ b/src/Sentry/Internal/SettingLocator.cs
@@ -34,10 +34,9 @@ internal class SettingLocator
     public string GetDsn()
     {
         // For DSN only
-        // An empty string set on the option should NOT be converted to null because it is used
-        // to indicate the the SDK is disabled.
 
-        // If the DSN has not been set
+        // If the DSN has not been set at all require it to be on either the environment or an AssemblyAttribute. If
+        // neither can be found: throw
         if (_options.Dsn is null)
         {
             _options.Dsn = GetEnvironmentVariable(Constants.DsnEnvironmentVariable)
@@ -50,6 +49,8 @@ internal class SettingLocator
                                                 "See https://docs.sentry.io/platforms/dotnet/configuration/options/#dsn");
             }
         }
+        // The SDK has been disabled by the user explicitly setting the DSN to `string.Empty`.
+        // By convention, the DSN can be overwritten in the environment
         else if (_options.Dsn.Equals(string.Empty))
         {
             var dsn = GetEnvironmentVariable(Constants.DsnEnvironmentVariable)

--- a/src/Sentry/Internal/SettingLocator.cs
+++ b/src/Sentry/Internal/SettingLocator.cs
@@ -1,4 +1,3 @@
-using Sentry.Extensibility;
 using Sentry.Internal.Extensions;
 
 namespace Sentry.Internal;


### PR DESCRIPTION
## TLDR;
This PR aims to let users control the SDK via environment variables by overwriting the DSN set to `string.Empty`.
`This "" behavior is 10 years old and set in all SDks.` https://github.com/getsentry/sentry-dotnet/issues/2494#issuecomment-1722098718

## What do?
Setting `options.Dsn = "";` disables the SDK except for when a DSN is present in the environment. In that case the DSN from the environment gets used.

## Context
[We've introduced](https://github.com/getsentry/sentry-dotnet/pull/2655/files) some friction by letting the SDK throw if there was no DSN provided during initialization. The idea was to make the onboarding process more explicit and let new users know immediately that there was something wrong with their current configuration. https://github.com/getsentry/sentry-dotnet/issues/2494

The change made it very awkward to control the SDK's behavior through the environment since now not setting the DSN via code implicitly gets treated as a configuration error.

The current order of priority:
- Code
- Binding through config files
- Environment
- AssemblyAttribute

2. and 3. are now following the convention of letting the environment overwrite config files but that's OK for now. We can [track](https://github.com/getsentry/sentry-dotnet/issues/3140) and document this.

Fixes https://github.com/getsentry/sentry-dotnet/issues/3136, 