### PR TITLE
Experimenting with implicit OpenTelemetry initialization

### DIFF
--- a/samples/Sentry.Samples.OpenTelemetry.Console/Program.cs
+++ b/samples/Sentry.Samples.OpenTelemetry.Console/Program.cs
@@ -6,25 +6,47 @@
  */
 
 using OpenTelemetry;
-using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Sentry.OpenTelemetry;
 
-var serviceName = "Sentry.Samples.OpenTelemetry.Console";
-var serviceVersion = "1.0.0";
+var activitySource = Sentry.OpenTelemetry.TracerProviderBuilderExtensions.DefaultActivitySource;
 
 SentrySdk.Init(options =>
 {
     // options.Dsn = "... Your DSN ...";
+    options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
     options.TracesSampleRate = 1.0;
     options.UseOpenTelemetry(); // <-- Configure Sentry to use OpenTelemetry trace information
 });
 
-using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-    .AddSource(serviceName)
-    .ConfigureResource(resource =>
-        resource.AddService(
-            serviceName: serviceName,
-            serviceVersion: serviceVersion))
-    .AddSentry() // <-- Configure OpenTelemetry to send traces to Sentry
-    .Build();
+// using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+//     .AddSentry() // <-- Configure OpenTelemetry to send traces to Sentry
+//     .Build();
+
+Console.WriteLine("Hello World!");
+Question();
+Console.WriteLine("Goodbye cruel world...");
+
+void Question()
+{
+    using var disposable = SentrySdk.PushScope();
+    SentrySdk.ConfigureScope(scope =>
+    {
+        scope.AddBreadcrumb("Asking the question...");
+        scope.SetTag("Question", "Meaning of life");
+        using var task = activitySource.StartActivity("Question");
+        Thread.Sleep(100); // simulate some work
+        Answer();
+    });
+}
+
+void Answer()
+{
+    SentrySdk.ConfigureScope(scope =>
+    {
+        scope.AddBreadcrumb("Giving the answer...");
+        scope.SetTag("Answer", "42");
+        using var task = activitySource.StartActivity("Answer");
+        Thread.Sleep(100); // simulate some work
+    });
+}

