### PR TITLE
fix: missing stack trace on exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix missing exception StackTraces in some situations ([#3215](https://github.com/getsentry/sentry-dotnet/pull/3215))
+
 ### API changes
 
 - Removed `SentryOptionsExtensions` class - all the public methods moved directly to `SentryOptions` ([#3195](https://github.com/getsentry/sentry-dotnet/pull/3195))

--- a/src/Sentry/Internal/MainSentryEventProcessor.cs
+++ b/src/Sentry/Internal/MainSentryEventProcessor.cs
@@ -86,9 +86,8 @@ internal class MainSentryEventProcessor : ISentryEventProcessor
         // if there's no exception with a stack trace, then get the current stack trace
         if (@event.Exception?.StackTrace is null)
         {
-            var stackTrace = @event.SentryExceptions?.FirstOrDefault() is { } sentryEx
-                ? sentryEx.Stacktrace
-                : SentryStackTraceFactoryAccessor().Create();
+            var stackTrace = @event.SentryExceptions?.FirstOrDefault()?.Stacktrace
+                            ?? SentryStackTraceFactoryAccessor().Create();
             if (stackTrace != null)
             {
                 var currentThread = Thread.CurrentThread;

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet6_0.verified.txt
@@ -55,6 +55,54 @@
                 }
               }
             ],
+            SentryThreads: [
+              {
+                Crashed: false,
+                Current: true
+              }
+            ],
+            DebugImages: [
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: null,
+                DebugFile: .../System.Private.CoreLib.pdb,
+                CodeId: ______________,
+                CodeFile: .../System.Private.CoreLib.dll
+              },
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: ______:________________________________________________________________,
+                DebugFile: .../Sentry.Tests.pdb,
+                CodeId: _____________,
+                CodeFile: .../Sentry.Tests.dll
+              },
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: ______:________________________________________________________________,
+                DebugFile: xunit.execution.dotnet.pdb,
+                CodeId: _____________,
+                CodeFile: .../xunit.execution.dotnet.dll
+              },
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: ______:________________________________________________________________,
+                DebugFile: xunit.core.pdb,
+                CodeId: _____________,
+                CodeFile: .../xunit.core.dll
+              }
+            ],
             Level: error,
             TransactionName: my transaction,
             Request: {},

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet7_0.verified.txt
@@ -55,6 +55,54 @@
                 }
               }
             ],
+            SentryThreads: [
+              {
+                Crashed: false,
+                Current: true
+              }
+            ],
+            DebugImages: [
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: ______:________________________________________________________________,
+                DebugFile: .../System.Private.CoreLib.pdb,
+                CodeId: ______________,
+                CodeFile: .../System.Private.CoreLib.dll
+              },
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: ______:________________________________________________________________,
+                DebugFile: .../Sentry.Tests.pdb,
+                CodeId: _____________,
+                CodeFile: .../Sentry.Tests.dll
+              },
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: ______:________________________________________________________________,
+                DebugFile: xunit.execution.dotnet.pdb,
+                CodeId: _____________,
+                CodeFile: .../xunit.execution.dotnet.dll
+              },
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: ______:________________________________________________________________,
+                DebugFile: xunit.core.pdb,
+                CodeId: _____________,
+                CodeFile: .../xunit.core.dll
+              }
+            ],
             Level: error,
             TransactionName: my transaction,
             Request: {},

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet8_0.verified.txt
@@ -55,6 +55,54 @@
                 }
               }
             ],
+            SentryThreads: [
+              {
+                Crashed: false,
+                Current: true
+              }
+            ],
+            DebugImages: [
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: ______:________________________________________________________________,
+                DebugFile: .../System.Private.CoreLib.pdb,
+                CodeId: ______________,
+                CodeFile: .../System.Private.CoreLib.dll
+              },
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: ______:________________________________________________________________,
+                DebugFile: .../Sentry.Tests.pdb,
+                CodeId: _____________,
+                CodeFile: .../Sentry.Tests.dll
+              },
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: ______:________________________________________________________________,
+                DebugFile: xunit.execution.dotnet.pdb,
+                CodeId: _____________,
+                CodeFile: .../xunit.execution.dotnet.dll
+              },
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: ______:________________________________________________________________,
+                DebugFile: xunit.core.pdb,
+                CodeId: _____________,
+                CodeFile: .../xunit.core.dll
+              }
+            ],
             Level: error,
             TransactionName: my transaction,
             Request: {},

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.Net4_8.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.Net4_8.verified.txt
@@ -55,6 +55,54 @@
                 }
               }
             ],
+            SentryThreads: [
+              {
+                Crashed: false,
+                Current: true
+              }
+            ],
+            DebugImages: [
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-_,
+                DebugChecksum: null,
+                DebugFile: mscorlib.pdb,
+                CodeId: ______________,
+                CodeFile: .../mscorlib.dll
+              },
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: ______:________________________________________________________________,
+                DebugFile: .../Sentry.Tests.pdb,
+                CodeId: _____________,
+                CodeFile: .../Sentry.Tests.dll
+              },
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: ______:________________________________________________________________,
+                DebugFile: xunit.execution.desktop.pdb,
+                CodeId: _____________,
+                CodeFile: .../xunit.execution.desktop.dll
+              },
+              {
+                Type: pe_dotnet,
+                ImageAddress: null,
+                ImageSize: null,
+                DebugId: ________-____-____-____-____________-________,
+                DebugChecksum: ______:________________________________________________________________,
+                DebugFile: xunit.core.pdb,
+                CodeId: _____________,
+                CodeFile: .../xunit.core.dll
+              }
+            ],
             Level: error,
             TransactionName: my transaction,
             Request: {},


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/getsentry/sentry-dotnet/pull/2709/files#diff-21cc5c4d89fdc7636600f7c8368d895929cf0da4ebb36d117f2e02444dfb9201