### PR TITLE
feat: Added properties to `CheckIns`

### DIFF
--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -74,7 +74,7 @@ jobs:
           path: bin
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@6cec5d49d4d6d4bb982fbed7047db31ea6d38f11 # pin@v3
+        uses: gradle/actions/setup-gradle@750cdda3edd6d51b7fdfc069d2e2818cf3c44f4c # pin@v3
 
       # Cached AVD setup per https://github.com/ReactiveCircus/android-emulator-runner/blob/main/README.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Extended the SDK's CheckIn support by adding Release, Environment and Trace ID to the event. CheckIns created via the Hangfire integration now also automatically report their duration ([#3320](https://github.com/getsentry/sentry-dotnet/pull/3320))
+
 ### Fixes
 
 -  `HttpResponse.Content` is no longer disposed by when using `SentryHttpFailedRequestHandler` on .NET Framework, which was causing an ObjectDisposedException when using Sentry with NSwag ([#3306](https://github.com/getsentry/sentry-dotnet/pull/3306))

--- a/src/Sentry.Hangfire/SentryServerFilter.cs
+++ b/src/Sentry.Hangfire/SentryServerFilter.cs
@@ -51,7 +51,8 @@ internal class SentryServerFilter : IServerFilter
         }
 
         var status = context.Exception is null ? CheckInStatus.Ok : CheckInStatus.Error;
+        var duration = context.BackgroundJob.CreatedAt - DateTime.Now;
 
-        _ = _hub.CaptureCheckIn(monitorSlug, status, checkInId);
+        _ = _hub.CaptureCheckIn(monitorSlug, status, checkInId, duration);
     }
 }

--- a/src/Sentry.Hangfire/SentryServerFilter.cs
+++ b/src/Sentry.Hangfire/SentryServerFilter.cs
@@ -53,6 +53,6 @@ internal class SentryServerFilter : IServerFilter
         var status = context.Exception is null ? CheckInStatus.Ok : CheckInStatus.Error;
         var duration = context.BackgroundJob.CreatedAt - DateTime.Now;
 
-        _ = _hub.CaptureCheckIn(monitorSlug, status, checkInId, duration);
+        _ = _hub.CaptureCheckIn(monitorSlug, status, checkInId, duration: duration);
     }
 }

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -183,7 +183,8 @@ public class DisabledHub : IHub, IDisposable
     /// <summary>
     /// No-Op
     /// </summary>
-    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, Scope? scope = null, TimeSpan? duration = null)
+    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null,
+        TimeSpan? duration = null, Scope? scope = null)
         => SentryId.Empty;
 
     /// <summary>

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -183,7 +183,7 @@ public class DisabledHub : IHub, IDisposable
     /// <summary>
     /// No-Op
     /// </summary>
-    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null)
+    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null)
         => SentryId.Empty;
 
     /// <summary>

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -183,7 +183,7 @@ public class DisabledHub : IHub, IDisposable
     /// <summary>
     /// No-Op
     /// </summary>
-    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null)
+    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, Scope? scope = null, TimeSpan? duration = null)
         => SentryId.Empty;
 
     /// <summary>

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -270,7 +270,7 @@ public sealed class HubAdapter : IHub
     /// <summary>
     /// Forwards the call to <see cref="SentrySdk"/>.
     /// </summary>
-    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null)
+    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, Scope? scope = null, TimeSpan? duration = null)
         => SentrySdk.CaptureCheckIn(monitorSlug, status, sentryId, duration);
 
     /// <summary>

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -270,8 +270,8 @@ public sealed class HubAdapter : IHub
     /// <summary>
     /// Forwards the call to <see cref="SentrySdk"/>.
     /// </summary>
-    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null)
-        => SentrySdk.CaptureCheckIn(monitorSlug, status, sentryId);
+    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null)
+        => SentrySdk.CaptureCheckIn(monitorSlug, status, sentryId, duration);
 
     /// <summary>
     /// Forwards the call to <see cref="SentrySdk"/>

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -270,7 +270,8 @@ public sealed class HubAdapter : IHub
     /// <summary>
     /// Forwards the call to <see cref="SentrySdk"/>.
     /// </summary>
