### PR TITLE
fix: `SentryMiddleware` re-entrant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- The Sentry Middleware on ASP.NET Core no longer throws an exception after having been initialized multiple times ([#3185](https://github.com/getsentry/sentry-dotnet/pull/3185))
 - Empty strings are used instead of underscores to replace invalid metric tag values ([#3176](https://github.com/getsentry/sentry-dotnet/pull/3176))
 
 ### Dependencies

--- a/src/Sentry.AspNetCore/SentryMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryMiddleware.cs
@@ -100,7 +100,7 @@ internal class SentryMiddleware : IMiddleware
             var didAdd = context.Items.TryAdd(TraceHeaderItemKey, traceHeader);
             if (!didAdd)
             {
-                _options.LogDebug("Sentry trace was already added. Did you initialize Sentry twice?");
+                _options.LogWarning("Sentry trace was already added. Did you initialize Sentry twice?");
             }
             context.Items.TryAdd(BaggageHeaderItemKey, baggageHeader);
             context.Items.TryAdd(TransactionContextItemKey, transactionContext);

--- a/src/Sentry.AspNetCore/SentryMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryMiddleware.cs
@@ -97,9 +97,13 @@ internal class SentryMiddleware : IMiddleware
             var transactionContext = hub.ContinueTrace(traceHeader, baggageHeader);
 
             // Adding the headers and the TransactionContext to the context to be picked up by the Sentry tracing middleware
-            context.Items.Add(TraceHeaderItemKey, traceHeader);
-            context.Items.Add(BaggageHeaderItemKey, baggageHeader);
-            context.Items.Add(TransactionContextItemKey, transactionContext);
+            var didAdd = context.Items.TryAdd(TraceHeaderItemKey, traceHeader);
+            if (!didAdd)
+            {
+                _options.LogDebug("Sentry trace was already added. Did you initialize Sentry twice?");
+            }
+            context.Items.TryAdd(BaggageHeaderItemKey, baggageHeader);
+            context.Items.TryAdd(TransactionContextItemKey, transactionContext);
 
             hub.ConfigureScope(scope =>
             {

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -36,7 +36,7 @@ internal class MainExceptionProcessor : ISentryEventExceptionProcessor
     {
         var exceptions = WalkExceptions(exception).Reverse().ToList();
 
-        // In the case of only one exception, ExceptionId and ParentId are useless./
+        // In the case of only one exception, ExceptionId and ParentId are useless.
         if (exceptions.Count == 1 && exceptions[0].Mechanism is { } mechanism)
         {
             mechanism.ExceptionId = null;

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -36,7 +36,7 @@ internal class MainExceptionProcessor : ISentryEventExceptionProcessor
     {
         var exceptions = WalkExceptions(exception).Reverse().ToList();
 
-        // In the case of only one exception, ExceptionId and ParentId are useless.
+        // In the case of only one exception, ExceptionId and ParentId are useless./
         if (exceptions.Count == 1 && exceptions[0].Mechanism is { } mechanism)
         {
             mechanism.ExceptionId = null;

--- a/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
@@ -750,6 +750,34 @@ public class SentryMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeAsync_InvokingWithTheSameContextTwice_DoesNotThrow()
+    {
+        var sut = _fixture.GetSut();
+        var request = Substitute.For<HttpRequest>();
+        var fakeHeaders = new HeaderDictionary
+        {
+            { "Sentry-Trace", "4b4d2878507b43d3af7dd8c4ab7a96d9-3cc6fd1337d243de"},
+            { "Baggage", "sentry-trace_id=4b4d2878507b43d3af7dd8c4ab7a96d9, sentry-public_key=eb18e953812b41c3aeb042e666fd3b5c"},
+        };
+        var contextItems = new Dictionary<object, object>();
+        _fixture.HttpContext.Items.When(items => items.Add(Arg.Any<object>(), Arg.Any<object>()))
+            .Do(info =>
+            {
+                contextItems.Add(info.Args()[0], info.Args()[1]);
+            });
+        _ = request.Headers.Returns(fakeHeaders);
+        _ = _fixture.HttpContext.Request.Returns(request);
+        _ = request.HttpContext.Returns(_fixture.HttpContext);
+
+        // Faking having added the middleware twice by invoking the request with the same context twice
+        await sut.InvokeAsync(_fixture.HttpContext, _fixture.RequestDelegate);
+        await sut.InvokeAsync(_fixture.HttpContext, _fixture.RequestDelegate);
+
+        _fixture.HttpContext.Items.Received(3); // Sanity check
+        Assert.Equal(3, contextItems.Count);
+    }
+
+    [Fact]
     public void PopulateScope_AddEventProcessors()
     {
         var customProcessor = Substitute.For<ISentryEventProcessor>();

--- a/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
@@ -761,10 +761,7 @@ public class SentryMiddlewareTests
         };
         var contextItems = new Dictionary<object, object>();
         _fixture.HttpContext.Items.When(items => items.Add(Arg.Any<object>(), Arg.Any<object>()))
-            .Do(info =>
-            {
-                contextItems.Add(info.Args()[0], info.Args()[1]);
-            });
+            .Do(info => contextItems.TryAdd(info.Args()[0], info.Args()[1]));
         _ = request.Headers.Returns(fakeHeaders);
         _ = _fixture.HttpContext.Request.Returns(request);
         _ = request.HttpContext.Returns(_fixture.HttpContext);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/3042

The middleware is now re-entrant again. I added logs for sanity.