### PR TITLE
chore: Bump device tests to .NET 8

### DIFF
--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           name: device-test-android
           if-no-files-found: error
-          path: test/Sentry.Maui.Device.TestApp/bin/Release/net7.0-android/android-x64/io.sentry.dotnet.maui.device.testapp-Signed.apk
+          path: test/Sentry.Maui.Device.TestApp/bin/Release/net8.0-android/android-x64/io.sentry.dotnet.maui.device.testapp-Signed.apk
 
   android:
     needs: [build]

--- a/.github/workflows/device-tests-ios.yml
+++ b/.github/workflows/device-tests-ios.yml
@@ -11,8 +11,7 @@ on:
 
 jobs:
   build:
-    # Pinning `macos-13` because Microsoft.iOS 16.4 requires Xcode 14.3 which is only built-in in 13
-    runs-on: macos-13
+    runs-on: macos-latest
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
@@ -42,7 +41,7 @@ jobs:
         with:
           name: device-test-ios
           if-no-files-found: error
-          path: test/Sentry.Maui.Device.TestApp/bin/Release/net7.0-ios/iossimulator-x64/Sentry.Maui.Device.TestApp.app
+          path: test/Sentry.Maui.Device.TestApp/bin/Release/net8.0-ios/iossimulator-x64/Sentry.Maui.Device.TestApp.app
 
   ios:
     needs: [build]


### PR DESCRIPTION
#skip-changelog