-    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, Scope? scope = null, TimeSpan? duration = null)
+    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null,
+        TimeSpan? duration = null, Scope? scope = null)
         => SentrySdk.CaptureCheckIn(monitorSlug, status, sentryId, duration);
 
     /// <summary>

--- a/src/Sentry/ISentryClient.cs
+++ b/src/Sentry/ISentryClient.cs
@@ -77,8 +77,9 @@ public interface ISentryClient
     /// <param name="monitorSlug"></param>
     /// <param name="status"></param>
     /// <param name="sentryId"></param>
-    /// /// <param name="duration"></param>
-    SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null);
+    /// <param name="scope"></param>
+    /// <param name="duration"></param>
+    SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, Scope? scope = null, TimeSpan? duration = null);
 
     /// <summary>
     /// Flushes the queue of captured events until the timeout is reached.

--- a/src/Sentry/ISentryClient.cs
+++ b/src/Sentry/ISentryClient.cs
@@ -77,7 +77,8 @@ public interface ISentryClient
     /// <param name="monitorSlug"></param>
     /// <param name="status"></param>
     /// <param name="sentryId"></param>
-    SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null);
+    /// /// <param name="duration"></param>
+    SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null);
 
     /// <summary>
     /// Flushes the queue of captured events until the timeout is reached.

--- a/src/Sentry/ISentryClient.cs
+++ b/src/Sentry/ISentryClient.cs
@@ -77,9 +77,10 @@ public interface ISentryClient
     /// <param name="monitorSlug"></param>
     /// <param name="status"></param>
     /// <param name="sentryId"></param>
-    /// <param name="scope"></param>
     /// <param name="duration"></param>
-    SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, Scope? scope = null, TimeSpan? duration = null);
+    /// <param name="scope"></param>
+    SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null,
+        TimeSpan? duration = null, Scope? scope = null);
 
     /// <summary>
     /// Flushes the queue of captured events until the timeout is reached.

--- a/src/Sentry/Internal/Enricher.cs
+++ b/src/Sentry/Internal/Enricher.cs
@@ -91,4 +91,10 @@ internal class Enricher
         // Default tags
         _options.ApplyDefaultTags(eventLike);
     }
+
+    public void Apply(SentryCheckIn checkIn)
+    {
+        checkIn.Release ??= _options.SettingLocator.GetRelease();
+        checkIn.Environment ??= _options.SettingLocator.GetEnvironment();
+    }
 }

--- a/src/Sentry/Internal/Extensions/JsonExtensions.cs
+++ b/src/Sentry/Internal/Extensions/JsonExtensions.cs
@@ -704,6 +704,17 @@ internal static class JsonExtensions
         }
     }
 
+    public static void WriteNumberIfNotNull(
+        this Utf8JsonWriter writer,
+        string propertyName,
+        double? value)
+    {
+        if (value is not null)
+        {
+            writer.WriteNumber(propertyName, value.Value);
+        }
+    }
+
     public static void WriteNumberIfNotZero(
         this Utf8JsonWriter writer,
         string propertyName,

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -566,7 +566,8 @@ internal class Hub : IHub, IMetricHub, IDisposable
         }
     }
 
