### PR TITLE
Fixed envelopes with large attachments persist on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `HttpResponse.Content` is no longer disposed by when using `SentryHttpFailedRequestHandler` on .NET Framework, which was causing an ObjectDisposedException when using Sentry with NSwag ([#3306](https://github.com/getsentry/sentry-dotnet/pull/3306))
 - Fix BackgroundWorker exiting when OperationCanceledException is not from shutdown request ([3284](https://github.com/getsentry/sentry-dotnet/pull/3284))
+- Envelopes with large attachments no longer get stuck in the queue when using `CacheDirectoryPath` ([#3328](https://github.com/getsentry/sentry-dotnet/pull/3328))
 
 ## 4.4.0
 

--- a/src/Sentry/Http/HttpTransportBase.cs
+++ b/src/Sentry/Http/HttpTransportBase.cs
@@ -127,7 +127,7 @@ public abstract class HttpTransportBase
 
         // If attachment, needs to respect attachment size limit
         if (string.Equals(item.TryGetType(), "attachment", StringComparison.OrdinalIgnoreCase) &&
-            item.TryGetLength() > _options.MaxAttachmentSize)
+            item.TryGetOrRecalculateLength() > _options.MaxAttachmentSize)
         {
             // note: attachment drops are not currently counted in discarded events
 

--- a/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
@@ -76,6 +76,21 @@ public sealed class EnvelopeItem : ISerializable, IDisposable
             var value => Convert.ToInt64(value) // can be int, long, or another numeric type
         };
 
+    internal long? TryGetOrRecalculateLength()
+    {
+        if (TryGetLength() is { } headerLength)
+        {
+            return headerLength;
+        }
+
+        if (Payload is StreamSerializable streamSerializable)
+        {
+            return streamSerializable.Source.TryGetLength();
+        }
+
+        return null;
+    }
+
     /// <summary>
     /// Returns the file name or null if no name exists.
     /// </summary>

--- a/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
@@ -749,6 +749,8 @@ public class EnvelopeTests
             .Which.Source.Should().BeEquivalentTo(@event);
 
         envelopeRoundtrip.Items[1].Payload.Should().BeOfType<StreamSerializable>();
+        envelopeRoundtrip.Items[1].TryGetLength().Should().BeNull();
+        envelopeRoundtrip.Items[1].TryGetOrRecalculateLength().Should().Be(attachment.Content.GetStream().Length);
     }
 
     [Fact]


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3209

## Problem summary

This is only a problem when using the `CachingTransport`.  The issue is in two parts. Firstly here:
https://github.com/getsentry/sentry-dotnet/blob/59f31642c10f8c8159d8294e0a48536b14ad4cd0/src/Sentry/Http/HttpTransportBase.cs#L129-L130

If the `length` header has not been set then the envelope item is not correctly identified as being too big... the result is that we only get an exception when we try to send the attachment in the envelope to Sentry.

The second factor contributing to the issue is that when deserializing an envelope from the cache, this header gets removed:
https://github.com/getsentry/sentry-dotnet/blob/59f31642c10f8c8159d8294e0a48536b14ad4cd0/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs#L446