### PR TITLE
Experimenting with Greedy Sampling

### DIFF
--- a/samples/Sentry.Samples.AspNetCore.Mvc/Program.cs
+++ b/samples/Sentry.Samples.AspNetCore.Mvc/Program.cs
@@ -29,9 +29,12 @@ builder.WebHost.UseSentry(options =>
         options.ShutdownTimeout = TimeSpan.FromSeconds(5);
 
         options.Debug = true;
-        options.DiagnosticLevel = SentryLevel.Info;
+        options.DiagnosticLevel = SentryLevel.Debug;
 
         options.TracesSampleRate = 1.0; // For production you may want to lower this to stay inside your quota
+
+        var sampler = new DynamicSampler(options);
+        options.TracesSampler = sampler.SampleRate;
 
         options.ExperimentalMetrics = new ExperimentalMetricsOptions()
         {

--- a/samples/Sentry.Samples.AspNetCore.Mvc/Program.cs
+++ b/samples/Sentry.Samples.AspNetCore.Mvc/Program.cs
@@ -25,10 +25,19 @@ builder.WebHost.UseSentry(options =>
         // Example: Disabling support to compressed responses:
         options.DecompressionMethods = DecompressionMethods.None;
 
-        options.MaxQueueItems = 100;
+        options.MaxQueueItems = 30;
         options.ShutdownTimeout = TimeSpan.FromSeconds(5);
 
+        options.Debug = true;
+        options.DiagnosticLevel = SentryLevel.Info;
+
         options.TracesSampleRate = 1.0; // For production you may want to lower this to stay inside your quota
+
+        options.ExperimentalMetrics = new ExperimentalMetricsOptions()
+        {
+            EnableCodeLocations = false,
+            CaptureSystemDiagnosticsMeters = SentryMeters.All
+        };
 
         // Configures the root scope
         options.ConfigureScope(s => s.SetTag("Always sent", "this tag"));

--- a/src/Sentry/DynamicSampler.cs
+++ b/src/Sentry/DynamicSampler.cs
@@ -7,7 +7,7 @@ namespace Sentry;
 /// <summary>
 /// Custom sampler that adjusts the sample rate based on the number of discarded envelopes and open queue slots.
 /// </summary>
-public class DynamicSampler: IDisposable
+public class DynamicSampler : IDisposable
 {
     private readonly SentryOptions _options;
     private readonly int _envelopesDiscardedThreshold;

--- a/src/Sentry/DynamicSampler.cs
+++ b/src/Sentry/DynamicSampler.cs
@@ -1,0 +1,186 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics.Metrics;
+using Sentry.Extensibility;
+
+namespace Sentry;
+
+/// <summary>
+/// Custom sampler that adjusts the sample rate based on the number of discarded envelopes and open queue slots.
+/// </summary>
+public class DynamicSampler: IDisposable
+{
+    private readonly SentryOptions _options;
+    private readonly int _envelopesDiscardedThreshold;
+    private readonly int _openQueueSlotsThreshold;
+
+    private readonly CancellationTokenSource _shutdownSource;
+
+    private double _sampleRate = 1.0;
+    private readonly ReaderWriterLockSlim _sampleLock = new();
+
+    private int _discardedEnvelopes = 0;
+
+    private List<int> _openQueueSlotObservations = new();
+    private readonly object _openQueueSlotObservationsLock = new();
+
+    private volatile bool _disposed;
+    private readonly MeterListener _meterListener = new();
+
+    private Task AdjustRateTask { get; }
+
+    /// <summary>
+    /// Creates a dynamic sampler
+    /// </summary>
+    /// <param name="options">A <see cref="SentryOptions"/> instance</param>
+    /// <param name="envelopesDiscardedThreshold">If the number of discarded envelopes in a given period is above this number, the sample rate will be adjusted down</param>
+    /// <param name="openQueueSlotsThreshold">If the average number of open queue slots is below this number in a given sample period, the sample rate will be adjusted up</param>
+    /// <param name="shutdownSource">A cancellation token for the sample update task</param>
+    public DynamicSampler(SentryOptions options, int envelopesDiscardedThreshold = 1,
+        int openQueueSlotsThreshold = 10, CancellationTokenSource? shutdownSource = null)
+    {
+        _options = options;
+        _envelopesDiscardedThreshold = envelopesDiscardedThreshold;
+        _openQueueSlotsThreshold = openQueueSlotsThreshold;
+        _shutdownSource = shutdownSource ?? new CancellationTokenSource();
+        _meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Meter.Name is "Sentry.Internal.Backgroundworker")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+
+        _meterListener.SetMeasurementEventCallback<int>(OnMeasurementRecorded);
+
+        // Start the meterListener, enabling InstrumentPublished callbacks.
+        _meterListener.Start();
+
+        AdjustRateTask = Task.Run(AdjustRateAsync);
+    }
+
+    private void OnMeasurementRecorded(Instrument instrument, int measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)
+    {
+        switch (instrument.Name)
+        {
+            case "sentry.open_queue_slots":
+                lock (_openQueueSlotObservationsLock)
+                {
+                    _openQueueSlotObservations.Add(measurement);
+                }
+                break;
+            case "sentry.envelopes_discarded":
+                Interlocked.Increment(ref _discardedEnvelopes);
+                break;
+        }
+    }
+
+    private async Task AdjustRateAsync()
+    {
+        while (!_shutdownSource.Token.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(1), _shutdownSource.Token).ConfigureAwait(false);
+
+            // Check if the rate should be adjusted down (e.g. if we're discarding too many envelopes)
+            var discardedEnvelopes = Interlocked.Exchange(ref _discardedEnvelopes, 0);
+            if (discardedEnvelopes > _envelopesDiscardedThreshold)
+            {
+                _sampleLock.EnterWriteLock();
+                try
+                {
+                    // Sample half as many events
+                    _sampleRate /= 2;
+                    _options.LogDebug("Sample rate lowered to {0}", _sampleRate);
+                }
+                finally
+                {
+                    _sampleLock.ExitWriteLock();
+                }
+                continue;
+            }
+
+            // Check if the rate should be adjusted up (e.g. if we're seeing lots of open queue slots)
+            double? observedMean = null;
+            lock (_openQueueSlotObservations)
+            {
+                if (_openQueueSlotObservations.Any())
+                {
+                    observedMean = _openQueueSlotObservations.Average();
+                    _openQueueSlotObservations = new();
+                }
+            }
+            if (observedMean is { } openQueueSlots && openQueueSlots > _openQueueSlotsThreshold)
+            {
+                _sampleLock.EnterUpgradeableReadLock();
+                try
+                {
+                    if (_sampleRate < 1.0)
+                    {
+                        _sampleLock.EnterWriteLock();
+                        try
+                        {
+                            // Sample twice as many events
+                            _sampleRate = Math.Min(1, _sampleRate * 2);
+                            _options.LogDebug("Sample rate increased to {0}", _sampleRate);
+                        }
+                        finally
+                        {
+                            _sampleLock.ExitWriteLock();
+                        }
+                    }
+                }
+                finally
+                {
+                    _sampleLock.ExitUpgradeableReadLock();
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the current sample rate
+    /// </summary>
+    /// <param name="context">The <see cref="TransactionSamplingContext"/></param>
+    /// <returns></returns>
+    public double? SampleRate(TransactionSamplingContext context)
+    {
+        _sampleLock.EnterReadLock();
+        try
+        {
+            return _sampleRate;
+        }
+        finally
+        {
+            _sampleLock.ExitReadLock();
+        }
+    }
+
+    /// <inheritdoc cref="IDisposable.Dispose"/>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        try
+        {
+            _shutdownSource.Cancel();
+            AdjustRateTask.Wait();
+        }
+        catch (OperationCanceledException)
+        {
+            _options.LogDebug("Stopping the background worker due to a cancellation.");
+        }
+        catch (Exception exception)
+        {
+            _options.LogError(exception, "Stopping the background worker threw an exception.");
+        }
+        finally
+        {
+            _shutdownSource.Dispose();
+            _sampleLock.Dispose();
+        }
+    }
+}
+#endif

--- a/src/Sentry/Internal/SentryMeterFactory.cs
+++ b/src/Sentry/Internal/SentryMeterFactory.cs
@@ -1,0 +1,76 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics.Metrics;
+
+namespace Sentry.Internal;
+
+/// <summary>
+/// This is a simplified MeterFactory that only caches meters and does not support scoping. It also assumes there will
+/// be no dimensionality in the meters. The main reason we have this is that that we can't rely on Dependency injection
+/// so we can't get a DefaultMeterFactory from DI.
+/// </summary>
+internal class SentryMeterFactory : IMeterFactory
+{
+    private static readonly Lazy<SentryMeterFactory> LazyInstance = new();
+    public static SentryMeterFactory Instance => LazyInstance.Value;
+
+    private readonly Dictionary<string, Meter> _cachedMeters = new();
+    private bool _disposed;
+
+    public Meter Create(MeterOptions options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        if (options.Scope is not null)
+        {
+            throw new ArgumentException("The SentryMeterFactory does not support scopes");
+        }
+
+        if (options.Tags != null && options.Tags.Any())
+        {
+            throw new ArgumentException("The SentryMeterFactory does not support tags");
+        }
+
+        Debug.Assert(options.Name is not null);
+
+        lock (_cachedMeters)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(SentryMeterFactory));
+            }
+
+            if (_cachedMeters.TryGetValue(options.Name, out var meter))
+            {
+                return meter;
+            }
+
+            meter = new Meter(options.Name, options.Version, options.Tags, scope: this);
+            _cachedMeters.Add(options.Name, meter);
+            return meter;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_cachedMeters)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            foreach (var meter in _cachedMeters.Values)
+            {
+                meter.Dispose();
+            }
+
+            _cachedMeters.Clear();
+        }
+    }
+}
+#endif

--- a/src/Sentry/SentryMeters.cs
+++ b/src/Sentry/SentryMeters.cs
@@ -1,0 +1,33 @@
+namespace Sentry;
+
+/// <summary>
+/// Sentry metrics that can be added to
+/// <see cref="ExperimentalMetricsOptions.CaptureSystemDiagnosticsMeters"/>
+/// </summary>
+public static partial class SentryMeters
+{
+    private const string BackgroundWorkerPattern = @"^Sentry\.Internal\.Backgroundworker$";
+
+    /// <summary>
+    /// Matches the built in <see cref="System.Net.Http"/> metrics
+    /// </summary>
+#if NET8_0_OR_GREATER
+    public static readonly SubstringOrRegexPattern BackgroundWorker = SystemNetHttpRegex();
+
+    [GeneratedRegex(BackgroundWorkerPattern, RegexOptions.Compiled)]
+    private static partial Regex SystemNetHttpRegex();
+#else
+    public static readonly SubstringOrRegexPattern BackgroundWorker = new Regex(BackgroundWorkerPattern, RegexOptions.Compiled);
+#endif
+
+    private static readonly Lazy<IList<SubstringOrRegexPattern>> LazyAll = new(() => new List<SubstringOrRegexPattern>
+    {
+        BackgroundWorker,
+    });
+
+    /// <summary>
+    /// Matches all built in metrics
+    /// </summary>
+    /// <returns></returns>
+    public static IList<SubstringOrRegexPattern> All => LazyAll.Value;
+}

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -605,6 +605,11 @@ namespace Sentry
         protected override System.Net.Http.HttpResponseMessage Send(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { }
     }
+    public static class SentryMeters
+    {
+        public static readonly Sentry.SubstringOrRegexPattern BackgroundWorker;
+        public static System.Collections.Generic.IList<Sentry.SubstringOrRegexPattern> All { get; }
+    }
     public class SentryOptions
     {
         public SentryOptions() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -605,6 +605,11 @@ namespace Sentry
         protected override System.Net.Http.HttpResponseMessage Send(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { }
     }
+    public static class SentryMeters
+    {
+        public static readonly Sentry.SubstringOrRegexPattern BackgroundWorker;
+        public static System.Collections.Generic.IList<Sentry.SubstringOrRegexPattern> All { get; }
+    }
     public class SentryOptions
     {
         public SentryOptions() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -606,6 +606,11 @@ namespace Sentry
         protected override System.Net.Http.HttpResponseMessage Send(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { }
     }
+    public static class SentryMeters
+    {
+        public static readonly Sentry.SubstringOrRegexPattern BackgroundWorker;
+        public static System.Collections.Generic.IList<Sentry.SubstringOrRegexPattern> All { get; }
+    }
     public class SentryOptions
     {
         public SentryOptions() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -603,6 +603,11 @@ namespace Sentry
         protected abstract Sentry.ISpan? ProcessRequest(System.Net.Http.HttpRequestMessage request, string method, string url);
         protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { }
     }
+    public static class SentryMeters
+    {
+        public static readonly Sentry.SubstringOrRegexPattern BackgroundWorker;
+        public static System.Collections.Generic.IList<Sentry.SubstringOrRegexPattern> All { get; }
+    }
     public class SentryOptions
     {
         public SentryOptions() { }

--- a/test/Sentry.Tests/Internals/BackgroundWorkerTests.cs
+++ b/test/Sentry.Tests/Internals/BackgroundWorkerTests.cs
@@ -53,8 +53,8 @@ public class BackgroundWorkerTests
             => new(
                 Transport,
                 SentryOptions,
-                CancellationTokenSource,
-                Queue);
+                shutdownSource: CancellationTokenSource,
+                queue: Queue);
 
         public void UseDefaultShutdownTimeout()
         {


### PR DESCRIPTION
Playing around with some ideas for how we could use internal Sentry metrics to avoid randomly dropping envelopes:

![image](https://github.com/getsentry/sentry-dotnet/assets/728212/54c66560-f9d9-4210-aed4-d051a18dd56d)

These are published as Sytem.Diagnostics.Metrics and we don't necessarily need to capture these and send them through to Sentry. I did that here just to provide a visual of the metrics being captured.

However, I figured it might be possible to listen to these metrics in process and use them in a custom TraceSampler that adjusted the sample rate down if envelopes started to get dropped and adjusted back up if there was lots of space in the queue... 

This could be thought of as a GreedySampler  or a PoliteSampler. It would try to find the maximum sample rate that could be sustained before envelopes start to get dropped. That way the envelopes that are being selected out are those related to traces (not those related to crash reports or metrics). 