-    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null)
+    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null,
+        Scope? scope = null, TimeSpan? duration = null)
     {
         if (!IsEnabled)
         {
@@ -576,7 +577,14 @@ internal class Hub : IHub, IMetricHub, IDisposable
         try
         {
             _options.LogDebug("Capturing '{0}' check-in for '{1}'", status, monitorSlug);
-            return _ownedClient.CaptureCheckIn(monitorSlug, status, sentryId, duration);
+
+            if (scope is null)
+            {
+                ScopeManager.GetCurrent().Deconstruct(out var currentScope, out _);
+                scope = currentScope;
+            }
+
+            return _ownedClient.CaptureCheckIn(monitorSlug, status, sentryId, scope, duration);
         }
         catch (Exception e)
         {

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -566,7 +566,7 @@ internal class Hub : IHub, IMetricHub, IDisposable
         }
     }
 
-    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null)
+    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null)
     {
         if (!IsEnabled)
         {
@@ -576,7 +576,7 @@ internal class Hub : IHub, IMetricHub, IDisposable
         try
         {
             _options.LogDebug("Capturing '{0}' check-in for '{1}'", status, monitorSlug);
-            return _ownedClient.CaptureCheckIn(monitorSlug, status, sentryId);
+            return _ownedClient.CaptureCheckIn(monitorSlug, status, sentryId, duration);
         }
         catch (Exception e)
         {

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -572,7 +572,7 @@ internal class Hub : IHub, IMetricHub, IDisposable
 
             if (scope is null)
             {
-                ScopeManager.GetCurrent().Deconstruct(out var currentScope, out _);
+                var (currentScope, _) = ScopeManager.GetCurrent();
                 scope = currentScope;
             }
 

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -557,7 +557,8 @@ internal class Hub : IHub, IMetricHub, IDisposable
     }
 
     public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null,
-        Scope? scope = null, TimeSpan? duration = null)
+        TimeSpan? duration = null,
+        Scope? scope = null)
     {
         if (!IsEnabled)
         {
@@ -574,7 +575,7 @@ internal class Hub : IHub, IMetricHub, IDisposable
                 scope = currentScope;
             }
 
-            return _ownedClient.CaptureCheckIn(monitorSlug, status, sentryId, scope, duration);
+            return _ownedClient.CaptureCheckIn(monitorSlug, status, sentryId, duration, scope);
         }
         catch (Exception e)
         {

--- a/src/Sentry/SentryCheckIn.cs
+++ b/src/Sentry/SentryCheckIn.cs
@@ -40,10 +40,31 @@ public class SentryCheckIn : ISentryJsonSerializable
     /// </summary>
     public string MonitorSlug { get; }
 
+
     /// <summary>
     /// The status of the Checkin
     /// </summary>
     public CheckInStatus Status { get; }
+
+    /// <summary>
+    /// The duration of the check-in in seconds. Will only take effect if the status is ok or error.
+    /// </summary>
+    public long? Duration { get; set; }
+
+    /// <summary>
+    /// The release.
+    /// </summary>
+    public string? Release { get; set; }
+
+    /// <summary>
+    /// The environment.
+    /// </summary>
+    public string? Environment { get; set; }
+
+    /// <summary>
+    /// A dictionary of contextual information about the environment running the check-in.
+    /// </summary>
+    internal Dictionary<string, string?>? Contexts { get; set; }
 
     /// <summary>
     /// Initializes a new instance of <see cref="SentryCheckIn"/>.
@@ -66,6 +87,12 @@ public class SentryCheckIn : ISentryJsonSerializable
         writer.WriteSerializable("check_in_id", Id, logger);
         writer.WriteString("monitor_slug", MonitorSlug);
         writer.WriteString("status", ToSnakeCase(Status));
+
+        writer.WriteNumberIfNotNull("duration", Duration);
+        writer.WriteStringIfNotWhiteSpace("release", Release);
+        writer.WriteStringIfNotWhiteSpace("environment", Environment);
+
+        writer.WriteStringDictionaryIfNotEmpty("contexts", Contexts);
 
         writer.WriteEndObject();
     }

--- a/src/Sentry/SentryCheckIn.cs
+++ b/src/Sentry/SentryCheckIn.cs
@@ -49,7 +49,7 @@ public class SentryCheckIn : ISentryJsonSerializable
     /// <summary>
     /// The duration of the check-in in seconds. Will only take effect if the status is ok or error.
     /// </summary>
-    public long? Duration { get; set; }
+    public double? Duration { get; set; }
 
     /// <summary>
     /// The release.

--- a/src/Sentry/SentryCheckIn.cs
+++ b/src/Sentry/SentryCheckIn.cs
@@ -64,7 +64,7 @@ public class SentryCheckIn : ISentryJsonSerializable
     /// <summary>
     /// A dictionary of contextual information about the environment running the check-in.
     /// </summary>
-    internal Dictionary<string, string?>? Contexts { get; set; }
+    public Dictionary<string, string?>? Contexts { get; set; }
 
     /// <summary>
     /// Initializes a new instance of <see cref="SentryCheckIn"/>.

