### PR TITLE
Allow OpenTelemetry child spans for Sentry Transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Features
 
-- Sentry Transactions now work with OpenTelemetry child spans ([#3288](https://github.com/getsentry/sentry-dotnet/pull/3288))
-### Fixes
+- The SDK's performance API now works in conjunction with OpenTelemetry's instrumentation. This means that SentrySpans and OTel spans now show up in the same span-tree. ([#3288](https://github.com/getsentry/sentry-dotnet/pull/3288))
 
+### Fixes
 -  `HttpResponse.Content` is no longer disposed by when using `SentryHttpFailedRequestHandler` on .NET Framework, which was causing an ObjectDisposedException when using Sentry with NSwag ([#3306](https://github.com/getsentry/sentry-dotnet/pull/3306))
 
 ## 4.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Features
+
+## Unreleased
+
+- Sentry Transactions now work with OpenTelemetry child spans ([#3288](https://github.com/getsentry/sentry-dotnet/pull/3288))
+
 ### Dependencies
 
 - Bump Java SDK from v7.7.0 to v7.8.0 ([#3275](https://github.com/getsentry/sentry-dotnet/pull/3275))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Sentry Transactions now work with OpenTelemetry child spans ([#3288](https://github.com/getsentry/sentry-dotnet/pull/3288))
+
 ## 4.4.0
 
 ### Features
@@ -9,12 +15,6 @@
 ### Fixes
 
 - Fixed normalization for metric tag values for carriage return, line feed and tab characters ([#3281](https://github.com/getsentry/sentry-dotnet/pull/3281))
-
-### Features
-
-## Unreleased
-
-- Sentry Transactions now work with OpenTelemetry child spans ([#3288](https://github.com/getsentry/sentry-dotnet/pull/3288))
 
 ### Dependencies
 

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -87,6 +87,10 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
             // Explicit ParentSpanId of another activity that we have already mapped
             CreateChildSpan(data, mappedParent, data.ParentSpanId);
         }
+        // Note if the current span on the hub is OTel instrumented and is not the parent of `data` then this may be
+        // intentional (see https://opentelemetry.io/docs/languages/net/instrumentation/#creating-new-root-activities)
+        // so we explicitly exclude OTel instrumented spans from the following check.
+        // of Sentry
         else if (_hub.GetSpan() is IBaseTracer { IsOtelInstrumenter: false } inferredParent)
         {
             // When mixing Sentry and OTel instrumentation and we infer that the currently active span is the parent.

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -82,58 +82,77 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
     /// <inheritdoc />
     public override void OnStart(Activity data)
     {
-        if (data.ParentSpanId != default && _map.TryGetValue(data.ParentSpanId, out var parentSpan))
+        if (data.ParentSpanId != default && _map.TryGetValue(data.ParentSpanId, out var mappedParent))
         {
-            // We can find the parent span - start a child span.
-            var context = new SpanContext(
-                data.OperationName,
-                data.SpanId.AsSentrySpanId(),
-                data.ParentSpanId.AsSentrySpanId(),
-                data.TraceId.AsSentryId(),
-                data.DisplayName,
-                null,
-                null)
-            {
-                Instrumenter = Instrumenter.OpenTelemetry
-            };
-
-            var span = (SpanTracer)parentSpan.StartChild(context);
-            span.StartTimestamp = data.StartTimeUtc;
-            // Used to filter out spans that are not recorded when finishing a transaction.
-            span.SetFused(data);
-            span.IsFiltered = () => span.GetFused<Activity>() is { IsAllDataRequested: false, Recorded: false };
-            _map[data.SpanId] = span;
+            // Explicit ParentSpanId of another activity that we have already mapped
+            CreateChildSpan(data, mappedParent, data.ParentSpanId);
+        }
+        else if (_hub.GetSpan() is IBaseTracer { IsOtelInstrumenter: false } inferredParent)
+        {
+            // When mixing Sentry and OTel instrumentation and we infer that the currently active span is the parent.
+            var inferredParentSpan = (ISpan)inferredParent;
+            CreateChildSpan(data, inferredParentSpan, inferredParentSpan.SpanId);
         }
         else
         {
-            // If a parent exists at all, then copy its sampling decision.
-            bool? isSampled = data.HasRemoteParent ? data.Recorded : null;
-
-            // No parent span found - start a new transaction
-            var transactionContext = new TransactionContext(data.DisplayName,
-                data.OperationName,
-                data.SpanId.AsSentrySpanId(),
-                data.ParentSpanId.AsSentrySpanId(),
-                data.TraceId.AsSentryId(),
-                data.DisplayName, null, isSampled, isSampled)
-            {
-                Instrumenter = Instrumenter.OpenTelemetry
-            };
-
-            var baggageHeader = data.Baggage.AsBaggageHeader();
-            var dynamicSamplingContext = baggageHeader.CreateDynamicSamplingContext();
-            var transaction = (TransactionTracer)_hub.StartTransaction(
-                transactionContext, new Dictionary<string, object?>(), dynamicSamplingContext
-                );
-            transaction.StartTimestamp = data.StartTimeUtc;
-            _hub.ConfigureScope(scope => scope.Transaction = transaction);
-            transaction.SetFused(data);
-            _map[data.SpanId] = transaction;
+            CreateRootSpan(data);
         }
 
         // Housekeeping
         PruneFilteredSpans();
     }
+
+    private void CreateChildSpan(Activity data, ISpan parentSpan, ActivitySpanId? parentSpanId = null)
+        => CreateChildSpan(data, parentSpan, parentSpanId?.AsSentrySpanId());
+
+    private void CreateChildSpan(Activity data, ISpan parentSpan, SpanId? parentSpanId = null)
+    {
+        // We can find the parent span - start a child span.
+        var context = new SpanContext(
+            data.OperationName,
+            data.SpanId.AsSentrySpanId(),
+            parentSpanId,
+            description: data.DisplayName
+        )
+        {
+            Instrumenter = Instrumenter.OpenTelemetry
+        };
+
+        var span = (SpanTracer)parentSpan.StartChild(context);
+        span.StartTimestamp = data.StartTimeUtc;
+        // Used to filter out spans that are not recorded when finishing a transaction.
+        span.SetFused(data);
+        span.IsFiltered = () => span.GetFused<Activity>() is { IsAllDataRequested: false, Recorded: false };
+        _map[data.SpanId] = span;
+    }
+
+    private void CreateRootSpan(Activity data)
+    {
+        // If a parent exists at all, then copy its sampling decision.
+        bool? isSampled = data.HasRemoteParent ? data.Recorded : null;
+
+        // No parent span found - start a new transaction
+        var transactionContext = new TransactionContext(data.DisplayName,
+            data.OperationName,
+            data.SpanId.AsSentrySpanId(),
+            data.ParentSpanId.AsSentrySpanId(),
+            data.TraceId.AsSentryId(),
+            data.DisplayName, null, isSampled, isSampled)
+        {
+            Instrumenter = Instrumenter.OpenTelemetry
+        };
+
+        var baggageHeader = data.Baggage.AsBaggageHeader();
+        var dynamicSamplingContext = baggageHeader.CreateDynamicSamplingContext();
+        var transaction = (TransactionTracer)_hub.StartTransaction(
+            transactionContext, new Dictionary<string, object?>(), dynamicSamplingContext
+        );
+        transaction.StartTimestamp = data.StartTimeUtc;
+        _hub.ConfigureScope(scope => scope.Transaction = transaction);
+        transaction.SetFused(data);
+        _map[data.SpanId] = transaction;
+    }
+
 
     /// <inheritdoc />
     public override void OnEnd(Activity data)

--- a/src/Sentry/IBaseTracer.cs
+++ b/src/Sentry/IBaseTracer.cs
@@ -1,0 +1,6 @@
+namespace Sentry;
+
+internal interface IBaseTracer
+{
+    internal bool IsOtelInstrumenter { get; }
+}

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -119,16 +119,6 @@ internal class Hub : IHub, IMetricHub, IDisposable
         IReadOnlyDictionary<string, object?> customSamplingContext,
         DynamicSamplingContext? dynamicSamplingContext)
     {
-        var instrumenter = (context as SpanContext)?.Instrumenter;
-        if (instrumenter != _options.Instrumenter)
-        {
-            _options.LogWarning(
-                $"Attempted to start a transaction via {instrumenter} instrumentation when the SDK is" +
-                $" configured for {_options.Instrumenter} instrumentation.  The transaction will not be created.");
-
-            return NoOpTransaction.Instance;
-        }
-
         var transaction = new TransactionTracer(this, context);
 
         // If the hub is disabled, we will always sample out.  In other words, starting a transaction

--- a/src/Sentry/SentryTransaction.cs
+++ b/src/Sentry/SentryTransaction.cs
@@ -288,7 +288,7 @@ public class SentryTransaction : ITransactionData, ISentryJsonSerializable
         var nonSentrySpans = tracer.Spans
             .Where(s => s is not SpanTracer { IsSentryRequest: true });
 
-        if (tracer is not TransactionTracer { IsOtelInstrumenter: true })
+        if (tracer is not IBaseTracer { IsOtelInstrumenter: true })
         {
             return nonSentrySpans.Select(s => new SentrySpan(s)).ToArray();
         }

--- a/src/Sentry/SpanTracer.cs
+++ b/src/Sentry/SpanTracer.cs
@@ -6,10 +6,14 @@ namespace Sentry;
 /// <summary>
 /// Transaction span tracer.
 /// </summary>
-public class SpanTracer : ISpan
+public class SpanTracer : IBaseTracer, ISpan
 {
     private readonly IHub _hub;
     private readonly SentryStopwatch _stopwatch = SentryStopwatch.StartNew();
+
+    private readonly Instrumenter _instrumenter = Instrumenter.Sentry;
+
+    bool IBaseTracer.IsOtelInstrumenter => _instrumenter == Instrumenter.OpenTelemetry;
 
     internal TransactionTracer Transaction { get; }
 
@@ -113,9 +117,11 @@ public class SpanTracer : ISpan
         SpanId spanId,
         SpanId? parentSpanId,
         SentryId traceId,
-        string operation)
+        string operation,
+        Instrumenter instrumenter = Instrumenter.Sentry)
     {
         _hub = hub;
+        _instrumenter = instrumenter;
         Transaction = transaction;
         SpanId = spanId;
         ParentSpanId = parentSpanId;

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -7,16 +7,17 @@ namespace Sentry;
 /// <summary>
 /// Transaction tracer.
 /// </summary>
-public class TransactionTracer : ITransactionTracer
+public class TransactionTracer : IBaseTracer, ITransactionTracer
 {
     private readonly IHub _hub;
     private readonly SentryOptions? _options;
     private readonly Timer? _idleTimer;
     private long _cancelIdleTimeout;
     private readonly SentryStopwatch _stopwatch = SentryStopwatch.StartNew();
+
     private readonly Instrumenter _instrumenter = Instrumenter.Sentry;
 
-    internal bool IsOtelInstrumenter => _instrumenter == Instrumenter.OpenTelemetry;
+    bool IBaseTracer.IsOtelInstrumenter => _instrumenter == Instrumenter.OpenTelemetry;
 
     /// <inheritdoc />
     public SpanId SpanId
@@ -281,7 +282,7 @@ public class TransactionTracer : ITransactionTracer
     internal ISpan StartChild(SpanId? spanId, SpanId parentSpanId, string operation,
         Instrumenter instrumenter = Instrumenter.Sentry)
     {
-        var span = new SpanTracer(_hub, this, parentSpanId, TraceId, operation);
+        var span = new SpanTracer(_hub, this, SpanId.Create(), parentSpanId, TraceId, operation, instrumenter: instrumenter);
         if (spanId is { } id)
         {
             span.SpanId = id;

--- a/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
@@ -189,6 +189,9 @@ public class SentrySpanProcessorTests : ActivitySourceTests
         // Arrange
         _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
         _fixture.ScopeManager = Substitute.For<IInternalScopeManager>();
+        var scope = new Scope();
+        var clientScope = new KeyValuePair<Scope, ISentryClient>(scope, _fixture.Client);
+        _fixture.ScopeManager.GetCurrent().Returns(clientScope);
         var sut = _fixture.GetSut();
 
         var data = Tracer.StartActivity("test op");
@@ -268,6 +271,9 @@ public class SentrySpanProcessorTests : ActivitySourceTests
         // Arrange
         _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
         _fixture.ScopeManager = Substitute.For<IInternalScopeManager>();
+        var dummyScope = new Scope();
+        var clientScope = new KeyValuePair<Scope, ISentryClient>(dummyScope, _fixture.Client);
+        _fixture.ScopeManager.GetCurrent().Returns(clientScope);
         var sut = _fixture.GetSut();
 
         var scope = new Scope();
@@ -288,6 +294,9 @@ public class SentrySpanProcessorTests : ActivitySourceTests
         // Arrange
         _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
         _fixture.ScopeManager = Substitute.For<IInternalScopeManager>();
+        var dummyScope = new Scope();
+        var clientScope = new KeyValuePair<Scope, ISentryClient>(dummyScope, _fixture.Client);
+        _fixture.ScopeManager.GetCurrent().Returns(clientScope);
         var sut = _fixture.GetSut();
 
         var scope = new Scope();

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -637,7 +637,7 @@ public partial class HubTests
     }
 
     [Fact]
-    public void StartTransaction_DifferentInstrumenter_NoOp()
+    public void StartTransaction_DifferentInstrumenter_SampledIn()
     {
         // Arrange
         _fixture.Options.EnableTracing = true;
@@ -653,7 +653,7 @@ public partial class HubTests
         var transaction = hub.StartTransaction(transactionContext);
 
         // Assert
-        transaction.Should().Be(NoOpTransaction.Instance);
+        transaction.IsSampled.Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3159

## Caveats

It's currently not possible to determine the best parent for OTel spans when mixing OTel and Sentry instrumentation. 

As an example, someone might instrument their code as follows:

```csharp
using var main = activitySource.StartActivity("Main")
{
  var wrapper = transaction.StartChild("Wrapper");

  using (var child = activitySource.StartActivity("Child"))
  {
    ...
  }

  wrapper.Finish();
}
```

Looking at how the code is structured, perhaps what the SDK user wants is for the `child.Parent` to be `wrapper`. However consider the code snippet below:

```csharp
using var main = activitySource.StartActivity("Main")
{
  var wrapper = transaction.StartChild("Wrapper");

  using (var child = activitySource.StartActivity("Child", ActivityKind.Internal, main!.Id))
  {
    ...
  }

  wrapper.Finish();
}
```

In this second code snippet `child.ParentId` has been set explicity to `main.Id` so it's clear that the SDK user wants `main` to be the parent. 

Both code snippets above result in the same inputs to the `SentrySpanProcessor`, which makes it impossible for us to know what the parent really should be.

A similar problem arises if `child` is [created explicitly as a new Root span](https://opentelemetry.io/docs/languages/net/shim/#creating-new-root-spans).

The only way to resolve this would be to leverage OTel instrumentation under the hood in the Sentry SDK itself... but that would imply an additional dependency on `System.Diagnostics.DiagnosticSource` for anyone targeting net5.0 and earlier (including .NET Framework), as we discovered in https://github.com/getsentry/sentry-dotnet/pull/3238. 