### PR TITLE
chore: Adding AOT check to demo crash

### DIFF
--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -707,6 +707,12 @@ public static partial class SentrySdk
                 break;
 #elif NET8_0_OR_GREATER
             case CrashType.Native:
+                if(!AotHelper.IsNativeAot)
+                {
+                    CurrentOptions?.LogError("The support for capturing native crashes is limited to AOT compilation.");
+                    return;
+                }
+
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     NativeStrlenMSVCRT(IntPtr.Zero);


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3244
The native crash support requires AOT. 

Can/should we link some additional info in the log? @jamescrosswell blogpost?


#skip-changelog