### PR TITLE
remove suffix profiling package

### DIFF
--- a/src/Sentry.Profiling/Sentry.Profiling.csproj
+++ b/src/Sentry.Profiling/Sentry.Profiling.csproj
@@ -4,7 +4,6 @@
     <!-- TODO check and update the list of supported frameworks. -->
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <PackageTags>$(PackageTags);Profiling;Diagnostic</PackageTags>
-    <VersionSuffix>-alpha.1</VersionSuffix>
     <Description>Performance profiling support for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
This somehow didn't apply and it's being out since 4.0.0:

https://www.nuget.org/packages/Sentry.Profiling


#skip-changelog