--- a/src/Sentry/SentryCheckIn.cs
+++ b/src/Sentry/SentryCheckIn.cs
@@ -49,7 +49,7 @@ public class SentryCheckIn : ISentryJsonSerializable
     /// <summary>
     /// The duration of the check-in in seconds. Will only take effect if the status is ok or error.
     /// </summary>
-    public double? Duration { get; set; }
+    public TimeSpan? Duration { get; set; }
 
     /// <summary>
     /// The release.
@@ -88,10 +88,11 @@ public class SentryCheckIn : ISentryJsonSerializable
         writer.WriteString("monitor_slug", MonitorSlug);
         writer.WriteString("status", ToSnakeCase(Status));
 
-        writer.WriteNumberIfNotNull("duration", Duration);
+        writer.WriteNumberIfNotNull("duration", Duration?.TotalSeconds);
         writer.WriteStringIfNotWhiteSpace("release", Release);
         writer.WriteStringIfNotWhiteSpace("environment", Environment);
 
+        // Check-Ins have their own context but that only support Trace ID
         if (TraceId is not null)
         {
             writer.WriteStartObject("contexts");

--- a/src/Sentry/SentryCheckIn.cs
+++ b/src/Sentry/SentryCheckIn.cs
@@ -62,9 +62,9 @@ public class SentryCheckIn : ISentryJsonSerializable
     public string? Environment { get; set; }
 
     /// <summary>
-    /// A dictionary of contextual information about the environment running the check-in.
+    /// The trace ID
     /// </summary>
-    public Dictionary<string, string?>? Contexts { get; set; }
+    internal SentryId? TraceId { get; set; }
 
     /// <summary>
     /// Initializes a new instance of <see cref="SentryCheckIn"/>.
@@ -92,7 +92,16 @@ public class SentryCheckIn : ISentryJsonSerializable
         writer.WriteStringIfNotWhiteSpace("release", Release);
         writer.WriteStringIfNotWhiteSpace("environment", Environment);
 
-        writer.WriteStringDictionaryIfNotEmpty("contexts", Contexts);
+        if (TraceId is not null)
+        {
+            writer.WriteStartObject("contexts");
+            writer.WriteStartObject("trace");
+
+            writer.WriteStringIfNotWhiteSpace("trace_id", TraceId.ToString());
+
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
 
         writer.WriteEndObject();
     }

--- a/src/Sentry/SentryCheckIn.cs
+++ b/src/Sentry/SentryCheckIn.cs
@@ -40,7 +40,6 @@ public class SentryCheckIn : ISentryJsonSerializable
     /// </summary>
     public string MonitorSlug { get; }
 
-
     /// <summary>
     /// The status of the Checkin
     /// </summary>

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -233,7 +233,7 @@ public class SentryClient : ISentryClient, IDisposable
         => CaptureEnvelope(Envelope.FromSession(sessionUpdate));
 
     /// <inheritdoc />
-    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, Scope? scope = null, TimeSpan? duration = null)
+    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null, Scope? scope = null)
     {
         scope ??= new Scope(_options);
 

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -247,7 +247,7 @@ public class SentryClient : ISentryClient, IDisposable
         var checkIn = new SentryCheckIn(monitorSlug, status, sentryId)
         {
             Duration = duration?.TotalSeconds,
-            Contexts = new Dictionary<string, string?> { { "trace_id", traceId.ToString() } }
+            TraceId = traceId
         };
 
         _enricher.Apply(checkIn);

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -233,9 +233,14 @@ public class SentryClient : ISentryClient, IDisposable
         => CaptureEnvelope(Envelope.FromSession(sessionUpdate));
 
     /// <inheritdoc />
-    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null)
+    public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null)
     {
-        var checkIn = new SentryCheckIn(monitorSlug, status, sentryId);
+        var checkIn = new SentryCheckIn(monitorSlug, status, sentryId)
+        {
+            Duration = duration?.TotalSeconds
+        };
+        _enricher.Apply(checkIn);
+
         return CaptureEnvelope(Envelope.FromCheckIn(checkIn))
             ? checkIn.Id
             : SentryId.Empty;

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -246,7 +246,7 @@ public class SentryClient : ISentryClient, IDisposable
 
         var checkIn = new SentryCheckIn(monitorSlug, status, sentryId)
         {
-            Duration = duration?.TotalSeconds,
+            Duration = duration,
             TraceId = traceId
         };
 

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -530,11 +530,12 @@ public static partial class SentrySdk
     /// <param name="monitorSlug">The monitor slug of the check-in.</param>
     /// <param name="status">The status of the check-in.</param>
     /// <param name="sentryId">The optional <see cref="SentryId"/>.</param>
+    /// <param name="scope">The optional <see cref="Scope"/>.</param>
     /// <param name="duration">The optional duratin of the check-in.</param>
     /// <returns>The Id of the check-in.</returns>
     [DebuggerStepThrough]
-    public static SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null)
-        => CurrentHub.CaptureCheckIn(monitorSlug, status, sentryId, duration: duration);
+    public static SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null, Scope? scope = null)
+        => CurrentHub.CaptureCheckIn(monitorSlug, status, sentryId, duration, scope);
 
     /// <summary>
     /// Starts a transaction.

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -530,10 +530,11 @@ public static partial class SentrySdk
     /// <param name="monitorSlug">The monitor slug of the check-in.</param>
     /// <param name="status">The status of the check-in.</param>
     /// <param name="sentryId">The optional <see cref="SentryId"/>.</param>
