### PR TITLE
chore: Removed `FirstChanceException` workaround for WinUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Fixed null IServiceProvider in anonymous routes with OpenTelemetry ([#3401](https://github.com/getsentry/sentry-dotnet/pull/3401))
 
+### API Changes
+- Removed `FirstChanceException` workaround for WinUI ([#3411](https://github.com/getsentry/sentry-dotnet/pull/3411))
+
 ### Dependencies
 
 - Bump CLI from v2.31.2 to v2.32.1 ([#3398](https://github.com/getsentry/sentry-dotnet/pull/3398))

--- a/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
@@ -32,7 +32,6 @@ internal class WinUIUnhandledExceptionIntegration : ISdkIntegration
     private static readonly byte[] WinUIPublicKeyToken = Convert.FromHexString("de31ebe4ad15742b");
     private static readonly Assembly? WinUIAssembly = GetWinUIAssembly();
 
-    private Exception? _lastFirstChanceException;
     private IHub _hub = null!;
     private SentryOptions _options = null!;
 
@@ -50,9 +49,6 @@ internal class WinUIUnhandledExceptionIntegration : ISdkIntegration
 
         // Hook the main event handler
         AttachEventHandler();
-
-        // First part of workaround for https://github.com/microsoft/microsoft-ui-xaml/issues/7160
-        AppDomain.CurrentDomain.FirstChanceException += (_, e) => _lastFirstChanceException = e.Exception;
     }
 
     private static Assembly? GetWinUIAssembly()
@@ -116,12 +112,6 @@ internal class WinUIUnhandledExceptionIntegration : ISdkIntegration
         {
             _options.LogError(ex, "Could not get exception details in WinUIUnhandledExceptionHandler.");
             return;
-        }
-
-        // Second part of workaround for https://github.com/microsoft/microsoft-ui-xaml/issues/7160
-        if (exception.StackTrace is null)
-        {
-            exception = _lastFirstChanceException!;
         }
 
         // Set some useful data and capture the exception


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/3312

Supposedly, the bug has been fixed and the `Application.UnhandledException` does not strip the message and the stacktrace.
How do we end up in a state where the `.stacktrace` is still `null` and the workaround `fristChanceException` is also `null`?