### PR TITLE
WIP: task profiling

### DIFF
--- a/samples/Sentry.Samples.Console.Profiling/Program.cs
+++ b/samples/Sentry.Samples.Console.Profiling/Program.cs
@@ -38,11 +38,16 @@ internal static class Program
             Console.WriteLine("Sequential computation finished in " + sw.Elapsed);
             SentrySdk.Flush(TimeSpan.FromMinutes(5));
             Console.WriteLine("Flushed in " + sw.Elapsed);
-            Thread.Sleep(500);
+            await Task.Delay(500);
 
             sw.Restart();
             tx = SentrySdk.StartTransaction("FindPrimeNumber", "Parallel");
-            var tasks = Enumerable.Range(1, count).ToList().Select(_ => Task.Run(() => FindPrimeNumber(100000)));
+            var tasks = Enumerable.Range(1, count).ToList().Select(_ => Task.Run(async () =>
+            {
+                FindPrimeNumber(100000);
+                await Task.Delay(500);
+                FindPrimeNumber(100000);
+            }));
             await Task.WhenAll(tasks).ConfigureAwait(false);
             tx.Finish();
             Console.WriteLine("Parallel computation finished in " + sw.Elapsed);

--- a/src/Sentry.Profiling/SampleProfileBuilder.cs
+++ b/src/Sentry.Profiling/SampleProfileBuilder.cs
@@ -1,5 +1,6 @@
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.Stacks;
 using Sentry.Extensibility;
 using Sentry.Protocol;
 
@@ -13,6 +14,8 @@ internal class SampleProfileBuilder
     private readonly SentryOptions _options;
     private readonly TraceLog _traceLog;
     private readonly ActivityComputer _activityComputer;
+    // private readonly StartStopActivityComputer _startStopActivityComputer;
+    private readonly MutableTraceEventStackSource _stackSource;
 
     // Output profile being built.
     public readonly SampleProfile Profile = new();
@@ -23,6 +26,9 @@ internal class SampleProfileBuilder
     // A dictionary from a CallStackIndex to an index in the output Profile.stacks.
     private readonly Dictionary<int, int> _stackIndexes = new();
 
+    // A dictionary from a StackSourceCallStackIndex to an index in the output Profile.stacks.
+    private readonly Dictionary<int, int> _stackSourceStackIndexes = new();
+
     // A sparse array mapping from a ThreadIndex to an index in Profile.Threads.
     private readonly Dictionary<int, int> _threadIndexes = new();
 
@@ -32,11 +38,16 @@ internal class SampleProfileBuilder
     // TODO make downsampling conditional once this is available: https://github.com/dotnet/runtime/issues/82939
     private readonly Downsampler _downsampler = new();
 
-    public SampleProfileBuilder(SentryOptions options, TraceLog traceLog, ActivityComputer activityComputer)
+    public SampleProfileBuilder(
+        SentryOptions options,
+        TraceLog traceLog,
+        MutableTraceEventStackSource stackSource,
+        ActivityComputer activityComputer)
     {
         _options = options;
         _traceLog = traceLog;
         _activityComputer = activityComputer;
+        _stackSource = stackSource;
     }
 
     internal void AddSample(TraceEvent data, double timestampMs)
@@ -48,13 +59,6 @@ internal class SampleProfileBuilder
             return;
         }
 
-        var callStackIndex = data.CallStackIndex();
-        if (callStackIndex == CallStackIndex.Invalid)
-        {
-            _options.DiagnosticLogger?.LogDebug("Encountered a Profiler Sample without an associated call stack. Skipping.");
-            return;
-        }
-
         var activity = _activityComputer.GetCurrentActivity(thread);
         if (activity is null)
         {
@@ -62,7 +66,7 @@ internal class SampleProfileBuilder
             return;
         }
 
-        var threadIndex = -1;
+        int threadIndex;
         if (activity.IsThreadActivity)
         {
             threadIndex = AddThread(thread);
@@ -84,10 +88,19 @@ internal class SampleProfileBuilder
             return;
         }
 
-        var stackIndex = AddStackTrace(callStackIndex);
+        int stackIndex;
+        if (activity.IsThreadActivity)
+        {
+            stackIndex = AddThreadStackTrace(data);
+        }
+        else
+        {
+            stackIndex = AddActivityStackTrace(thread, data);
+        }
+
         if (stackIndex < 0)
         {
-            _options.DiagnosticLogger?.LogDebug("Invalid stackIndex for Profiler Sample. Skipping.");
+            _options.DiagnosticLogger?.LogDebug("Encountered a Profiler Sample without an associated call stack. Skipping.");
             return;
         }
 
@@ -103,17 +116,50 @@ internal class SampleProfileBuilder
     /// Adds stack trace and frames, if missing.
     /// </summary>
     /// <returns>The index into the Profile's stacks list</returns>
