### PR TITLE
chore: Replace `<Version>` with `<VersionPrefix>` to allow use of `<VersionSuffix>`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>4.7.0</Version>
+    <VersionPrefix>4.7.0</VersionPrefix>
     <LangVersion>12</LangVersion>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/integration-test/common.ps1
+++ b/integration-test/common.ps1
@@ -60,7 +60,7 @@ BeforeAll {
 
     function GetSentryPackageVersion()
     {
-        (Select-Xml -Path "$PSScriptRoot/../Directory.Build.props" -XPath "/Project/PropertyGroup/Version").Node.InnerText
+        (Select-Xml -Path "$PSScriptRoot/../Directory.Build.props" -XPath "/Project/PropertyGroup/VersionPrefix").Node.InnerText
     }
 
     function RegisterLocalPackage([string] $name)

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -10,4 +10,4 @@ function Replace-TextInFile {
 }
 
 # Version of .NET assemblies:
-Replace-TextInFile "$PSScriptRoot/../Directory.Build.props" '(?<=<Version>)(.*?)(?=</Version>)' $newVersion
+Replace-TextInFile "$PSScriptRoot/../Directory.Build.props" '(?<=<VersionPrefix>)(.*?)(?=</VersionPrefix>)' $newVersion

--- a/src/Sentry.AspNetCore.Blazor.WebAssembly/Sentry.AspNetCore.Blazor.WebAssembly.csproj
+++ b/src/Sentry.AspNetCore.Blazor.WebAssembly/Sentry.AspNetCore.Blazor.WebAssembly.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <VersionSuffix>-preview.1</VersionSuffix>
+    <VersionSuffix>preview.1</VersionSuffix>
     <RootNamespace>Sentry.AspNetCore.Blazor.WebAssembly</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
Turns out, setting `<Version>` sets the version in stone: https://github.com/dotnet/docs/pull/25751/files
And this is why the profiling package slipped through during the `4.0.0`.

```
If you want to use `--version-suffix`, specify `VersionPrefix` and not `Version` in the project file.
```

I've updated the bump-script as well. So craft should be happy with the change.

#skip-changelog