+    /// <param name="duration">The optional duratin of the check-in.</param>
     /// <returns>The Id of the check-in.</returns>
     [DebuggerStepThrough]
-    public static SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null)
-        => CurrentHub.CaptureCheckIn(monitorSlug, status, sentryId);
+    public static SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null)
+        => CurrentHub.CaptureCheckIn(monitorSlug, status, sentryId, duration);
 
     /// <summary>
     /// Starts a transaction.

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -534,7 +534,7 @@ public static partial class SentrySdk
     /// <returns>The Id of the check-in.</returns>
     [DebuggerStepThrough]
     public static SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null)
-        => CurrentHub.CaptureCheckIn(monitorSlug, status, sentryId, duration);
+        => CurrentHub.CaptureCheckIn(monitorSlug, status, sentryId, duration: duration);
 
     /// <summary>
     /// Starts a transaction.

--- a/test/Sentry.Hangfire.Tests/HangfireTests.cs
+++ b/test/Sentry.Hangfire.Tests/HangfireTests.cs
@@ -10,7 +10,7 @@ public class HangfireTests : IClassFixture<HangfireFixture>
     }
 
     [Fact]
-    public async void ExecuteJobWithAttribute_CapturesCheckInInProgressAndOk()
+    public async void ExecuteJobWithAttribute_CapturesCheckInInProgressAndOkWithDuration()
     {
         var sentryId = SentryId.Create();
         _fixture.Hub.CaptureCheckIn(Arg.Any<string>(), Arg.Any<CheckInStatus>()).Returns(sentryId);
@@ -24,11 +24,13 @@ public class HangfireTests : IClassFixture<HangfireFixture>
         _fixture.Hub.Received(1).CaptureCheckIn(
             Arg.Is<string>("test-job"),
             Arg.Is<CheckInStatus>(status => status == CheckInStatus.Ok),
-            Arg.Is<SentryId?>(id => id == sentryId));
+            Arg.Is<SentryId?>(id => id == sentryId),
+            Arg.Any<Scope>(),
+            Arg.Is<TimeSpan?>(duration => duration != null));
     }
 
     [Fact]
-    public async void ExecuteJobWithException_CapturesCheckInInProgressAndError()
+    public async void ExecuteJobWithException_CapturesCheckInInProgressAndErrorWithDuration()
     {
         var sentryId = SentryId.Create();
         _fixture.Hub.CaptureCheckIn(Arg.Any<string>(), Arg.Any<CheckInStatus>()).Returns(sentryId);
@@ -44,7 +46,9 @@ public class HangfireTests : IClassFixture<HangfireFixture>
         _fixture.Hub.Received(1).CaptureCheckIn(
             Arg.Is<string>("test-job-with-exception"),
             Arg.Is<CheckInStatus>(status => status == CheckInStatus.Error),
-            Arg.Is<SentryId?>(id => id == sentryId));
+            Arg.Is<SentryId?>(id => id == sentryId),
+            Arg.Any<Scope>(),
+            Arg.Is<TimeSpan?>(duration => duration != null));
     }
 
     [Fact]

