### PR TITLE
Fix memory leak when tracing is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed Monitor duration calculation ([#3420]https://github.com/getsentry/sentry-dotnet/pull/3420)
 - Fixed null IServiceProvider in anonymous routes with OpenTelemetry ([#3401](https://github.com/getsentry/sentry-dotnet/pull/3401))
 - Fixed Trim warnings in Sentry.DiagnosticSource and WinUIUnhandledException integrations ([#3410](https://github.com/getsentry/sentry-dotnet/pull/3410))
+- Fix memory leak when tracing is enabled ([#3432](https://github.com/getsentry/sentry-dotnet/pull/3432))
 
 ### Dependencies
 

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -167,7 +167,11 @@ public class TransactionTracer : IBaseTracer, ITransactionTracer
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string> Tags => _tags;
 
+#if NETSTANDARD2_1_OR_GREATER
     private readonly ConcurrentBag<ISpan> _spans = new();
+#else
+    private ConcurrentBag<ISpan> _spans = new();
+#endif
 
     /// <inheritdoc />
     public IReadOnlyCollection<ISpan> Spans => _spans;
@@ -337,6 +341,14 @@ public class TransactionTracer : IBaseTracer, ITransactionTracer
                 return null;
             }
         }
+
+        public void Clear()
+        {
+            lock (_lock)
+            {
+                TrackedSpans.Clear();
+            }
+        }
     }
     private readonly LastActiveSpanTracker _activeSpanTracker = new LastActiveSpanTracker();
 
@@ -373,6 +385,9 @@ public class TransactionTracer : IBaseTracer, ITransactionTracer
 
         // Client decides whether to discard this transaction based on sampling
         _hub.CaptureTransaction(new SentryTransaction(this));
+
+        // Release tracked spans
+        ReleaseSpans();
     }
 
     /// <inheritdoc />
@@ -395,4 +410,14 @@ public class TransactionTracer : IBaseTracer, ITransactionTracer
 
     /// <inheritdoc />
     public SentryTraceHeader GetTraceHeader() => new(TraceId, SpanId, IsSampled);
+
+    private void ReleaseSpans()
+    {
+#if NETSTANDARD2_1_OR_GREATER
+        _spans.Clear();
+#else
+        _spans = new ConcurrentBag<ISpan>();
+#endif
+        _activeSpanTracker.Clear();
+    }
 }

--- a/test/Sentry.Tests/Protocol/SentryTransactionTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryTransactionTests.cs
@@ -130,7 +130,8 @@ public class SentryTransactionTests
         child2.SetExtra("f222", "p111");
         child2.Finish(SpanStatus.OutOfRange);
 
-        txTracer.Finish(SpanStatus.Aborted);
+        // Don't finish the tracer - that would cause the spans to be released
+        // txTracer.Finish(SpanStatus.Aborted);
 
         // Act
         var transaction = new SentryTransaction(txTracer);


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3431

## Memory Profile prior to this PR

<img width="1715" alt="image" src="https://github.com/getsentry/sentry-dotnet/assets/728212/71185596-5cf3-48f0-b53d-bf1d3d838dbb">

## Memory Profile after this PR

<img width="1712" alt="image" src="https://github.com/getsentry/sentry-dotnet/assets/728212/dc49909a-c542-492c-a565-0fce8197874a">
