### PR TITLE
Fixed issue resolving scope in ASP.NET Core with OTel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix missing exception StackTraces in some situations ([#3215](https://github.com/getsentry/sentry-dotnet/pull/3215))
+- Scopes now get applied to OTEL spans in ASP.NET Core ([#3221](https://github.com/getsentry/sentry-dotnet/pull/3221))
 
 ### API changes
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3220

This is hard to test as the Hub that we weren't resolving before (but now do) is SentrySdk.CurrentHub, which is static... We could possibly add an integration test using a TestServer. 

Here's the resulting trace though (includes breadcrumbs and tags now):

![image](https://github.com/getsentry/sentry-dotnet/assets/728212/87c3ab63-96ff-4c21-82f4-1b476a532dfc)
