### PR TITLE
chore: Use `gradle/actions/setup-gradle`

### DIFF
--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -74,7 +74,7 @@ jobs:
           path: bin
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@8baac4c8ef753599f92eeb509c246d09d6250fa6 # pin@v3
+        uses: gradle/actions/setup-gradle@6cec5d49d4d6d4bb982fbed7047db31ea6d38f11 # pin@v3
 
       # Cached AVD setup per https://github.com/ReactiveCircus/android-emulator-runner/blob/main/README.md
 


### PR DESCRIPTION
Based on the readme [here](https://github.com/gradle/gradle-build-action/blob/main/README.md)
```
Users are encouraged to update their workflows, replacing:
uses: gradle/gradle-build-action@v3
with
uses: gradle/actions/setup-gradle@v3
```

#skip-changelog