### PR TITLE
fix: Fixed duration calculation for Sentry.Hangfire crons checkIn

### DIFF
--- a/src/Sentry.Hangfire/SentryServerFilter.cs
+++ b/src/Sentry.Hangfire/SentryServerFilter.cs
@@ -51,7 +51,7 @@ internal class SentryServerFilter : IServerFilter
         }
 
         var status = context.Exception is null ? CheckInStatus.Ok : CheckInStatus.Error;
-        var duration = context.BackgroundJob.CreatedAt - DateTime.Now;
+        var duration = DateTime.UtcNow - context.BackgroundJob.CreatedAt;
 
         _ = _hub.CaptureCheckIn(monitorSlug, status, checkInId, duration: duration);
     }


### PR DESCRIPTION
In the current implementation `duration` is wrong and even sometimes negative. As a result, it will be ignored on `Sentry` and crons will fail by timeout or Sentry will display the wrong value.