--- a/test/Sentry.Hangfire.Tests/HangfireTests.cs
+++ b/test/Sentry.Hangfire.Tests/HangfireTests.cs
@@ -25,8 +25,7 @@ public class HangfireTests : IClassFixture<HangfireFixture>
             Arg.Is<string>("test-job"),
             Arg.Is<CheckInStatus>(status => status == CheckInStatus.Ok),
             Arg.Is<SentryId?>(id => id == sentryId),
-            Arg.Any<Scope>(),
-            Arg.Is<TimeSpan?>(duration => duration != null));
+            Arg.Is<TimeSpan?>(duration => duration != null), Arg.Any<Scope>());
     }
 
     [Fact]
@@ -47,8 +46,7 @@ public class HangfireTests : IClassFixture<HangfireFixture>
             Arg.Is<string>("test-job-with-exception"),
             Arg.Is<CheckInStatus>(status => status == CheckInStatus.Error),
             Arg.Is<SentryId?>(id => id == sentryId),
-            Arg.Any<Scope>(),
-            Arg.Is<TimeSpan?>(duration => duration != null));
+            Arg.Is<TimeSpan?>(duration => duration != null), Arg.Any<Scope>());
     }
 
     [Fact]

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -230,7 +230,7 @@ namespace Sentry
     public interface ISentryClient
     {
         bool IsEnabled { get; }
-        Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default);
+        Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default);
         bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null);
         void CaptureSession(Sentry.SessionUpdate sessionUpdate);