-    private int AddStackTrace(CallStackIndex callstackIndex)
+    private int AddThreadStackTrace(TraceEvent data)
     {
-        var key = (int)callstackIndex;
-
-        if (!_stackIndexes.ContainsKey(key))
+        var callStackIndex = data.CallStackIndex();
+        if (callStackIndex == CallStackIndex.Invalid)
         {
-            Profile.Stacks.Add(CreateStackTrace(callstackIndex));
-            _stackIndexes[key] = Profile.Stacks.Count - 1;
+            return -1;
         }
 
-        return _stackIndexes[key];
+        var key = (int)callStackIndex;
+        if (!_stackIndexes.TryGetValue(key, out var value))
+        {
+            Profile.Stacks.Add(CreateStackTrace(callStackIndex));
+            value = Profile.Stacks.Count - 1;
+            _stackIndexes[key] = value;
+        }
+        return value;
+    }
+
+    /// <summary>
+    /// Adds stack trace and frames, if missing.
+    /// </summary>
+    /// <returns>The index into the Profile's stacks list</returns>
+    private int AddActivityStackTrace(TraceThread thread, TraceEvent data)
+    {
+        var stackSourceCallStackIndex = StackSourceCallStackIndex.Invalid;
+        lock (_stackSource)
+        {
+            stackSourceCallStackIndex = _activityComputer.GetCallStack(_stackSource, data,
+                null // TODO topThread => _startStopActivityComputer.GetCurrentStartStopActivityStack(_stackSource, thread, topThread)
+            );
+        }
+        if (stackSourceCallStackIndex == StackSourceCallStackIndex.Invalid)
+        {
+            return -1;
+        }
+
+        var key = (int)stackSourceCallStackIndex;
+        if (!_stackSourceStackIndexes.TryGetValue(key, out var value))
+        {
+            Profile.Stacks.Add(CreateStackTrace(stackSourceCallStackIndex));
+            value = Profile.Stacks.Count - 1;
+            _stackIndexes[key] = value;
+        }
+        return value;
     }
 
     private Internal.GrowableArray<int> CreateStackTrace(CallStackIndex callstackIndex)
@@ -122,16 +168,42 @@ internal class SampleProfileBuilder
         while (callstackIndex != CallStackIndex.Invalid)
         {
             var codeAddressIndex = _traceLog.CallStacks.CodeAddressIndex(callstackIndex);
-            if (codeAddressIndex != CodeAddressIndex.Invalid)
-            {
-                stackTrace.Add(AddStackFrame(codeAddressIndex));
-                callstackIndex = _traceLog.CallStacks.Caller(callstackIndex);
-            }
-            else
+            if (codeAddressIndex == CodeAddressIndex.Invalid)
             {
                 // No need to traverse further up the stack when we're on the thread/process.
                 break;
             }
+
+            stackTrace.Add(AddStackFrame(codeAddressIndex));
+            callstackIndex = _traceLog.CallStacks.Caller(callstackIndex);
+        }
+
+        stackTrace.Trim(10);
+        return stackTrace;
+    }
+
+    private Internal.GrowableArray<int> CreateStackTrace(StackSourceCallStackIndex callstackIndex)
+    {
+        var stackTrace = new Internal.GrowableArray<int>(10);
+        CodeAddressIndex codeAddressIndex;
+        while (callstackIndex != StackSourceCallStackIndex.Invalid
+            // GetFrameIndex() throws... seems to be happening on top thread frames for some reason...
+            && (callstackIndex - _stackSource.Interner.CallStackStartIndex) < _stackSource.Interner.CallStackCount)
+        {
+            lock (_stackSource)
+            {
+                var frameIndex = _stackSource.GetFrameIndex(callstackIndex);
+                codeAddressIndex = _stackSource.GetFrameCodeAddress(frameIndex);
+                if (codeAddressIndex == CodeAddressIndex.Invalid)
+                {
+                    // No need to traverse further up the stack when we're on the thread/process.
+                    break;
+                }
+
+                callstackIndex = _stackSource.GetCallerIndex(callstackIndex);
+            }
+
+            stackTrace.Add(AddStackFrame(codeAddressIndex));
         }
 
         stackTrace.Trim(10);
@@ -146,13 +218,14 @@ internal class SampleProfileBuilder
     {
         var key = (int)codeAddressIndex;
 
-        if (!_frameIndexes.ContainsKey(key))
+        if (!_frameIndexes.TryGetValue(key, out var value))
         {
             Profile.Frames.Add(CreateStackFrame(codeAddressIndex));
-            _frameIndexes[key] = Profile.Frames.Count - 1;
+            value = Profile.Frames.Count - 1;
+            _frameIndexes[key] = value;
         }
 
-        return _frameIndexes[key];
+        return value;
     }
 
     /// <summary>
@@ -182,7 +255,9 @@ internal class SampleProfileBuilder
 
         if (!_activityIndexes.TryGetValue(key, out var value))
         {
-            value = AddSampleProfileThread(activity.Name ?? $"Activity {activity.Path}");
+            // Note: there's also activity.Name but it's rather verbose:
+            // '<Activity (continuation) Index="8" Thread="Thread (1652)" Create="216.744" Start="216.938" kind="TaskScheduled" RawID="0x2072a40000000004"/>'
+            value = AddSampleProfileThread($"Activity {activity.Path}");
             _activityIndexes[key] = value;
         }
 

--- a/src/Sentry.Profiling/SampleProfilerSession.cs
+++ b/src/Sentry.Profiling/SampleProfilerSession.cs
@@ -17,7 +17,7 @@ internal class SampleProfilerSession : IDisposable
     private readonly TraceLogEventSource _eventSource;
     private readonly MutableTraceEventStackSource _stackSource;
     private readonly SampleProfilerTraceEventParser _sampleEventParser;
-    private readonly SymbolReader _symboReader;
+    private readonly SymbolReader _symbolReader;
     private readonly ActivityComputer _activityComputer;
     // private readonly StartStopActivityComputer _startStopActivityComputer;
     private readonly IDiagnosticLogger? _logger;
@@ -30,8 +30,8 @@ internal class SampleProfilerSession : IDisposable
         _logger = logger;
         _eventSource = eventSource;
         _sampleEventParser = new SampleProfilerTraceEventParser(_eventSource);
-        _symboReader = new SymbolReader(TextWriter.Null);
-        _activityComputer = new ActivityComputer(eventSource, _symboReader);
+        _symbolReader = new SymbolReader(TextWriter.Null);
+        _activityComputer = new ActivityComputer(eventSource, _symbolReader);
         // _startStopActivityComputer = new StartStopActivityComputer(eventSource, _activityComputer);
         _stopwatch = stopwatch;
         _stackSource = new MutableTraceEventStackSource(eventSource.TraceLog)
@@ -141,7 +141,7 @@ internal class SampleProfilerSession : IDisposable
                 _stopped = true;
                 _session.Stop();
                 _session.Dispose();
-                _symboReader.Dispose();
+                _symbolReader.Dispose();
                 _eventSource.Dispose();
             }
             catch (Exception ex)