--- a/src/Sentry.OpenTelemetry/InternalTracerProvider.cs
+++ b/src/Sentry.OpenTelemetry/InternalTracerProvider.cs
@@ -1,0 +1,76 @@
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using Sentry.Extensibility;
+
+namespace Sentry.OpenTelemetry;
+
+internal static class InternalTracerProvider
+{
+    internal static IHub? FallbackHub;
+    private static TracerProvider? FallbackTracerProvider;
+    private static bool WasInitializedExternally;
+
+    internal static bool InitializedExternally
+    {
+        get => WasInitializedExternally;
+        set
+        {
+            if (value)
+            {
+                ClearProvider();
+            }
+
+            WasInitializedExternally = value;
+        }
+    }
+
+    public static void InitializeFallbackTracerProvider(this SentryOptions options)
+    {
+        try
+        {
+            ClearProvider();
+            // This is a dummy/naive example. It works for something like a Console app. Wiring up an ASP.NET Core app
+            // should be done using the OpenTelemetryBuilder extensions... If we knew OpenTelemetry was being used as
+            // the trace implementation, we could do something like this in the SentryOptions class, rather than in an
+            // extension method, and override it in SentryAspNetCoreOptions etc. to be platform specific.
+            options.PostInitCallbacks.Add(hub =>
+            {
+                FallbackHub = hub;
+                FallbackTracerProvider = Sdk.CreateTracerProviderBuilder()
+                    .AddSentryInternal(true) // <-- Configure OpenTelemetry to send traces to Sentry
+                    .Build();
+            });
+        }
+        catch (InternalTracerProviderException)
+        {
+            options.LogDebug("OpenTelemetry has been initialized externally: skipping auto-initialization");
+        }
+    }
+
+    public static void CancelInitialization()
+    {
+        throw new InternalTracerProviderException();
+    }
+
+    public static void ClearProvider()
+    {
+        FallbackHub = null;
+        FallbackTracerProvider?.Dispose();
+        FallbackTracerProvider = null;
+    }
+
+    internal class InternalTracerProviderException : Exception
+    {
+        public InternalTracerProviderException(string message) : base(message)
+        {
+        }
+
+        public InternalTracerProviderException() : base()
+        {
+        }
+
+        public InternalTracerProviderException(string? message, Exception? innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Sentry.OpenTelemetry/SentryOptionsExtensions.cs
+++ b/src/Sentry.OpenTelemetry/SentryOptionsExtensions.cs
@@ -1,5 +1,7 @@
+using OpenTelemetry;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
+using Sentry.Extensibility;
 
 namespace Sentry.OpenTelemetry;
 
@@ -53,5 +55,6 @@ public static class SentryOptionsExtensions
         options.AddTransactionProcessor(
             new OpenTelemetryTransactionProcessor()
             );
+        options.InitializeFallbackTracerProvider();
     }
 }

--- a/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -14,7 +14,7 @@ public static class TracerProviderBuilderExtensions
     /// <summary>
     /// The default <see cref="ActivitySource"/> for spans created by Sentry's instrumentation
     /// </summary>
-    public static readonly ActivitySource DefaultActivitySource = new ("Sentry");
+    public static readonly ActivitySource DefaultActivitySource = new("Sentry");
 
     /// <summary>
     /// Ensures OpenTelemetry trace information is sent to Sentry.


### PR DESCRIPTION
Playing around with one idea to implement:
- https://github.com/getsentry/sentry-dotnet/issues/3228

This is a total hack at the moment, just to get an idea of the kinds of challenges involved. 

## Approach

OpenTelemetry Tracing is configured via a [Static API](https://github.com/open-telemetry/opentelemetry-dotnet/blob/680115f9dca33d8d730093cfd14c7917262c34e2/src/OpenTelemetry/Sdk.cs#L92-L95) that returns a `TracerProviderBuilderBase`. 

In the context of a Console application especially (where there's no common `IServiceCollection` for DI), it's relatively difficult to work out whether OpenTelemetry has already been initialized or not. The OpenTelemetry static API doesn't provide an `Sdk.Current` property or anything similar.

However one possible solution might be to leverage our own AddSentry extension method:
https://github.com/getsentry/sentry-dotnet/blob/818e4043303a83f32d554c3e72f1ffd2f3d3c3b3/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs#L30-L35

If we **_always_** [initialise OpenTelemetry when initializing Sentry](https://github.com/getsentry/sentry-dotnet/blob/01beb42931717d3d0893e443c7ec1afeabf8b0a2/src/Sentry.OpenTelemetry/SentryOptionsExtensions.cs#L58), and we do so using the above extension method... we can guarantee it will be called _**at least once**_... If this extension method gets called twice, we know the initialization we made internally was unecessary and can either [skip our own initialization](https://github.com/getsentry/sentry-dotnet/blob/01beb42931717d3d0893e443c7ec1afeabf8b0a2/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs#L43-L46) of the Otel SDK or [dispose of any `TracerProvider` we created previously](https://github.com/getsentry/sentry-dotnet/blob/01beb42931717d3d0893e443c7ec1afeabf8b0a2/src/Sentry.OpenTelemetry/InternalTracerProvider.cs#L18-L21).

Broadly speaking, this [seems to work](https://github.com/getsentry/sentry-dotnet/blob/20f807a13219859d8688e3f8ea9fe13a236020e4/samples/Sentry.Samples.OpenTelemetry.Console/Program.cs#L22-L24)... there are a few challenges to making this production ready however.

## Challenges

- This POC uses the [`Sdk.CreateTracerProviderBuilder` method](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/Sdk.cs#L82). In an ASP.NET Core app we would need to use the [OpenTelemetryBuilder extensions](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs) instead. 
  - If we knew OpenTelemetry was being used as **_the_** trace implementation for Sentry then we could wire this up in the SentryOptions class and override it in SentryAspNetCoreOptions etc. to be platform specific.
- If we're automatically instrumenting OpenTelemetry we have to make some assumptions about the ActivitySource names to listen to. We'd probably need to create our own ActivitySources and use these internally (e.g. in the implementation of IHub.StartTransaction) to start new OpenTelemetry activities instead of creating Sentry Spans. 
- Wiring this up has a dependency on OpenTelemetry, so we'd have to move a bunch of the Tracing stuff to the Sentry.OpenTelemetry package... if people wanted Tracing, they'd need to add that NuGet package to their project...
- If we did want to continue to support both Sentry's proprietary tracing and OpenTelemetry tracing, we'd need to create some common interface and have an implementation of this for Sentry plus another for OpenTelemetry.
- We'd need to work out what to do with our own integrations that are part crash reporting and part tracing. In some cases the tracing part would be obsolete... for example our ASP.NET Core integration (the tracing has already been done in OpenTelemetry by Microsoft). In other cases, we'd need to work out what to do however. This needs a bit of an audit of our integrations and a plan for what to do about them. 