### PR TITLE
fix: Cocoa Bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix missing exception StackTraces in some situations ([#3215](https://github.com/getsentry/sentry-dotnet/pull/3215))
 - Scopes now get applied to OTEL spans in ASP.NET Core ([#3221](https://github.com/getsentry/sentry-dotnet/pull/3221))
 - Fixed InvalidCastException when setting the SampleRate on Android ([#3258](https://github.com/getsentry/sentry-dotnet/pull/3258))
+- Fixed MAUI iOS build issue related to `SentryVersionNumber` and `SentryVersionString` ([#3278](https://github.com/getsentry/sentry-dotnet/pull/3278))
 
 ### API changes
 

--- a/scripts/generate-cocoa-bindings.ps1
+++ b/scripts/generate-cocoa-bindings.ps1
@@ -156,6 +156,7 @@ $t = $Text -split $s, 2
 $t[1] = $t[1] -replace "\[Static\]\n\[Internal\]\n$s", $s
 $Text = $t -join $s
 
+# Remove empty Constants block
 $Text = $Text -replace '\[Static\]\s*\[Internal\]\s*partial\s+interface\s+Constants\s\{[\s\n]*\}\n\n', ''
 
 # Update MethodToProperty translations

--- a/scripts/generate-cocoa-bindings.ps1
+++ b/scripts/generate-cocoa-bindings.ps1
@@ -38,8 +38,7 @@ if (!(Test-Path '/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/
 }
 
 # Get iPhone SDK version
-# $iPhoneSdkVersion = sharpie xcode -sdks | grep -o -m 1 'iphoneos\S*'
-$iPhoneSdkVersion = "iphoneos17.2"
+$iPhoneSdkVersion = sharpie xcode -sdks | grep -o -m 1 'iphoneos\S*'
 Write-Output "iPhoneSdkVersion: $iPhoneSdkVersion"
 
 # Generate bindings

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -10,20 +10,6 @@ using ObjCRuntime;
 
 namespace Sentry.CocoaSdk;
 
-[Static]
-[Internal]
-partial interface Constants
-{
-    // extern double SentryVersionNumber;
-    [Field ("SentryVersionNumber", "__Internal")]
-    double SentryVersionNumber { get; }
-
-    // extern const unsigned char[] SentryVersionString;
-    [Field ("SentryVersionString", "__Internal")]
-    [PlainString]
-    NSString SentryVersionString { get; }
-}
-
 // typedef void (^SentryRequestFinished)(NSError * _Nullable);
 [Internal]
 delegate void SentryRequestFinished ([NullAllowed] NSError error);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/3233

We're not using `SentryVersionNumber` or `SentryVersionString`. They are equivalent to the assembly version and are not touched by the .NET SDK.