### PR TITLE
Fix memory leak when OpenTelemetry spans get filtered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - The Sentry Middleware on ASP.NET Core no longer throws an exception after having been initialized multiple times ([#3185](https://github.com/getsentry/sentry-dotnet/pull/3185))
 - Empty strings are used instead of underscores to replace invalid metric tag values ([#3176](https://github.com/getsentry/sentry-dotnet/pull/3176))
+- Filtered OpenTelemetry spans are garbage collected correctly ([#3198](https://github.com/getsentry/sentry-dotnet/pull/3198))
 
 ### Dependencies
 

--- a/src/Sentry.OpenTelemetry/Sentry.OpenTelemetry.csproj
+++ b/src/Sentry.OpenTelemetry/Sentry.OpenTelemetry.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Sentry.OpenTelemetry.AspNetCore" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.OpenTelemetry.Tests" PublicKey="$(SentryPublicKey)" />
+    <InternalsVisibleTo Include="Sentry.Benchmarks" PublicKey="$(SentryPublicKey)" />
   </ItemGroup>
 
 </Project>

--- a/src/Sentry/SpanTracer.cs
+++ b/src/Sentry/SpanTracer.cs
@@ -17,7 +17,7 @@ public class SpanTracer : ISpan
     public SpanId SpanId { get; internal set; }
 
     /// <inheritdoc />
-    public SpanId? ParentSpanId { get; }
+    public SpanId? ParentSpanId { get; internal set; }
 
     /// <inheritdoc />
     public SentryId TraceId { get; }
@@ -81,6 +81,8 @@ public class SpanTracer : ISpan
 
     /// <inheritdoc />
     public void SetExtra(string key, object? value) => _data[key] = value;
+
+    internal Func<bool>? IsFiltered { get; set; }
 
     /// <summary>
     /// Initializes an instance of <see cref="SpanTracer"/>.

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -16,6 +16,8 @@ public class TransactionTracer : ITransactionTracer
     private readonly SentryStopwatch _stopwatch = SentryStopwatch.StartNew();
     private readonly Instrumenter _instrumenter = Instrumenter.Sentry;
 
+    internal bool IsOtelInstrumenter => _instrumenter == Instrumenter.OpenTelemetry;
+
     /// <inheritdoc />
     public SpanId SpanId
     {

--- a/test/Sentry.DiagnosticSource.Tests/SentrySqlListenerTests.cs
+++ b/test/Sentry.DiagnosticSource.Tests/SentrySqlListenerTests.cs
@@ -122,7 +122,8 @@ public class SentrySqlListenerTests
         var spans = _fixture.Spans.Where(s => s.Operation != "abc");
         Assert.NotEmpty(spans);
 
-        Assert.True(GetValidator(key)(_fixture.Spans.First()));
+        var firstSpan = _fixture.Spans.OrderByDescending(x => x.StartTimestamp).First();
+        Assert.True(GetValidator(key)(firstSpan));
     }
 
     [Theory]

--- a/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
@@ -482,7 +482,7 @@ public class SentrySpanProcessorTests : ActivitySourceTests
         _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
         var sut = _fixture.GetSut();
 
-        sut._lastPruned = DateTimeOffset.MaxValue; // fake a recent prune
+        sut._lastPruned = DateTimeOffset.MaxValue.Ticks; // fake a recent prune
 
         using var parent = Tracer.StartActivity();
         sut.OnStart(parent!);

--- a/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
@@ -405,4 +405,101 @@ public class SentrySpanProcessorTests : ActivitySourceTests
 
         transaction.IsSentryRequest.Should().BeTrue();
     }
+
+    private static void FilterActivity(Activity activity)
+    {
+        // Simulates filtering an activity - see https://github.com/getsentry/sentry-dotnet/pull/3198
+        activity.IsAllDataRequested = false;
+        activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
+    }
+
+    [Fact]
+    public void PruneFilteredSpans_FilteredTransactions_Pruned()
+    {
+        // Arrange
+        _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
+        var sut = _fixture.GetSut();
+
+        using var parent = Tracer.StartActivity();
+        sut.OnStart(parent!);
+
+        FilterActivity(parent);
+
+        // Act
+        sut.PruneFilteredSpans(true);
+
+        // Assert
+        Assert.False(sut._map.TryGetValue(parent.SpanId, out var _));
+    }
+
+    [Fact]
+    public void PruneFilteredSpans_UnFilteredTransactions_NotPruned()
+    {
+        // Arrange
+        _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
+        var sut = _fixture.GetSut();
+
+        using var parent = Tracer.StartActivity();
+        sut.OnStart(parent!);
+
+        // Act
+        sut.PruneFilteredSpans(true);
+
+        // Assert
+        Assert.True(sut._map.TryGetValue(parent.SpanId, out var _));
+    }
+
+    [Fact]
+    public void PruneFilteredSpans_FilteredSpans_Pruned()
+    {
+        // Arrange
+        _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
+        var sut = _fixture.GetSut();
+
+        using var parent = Tracer.StartActivity();
+        sut.OnStart(parent!);
+
+        using var activity1 = Tracer.StartActivity();
+        sut.OnStart(activity1!);
+
+        using var activity2 = Tracer.StartActivity();
+        sut.OnStart(activity2!);
+
+        FilterActivity(activity2);
+
+        // Act
+        sut.PruneFilteredSpans(true);
+
+        // Assert
+        Assert.True(sut._map.TryGetValue(activity1.SpanId, out var _));
+        Assert.False(sut._map.TryGetValue(activity2.SpanId, out var _));
+    }
+
+    [Fact]
+    public void PruneFilteredSpans_RecentlyPruned_DoesNothing()
+    {
+        // Arrange
+        _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
+        var sut = _fixture.GetSut();
+
+        sut._lastPruned = DateTimeOffset.MaxValue; // fake a recent prune
+
+        using var parent = Tracer.StartActivity();
+        sut.OnStart(parent!);
+
+        using var activity1 = Tracer.StartActivity();
+        sut.OnStart(activity1!);
+
+        using var activity2 = Tracer.StartActivity();
+        sut.OnStart(activity2!);
+
+        FilterActivity(activity2);
+
+        // Act
+        sut.PruneFilteredSpans();
+
+        // Assert
+        Assert.True(sut._map.TryGetValue(activity1.SpanId, out var _));
+        Assert.True(sut._map.TryGetValue(activity2.SpanId, out var _));
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/3197

## Solution

For the Sentry spans we hold in `SentrySpanProcessor._map`, we need a way to detect when the associated Activities have been filtered out. The OpenTelemetry SDK doesn't provide a mechanism for I had to get a bit creative. 

Previously we only held on to the Activity.Id for OpenTelemetry spans that we'd processed and there's no way to lookup an Activity by Id. 

With this PR we now retain weak references to the Activities themselves (not just the Activity.Id)... and we periodically loop through each of the spans in our `_map` to check if the associated Activities have been filtered out. When Activities get filtered, `IsAllDataRequested` gets set and the `ActivityTraceFlags.Recorded` flag gets removed ([see code](https://github.com/open-telemetry/opentelemetry-dotnet/blob/5784b45c4e310fc54d84278891bb22d6b93a1246/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs#L149-L150)). When that happens, we know we're not going to receive anymore OnStart/OnEnd events relating to the Activity, so we can remove it from our map.

Additionally, when finishing transactions that were instrumented using OpenTelemetry, we now surgically remove any spans that were filtered... since although those spans were removed from the `_map` they still exist in the `SentryTransaction.Spans`. 

## Testing Manually

To test this manually, [this line in our sample project](https://github.com/getsentry/sentry-dotnet/blob/088557ec20c2478578a6d1642d2bb82b7fc1a3e2/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Program.cs#L23) can be changed to:
```csharp
            .AddHttpClientInstrumentation(o => o.FilterHttpRequestMessage = _ => false)
```

That basically filters every outgoing HTTP request. You can then see in resulting traces that these have magically disappeared (there's a suspicious gap in the timings, but there's no trace event for these). 

Before this PR, this was not the case... we were seeing:
a) A bunch of unfinished spans relating to outgoing HTTP requests that were filtered by OTEL
b) An accumulation of those spans in our SentrySpanProcessor, resulting in ever increasing memory consumption