--- a/src/Sentry.Profiling/SamplingTransactionProfiler.cs
+++ b/src/Sentry.Profiling/SamplingTransactionProfiler.cs
@@ -24,7 +24,7 @@ internal class SamplingTransactionProfiler : ITransactionProfiler
         _cancellationToken = cancellationToken;
         _startTimeMs = session.Elapsed.TotalMilliseconds;
         _endTimeMs = double.MaxValue;
-        _processor = new SampleProfileBuilder(options, session.TraceLog, session.ActivityComputer);
+        _processor = session.CreateProfileBuilder(options);
         session.SampleEventParser.ThreadSample += OnThreadSample;
         cancellationToken.Register(() =>
         {

--- a/src/Sentry.Profiling/SamplingTransactionProfiler.cs
+++ b/src/Sentry.Profiling/SamplingTransactionProfiler.cs
@@ -24,7 +24,7 @@ internal class SamplingTransactionProfiler : ITransactionProfiler
         _cancellationToken = cancellationToken;
         _startTimeMs = session.Elapsed.TotalMilliseconds;
         _endTimeMs = double.MaxValue;
-        _processor = new SampleProfileBuilder(options, session.TraceLog);
+        _processor = new SampleProfileBuilder(options, session.TraceLog, session.ActivityComputer);
         session.SampleEventParser.ThreadSample += OnThreadSample;
         cancellationToken.Register(() =>
         {
@@ -61,7 +61,6 @@ internal class SamplingTransactionProfiler : ITransactionProfiler
         return false;
     }
 
-    // We need custom sampling because the TraceLog dispatches events from a queue with a delay of about 2 seconds.
     private void OnThreadSample(TraceEvent data)
     {
         var timestampMs = data.TimeStampRelativeMSec;

--- a/test/Sentry.Profiling.Tests/TraceLogProcessorTests.ProfileInfo_Serialization_Works.verified.txt
+++ b/test/Sentry.Profiling.Tests/TraceLogProcessorTests.ProfileInfo_Serialization_Works.verified.txt
@@ -42,7 +42,19 @@
         name: Thread 7860
       },
       6: {
+        name: Activity //14/18
+      },
+      7: {
+        name: Activity //14/18/24/28/32
+      },
+      8: {
+        name: Activity //2/23
+      },
+      9: {
         name: Thread 12688
+      },
+      10: {
+        name: Activity //2/23/39
       }
     },
     stacks: [
@@ -107,95 +119,147 @@
         36
       ],
       [
+        0,
+        1,
         37
+      ],
+      [
+        38
       ],
       [
         0,
         1,
-        38,
+        37
+      ],
+      [
         39,
         40,
         41,
         42,
         43,
         44,
-        45,
-        46,
-        22
+        38
       ],
       [
+        0,
+        1,
+        37
+      ],
+      [
+        0,
+        1,
+        37
+      ],
+      [
+        45,
+        46,
         47,
         48,
         49,
+        38
+      ],
+      [
+        0,
+        1,
+        37
+      ],
+      [
         50,
         51,
         52,
+        53,
+        54
+      ],
+      [
+        0,
+        1,
         37
       ],
       [
-        53,
-        54,
         55,
         56,
         57,
-        37
-      ],
-      [
         58,
         59,
         60,
         61,
-        62
-      ],
-      [
+        62,
         63,
         64,
+        50,
+        51,
+        52,
+        53,
+        54
+      ],
+      [
+        0,
+        1,
+        37
+      ],
+      [
         65,
         66,
         67,
         68,
         69,
         70,
+        50,
+        51,
+        52,
+        53,
+        54
+      ],
+      [
+        0,
+        1,
+        37
+      ],
+      [
         71,
         72,
-        58,
-        59,
-        60,
-        61,
-        62
+        70,
+        50,
+        51,
+        52,
+        53,
+        54
+      ],
+      [
+        0,
+        1,
+        37
       ],
       [
         73,
+        51,
+        52,
+        53,
+        54
+      ],
+      [
+        0,
+        1,
+        37
+      ],
+      [
         74,
         75,
         76,
         77,
         78,
-        58,
-        59,
-        60,
-        61,
-        62
-      ],
-      [
         79,
         80,
-        78,
-        58,
-        59,
-        60,
-        61,
-        62
-      ],
-      [
         81,
-        59,
-        60,
-        61,
-        62
+        82,
+        54
       ],
       [
-        82,
+        0,
+        1,
+        37
+      ],
+      [
         83,
         84,
         85,
@@ -204,48 +268,38 @@
         88,
         89,
         90,
-        62
-      ],
-      [
         91,
         92,
-        93,
-        94,
-        95,
-        96,
-        97,
-        98,
-        99,
-        100,
-        84,
-        85,
-        86,
-        87,
-        88,
-        89,
-        90,
-        62
+        76,
+        77,
+        78,
+        79,
+        80,
+        81,
+        82,
+        54
       ],
       [
-        0,
-        1,
-        38,
-        39,
-        40,
-        41,
-        42,
-        43,
-        44,
-        45,
-        46,
-        22
+        93,
+        94,
+        95
       ],
       [
         18,
         19,
         20,
-        101,
+        96,
         22
+      ],
+      [
+        0,
+        1,
+        37
+      ],
+      [
+        97,
+        98,
+        99
       ]
     ],
     frames: [
@@ -434,54 +488,14 @@
         in_app: false
       },
       {
-        function: Aura.UI.Gallery.NetCore.Program.Main(class System.String[]),
-        module: Aura.UI.Gallery.NetCore,
-        in_app: true
-      },
-      {
         function: System.IO.Stream+<>c.<BeginReadInternal>b__40_0(class System.Object),
         module: System.Private.CoreLib.il,
         in_app: false
       },
       {
-        function: System.Threading.Tasks.Task`1[System.Int32].InnerInvoke(),
-        module: System.Private.CoreLib.il,
-        in_app: false
-      },
-      {
-        function: System.Threading.Tasks.Task+<>c.<.cctor>b__272_0(class System.Object),
-        module: System.Private.CoreLib.il,
-        in_app: false
-      },
-      {
-        function: System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(class System.Threading.Thread,class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object),
-        module: System.Private.CoreLib.il,
-        in_app: false
-      },
-      {
-        function: System.Threading.Tasks.Task.ExecuteWithThreadLocal(class System.Threading.Tasks.Task&,class System.Threading.Thread),
-        module: System.Private.CoreLib.il,
-        in_app: false
-      },
-      {
-        function: System.Threading.Tasks.Task.ExecuteEntryUnsafe(class System.Threading.Thread),
-        module: System.Private.CoreLib.il,
-        in_app: false
-      },
-      {
-        function: System.Threading.Tasks.Task.ExecuteFromThreadPool(class System.Threading.Thread),
-        module: System.Private.CoreLib.il,
-        in_app: false
-      },
-      {
-        function: System.Threading.ThreadPoolWorkQueue.Dispatch(),
-        module: System.Private.CoreLib.il,
-        in_app: false
-      },
-      {
-        function: System.Threading.PortableThreadPool+WorkerThread.WorkerThreadStart(),
-        module: System.Private.CoreLib.il,
-        in_app: false
+        function: Aura.UI.Gallery.NetCore.Program.Main(class System.String[]),
+        module: Aura.UI.Gallery.NetCore,
+        in_app: true
       },
       {
         function: System.Collections.Concurrent.ConcurrentDictionary`2[System.__Canon,System.IntPtr].TryAddInternal(!0,value class System.Nullable`1<int32>,!1,bool,bool,!1&),
@@ -752,7 +766,37 @@
         in_app: true
       },
       {
+        function: Aura.UI.Gallery.NetCore.Program+<>c__DisplayClass1_0.<Main>b__1(class System.Threading.Tasks.Task),
+        module: Aura.UI.Gallery.NetCore,
+        in_app: true
+      },
+      {
+        function: System.Threading.Tasks.ContinuationTaskFromTask.InnerInvoke(),
+        module: System.Private.CoreLib.il,
+        in_app: false
+      },
+      {
+        function: System.Threading.Tasks.Task+<>c.<.cctor>b__272_0(class System.Object),
+        module: System.Private.CoreLib.il,
+        in_app: false
+      },
+      {
         function: System.Threading.PortableThreadPool+WorkerThread.WorkerThreadStart(),
+        module: System.Private.CoreLib.il,
+        in_app: false
+      },
+      {
+        function: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.__Canon,Microsoft.Diagnostics.NETCore.Client.IpcEndpointHelper+<ConnectAsync>d__1].MoveNext(),
+        module: System.Private.CoreLib.il,
+        in_app: false
+      },
+      {
+        function: System.Runtime.CompilerServices.TaskAwaiter+<>c.<OutputWaitEtwEvents>b__12_0(class System.Action,class System.Threading.Tasks.Task),
+        module: System.Private.CoreLib.il,
+        in_app: false
+      },
+      {
+        function: System.Runtime.CompilerServices.AsyncMethodBuilderCore+ContinuationWrapper.Invoke(),
         module: System.Private.CoreLib.il,
         in_app: false
       }
@@ -789,13 +833,13 @@
         stack_id: 5
       },
       {
-        elapsed_since_start_ns: 11253400,
-        thread_id: 0,
+        elapsed_since_start_ns: 9261600,
+        thread_id: 6,
         stack_id: 6
       },
       {
-        elapsed_since_start_ns: 11260100,
-        thread_id: 1,
+        elapsed_since_start_ns: 11253400,
+        thread_id: 0,
         stack_id: 7
       },
       {
@@ -814,14 +858,14 @@
         stack_id: 4
       },
       {
-        elapsed_since_start_ns: 21259900,
-        thread_id: 0,
+        elapsed_since_start_ns: 19314800,
+        thread_id: 6,
         stack_id: 8
       },
       {
-        elapsed_since_start_ns: 21267900,
-        thread_id: 1,
-        stack_id: 7
+        elapsed_since_start_ns: 21259900,
+        thread_id: 0,
+        stack_id: 9
       },
       {
         elapsed_since_start_ns: 21270000,
@@ -839,13 +883,13 @@
         stack_id: 4
       },
       {
-        elapsed_since_start_ns: 31243800,
-        thread_id: 0,
-        stack_id: 6
+        elapsed_since_start_ns: 29316000,
+        thread_id: 6,
+        stack_id: 10
       },
       {
-        elapsed_since_start_ns: 31248600,
-        thread_id: 1,
+        elapsed_since_start_ns: 31243800,
+        thread_id: 0,
         stack_id: 7
       },
       {
@@ -864,14 +908,14 @@
         stack_id: 4
       },
       {
-        elapsed_since_start_ns: 41251400,
-        thread_id: 0,
-        stack_id: 9
+        elapsed_since_start_ns: 39246300,
+        thread_id: 6,
+        stack_id: 11
       },
       {
-        elapsed_since_start_ns: 41261500,
-        thread_id: 1,
-        stack_id: 7
+        elapsed_since_start_ns: 41251400,
+        thread_id: 0,
+        stack_id: 12
       },
       {
         elapsed_since_start_ns: 41263200,
@@ -889,14 +933,14 @@
         stack_id: 4
       },
       {
-        elapsed_since_start_ns: 51268200,
-        thread_id: 0,
-        stack_id: 10
+        elapsed_since_start_ns: 49374000,
+        thread_id: 6,
+        stack_id: 13
       },
       {
-        elapsed_since_start_ns: 51291300,
-        thread_id: 1,
-        stack_id: 7
+        elapsed_since_start_ns: 51268200,
+        thread_id: 0,
+        stack_id: 14
       },
       {
         elapsed_since_start_ns: 51294700,
@@ -914,14 +958,14 @@
         stack_id: 4
       },
       {
-        elapsed_since_start_ns: 61258600,
-        thread_id: 0,
-        stack_id: 11
+        elapsed_since_start_ns: 59327100,
+        thread_id: 6,
+        stack_id: 15
       },
       {
-        elapsed_since_start_ns: 61269400,
-        thread_id: 1,
-        stack_id: 7
+        elapsed_since_start_ns: 61258600,
+        thread_id: 0,
+        stack_id: 16
       },
       {
         elapsed_since_start_ns: 61271800,
@@ -939,14 +983,14 @@
         stack_id: 4
       },
       {
-        elapsed_since_start_ns: 71256100,
-        thread_id: 0,
-        stack_id: 12
+        elapsed_since_start_ns: 69308800,
+        thread_id: 6,
+        stack_id: 17
       },
       {
-        elapsed_since_start_ns: 71268300,
-        thread_id: 1,
-        stack_id: 7
+        elapsed_since_start_ns: 71256100,
+        thread_id: 0,
+        stack_id: 18
       },
       {
         elapsed_since_start_ns: 71271900,
@@ -964,14 +1008,14 @@
         stack_id: 4
       },
       {
-        elapsed_since_start_ns: 81242100,
-        thread_id: 0,
-        stack_id: 13
+        elapsed_since_start_ns: 79267700,
+        thread_id: 6,
+        stack_id: 19
       },
       {
-        elapsed_since_start_ns: 81247700,
-        thread_id: 1,
-        stack_id: 7
+        elapsed_since_start_ns: 81242100,
+        thread_id: 0,
+        stack_id: 20
       },
       {
         elapsed_since_start_ns: 81248900,
@@ -989,14 +1033,14 @@
         stack_id: 4
       },
       {
-        elapsed_since_start_ns: 91316900,
-        thread_id: 0,
-        stack_id: 14
+        elapsed_since_start_ns: 89286500,
+        thread_id: 6,
+        stack_id: 21
       },
       {
-        elapsed_since_start_ns: 91324700,
-        thread_id: 1,
-        stack_id: 7
+        elapsed_since_start_ns: 91316900,
+        thread_id: 0,
+        stack_id: 22
       },
       {
         elapsed_since_start_ns: 91326400,
@@ -1014,14 +1058,14 @@
         stack_id: 4
       },
       {
-        elapsed_since_start_ns: 101264900,
-        thread_id: 0,
-        stack_id: 15
+        elapsed_since_start_ns: 99267900,
+        thread_id: 6,
+        stack_id: 23
       },
       {
-        elapsed_since_start_ns: 101272700,
-        thread_id: 1,
-        stack_id: 7
+        elapsed_since_start_ns: 101264900,
+        thread_id: 0,
+        stack_id: 24
       },
       {
         elapsed_since_start_ns: 101274300,
@@ -1039,14 +1083,19 @@
         stack_id: 4
       },
       {
-        elapsed_since_start_ns: 112828800,
-        thread_id: 0,
-        stack_id: 16
-      },
-      {
-        elapsed_since_start_ns: 112839000,
+        elapsed_since_start_ns: 108788100,
         thread_id: 1,
         stack_id: 1
+      },
+      {
+        elapsed_since_start_ns: 108797900,
+        thread_id: 7,
+        stack_id: 25
+      },
+      {
+        elapsed_since_start_ns: 112828800,
+        thread_id: 0,
+        stack_id: 26
       },
       {
         elapsed_since_start_ns: 112843800,
@@ -1059,14 +1108,24 @@
         stack_id: 3
       },
       {
-        elapsed_since_start_ns: 112863500,
-        thread_id: 4,
-        stack_id: 17
+        elapsed_since_start_ns: 114797500,
+        thread_id: 8,
+        stack_id: 27
       },
       {
         elapsed_since_start_ns: 114809100,
-        thread_id: 6,
-        stack_id: 18
+        thread_id: 9,
+        stack_id: 28
+      },
+      {
+        elapsed_since_start_ns: 118824700,
+        thread_id: 7,
+        stack_id: 29
+      },
+      {
+        elapsed_since_start_ns: 118832200,
+        thread_id: 10,
+        stack_id: 30
       }
     ]
   }

--- a/test/Sentry.Profiling.Tests/TraceLogProcessorTests.Profile_Serialization_Works.verified.txt
+++ b/test/Sentry.Profiling.Tests/TraceLogProcessorTests.Profile_Serialization_Works.verified.txt
@@ -19,7 +19,19 @@
       name: Thread 7860
     },
     6: {
+      name: Activity //14/18
+    },
+    7: {
+      name: Activity //14/18/24/28/32
+    },
+    8: {
+      name: Activity //2/23
+    },
+    9: {
       name: Thread 12688
+    },
+    10: {
+      name: Activity //2/23/39
     }
   },
   stacks: [
@@ -84,95 +96,147 @@
       36
     ],
     [
+      0,
+      1,
       37
+    ],
+    [
+      38
     ],
     [
       0,
       1,
-      38,
+      37
+    ],
+    [
       39,
       40,
       41,
       42,
       43,
       44,
-      45,
-      46,
-      22
+      38
     ],
     [
+      0,
+      1,
+      37
+    ],
+    [
+      0,
+      1,
+      37
+    ],
+    [
+      45,
+      46,
       47,
       48,
       49,
+      38
+    ],
+    [
+      0,
+      1,
+      37
+    ],
+    [
       50,
       51,
       52,
+      53,
+      54
+    ],
+    [
+      0,
+      1,
       37
     ],
     [
-      53,
-      54,
       55,
       56,
       57,
-      37
-    ],
-    [
       58,
       59,
       60,
       61,
-      62
-    ],
-    [
+      62,
       63,
       64,
+      50,
+      51,
+      52,
+      53,
+      54
+    ],
+    [
+      0,
+      1,
+      37
+    ],
+    [
       65,
       66,
       67,
       68,
       69,
       70,
+      50,
+      51,
+      52,
+      53,
+      54
+    ],
+    [
+      0,
+      1,
+      37
+    ],
+    [
       71,
       72,
-      58,
-      59,
-      60,
-      61,
-      62
+      70,
+      50,
+      51,
+      52,
+      53,
+      54
+    ],
+    [
+      0,
+      1,
+      37
     ],
     [
       73,
+      51,
+      52,
+      53,
+      54
+    ],
+    [
+      0,
+      1,
+      37
+    ],
+    [
       74,
       75,
       76,
       77,
       78,
-      58,
-      59,
-      60,
-      61,
-      62
-    ],
-    [
       79,
       80,
-      78,
-      58,
-      59,
-      60,
-      61,
-      62
-    ],
-    [
       81,
-      59,
-      60,
-      61,
-      62
+      82,
+      54
     ],
     [
-      82,
+      0,
+      1,
+      37
+    ],
+    [
       83,
       84,
       85,
@@ -181,48 +245,38 @@
       88,
       89,
       90,
-      62
-    ],
-    [
       91,
       92,
-      93,
-      94,
-      95,
-      96,
-      97,
-      98,
-      99,
-      100,
-      84,
-      85,
-      86,
-      87,
-      88,
-      89,
-      90,
-      62
+      76,
+      77,
+      78,
+      79,
+      80,
+      81,
+      82,
+      54
     ],
     [
-      0,
-      1,
-      38,
-      39,
-      40,
-      41,
-      42,
-      43,
-      44,
-      45,
-      46,
-      22
+      93,
+      94,
+      95
     ],
     [
       18,
       19,
       20,
-      101,
+      96,
       22
+    ],
+    [
+      0,
+      1,
+      37
+    ],
+    [
+      97,
+      98,
+      99
     ]
   ],
   frames: [
@@ -411,54 +465,14 @@
       in_app: false
     },
     {
-      function: Aura.UI.Gallery.NetCore.Program.Main(class System.String[]),
-      module: Aura.UI.Gallery.NetCore,
-      in_app: true
-    },
-    {
       function: System.IO.Stream+<>c.<BeginReadInternal>b__40_0(class System.Object),
       module: System.Private.CoreLib.il,
       in_app: false
     },
     {
-      function: System.Threading.Tasks.Task`1[System.Int32].InnerInvoke(),
-      module: System.Private.CoreLib.il,
-      in_app: false
-    },
-    {
-      function: System.Threading.Tasks.Task+<>c.<.cctor>b__272_0(class System.Object),
-      module: System.Private.CoreLib.il,
-      in_app: false
-    },
-    {
-      function: System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(class System.Threading.Thread,class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object),
-      module: System.Private.CoreLib.il,
-      in_app: false
-    },
-    {
-      function: System.Threading.Tasks.Task.ExecuteWithThreadLocal(class System.Threading.Tasks.Task&,class System.Threading.Thread),
-      module: System.Private.CoreLib.il,
-      in_app: false
-    },
-    {
-      function: System.Threading.Tasks.Task.ExecuteEntryUnsafe(class System.Threading.Thread),
-      module: System.Private.CoreLib.il,
-      in_app: false
-    },
-    {
-      function: System.Threading.Tasks.Task.ExecuteFromThreadPool(class System.Threading.Thread),
-      module: System.Private.CoreLib.il,
-      in_app: false
-    },
-    {
-      function: System.Threading.ThreadPoolWorkQueue.Dispatch(),
-      module: System.Private.CoreLib.il,
-      in_app: false
-    },
-    {
-      function: System.Threading.PortableThreadPool+WorkerThread.WorkerThreadStart(),
-      module: System.Private.CoreLib.il,
-      in_app: false
+      function: Aura.UI.Gallery.NetCore.Program.Main(class System.String[]),
+      module: Aura.UI.Gallery.NetCore,
+      in_app: true
     },
     {
       function: System.Collections.Concurrent.ConcurrentDictionary`2[System.__Canon,System.IntPtr].TryAddInternal(!0,value class System.Nullable`1<int32>,!1,bool,bool,!1&),
@@ -729,7 +743,37 @@
       in_app: true
     },
     {
+      function: Aura.UI.Gallery.NetCore.Program+<>c__DisplayClass1_0.<Main>b__1(class System.Threading.Tasks.Task),
+      module: Aura.UI.Gallery.NetCore,
+      in_app: true
+    },
+    {
+      function: System.Threading.Tasks.ContinuationTaskFromTask.InnerInvoke(),
+      module: System.Private.CoreLib.il,
+      in_app: false
+    },
+    {
+      function: System.Threading.Tasks.Task+<>c.<.cctor>b__272_0(class System.Object),
+      module: System.Private.CoreLib.il,
+      in_app: false
+    },
+    {
       function: System.Threading.PortableThreadPool+WorkerThread.WorkerThreadStart(),
+      module: System.Private.CoreLib.il,
+      in_app: false
+    },
+    {
+      function: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.__Canon,Microsoft.Diagnostics.NETCore.Client.IpcEndpointHelper+<ConnectAsync>d__1].MoveNext(),
+      module: System.Private.CoreLib.il,
+      in_app: false
+    },
+    {
+      function: System.Runtime.CompilerServices.TaskAwaiter+<>c.<OutputWaitEtwEvents>b__12_0(class System.Action,class System.Threading.Tasks.Task),
+      module: System.Private.CoreLib.il,
+      in_app: false
+    },
+    {
+      function: System.Runtime.CompilerServices.AsyncMethodBuilderCore+ContinuationWrapper.Invoke(),
       module: System.Private.CoreLib.il,
       in_app: false
     }
