### PR TITLE
Added warning when attempting to use Sentry with UWP .NET Native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2311)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.31.0...2.31.1)
 
+## Fixes
+
+- Added warning when attempting to use Sentry with UWP .NET Native ([#3343](https://github.com/getsentry/sentry-dotnet/pull/3343))
+
 ## 4.5.0
 
 ### Features

--- a/src/Sentry/Internal/AotHelper.cs
+++ b/src/Sentry/Internal/AotHelper.cs
@@ -1,16 +1,25 @@
 namespace Sentry.Internal;
 
+/// <summary>
+/// Helper class to detect if the application has been compiled Ahead of Time (AOT)
+/// either for UWP .NET Native or on .NET 8.0+
+/// </summary>
 internal static class AotHelper
 {
     internal const string SuppressionJustification = "Non-trimmable code is avoided at runtime";
 
-    private class AotTester
-    {
-        public void Test() { }
-    }
+#if NETSTANDARD
+    internal const bool IsNativeAot = false;
+    internal static bool IsDotNetNative { get; }
 
-#if NET8_0_OR_GREATER
+    static AotHelper()
+    {
+        var stackTrace = new StackTrace(false);
+        IsDotNetNative = stackTrace.GetFrame(0)?.GetMethod() is null;
+    }
+#elif NET8_0_OR_GREATER
     internal static bool IsNativeAot { get; }
+    internal const bool IsDotNetNative = false;
 
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = AotHelper.SuppressionJustification)]
     static AotHelper()
@@ -19,7 +28,7 @@ internal static class AotHelper
         IsNativeAot = stackTrace.GetFrame(0)?.GetMethod() is null;
     }
 #else
-    // This is a compile-time const so that the irrelevant code is removed during compilation.
     internal const bool IsNativeAot = false;
+    internal const bool IsDotNetNative = false;
 #endif
 }

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -31,8 +31,11 @@ public static partial class SentrySdk
 #if NETSTANDARD
         if (AotHelper.IsDotNetNative)
         {
-            options.LogWarning("Sentry doesn't yet support .NET Native compilation. The SDK will be disabled.");
-            return DisabledHub.Instance;
+            throw new Exception(
+                "Sentry does not support .NET Native compilation. " +
+                "To use Sentry, you must disable the .NET Native toolchain. For further information see: " +
+                "https://learn.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/use-csharp-component-from-cpp-winrt#building-for-net-native"
+            );
         }
 #endif
 

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -2,7 +2,6 @@ using Sentry.Extensibility;
 using Sentry.Infrastructure;
 using Sentry.Internal;
 using Sentry.Protocol.Envelopes;
-using Sentry.Protocol.Metrics;
 
 namespace Sentry;
 
@@ -28,6 +27,14 @@ public static partial class SentrySdk
     internal static IHub InitHub(SentryOptions options)
     {
         options.SetupLogging();
+
+#if NETSTANDARD
+        if (AotHelper.IsDotNetNative)
+        {
+            options.LogWarning("Sentry doesn't yet support .NET Native compilation. The SDK will be disabled.");
+            return DisabledHub.Instance;
+        }
+#endif
 
         ProcessInfo.Instance ??= new ProcessInfo(options);
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3240

Until we can carve some time out to enable Sentry to work with .NET Native, this PR logs a warning when trying to use Sentry with UWP and `<UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>`.