### PR TITLE
Fixed: SentryHttpFailedRequestHandler disposes Content on .net framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fixed: SentryHttpFailedRequestHandler disposes Content on .net framework ([#3306](https://github.com/getsentry/sentry-dotnet/pull/3306))
+- response.Content is not disposed by SentryHttpFailedRequestHandler on .net framework ([#3306](https://github.com/getsentry/sentry-dotnet/pull/3306))
 
 ## 4.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- response.Content is not disposed by SentryHttpFailedRequestHandler on .net framework ([#3306](https://github.com/getsentry/sentry-dotnet/pull/3306))
+-  `HttpResponse.Content` is no longer disposed by when using `SentryHttpFailedRequestHandler` on .NET Framework, which was causing an ObjectDisposedException when using Sentry with NSwag ([#3306](https://github.com/getsentry/sentry-dotnet/pull/3306))
 
 ## 4.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixed: SentryHttpFailedRequestHandler disposes Content on .net framework ([#3306](https://github.com/getsentry/sentry-dotnet/pull/3306))
+
 ## 4.4.0
 
 ### Features

--- a/src/Sentry/Internal/Extensions/HttpStatusExtensions.cs
+++ b/src/Sentry/Internal/Extensions/HttpStatusExtensions.cs
@@ -1,0 +1,28 @@
+namespace Sentry.Internal.Extensions;
+
+#if !NET5_0_OR_GREATER
+internal static class HttpStatusExtensions
+{
+    private const string HttpRequestExceptionMessage = "Response status code does not indicate success: {0}";
+
+    /// <summary>
+    /// This mimics the behaviour of <see cref="HttpResponseMessage.EnsureSuccessStatusCode"/> for netcore3.0 and later
+    /// by throwing an exception if the status code is outside the 200 range without disposing the content.
+    ///
+    /// See https://github.com/getsentry/sentry-dotnet/issues/2684
+    /// </summary>
+    /// <param name="statusCode"></param>
+    /// <exception cref="HttpRequestException"></exception>
+    public static void EnsureSuccessStatusCode(this HttpStatusCode statusCode)
+    {
+        if ((int)statusCode < 200 || (int)statusCode > 299)
+        {
+            throw new HttpRequestException(string.Format(
+                CultureInfo.InvariantCulture,
+                HttpRequestExceptionMessage,
+                (int)statusCode
+            ));
+        }
+    }
+}
+#endif

--- a/test/Sentry.Tests/Internals/Extensions/HttpRequestExceptionMessageTests.cs
+++ b/test/Sentry.Tests/Internals/Extensions/HttpRequestExceptionMessageTests.cs
@@ -1,0 +1,41 @@
+namespace Sentry.Tests.Internals.Extensions;
+
+#if !NET5_0_OR_GREATER
+public class HttpRequestExceptionMessageTests
+{
+    [Fact]
+    public void EnsureSuccessStatusCode_StatusCodeInRange_DoesNotThrow()
+    {
+        // Arrange
+        const HttpStatusCode statusCode = HttpStatusCode.OK; // Any status code in the 200-299 range
+
+        // Act
+        var act = () => statusCode.EnsureSuccessStatusCode();
+
+        // Assert
+        act.Should().NotThrow<HttpRequestException>();
+    }
+
+    [Fact]
+    public void EnsureSuccessStatusCode_StatusCodeOutOfRange_ThrowsHttpRequestException()
+    {
+        var unsuccessfulStatusCodes = new List<int>();
+        unsuccessfulStatusCodes.AddRange(Enumerable.Range(0, 199));
+        unsuccessfulStatusCodes.AddRange(Enumerable.Range(300, 600));
+        foreach (var i in unsuccessfulStatusCodes)
+        {
+            // Arrange and Act
+            var statusCode = (HttpStatusCode)i;
+            var act = () => statusCode.EnsureSuccessStatusCode();
+
+            // Assert
+            act.Should().Throw<HttpRequestException>()
+                .WithMessage(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Response status code does not indicate success: {0}",
+                    (int)statusCode
+                ));
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/2684