### PR TITLE
Fix BackgroundWorker exiting when OperationCanceledException is not from shutdown request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+## Fixes
+
+- Fix BackgroundWorker exiting when OperationCanceledException is not from shutdown request ([3284](https://github.com/getsentry/sentry-dotnet/pull/3284))
+
 ## 4.3.0
 
 ### Features

--- a/src/Sentry/Internal/BackgroundWorker.cs
+++ b/src/Sentry/Internal/BackgroundWorker.cs
@@ -157,7 +157,7 @@ internal class BackgroundWorker : IBackgroundWorker, IDisposable
 
                         await task.ConfigureAwait(false);
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException) when (shutdownTimeout.IsCancellationRequested)
                     {
                         _options.LogInfo(
                             "Shutdown token triggered. Time to exit. {0} items in queue.",

--- a/src/Sentry/Internal/BackgroundWorker.cs
+++ b/src/Sentry/Internal/BackgroundWorker.cs
@@ -17,7 +17,7 @@ internal class BackgroundWorker : IBackgroundWorker, IDisposable
     private volatile bool _disposed;
     private int _currentItems;
 
-    private event EventHandler? OnFlushObjectReceived;
+    internal event EventHandler? OnFlushObjectReceived;
 
     internal Task WorkerTask { get; }
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/3274