### PR TITLE
chore: Bump Hangfire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Dependencies
+
+- Bump Hangfire ([#3361](https://github.com/getsentry/sentry-dotnet/pull/3361))
+
 ## 4.6.0
 
 ### Features

--- a/samples/Sentry.Samples.Hangfire/Sentry.Samples.Hangfire.csproj
+++ b/samples/Sentry.Samples.Hangfire/Sentry.Samples.Hangfire.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.Core" Version="1.8.7" />
-    <PackageReference Include="Hangfire.MemoryStorage" Version="1.8.0" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.7" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.12" />
+    <PackageReference Include="Hangfire.MemoryStorage" Version="1.8.1" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sentry.Hangfire/Sentry.Hangfire.csproj
+++ b/src/Sentry.Hangfire/Sentry.Hangfire.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Sentry\Sentry.csproj" />
-    <PackageReference Include="Hangfire.Core" Version="1.8.7" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.12" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As far as I can tell those dependencies come transitive through the `Hangfire.Core` package.

```
Project `Sentry.Hangfire` has the following vulnerable packages
   [net462]: 
   Transitive Package      Resolved   Severity   Advisory URL                                     
   > Newtonsoft.Json       5.0.1      High       https://github.com/advisories/GHSA-5crp-9r3c-p9vr

   [net6.0]: 
   Transitive Package      Resolved   Severity   Advisory URL                                     
   > Newtonsoft.Json       11.0.1     High       https://github.com/advisories/GHSA-5crp-9r3c-p9vr

   [net8.0]: 
   Transitive Package      Resolved   Severity   Advisory URL                                     
   > Newtonsoft.Json       11.0.1     High       https://github.com/advisories/GHSA-5crp-9r3c-p9vr
```