@@ -442,8 +442,11 @@ namespace Sentry
     public class SentryCheckIn : Sentry.ISentryJsonSerializable
     {
         public SentryCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public System.TimeSpan? Duration { get; set; }
+        public string? Environment { get; set; }
         public Sentry.SentryId Id { get; }
         public string MonitorSlug { get; }
+        public string? Release { get; set; }
         public Sentry.CheckInStatus Status { get; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
     }
@@ -451,7 +454,7 @@ namespace Sentry
     {
         public SentryClient(Sentry.SentryOptions options) { }
         public bool IsEnabled { get; }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
@@ -759,7 +762,7 @@ namespace Sentry
         public static void AddBreadcrumb(Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void BindClient(Sentry.ISentryClient client) { }
         public static void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public static Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public static Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default) { }
         public static bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
@@ -1248,7 +1251,7 @@ namespace Sentry.Extensibility
         public Sentry.IMetricAggregator Metrics { get; }
         public void BindClient(Sentry.ISentryClient client) { }
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
@@ -1290,7 +1293,7 @@ namespace Sentry.Extensibility
         public void AddBreadcrumb(Sentry.Infrastructure.ISystemClock clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public void BindClient(Sentry.ISentryClient client) { }
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -230,7 +230,7 @@ namespace Sentry
     public interface ISentryClient
     {
         bool IsEnabled { get; }
-        Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default);
+        Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null);
         bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null);
         void CaptureSession(Sentry.SessionUpdate sessionUpdate);
@@ -454,7 +454,7 @@ namespace Sentry
     {
         public SentryClient(Sentry.SentryOptions options) { }
         public bool IsEnabled { get; }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
@@ -762,7 +762,7 @@ namespace Sentry
         public static void AddBreadcrumb(Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void BindClient(Sentry.ISentryClient client) { }
         public static void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public static Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default) { }
+        public static Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public static bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
@@ -1251,7 +1251,7 @@ namespace Sentry.Extensibility
         public Sentry.IMetricAggregator Metrics { get; }
         public void BindClient(Sentry.ISentryClient client) { }
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
@@ -1293,7 +1293,7 @@ namespace Sentry.Extensibility
         public void AddBreadcrumb(Sentry.Infrastructure.ISystemClock clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public void BindClient(Sentry.ISentryClient client) { }
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -230,7 +230,7 @@ namespace Sentry
     public interface ISentryClient
     {
         bool IsEnabled { get; }
-        Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default);
+        Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null);
         bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null);
         void CaptureSession(Sentry.SessionUpdate sessionUpdate);
@@ -442,8 +442,11 @@ namespace Sentry
     public class SentryCheckIn : Sentry.ISentryJsonSerializable
     {
         public SentryCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public System.TimeSpan? Duration { get; set; }
+        public string? Environment { get; set; }
         public Sentry.SentryId Id { get; }
         public string MonitorSlug { get; }
+        public string? Release { get; set; }
         public Sentry.CheckInStatus Status { get; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
     }
@@ -451,7 +454,7 @@ namespace Sentry
     {
         public SentryClient(Sentry.SentryOptions options) { }
         public bool IsEnabled { get; }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
@@ -759,7 +762,7 @@ namespace Sentry
         public static void AddBreadcrumb(Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void BindClient(Sentry.ISentryClient client) { }
         public static void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public static Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public static Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public static bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
@@ -1248,7 +1251,7 @@ namespace Sentry.Extensibility
         public Sentry.IMetricAggregator Metrics { get; }
         public void BindClient(Sentry.ISentryClient client) { }
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
@@ -1290,7 +1293,7 @@ namespace Sentry.Extensibility
         public void AddBreadcrumb(Sentry.Infrastructure.ISystemClock clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public void BindClient(Sentry.ISentryClient client) { }
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -231,7 +231,7 @@ namespace Sentry
     public interface ISentryClient
     {
         bool IsEnabled { get; }
-        Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default);
+        Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null);
         bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null);
         void CaptureSession(Sentry.SessionUpdate sessionUpdate);
@@ -455,7 +455,7 @@ namespace Sentry
     {
         public SentryClient(Sentry.SentryOptions options) { }
         public bool IsEnabled { get; }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
@@ -764,7 +764,7 @@ namespace Sentry
         public static void AddBreadcrumb(Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void BindClient(Sentry.ISentryClient client) { }
         public static void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public static Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default) { }
+        public static Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public static bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
@@ -1253,7 +1253,7 @@ namespace Sentry.Extensibility
         public Sentry.IMetricAggregator Metrics { get; }
         public void BindClient(Sentry.ISentryClient client) { }
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
@@ -1295,7 +1295,7 @@ namespace Sentry.Extensibility
         public void AddBreadcrumb(Sentry.Infrastructure.ISystemClock clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public void BindClient(Sentry.ISentryClient client) { }
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -231,7 +231,7 @@ namespace Sentry
     public interface ISentryClient
     {
         bool IsEnabled { get; }
-        Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default);
+        Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default);
         bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null);
         void CaptureSession(Sentry.SessionUpdate sessionUpdate);
@@ -443,8 +443,11 @@ namespace Sentry
     public class SentryCheckIn : Sentry.ISentryJsonSerializable
     {
         public SentryCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public System.TimeSpan? Duration { get; set; }
+        public string? Environment { get; set; }
         public Sentry.SentryId Id { get; }
         public string MonitorSlug { get; }
+        public string? Release { get; set; }
         public Sentry.CheckInStatus Status { get; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
     }
@@ -452,7 +455,7 @@ namespace Sentry
     {
         public SentryClient(Sentry.SentryOptions options) { }
         public bool IsEnabled { get; }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
@@ -761,7 +764,7 @@ namespace Sentry
         public static void AddBreadcrumb(Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void BindClient(Sentry.ISentryClient client) { }
         public static void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public static Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public static Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default) { }
         public static bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
@@ -1250,7 +1253,7 @@ namespace Sentry.Extensibility
         public Sentry.IMetricAggregator Metrics { get; }
         public void BindClient(Sentry.ISentryClient client) { }
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
@@ -1292,7 +1295,7 @@ namespace Sentry.Extensibility
         public void AddBreadcrumb(Sentry.Infrastructure.ISystemClock clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public void BindClient(Sentry.ISentryClient client) { }
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -229,7 +229,7 @@ namespace Sentry
     public interface ISentryClient
     {
         bool IsEnabled { get; }
-        Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default);
+        Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null);
         bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null);
         void CaptureSession(Sentry.SessionUpdate sessionUpdate);
@@ -453,7 +453,7 @@ namespace Sentry
     {
         public SentryClient(Sentry.SentryOptions options) { }
         public bool IsEnabled { get; }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
@@ -759,7 +759,7 @@ namespace Sentry
         public static void AddBreadcrumb(Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void BindClient(Sentry.ISentryClient client) { }
         public static void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public static Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default) { }
+        public static Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public static bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
@@ -1248,7 +1248,7 @@ namespace Sentry.Extensibility
         public Sentry.IMetricAggregator Metrics { get; }
         public void BindClient(Sentry.ISentryClient client) { }
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
@@ -1290,7 +1290,7 @@ namespace Sentry.Extensibility
         public void AddBreadcrumb(Sentry.Infrastructure.ISystemClock clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public void BindClient(Sentry.ISentryClient client) { }
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default, Sentry.Scope? scope = null) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -229,7 +229,7 @@ namespace Sentry
     public interface ISentryClient
     {
         bool IsEnabled { get; }
-        Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default);
+        Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default);
         bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope);
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null);
         void CaptureSession(Sentry.SessionUpdate sessionUpdate);
@@ -441,8 +441,11 @@ namespace Sentry
     public class SentryCheckIn : Sentry.ISentryJsonSerializable
     {
         public SentryCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public System.TimeSpan? Duration { get; set; }
+        public string? Environment { get; set; }
         public Sentry.SentryId Id { get; }
         public string MonitorSlug { get; }
+        public string? Release { get; set; }
         public Sentry.CheckInStatus Status { get; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, Sentry.Extensibility.IDiagnosticLogger? logger) { }
     }
@@ -450,7 +453,7 @@ namespace Sentry
     {
         public SentryClient(Sentry.SentryOptions options) { }
         public bool IsEnabled { get; }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent? @event, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public void CaptureSession(Sentry.SessionUpdate sessionUpdate) { }
@@ -756,7 +759,7 @@ namespace Sentry
         public static void AddBreadcrumb(Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void BindClient(Sentry.ISentryClient client) { }
         public static void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public static Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public static Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, System.TimeSpan? duration = default) { }
         public static bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
@@ -1245,7 +1248,7 @@ namespace Sentry.Extensibility
         public Sentry.IMetricAggregator Metrics { get; }
         public void BindClient(Sentry.ISentryClient client) { }
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, System.Action<Sentry.Scope> configureScope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
@@ -1287,7 +1290,7 @@ namespace Sentry.Extensibility
         public void AddBreadcrumb(Sentry.Infrastructure.ISystemClock clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public void BindClient(Sentry.ISentryClient client) { }
         public void BindException(System.Exception exception, Sentry.ISpan span) { }
-        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default) { }
+        public Sentry.SentryId CaptureCheckIn(string monitorSlug, Sentry.CheckInStatus status, Sentry.SentryId? sentryId = default, Sentry.Scope? scope = null, System.TimeSpan? duration = default) { }
         public bool CaptureEnvelope(Sentry.Protocol.Envelopes.Envelope envelope) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt) { }
         public Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.Scope? scope) { }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1468,8 +1468,6 @@ public partial class HubTests
         Assert.Equal(checkInId, SentryId.Empty);
     }
 
-
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1451,7 +1451,7 @@ public partial class HubTests
         _ = hub.CaptureCheckIn("test-slug", CheckInStatus.InProgress);
 
         // Assert
-        _fixture.Client.Received(enabled ? 1 : 0).CaptureCheckIn(Arg.Any<string>(), Arg.Any<CheckInStatus>());
+        _fixture.Client.Received(enabled ? 1 : 0).CaptureCheckIn(Arg.Any<string>(), Arg.Any<CheckInStatus>(), scope: Arg.Any<Scope>());
     }
 
     [Fact]

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1468,6 +1468,8 @@ public partial class HubTests
         Assert.Equal(checkInId, SentryId.Empty);
     }
 
+
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/3259

Based on our [dev docs](https://develop.sentry.dev/sdk/check-ins/) check-ins now have 
```
- CheckIn ID
- Monitor Slug
- Status
- Duration
- Release
- Environment
- Contexts -> trace -> trace ID
```

`Release` and `Environment` are getting applied by the Enricher.
`Duration` is an optional parameter and currently gets set by the Hangfire Integration when a task is finished.
The `Trace ID` gets taken from the scope. Either from the propagation context or, if present, from the current span.