### PR TITLE
Fixed Trim warnings in DiagnosticSource and WinUIUnhandledException integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fixed null IServiceProvider in anonymous routes with OpenTelemetry ([#3401](https://github.com/getsentry/sentry-dotnet/pull/3401))
+- Fixed Trim warnings in Sentry.DiagnosticSource ([#3410](https://github.com/getsentry/sentry-dotnet/pull/3410))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fixed null IServiceProvider in anonymous routes with OpenTelemetry ([#3401](https://github.com/getsentry/sentry-dotnet/pull/3401))
+
 ### Dependencies
 
 - Bump CLI from v2.31.2 to v2.32.1 ([#3398](https://github.com/getsentry/sentry-dotnet/pull/3398))

--- a/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
+++ b/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
@@ -5,7 +5,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TargetFrameworks>net8.0;net6.0;net462</TargetFrameworks>
-    <PublishAot Condition="$(TargetFramework.StartsWith('net8'))">true</PublishAot>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8'))">
+    <PublishAot>true</PublishAot>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -34,6 +37,9 @@
   <!-- In your own project, this would be a PackageReference to the latest version of Sentry. -->
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <TrimmerRootAssembly Include="Sentry" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/Sentry.AspNetCore/ScopeExtensions.cs
+++ b/src/Sentry.AspNetCore/ScopeExtensions.cs
@@ -38,7 +38,10 @@ public static class ScopeExtensions
 
         if (options.SendDefaultPii && !scope.HasUser())
         {
-            var userFactory = context.RequestServices.GetService<ISentryUserFactory>();
+            // Although the compiler suggests context.RequestServices cannot be null, in practice it can be, so we
+            // have a null check here.
+            // See: https://github.com/getsentry/sentry-dotnet/issues/3395
+            var userFactory = context.RequestServices?.GetService<ISentryUserFactory>();
             var user = userFactory?.Create();
 
             if (user != null)

--- a/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/EFCommandDiagnosticSourceHelper.cs
+++ b/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/EFCommandDiagnosticSourceHelper.cs
@@ -13,7 +13,7 @@ internal class EFCommandDiagnosticSourceHelper : EFDiagnosticSourceHelper
 
     protected override string GetDescription(object? diagnosticSourceValue) => FilterNewLineValue(diagnosticSourceValue) ?? string.Empty;
 
-    private static Guid? GetCommandId(object? diagnosticSourceValue) => diagnosticSourceValue?.GetGuidProperty("CommandId");
+    private Guid? GetCommandId(object? diagnosticSourceValue) => diagnosticSourceValue?.GetGuidProperty("CommandId", Options.DiagnosticLogger);
 
     private static void SetCommandId(ISpan span, Guid? commandId)
     {

--- a/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/EFDiagnosticSourceHelper.cs
+++ b/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/EFDiagnosticSourceHelper.cs
@@ -11,27 +11,22 @@ internal abstract class EFDiagnosticSourceHelper
 
     protected abstract string? GetDescription(object? diagnosticSourceValue);
 
-    protected static string? GetDatabaseName(object? diagnosticSourceValue) =>
-        diagnosticSourceValue?.GetStringProperty("Connection.Database");
+    protected string? GetDatabaseName(object? diagnosticSourceValue) =>
+        diagnosticSourceValue?.GetStringProperty("Connection.Database", Options.DiagnosticLogger);
 
-    protected static string? GetDatabaseSystem(object? diagnosticSourceValue)
+    protected string? GetDatabaseSystem(object? diagnosticSourceValue)
     {
-        var providerName = diagnosticSourceValue?.GetStringProperty("Context.Database.ProviderName");
+        var providerName = diagnosticSourceValue?.GetStringProperty("Context.Database.ProviderName", Options.DiagnosticLogger);
         if (providerName is null)
         {
             return null;
         }
 
-        if (DatabaseProviderSystems.ProviderSystems.TryGetValue(providerName, out var dbSystem))
-        {
-            return dbSystem;
-        }
-
-        return null;
+        return DatabaseProviderSystems.ProviderSystems.GetValueOrDefault(providerName);
     }
 
-    protected static string? GetDatabaseServerAddress(object? diagnosticSourceValue) =>
-        diagnosticSourceValue?.GetStringProperty("Connection.DataSource");
+    protected string? GetDatabaseServerAddress(object? diagnosticSourceValue) =>
+        diagnosticSourceValue?.GetStringProperty("Connection.DataSource", Options.DiagnosticLogger);
 
     internal EFDiagnosticSourceHelper(IHub hub, SentryOptions options)
     {
@@ -41,7 +36,7 @@ internal abstract class EFDiagnosticSourceHelper
 
     protected static Guid? TryGetConnectionId(ISpan span) => span.Extra.TryGetValue<string, Guid?>(EFKeys.DbConnectionId);
 
-    protected static Guid? GetConnectionId(object? diagnosticSourceValue) => diagnosticSourceValue?.GetGuidProperty("ConnectionId");
+    protected Guid? GetConnectionId(object? diagnosticSourceValue) => diagnosticSourceValue?.GetGuidProperty("ConnectionId", Options.DiagnosticLogger);
 
     protected static void SetConnectionId(ISpan span, Guid? connectionId)
     {

--- a/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/ReflectionHelper.cs
+++ b/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/ReflectionHelper.cs
@@ -1,3 +1,5 @@
+using Sentry.Extensibility;
+
 namespace Sentry.Internal.DiagnosticSource;
 
 /// <summary>
@@ -11,11 +13,11 @@ namespace Sentry.Internal.DiagnosticSource;
 internal static class ReflectionHelper
 {
     [UnconditionalSuppressMessage("TrimAnalyzer", "IL2075", Justification = AotHelper.SuppressionJustification)]
-    public static object? GetProperty(this object obj, string name)
+    public static object? GetProperty(this object obj, string name, IDiagnosticLogger? logger = null)
     {
         if (AotHelper.IsTrimmed)
         {
-            Debug.WriteLine("ReflectionHelper.GetProperty should not be used when trimming is enabled");
+            logger?.LogInfo("ReflectionHelper.GetProperty should not be used when trimming is enabled");
             return null;
         }
 
@@ -36,9 +38,9 @@ internal static class ReflectionHelper
         return currentObj;
     }
 
-    public static Guid? GetGuidProperty(this object obj, string name) =>
-        obj.GetProperty(name) as Guid?;
+    public static Guid? GetGuidProperty(this object obj, string name, IDiagnosticLogger? logger = null) =>
+        obj.GetProperty(name, logger) as Guid?;
 
-    public static string? GetStringProperty(this object obj, string name) =>
-        obj.GetProperty(name) as string;
+    public static string? GetStringProperty(this object obj, string name, IDiagnosticLogger? logger = null) =>
+        obj.GetProperty(name, logger) as string;
 }

--- a/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/ReflectionHelper.cs
+++ b/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/ReflectionHelper.cs
@@ -1,0 +1,44 @@
+namespace Sentry.Internal.DiagnosticSource;
+
+/// <summary>
+/// Various reflection helper methods.
+/// </summary>
+/// <remarks>
+/// Note that the methods in this class are incompatible with Trimming. They are
+/// used exclusively in the `Sentry.Internal.DiagnosticSource` integration, which
+/// we disable if trimming is enabled to avoid problems at runtime.
+/// </remarks>
+internal static class ReflectionHelper
+{
+    [UnconditionalSuppressMessage("TrimAnalyzer", "IL2075", Justification = AotHelper.SuppressionJustification)]
+    public static object? GetProperty(this object obj, string name)
+    {
+        if (AotHelper.IsTrimmed)
+        {
+            Debug.WriteLine("ReflectionHelper.GetProperty should not be used when trimming is enabled");
+            return null;
+        }
+
+        var propertyNames = name.Split('.');
+        var currentObj = obj;
+
+        foreach (var propertyName in propertyNames)
+        {
+            var property = currentObj?.GetType().GetProperty(propertyName);
+            if (property == null)
+            {
+                return null;
+            }
+
+            currentObj = property.GetValue(currentObj);
+        }
+
+        return currentObj;
+    }
+
+    public static Guid? GetGuidProperty(this object obj, string name) =>
+        obj.GetProperty(name) as Guid?;
+
+    public static string? GetStringProperty(this object obj, string name) =>
+        obj.GetProperty(name) as string;
+}

--- a/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentryDiagnosticListenerIntegration.cs
+++ b/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentryDiagnosticListenerIntegration.cs
@@ -13,6 +13,12 @@ internal class SentryDiagnosticListenerIntegration : ISdkIntegration
             return;
         }
 
+        if (AotHelper.IsTrimmed)
+        {
+            options.Log(SentryLevel.Info, "DiagnosticSource Integration is disabled because trimming is enabled.");
+            return;
+        }
+
         var subscriber = new SentryDiagnosticSubscriber(hub, options);
         DiagnosticListener.AllListeners.Subscribe(subscriber);
     }

--- a/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentrySqlListener.cs
+++ b/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentrySqlListener.cs
@@ -81,8 +81,8 @@ internal class SentrySqlListener : IObserver<KeyValuePair<string, object?>>
         var parent = transaction.GetDbParentSpan();
         var span = parent.StartChild(operation);
         span.SetExtra(OTelKeys.DbSystem, "sql");
-        SetOperationId(span, value?.GetGuidProperty("OperationId"));
-        SetConnectionId(span, value?.GetGuidProperty("ConnectionId"));
+        SetOperationId(span, value?.GetGuidProperty("OperationId", _options.DiagnosticLogger));
+        SetConnectionId(span, value?.GetGuidProperty("ConnectionId", _options.DiagnosticLogger));
     }
 
     private ISpan? GetSpan(SentrySqlSpanType type, object? value)
@@ -96,7 +96,7 @@ internal class SentrySqlListener : IObserver<KeyValuePair<string, object?>>
         switch (type)
         {
             case SentrySqlSpanType.Execution:
-                var operationId = value?.GetGuidProperty("OperationId");
+                var operationId = value?.GetGuidProperty("OperationId", _options.DiagnosticLogger);
                 if (TryGetQuerySpan(transaction, operationId) is { } querySpan)
                 {
                     return querySpan;
@@ -108,7 +108,7 @@ internal class SentrySqlListener : IObserver<KeyValuePair<string, object?>>
                 return null;
 
             case SentrySqlSpanType.Connection:
-                var connectionId = value?.GetGuidProperty("ConnectionId");
+                var connectionId = value?.GetGuidProperty("ConnectionId", _options.DiagnosticLogger);
                 if (TryGetConnectionSpan(transaction, connectionId) is { } connectionSpan)
                 {
                     return connectionSpan;
@@ -150,7 +150,7 @@ internal class SentrySqlListener : IObserver<KeyValuePair<string, object?>>
             return;
         }
 
-        var operationId = value.GetGuidProperty("OperationId");
+        var operationId = value.GetGuidProperty("OperationId", _options.DiagnosticLogger);
         if (operationId == null)
         {
             return;
@@ -159,18 +159,18 @@ internal class SentrySqlListener : IObserver<KeyValuePair<string, object?>>
         var spans = transaction.Spans.Where(span => span.Operation is "db.connection").ToList();
         if (spans.Find(span => !span.IsFinished && TryGetOperationId(span) == operationId) is { } connectionSpan)
         {
-            if (value.GetGuidProperty("ConnectionId") is { } connectionId)
+            if (value.GetGuidProperty("ConnectionId", _options.DiagnosticLogger) is { } connectionId)
             {
                 SetConnectionId(connectionSpan, connectionId);
             }
 
-            if (value.GetStringProperty("Connection.Database") is { } dbName)
+            if (value.GetStringProperty("Connection.Database", _options.DiagnosticLogger) is { } dbName)
             {
                 connectionSpan.Description = dbName;
                 SetDatabaseName(connectionSpan, dbName);
             }
 
-            if (value.GetStringProperty("Connection.DataSource") is { } dbSource)
+            if (value.GetStringProperty("Connection.DataSource", _options.DiagnosticLogger) is { } dbSource)
             {
                 SetDatabaseAddress(connectionSpan, dbSource);
             }
@@ -193,7 +193,7 @@ internal class SentrySqlListener : IObserver<KeyValuePair<string, object?>>
         // Try to lookup the associated connection span so that we can store the db.name in
         // the command span as well. This will be easier for users to read/identify than the
         // ConnectionId (which is a Guid)
-        var connectionId = value.GetGuidProperty("ConnectionId");
+        var connectionId = value.GetGuidProperty("ConnectionId", _options.DiagnosticLogger);
         var transaction = _hub.GetTransactionIfSampled();
         if (TryGetConnectionSpan(transaction!, connectionId) is { } connectionSpan)
         {
@@ -203,7 +203,7 @@ internal class SentrySqlListener : IObserver<KeyValuePair<string, object?>>
             }
         }
 
-        commandSpan.Description = value.GetStringProperty("Command.CommandText");
+        commandSpan.Description = value.GetStringProperty("Command.CommandText", _options.DiagnosticLogger);
         commandSpan.Finish(spanStatus);
     }
 
@@ -248,9 +248,9 @@ internal class SentrySqlListener : IObserver<KeyValuePair<string, object?>>
         }
     }
 
-    private static void TrySetConnectionStatistics(ISpan span, object? value)
+    private void TrySetConnectionStatistics(ISpan span, object? value)
     {
-        if (value?.GetProperty("Statistics") is not Dictionary<object, object> statistics)
+        if (value?.GetProperty("Statistics", _options.DiagnosticLogger) is not Dictionary<object, object> statistics)
         {
             return;
         }

--- a/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
@@ -19,7 +19,9 @@ namespace Sentry.Integrations;
 //   See: https://github.com/microsoft/microsoft-ui-xaml/issues/5221
 //
 // Note that we use reflection in this integration to get at WinUI code.
-// If we ever add a Windows platform target (net6.0-windows, etc.), we could refactor to avoid reflection.
+// If we ever add a Windows platform target (net6.0-windows, etc.), we could refactor
+// to avoid reflection (which would also allow us to support trimming with this
+// integration).
 //
 // This integration is for WinUI 3.  It does NOT work for UWP (WinUI 2).
 // For UWP, the calling application will need to hook the event handler.
@@ -42,6 +44,12 @@ internal class WinUIUnhandledExceptionIntegration : ISdkIntegration
     {
         if (!IsApplicable)
         {
+            return;
+        }
+
+        if (AotHelper.IsTrimmed)
+        {
+            options.Log(SentryLevel.Info, "WinUIUnhandledExceptionIntegration Integration is disabled because trimming is enabled.");
             return;
         }
 
@@ -102,6 +110,7 @@ internal class WinUIUnhandledExceptionIntegration : ISdkIntegration
         }
     }
 
+    [UnconditionalSuppressMessage("TrimAnalyzer", "IL2075", Justification = AotHelper.SuppressionJustification)]
     private void WinUIUnhandledExceptionHandler(object sender, object e)
     {
         bool handled;

--- a/src/Sentry/Internal/AotHelper.cs
+++ b/src/Sentry/Internal/AotHelper.cs
@@ -3,6 +3,7 @@ namespace Sentry.Internal;
 internal static class AotHelper
 {
     internal const string SuppressionJustification = "Non-trimmable code is avoided at runtime";
+    internal static bool IsTrimmed { get; }
 
     private class AotTester
     {
@@ -17,10 +18,18 @@ internal static class AotHelper
     static AotHelper()
     {
         var stackTrace = new StackTrace(false);
-        IsNativeAot = stackTrace.GetFrame(0)?.GetMethod() is null;
+        IsTrimmed = stackTrace.GetFrame(0)?.GetMethod() is null;
+        IsNativeAot = IsTrimmed;
     }
 #else
     // This is a compile-time const so that the irrelevant code is removed during compilation.
     internal const bool IsNativeAot = false;
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = AotHelper.SuppressionJustification)]
+    static AotHelper()
+    {
+        var stackTrace = new StackTrace(false);
+        IsTrimmed = stackTrace.GetFrame(0)?.GetMethod() is null;
+    }
 #endif
 }

--- a/src/Sentry/Internal/Extensions/MiscExtensions.cs
+++ b/src/Sentry/Internal/Extensions/MiscExtensions.cs
@@ -68,31 +68,6 @@ internal static class MiscExtensions
     /// </remarks>
     public static bool IsNull(this object? o) => o is null;
 
-    public static object? GetProperty(this object obj, string name)
-    {
-        var propertyNames = name.Split('.');
-        var currentObj = obj;
-
-        foreach (var propertyName in propertyNames)
-        {
-            var property = currentObj?.GetType().GetProperty(propertyName);
-            if (property == null)
-            {
-                return null;
-            }
-
-            currentObj = property.GetValue(currentObj);
-        }
-
-        return currentObj;
-    }
-
-    public static Guid? GetGuidProperty(this object obj, string name) =>
-        obj.GetProperty(name) as Guid?;
-
-    public static string? GetStringProperty(this object obj, string name) =>
-        obj.GetProperty(name) as string;
-
     public static void Add<TKey, TValue>(
         this ICollection<KeyValuePair<TKey, TValue>> collection,
         TKey key,

--- a/test/Sentry.DiagnosticSource.Tests/ReflectionHelperTests.cs
+++ b/test/Sentry.DiagnosticSource.Tests/ReflectionHelperTests.cs
@@ -1,6 +1,8 @@
-namespace Sentry.Tests.Internals.Extensions;
+using Sentry.Internal.DiagnosticSource;
 
-public class MiscExtensionsTests
+namespace Sentry.DiagnosticSource.Tests;
+
+public class ReflectionHelperTests
 {
     public class MyClass
     {

--- a/test/Sentry.Testing/BindableTests.cs
+++ b/test/Sentry.Testing/BindableTests.cs
@@ -1,5 +1,6 @@
 #if !NETFRAMEWORK
 using Microsoft.Extensions.Configuration;
+using Sentry.Internal.DiagnosticSource;
 
 namespace Sentry.Testing;
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3304

## TODO: Testing
- We should add an integration test (maybe using pester) to ensure we don't get any trimming warnings when publishing the `Sentry.Samples.Console.Basic` project with trimming enabled
- Ideally we'd have some tests to ensure the WinUI and DiagnosticSource integrations would not be registered if trimming is enabled as well... we could maybe make that easier if we added an internal setter to `AotHelper.IsTrimmed` so that we could "mock" this during testing.