### PR TITLE
Revert "GitHubActions(build job): relax branch restrictions (#3085)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,8 @@ name: build
 on:
   push:
     branches:
-      - '**'
+      - main
+      - release/*
   pull_request:
     paths-ignore:
       - "**.md"


### PR DESCRIPTION
This reverts PR #3085. Since the PR, there's a lot of duplicate CI runs. 

The goal of the PR was to allow 3rd party contributors easier access to CI. As it has been explained in the original CI, that is already possible with either creating a draft PR targeting this upstream repo from the fork (even before it is ready for review), or creating a PR inside the fork itself. 

I've had a look at the GH Action docs whether there's a better option, e.g. to filter the `push` trigger to only run on forks, but it doesn't seem to be the case. 
Also, I've checked ou some of the most-starred GH repos and haven't seen a better solution - it seems they're either doing the same as we do here or having manual workflow triggers.

If there's a better solution that would not incurr duplicate CI runs, we can follow up in a new issue/PR. For the time being, I suggest we fix the duplicate CI by going beck to the working solution.

cc @knocte  

#skip-changelog
