### PR TITLE
Added EnableNetworkEventBreadcrumbs to Native Android options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- EnableNetworkEventBreadcrumbs can now be set on the Native Android options ([#3267](https://github.com/getsentry/sentry-dotnet/pull/3267))
+
 ### Fixes
 
 - Fix missing exception StackTraces in some situations ([#3215](https://github.com/getsentry/sentry-dotnet/pull/3215))

--- a/src/Sentry/Platforms/Android/BindableNativeSentryOptions.cs
+++ b/src/Sentry/Platforms/Android/BindableNativeSentryOptions.cs
@@ -18,6 +18,7 @@ internal partial class BindableSentryOptions
         public bool? EnableAppComponentBreadcrumbs { get; set; }
         public bool? EnableAppLifecycleBreadcrumbs { get; set; }
         public bool? EnableRootCheck { get; set; }
+        public bool? EnableNetworkEventBreadcrumbs { get; set; }
         public bool? EnableSystemEventBreadcrumbs { get; set; }
         public bool? EnableUserInteractionBreadcrumbs { get; set; }
         public bool? EnableAutoActivityLifecycleTracing { get; set; }
@@ -44,6 +45,7 @@ internal partial class BindableSentryOptions
             options.EnableAppComponentBreadcrumbs = EnableAppComponentBreadcrumbs ?? options.EnableAppComponentBreadcrumbs;
             options.EnableAppLifecycleBreadcrumbs = EnableAppLifecycleBreadcrumbs ?? options.EnableAppLifecycleBreadcrumbs;
             options.EnableRootCheck = EnableRootCheck ?? options.EnableRootCheck;
+            options.EnableNetworkEventBreadcrumbs = EnableNetworkEventBreadcrumbs ?? options.EnableNetworkEventBreadcrumbs;
             options.EnableSystemEventBreadcrumbs = EnableSystemEventBreadcrumbs ?? options.EnableSystemEventBreadcrumbs;
             options.EnableUserInteractionBreadcrumbs = EnableUserInteractionBreadcrumbs ?? options.EnableUserInteractionBreadcrumbs;
             options.EnableAutoActivityLifecycleTracing = EnableAutoActivityLifecycleTracing ?? options.EnableAutoActivityLifecycleTracing;

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -95,6 +95,15 @@ public partial class SentryOptions
         public bool EnableRootCheck { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value that indicates if automatic breadcrumbs for network events are enabled.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        /// <remarks>
+        /// See https://docs.sentry.io/platforms/android/enriching-events/breadcrumbs/
+        /// </remarks>
+        public bool EnableNetworkEventBreadcrumbs { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets a value that indicates if automatic breadcrumbs for system events are enabled.
         /// The default value is <c>true</c> (enabled).
         /// </summary>

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -143,6 +143,7 @@ public static partial class SentrySdk
             o.EnableAppLifecycleBreadcrumbs = options.Native.EnableAppLifecycleBreadcrumbs;
             o.EnableRootCheck = options.Native.EnableRootCheck;
             o.EnableSystemEventBreadcrumbs = options.Native.EnableSystemEventBreadcrumbs;
+            o.EnableNetworkEventBreadcrumbs = options.Native.EnableNetworkEventBreadcrumbs;
             o.EnableUserInteractionBreadcrumbs = options.Native.EnableUserInteractionBreadcrumbs;
             o.EnableUserInteractionTracing = options.Native.EnableUserInteractionTracing;
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3255