### PR TITLE
Suppress P/Invoke warning for GetWindowThreadProcessId in UWP

### DIFF
--- a/src/Sentry/Internal/ProcessInfo.cs
+++ b/src/Sentry/Internal/ProcessInfo.cs
@@ -149,6 +149,9 @@ internal class ProcessInfo
     [DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
     private static extern IntPtr GetForegroundWindow();
 
-    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    // GetWindowThreadProcessId is only available in the Windows SDK, so trying to call this from UWP apps will fail.
+    // We wrap use of this in a try/catch as a workaround. However, we need `ExactSpelling = true` here  to suppress
+    // warnings about the use of this API when compiling UWP applications.
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true, ExactSpelling = true)]
     private static extern int GetWindowThreadProcessId(IntPtr handle, out int processId);
 }


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3249