### PR TITLE
Fix/trace root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- The SDK no longer fails to create a trace root ([#3453](https://github.com/getsentry/sentry-dotnet/pull/3453))
 - Debug logs are now visible for MAUI apps in Visual Studio when using Sentry's default DiagnosticLogger ([#3373](https://github.com/getsentry/sentry-dotnet/pull/3373))
 - Fixed Monitor duration calculation ([#3420]https://github.com/getsentry/sentry-dotnet/pull/3420)
 - Fixed null IServiceProvider in anonymous routes with OpenTelemetry ([#3401](https://github.com/getsentry/sentry-dotnet/pull/3401))

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -254,8 +254,8 @@ internal class Hub : IHub, IMetricHub, IDisposable
         return new TransactionContext(
             name: name ?? string.Empty,
             operation: operation ?? string.Empty,
-            parentSpanId: propagationContext.ParentSpanId,
             spanId: propagationContext.SpanId,
+            parentSpanId: propagationContext.ParentSpanId,
             traceId: propagationContext.TraceId,
             isSampled: traceHeader?.IsSampled,
             isParentSampled: traceHeader?.IsSampled);

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -251,12 +251,14 @@ internal class Hub : IHub, IMetricHub, IDisposable
         var propagationContext = SentryPropagationContext.CreateFromHeaders(_options.DiagnosticLogger, traceHeader, baggageHeader);
         ConfigureScope(scope => scope.PropagationContext = propagationContext);
 
-        // If we have to create a new SentryTraceHeader we don't make a sampling decision
-        traceHeader ??= new SentryTraceHeader(propagationContext.TraceId, propagationContext.SpanId, null);
         return new TransactionContext(
-            name ?? string.Empty,
-            operation ?? string.Empty,
-            traceHeader);
+            name: name ?? string.Empty,
+            operation: operation ?? string.Empty,
+            parentSpanId: propagationContext.ParentSpanId,
+            spanId: propagationContext.SpanId,
+            traceId: propagationContext.TraceId,
+            isSampled: traceHeader?.IsSampled,
+            isParentSampled: traceHeader?.IsSampled);
     }
 
     public void StartSession()

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -971,6 +971,24 @@ public partial class HubTests
     }
 
     [Fact]
+    public void ContinueTrace_DoesNotReceiveHeaders_CreatesRootTrace()
+    {
+        // Arrange
+        var hub = _fixture.GetSut();
+
+        // Act
+        var transactionContext = hub.ContinueTrace((string)null, null, "test-name");
+
+        // Assert
+        transactionContext.Name.Should().Be("test-name");
+        transactionContext.SpanId.Should().NotBe(null);
+        transactionContext.ParentSpanId.Should().Be(null);
+        transactionContext.TraceId.Should().NotBe(null);
+        transactionContext.IsSampled.Should().Be(null);
+        transactionContext.IsParentSampled.Should().Be(null);
+    }
+
+    [Fact]
     public void CaptureTransaction_AfterTransactionFinishes_ResetsTransactionOnScope()
     {
         // Arrange


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/3440

Creating a `SentryTraceHeader` out of convenience to create a `TransactionContext` seems wrong in the first place and this time caused an actual bug. The newly created `TransactionContext` automatically sets the spanId of the provided `TraceHeader` as a parent, causing the SDK to end up in a situation without a trace root (a transaction without a parent).