@@ -766,13 +810,13 @@
       stack_id: 5
     },
     {
-      elapsed_since_start_ns: 11253400,
-      thread_id: 0,
+      elapsed_since_start_ns: 9261600,
+      thread_id: 6,
       stack_id: 6
     },
     {
-      elapsed_since_start_ns: 11260100,
-      thread_id: 1,
+      elapsed_since_start_ns: 11253400,
+      thread_id: 0,
       stack_id: 7
     },
     {
@@ -791,14 +835,14 @@
       stack_id: 4
     },
     {
-      elapsed_since_start_ns: 21259900,
-      thread_id: 0,
+      elapsed_since_start_ns: 19314800,
+      thread_id: 6,
       stack_id: 8
     },
     {
-      elapsed_since_start_ns: 21267900,
-      thread_id: 1,
-      stack_id: 7
+      elapsed_since_start_ns: 21259900,
+      thread_id: 0,
+      stack_id: 9
     },
     {
       elapsed_since_start_ns: 21270000,
@@ -816,13 +860,13 @@
       stack_id: 4
     },
     {
-      elapsed_since_start_ns: 31243800,
-      thread_id: 0,
-      stack_id: 6
+      elapsed_since_start_ns: 29316000,
+      thread_id: 6,
+      stack_id: 10
     },
     {
-      elapsed_since_start_ns: 31248600,
-      thread_id: 1,
+      elapsed_since_start_ns: 31243800,
+      thread_id: 0,
       stack_id: 7
     },
     {
@@ -841,14 +885,14 @@
       stack_id: 4
     },
     {
-      elapsed_since_start_ns: 41251400,
-      thread_id: 0,
-      stack_id: 9
+      elapsed_since_start_ns: 39246300,
+      thread_id: 6,
+      stack_id: 11
     },
     {
-      elapsed_since_start_ns: 41261500,
-      thread_id: 1,
-      stack_id: 7
+      elapsed_since_start_ns: 41251400,
+      thread_id: 0,
+      stack_id: 12
     },
     {
       elapsed_since_start_ns: 41263200,
@@ -866,14 +910,14 @@
       stack_id: 4
     },
     {
-      elapsed_since_start_ns: 51268200,
-      thread_id: 0,
-      stack_id: 10
+      elapsed_since_start_ns: 49374000,
+      thread_id: 6,
+      stack_id: 13
     },
     {
-      elapsed_since_start_ns: 51291300,
-      thread_id: 1,
-      stack_id: 7
+      elapsed_since_start_ns: 51268200,
+      thread_id: 0,
+      stack_id: 14
     },
     {
       elapsed_since_start_ns: 51294700,
@@ -891,14 +935,14 @@
       stack_id: 4
     },
     {
-      elapsed_since_start_ns: 61258600,
-      thread_id: 0,
-      stack_id: 11
+      elapsed_since_start_ns: 59327100,
+      thread_id: 6,
+      stack_id: 15
     },
     {
-      elapsed_since_start_ns: 61269400,
-      thread_id: 1,
-      stack_id: 7
+      elapsed_since_start_ns: 61258600,
+      thread_id: 0,
+      stack_id: 16
     },
     {
       elapsed_since_start_ns: 61271800,
@@ -916,14 +960,14 @@
       stack_id: 4
     },
     {
-      elapsed_since_start_ns: 71256100,
-      thread_id: 0,
-      stack_id: 12
+      elapsed_since_start_ns: 69308800,
+      thread_id: 6,
+      stack_id: 17
     },
     {
-      elapsed_since_start_ns: 71268300,
-      thread_id: 1,
-      stack_id: 7
+      elapsed_since_start_ns: 71256100,
+      thread_id: 0,
+      stack_id: 18
     },
     {
       elapsed_since_start_ns: 71271900,
@@ -941,14 +985,14 @@
       stack_id: 4
     },
     {
-      elapsed_since_start_ns: 81242100,
-      thread_id: 0,
-      stack_id: 13
+      elapsed_since_start_ns: 79267700,
+      thread_id: 6,
+      stack_id: 19
     },
     {
-      elapsed_since_start_ns: 81247700,
-      thread_id: 1,
-      stack_id: 7
+      elapsed_since_start_ns: 81242100,
+      thread_id: 0,
+      stack_id: 20
     },
     {
       elapsed_since_start_ns: 81248900,
@@ -966,14 +1010,14 @@
       stack_id: 4
     },
     {
-      elapsed_since_start_ns: 91316900,
-      thread_id: 0,
-      stack_id: 14
+      elapsed_since_start_ns: 89286500,
+      thread_id: 6,
+      stack_id: 21
     },
     {
-      elapsed_since_start_ns: 91324700,
-      thread_id: 1,
-      stack_id: 7
+      elapsed_since_start_ns: 91316900,
+      thread_id: 0,
+      stack_id: 22
     },
     {
       elapsed_since_start_ns: 91326400,
@@ -991,14 +1035,14 @@
       stack_id: 4
     },
     {
-      elapsed_since_start_ns: 101264900,
-      thread_id: 0,
-      stack_id: 15
+      elapsed_since_start_ns: 99267900,
+      thread_id: 6,
+      stack_id: 23
     },
     {
-      elapsed_since_start_ns: 101272700,
-      thread_id: 1,
-      stack_id: 7
+      elapsed_since_start_ns: 101264900,
+      thread_id: 0,
+      stack_id: 24
     },
     {
       elapsed_since_start_ns: 101274300,
@@ -1016,14 +1060,19 @@
       stack_id: 4
     },
     {
-      elapsed_since_start_ns: 112828800,
-      thread_id: 0,
-      stack_id: 16
-    },
-    {
-      elapsed_since_start_ns: 112839000,
+      elapsed_since_start_ns: 108788100,
       thread_id: 1,
       stack_id: 1
+    },
+    {
+      elapsed_since_start_ns: 108797900,
+      thread_id: 7,
+      stack_id: 25
+    },
+    {
+      elapsed_since_start_ns: 112828800,
+      thread_id: 0,
+      stack_id: 26
     },
     {
       elapsed_since_start_ns: 112843800,
@@ -1036,14 +1085,24 @@
       stack_id: 3
     },
     {
-      elapsed_since_start_ns: 112863500,
-      thread_id: 4,
-      stack_id: 17
+      elapsed_since_start_ns: 114797500,
+      thread_id: 8,
+      stack_id: 27
     },
     {
       elapsed_since_start_ns: 114809100,
-      thread_id: 6,
-      stack_id: 18
+      thread_id: 9,
+      stack_id: 28
+    },
+    {
+      elapsed_since_start_ns: 118824700,
+      thread_id: 7,
+      stack_id: 29
+    },
+    {
+      elapsed_since_start_ns: 118832200,
+      thread_id: 10,
+      stack_id: 30
     }
   ]
 }


### PR DESCRIPTION
This changes the profiler to track tasks across threadpools. It makes use of ActivityComputer, which is [currently only patched in our fork](https://github.com/vaind/perfview/compare/feat/eventpipe-tracelog-streaming...getsentry:perfview:5a57f1044d94f77b74d984199b2bf2f9869721bf#diff-707bb23f66ccf9d959ea54151c895b438323cc36a94ed0218999838e99e0db4f) and not upstream. 

Also, **there's currently a blocking issue** because with a recent change in TraceLog to clean data structures after a sample is processed (see https://github.com/getsentry/sentry-dotnet/issues/3375#issuecomment-2126916154). The problem is that the ActivityComputer relies on reading older stacks when figuring out creator stacktraces (AFAICT). We'd need to find solution for that to make the ActivityComputer work with realtime sessions, while not reverting the indefinitely growing data structures.
Maybe, we could make ActivityComputer process and keep the needed stack trace information at the time that sample occurs, if that is possible?
In any case, I'd wait until the perfview PR with the main changes we need is merged, before opening another set of changes.