### PR TITLE
feat: Hints now accept `byte[]` as attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Hints now accept `byte[]` as attachment ([#3352](https://github.com/getsentry/sentry-dotnet/pull/3352))
 - InApp includes/excludes can now be configured using regular expressions ([#3321](https://github.com/getsentry/sentry-dotnet/pull/3321))
 
 ### Dependencies

--- a/src/Sentry/SentryHint.cs
+++ b/src/Sentry/SentryHint.cs
@@ -59,7 +59,7 @@ public class SentryHint
     internal void AddAttachmentsFromScope(Scope scope) => _attachments.AddRange(scope.Attachments);
 
     /// <summary>
-    /// Creates a new Hint with one or more attachments.
+    /// Takes a path and adds the file as an attachment to the hint.
     /// </summary>
     /// <param name="filePath">The path to the file to attach.</param>
     /// <param name="type">The type of attachment.</param>
@@ -76,6 +76,30 @@ public class SentryHint
                     type,
                     new FileAttachmentContent(filePath, _options.UseAsyncFileIO),
                     Path.GetFileName(filePath),
+                    contentType));
+        }
+    }
+
+    /// <summary>
+    /// Adds a 'byte[]' as attachment to the hind.
+    /// </summary>
+    /// <param name="data">The byte array to be attached</param>
+    /// <param name="fileName">The filename for the attachment</param>
+    /// <param name="type">The type of attachment.</param>
+    /// <param name="contentType">The content type of the attachment.</param>
+    public void AddAttachment(
+        byte[] data,
+        string fileName,
+        AttachmentType type = AttachmentType.Default,
+        string? contentType = null)
+    {
+        if (_options is not null)
+        {
+            _attachments.Add(
+                new SentryAttachment(
+                    type,
+                    new ByteAttachmentContent(data),
+                    fileName,
                     contentType));
         }
     }

--- a/src/Sentry/SentryHint.cs
+++ b/src/Sentry/SentryHint.cs
@@ -93,15 +93,12 @@ public class SentryHint
         AttachmentType type = AttachmentType.Default,
         string? contentType = null)
     {
-        if (_options is not null)
-        {
-            _attachments.Add(
-                new SentryAttachment(
-                    type,
-                    new ByteAttachmentContent(data),
-                    fileName,
-                    contentType));
-        }
+        _attachments.Add(
+            new SentryAttachment(
+                type,
+                new ByteAttachmentContent(data),
+                fileName,
+                contentType));
     }
 
     /// <summary>

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -558,6 +558,7 @@ namespace Sentry
         public System.Collections.Generic.ICollection<Sentry.SentryAttachment> Attachments { get; }
         public System.Collections.Generic.IDictionary<string, object?> Items { get; }
         public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
+        public void AddAttachment(byte[] data, string fileName, Sentry.AttachmentType type = 0, string? contentType = null) { }
         public static Sentry.SentryHint WithAttachments(params Sentry.SentryAttachment[] attachments) { }
         public static Sentry.SentryHint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.SentryAttachment> attachments) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -558,6 +558,7 @@ namespace Sentry
         public System.Collections.Generic.ICollection<Sentry.SentryAttachment> Attachments { get; }
         public System.Collections.Generic.IDictionary<string, object?> Items { get; }
         public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
+        public void AddAttachment(byte[] data, string fileName, Sentry.AttachmentType type = 0, string? contentType = null) { }
         public static Sentry.SentryHint WithAttachments(params Sentry.SentryAttachment[] attachments) { }
         public static Sentry.SentryHint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.SentryAttachment> attachments) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -559,6 +559,7 @@ namespace Sentry
         public System.Collections.Generic.ICollection<Sentry.SentryAttachment> Attachments { get; }
         public System.Collections.Generic.IDictionary<string, object?> Items { get; }
         public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
+        public void AddAttachment(byte[] data, string fileName, Sentry.AttachmentType type = 0, string? contentType = null) { }
         public static Sentry.SentryHint WithAttachments(params Sentry.SentryAttachment[] attachments) { }
         public static Sentry.SentryHint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.SentryAttachment> attachments) { }
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -557,6 +557,7 @@ namespace Sentry
         public System.Collections.Generic.ICollection<Sentry.SentryAttachment> Attachments { get; }
         public System.Collections.Generic.IDictionary<string, object?> Items { get; }
         public void AddAttachment(string filePath, Sentry.AttachmentType type = 0, string? contentType = null) { }
+        public void AddAttachment(byte[] data, string fileName, Sentry.AttachmentType type = 0, string? contentType = null) { }
         public static Sentry.SentryHint WithAttachments(params Sentry.SentryAttachment[] attachments) { }
         public static Sentry.SentryHint WithAttachments(System.Collections.Generic.IEnumerable<Sentry.SentryAttachment> attachments) { }
     }

--- a/test/Sentry.Tests/HintTests.cs
+++ b/test/Sentry.Tests/HintTests.cs
@@ -11,7 +11,7 @@ public class HintTests : IDisposable
     }
 
     [Fact]
-    public void AddAttachment_AddsToHint()
+    public void AddAttachment_Files_AddsToHint()
     {
         // Arrange
         var attachmentPath1 = Path.Combine(_testDirectory, Path.GetTempFileName());
@@ -24,6 +24,24 @@ public class HintTests : IDisposable
         // Act
         hint.AddAttachment(attachmentPath1);
         hint.AddAttachment(attachmentPath2);
+
+        // Assert
+        Assert.Equal(2, hint.Attachments.Count);
+    }
+
+    [Fact]
+    public void AddAttachment_ByteArray_AddsToHint()
+    {
+        // Arrange
+        var byteArray1 = new byte[5];
+        var byteArray2 = new byte[10];
+
+
+        var hint = new SentryHint(new SentryOptions());
+
+        // Act
+        hint.AddAttachment(byteArray1, "byteArray1");
+        hint.AddAttachment(byteArray2, "byteArray2");
 
         // Assert
         Assert.Equal(2, hint.Attachments.Count);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/3350