### PR TITLE
fix: Blazor WASM & AOT

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -39,7 +39,7 @@ runs:
       shell: bash
       run: >
         dotnet workload install \
-          maui-android \
+          wasm-tools maui-android \
           ${{ runner.os == 'macOS' && 'maui-ios maui-maccatalyst maui-windows macos' || '' }} \
           ${{ runner.os == 'Windows' && 'maui-windows' || '' }} \
           --temp-dir "${{ runner.temp }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - InApp includes/excludes can now be configured using regular expressions ([#3321](https://github.com/getsentry/sentry-dotnet/pull/3321))
 
+### Fixes
+
+- Remove SentryNative initialization from blazor WASM with `RunAOTCompilation` enabled. ([#3349](https://github.com/getsentry/sentry-dotnet/pull/3349))
+
 ### Dependencies
 
 - Bump CLI from v2.31.0 to v2.31.2 ([#3342](https://github.com/getsentry/sentry-dotnet/pull/3342), [#3345](https://github.com/getsentry/sentry-dotnet/pull/3345))

--- a/integration-test/runtime.Tests.ps1
+++ b/integration-test/runtime.Tests.ps1
@@ -114,7 +114,7 @@ internal class FakeTransport : ITransport
     }
 
     It "'dotnet run' produces an app that's recognized as JIT by Sentry" {
-        runConsoleApp $false | Should -AnyElementMatch 'This looks like a standard JIT/AOT application build.'
+        runConsoleApp $false | Should -AnyElementMatch 'This doesn''t look like a Native AOT application build.'
     }
 
     It 'Produces the expected exception (Managed, AOT=<_>)' -ForEach @($true, $false) {

--- a/integration-test/runtime.Tests.ps1
+++ b/integration-test/runtime.Tests.ps1
@@ -110,7 +110,7 @@ internal class FakeTransport : ITransport
     }
 
     It "'dotnet publish' produces an app that's recognized as AOT by Sentry" {
-        runConsoleApp | Should -AnyElementMatch 'This looks like a NativeAOT application build.'
+        runConsoleApp | Should -AnyElementMatch 'This looks like a Native AOT application build.'
     }
 
     It "'dotnet run' produces an app that's recognized as JIT by Sentry" {

--- a/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Sentry.Samples.AspNetCore.Blazor.Wasm.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Sentry.Samples.AspNetCore.Blazor.Wasm.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <RunAOTCompilation>true</RunAOTCompilation>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Sentry.Samples.AspNetCore.Blazor.Wasm.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Sentry.Samples.AspNetCore.Blazor.Wasm.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RunAOTCompilation>true</RunAOTCompilation>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.19" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.3"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.3" PrivateAssets="all"/>
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
   </ItemGroup>

--- a/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/wwwroot/index.html
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/wwwroot/index.html
@@ -5,7 +5,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>BlazorApp1</title>
-    <base href="/" />
 </head>
 
 <body>

--- a/src/Sentry/Internal/AotHelper.cs
+++ b/src/Sentry/Internal/AotHelper.cs
@@ -10,6 +10,7 @@ internal static class AotHelper
     }
 
 #if NET8_0_OR_GREATER
+    // TODO this probably more closely represents trimming rather than NativeAOT?
     internal static bool IsNativeAot { get; }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = AotHelper.SuppressionJustification)]

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -625,7 +625,7 @@ internal class Hub : IHub, IMetricHub, IDisposable
 #elif ANDROID
             // TODO
 #elif NET8_0_OR_GREATER
-        if (AotHelper.IsNativeAot)
+        if (SentryNative.IsAvailable)
         {
             _options?.LogDebug("Closing native SDK");
             SentrySdk.CloseNativeSdk();

--- a/src/Sentry/Platforms/Native/SentryNative.cs
+++ b/src/Sentry/Platforms/Native/SentryNative.cs
@@ -1,0 +1,23 @@
+using Sentry.Internal;
+using Sentry.PlatformAbstractions;
+
+// ReSharper disable once CheckNamespace
+namespace Sentry;
+
+internal static class SentryNative
+{
+#if NET8_0_OR_GREATER
+    internal static bool IsAvailable { get; }
+
+    static SentryNative()
+    {
+        if (AotHelper.IsNativeAot)
+        {
+            IsAvailable = !SentryRuntime.Current.IsBrowserWasm();
+        }
+    }
+#else
+    // This is a compile-time const so that the irrelevant code is removed during compilation.
+    internal const bool IsAvailable = false;
+#endif
+}

--- a/src/Sentry/Platforms/Native/SentryNative.cs
+++ b/src/Sentry/Platforms/Native/SentryNative.cs
@@ -11,10 +11,7 @@ internal static class SentryNative
 
     static SentryNative()
     {
-        if (AotHelper.IsNativeAot)
-        {
-            IsAvailable = !SentryRuntime.Current.IsBrowserWasm();
-        }
+        IsAvailable = AotHelper.IsNativeAot && !SentryRuntime.Current.IsBrowserWasm();
     }
 #else
     // This is a compile-time const so that the irrelevant code is removed during compilation.

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -50,19 +50,6 @@ public class SentryClient : ISentryClient, IDisposable
 
         options.SetupLogging(); // Only relevant if this client wasn't created as a result of calling Init
 
-        if (AotHelper.IsNativeAot)
-#pragma warning disable CS0162 // Unreachable code detected
-        {
-#pragma warning disable 0162 // Unreachable code on old .NET frameworks
-            options.LogDebug("This looks like a NativeAOT application build.");
-#pragma warning restore 0162
-        }
-        else
-        {
-#pragma warning restore CS0162 // Unreachable code detected
-            options.LogDebug("This looks like a standard JIT/AOT application build.");
-        }
-
         if (worker == null)
         {
             var composer = new SdkComposer(options);

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -975,14 +975,14 @@ public class SentryOptions
     /// </summary>
     /// <remarks>
     /// Note that the highest precision value relies on <see cref="System.Diagnostics.Process.GetCurrentProcess"/>
-    /// which might not be available. For example on Unity's IL2CPP.
+    /// which might not be available. For example on Unity's IL2CPP or WebAssembly.
     /// Additionally, "Best" mode is not available on mobile platforms.
     /// </remarks>
     public StartupTimeDetectionMode DetectStartupTime { get; set; } =
 #if __MOBILE__
         StartupTimeDetectionMode.Fast;
 #else
-        StartupTimeDetectionMode.Best;
+        SentryRuntime.Current.IsBrowserWasm() ? StartupTimeDetectionMode.Fast : StartupTimeDetectionMode.Best;
 #endif
 
     /// <summary>

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -49,6 +49,19 @@ public static partial class SentrySdk
             options.LogWarning("The provided DSN that contains a secret key. This is not required and will be ignored.");
         }
 
+        if (AotHelper.IsNativeAot)
+#pragma warning disable CS0162 // Unreachable code detected
+        {
+#pragma warning disable 0162 // Unreachable code on old .NET frameworks
+            options.LogDebug("This looks like a Native AOT application build.");
+#pragma warning restore 0162
+        }
+        else
+        {
+#pragma warning restore CS0162 // Unreachable code detected
+            options.LogDebug("This doesn't look like a Native AOT application build.");
+        }
+
         // Initialize native platform SDKs here
         if (options.InitNativeSdks)
         {
@@ -57,7 +70,7 @@ public static partial class SentrySdk
 #elif ANDROID
             InitSentryAndroidSdk(options);
 #elif NET8_0_OR_GREATER
-            if (AotHelper.IsNativeAot)
+            if (SentryNative.IsAvailable)
             {
                 InitNativeSdk(options);
             }
@@ -709,9 +722,9 @@ public static partial class SentrySdk
                 break;
 #elif NET8_0_OR_GREATER
             case CrashType.Native:
-                if (!AotHelper.IsNativeAot)
+                if (!SentryNative.IsAvailable)
                 {
-                    CurrentOptions?.LogError("The support for capturing native crashes is limited to AOT compilation.");
+                    CurrentOptions?.LogError("The support for capturing native crashes is limited to AOT compilation on platforms with SentryNative support.");
                     return;
                 }
 


### PR DESCRIPTION
Fixes #3263 by disabling sentry-native SDK init when running under WASM AOT.

Tested manually by running the Sentry.Samples.AspNetCore.Blazor.Wasm app produced by `dotnet publish -c Release`. Proper tests could be part of #2021 