### PR TITLE
Fix: replace invalid metric tag values with an empty string instead of _

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Empty strings are used instead of underscores to replace invalid metric tag values ([#3176](https://github.com/getsentry/sentry-dotnet/pull/3176))
+
 ### Dependencies
 
 - Bump Java SDK from v7.3.0 to v7.4.0 ([#3164](https://github.com/getsentry/sentry-dotnet/pull/3164))

--- a/src/Sentry/MetricHelper.cs
+++ b/src/Sentry/MetricHelper.cs
@@ -49,7 +49,7 @@ internal static partial class MetricHelper
 
     [GeneratedRegex(InvalidValueCharactersPattern, RegexOptions.Compiled)]
     private static partial Regex InvalidValueCharacters();
-    internal static string SanitizeValue(string input) => InvalidValueCharacters().Replace(input, "_");
+    internal static string SanitizeValue(string input) => InvalidValueCharacters().Replace(input, "");
 
     [GeneratedRegex(InvalidMetricUnitCharactersPattern, RegexOptions.Compiled)]
     private static partial Regex InvalidMetricUnitCharacters();
@@ -59,7 +59,7 @@ internal static partial class MetricHelper
     internal static string SanitizeKey(string input) => InvalidKeyCharacters.Replace(input, "_");
 
     private static readonly Regex InvalidValueCharacters = new(InvalidValueCharactersPattern, RegexOptions.Compiled);
-    internal static string SanitizeValue(string input) => InvalidValueCharacters.Replace(input, "_");
+    internal static string SanitizeValue(string input) => InvalidValueCharacters.Replace(input, "");
 
     private static readonly Regex InvalidMetricUnitCharacters = new(InvalidMetricUnitCharactersPattern, RegexOptions.Compiled);
     internal static string SanitizeMetricUnit(string input) => InvalidMetricUnitCharacters.Replace(input, "_");

--- a/test/Sentry.Tests/MetricHelperTests.cs
+++ b/test/Sentry.Tests/MetricHelperTests.cs
@@ -37,9 +37,9 @@ public class MetricHelperTests
 
     [Theory]
     [InlineData("Test123_:/@.{}[]$-", "Test123_:/@.{}[]$-")] // Valid characters
-    [InlineData("test&value", "test_value")]
-    [InlineData("test\"value", "test_value")]
-    public void SanitizeValue_ShouldReplaceInvalidCharactersWithUnderscore(string input, string expected)
+    [InlineData("test&value", "testvalue")]
+    [InlineData("test\"value", "testvalue")]
+    public void SanitizeValue_ShouldRemoveInvalidCharacters(string input, string expected)
     {
         // Act
         var result = MetricHelper.SanitizeValue(input);


### PR DESCRIPTION
[According to our spec](https://develop.sentry.dev/sdk/metrics/#normalization) invalid tag values should be replaced with no string.

> Tag Values: regex [^\w\d_:/@\.{}\[\]$-]+ with no replacement character.

I cross checked with [PHP](https://github.com/getsentry/sentry-php/blob/6f8cce5441da92829e84c3c2549625860f11787f/src/Serializer/EnvelopItems/MetricsItem.php#L59) and [JS](https://github.com/getsentry/sentry-javascript/blob/2a8ef4094ff283a207d3522db3e4c3357d73bb30/packages/core/src/metrics/utils.ts#L65): both of them also use no replacement character.

Relevant Python PR: https://github.com/getsentry/sentry-python/pull/2773