### PR TITLE
Allow creating releases and uploading commits from MSBuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Added build properties to automatically create releases and associated commits ([#3462](https://github.com/getsentry/sentry-dotnet/pull/3462))
+
 ### Fixes
 
 - The SDK no longer fails to create a trace root ([#3453](https://github.com/getsentry/sentry-dotnet/pull/3453))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Added build properties to automatically create releases and associated commits ([#3462](https://github.com/getsentry/sentry-dotnet/pull/3462))
+
 ## 4.9.0
 
 ### Fixes
@@ -9,7 +15,6 @@
 ### Features
 
 - Client reports now include dropped spans ([#3463](https://github.com/getsentry/sentry-dotnet/pull/3463))
-- Added build properties to automatically create releases and associated commits ([#3462](https://github.com/getsentry/sentry-dotnet/pull/3462))
 
 ### API Changes
 

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -334,6 +334,11 @@
       <SentryRelease>%(MainAssemblyIdentity.Name)@%(Version)</SentryRelease>
     </PropertyGroup>
 
+    <Exec ConsoleToMSBuild="true"  Condition="'$(SentryRelease)' == ''"
+          Command="sentry-cli releases propose-version">
+      <Output TaskParameter="ConsoleOutput" PropertyName="SentryRelease"/>
+    </Exec>
+
     <Message Importance="High" Text="Sentry Release: $(SentryRelease)" />
   </Target>
 

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -37,12 +37,14 @@
       <!-- Set defaults for the Sentry properties. -->
       <SentryUploadSymbols Condition="'$(SentryUploadSymbols)' == ''">false</SentryUploadSymbols>
       <SentryUploadSources Condition="'$(SentryUploadSources)' == ''">false</SentryUploadSources>
+      <SentryCreateRelease Condition="'$(SentryCreateRelease)' == ''">false</SentryCreateRelease>
+      <SentrySetCommits Condition="'$(SentrySetCommits)' == ''">false</SentrySetCommits>
 
       <!-- This property controls if the Sentry CLI is to be used at all. Setting false will disable all Sentry CLI usage.
            We're explicitly skipping uploads for Sentry projects because they interfere with CLI integration test asserts. -->
       <UseSentryCLI Condition="
         '$(UseSentryCLI)' == ''
-        and ('$(SentryUploadSymbols)' == 'true' or '$(SentryUploadSources)' == 'true' or $(SentryUploadAndroidProguardMapping) == 'true')
+        and ('$(SentryUploadSymbols)' == 'true' or '$(SentryUploadSources)' == 'true' or $(SentryUploadAndroidProguardMapping) == 'true' or $(SentryCreateRelease) == 'true' or $(SentrySetCommits) == 'true')
         and '$(MSBuildProjectName)' != 'Sentry'
         and !$(MSBuildProjectName.StartsWith('Sentry.'))">true</UseSentryCLI>
     </PropertyGroup>
@@ -91,6 +93,8 @@
       <SentryCLIBaseOptions Condition="'$(SentryUrl)' != ''">$(SentryCLIBaseOptions) --url $(SentryUrl)</SentryCLIBaseOptions>
       <SentryCLIBaseCommand>&quot;$(SentryCLI)&quot;</SentryCLIBaseCommand>
       <SentryCLIBaseCommand Condition="'$(SentryCLIBaseOptions.Trim())' != ''">$(SentryCLIBaseCommand) $(SentryCLIBaseOptions.Trim())</SentryCLIBaseCommand>
+
+      <SentryReleaseOptions Condition="'$(SentryProject)' != ''">$(SentryReleaseOptions) --project $(SentryProject)</SentryReleaseOptions>
 
       <SentryCLIUploadOptions Condition="'$(SentryOrg)' != ''">$(SentryCLIUploadOptions) --org $(SentryOrg)</SentryCLIUploadOptions>
       <SentryCLIUploadOptions Condition="'$(SentryProject)' != ''">$(SentryCLIUploadOptions) --project $(SentryProject)</SentryCLIUploadOptions>
@@ -241,6 +245,106 @@
     </Exec>
     <Warning Condition="'$(_SentryCLIExitCode)' != '0'" Text="Sentry CLI could not upload proguard mapping." />
   </Target>
+
+  <UsingTask TaskName="SentryGetReleaseFromInformationalVersion" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <AssemblyPath Required="true" />
+      <Release Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System"/>
+      <Using Namespace="System.Reflection"/>
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+  try
+  {
+    var path = Path.GetFullPath(AssemblyPath);
+    var assembly = Assembly.LoadFile(path);
+
+    var assemblyName = assembly.GetName();
+    var name = assemblyName.Name;
+    var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+    if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(version))
+    {
+      Release = $"{name}@{version}";
+    }
+  }
+  catch
+  {
+  }
+  ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <UsingTask TaskName="SentryGetReleaseFromAppManifest" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"
+             Condition="$(TargetFramework.Contains('ios')) Or $(TargetFramework.Contains('maccatalyst'))">
+    <ParameterGroup>
+      <AppManifestPath Required="true" />
+      <Release Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Reference Include="$(_XamarinTaskAssembly)" />
+      <Using Namespace="Xamarin.MacDev"/>
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+  try
+  {
+    var plist = PDictionary.FromFile(AppManifestPath);
+
+    var packageName = plist.GetCFBundleIdentifier();
+    var packageVersion = plist.GetCFBundleShortVersionString();
+    var buildVersion = plist.GetCFBundleVersion();
+
+    Release = $"{packageName}@{packageVersion}+{buildVersion}";
+  }
+  catch
+  {
+  }
+  ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="_GetSentryRelease" AfterTargets="DispatchToInnerBuilds;AfterBuild" Condition="'$(SentryCreateRelease)' == 'true' And '$(UseSentryCLI)' == 'true'">
+
+    <Message Importance="High" Text="Getting Sentry Release..." />
+
+    <PropertyGroup Condition="'$(SentryRelease)' == '' And $(TargetFramework.Contains('android'))">
+      <SentryRelease>$(ApplicationId)@$(ApplicationDisplayVersion)+$(ApplicationVersion)</SentryRelease>
+    </PropertyGroup>
+
+    <SentryGetReleaseFromAppManifest AppManifestPath="$(_TemporaryAppManifest)"
+                                     Condition="'$(SentryRelease)' == '' And ($(TargetFramework.Contains('ios')) Or $(TargetFramework.Contains('maccatalyst')))">
+      <Output TaskParameter="Release" PropertyName="SentryRelease" />
+    </SentryGetReleaseFromAppManifest>
+
+    <SentryGetReleaseFromInformationalVersion Condition="'$(SentryRelease)' == ''" AssemblyPath="$(IntermediateOutputPath)$(TargetName)$(TargetExt)">
+      <Output TaskParameter="Release" PropertyName="SentryRelease" />
+    </SentryGetReleaseFromInformationalVersion>
+
+    <GetAssemblyIdentity Condition="'$(SentryRelease)' == '' And '$(TargetName)' != ''" AssemblyFiles="$(IntermediateOutputPath)$(TargetName)$(TargetExt)">
+      <Output TaskParameter="Assemblies" ItemName="MainAssemblyIdentity" />
+    </GetAssemblyIdentity>
+    <PropertyGroup Condition="'$(SentryRelease)' == '' And '@(MainAssemblyIdentity)' != ''">
+      <SentryRelease>%(MainAssemblyIdentity.Name)@%(Version)</SentryRelease>
+    </PropertyGroup>
+
+    <Message Importance="High" Text="Sentry Release: $(SentryRelease)" />
+  </Target>
+
+  <!-- Set release information after the build -->
+  <Target Name="_CreateSentryRelease" AfterTargets="Build" DependsOnTargets="_GetSentryRelease"
+          Condition="'$(SentryCLI)' != '' and '$(SentryCreateRelease)' == 'true'">
+    <Message Importance="High" Text="Creating Sentry Release: $(SentryRelease)" />
+    <Exec
+      Command="$(SentryCLIBaseCommand) releases new '$(SentryRelease)' $(SentryReleaseOptions)"
+      IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
+      <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
+    </Exec>
+  </Target>
+
+<!--    TODO: send commit details to Sentry -->
 
   <Import Condition="'$(MSBuildProjectName)' != 'Sentry' and !$(MSBuildProjectName.StartsWith('Sentry.')) and '$(IsSentryTestProject)' == ''" Project="$(MSBuildThisFileDirectory)Sentry.Native.targets"/>
 </Project>

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -263,23 +263,42 @@
         <![CDATA[
   try
   {
+#nullable enable
+    Log.LogMessage($"Loading assembly: {AssemblyPath}");
     var path = Path.GetFullPath(AssemblyPath);
     var assembly = Assembly.LoadFile(path);
 
+    Log.LogMessage($"Getting assembly name...");
     var assemblyName = assembly.GetName();
     var name = assemblyName.Name;
+    Log.LogMessage($"Assembly name: {name}");
 
-    var infoVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-    var version = infoVersionAttribute?.InformationalVersion ?? assemblyName.Version?.ToString();
+    Log.LogMessage($"Reading AssemblyInformationalVersionAttribute...");
+    string? version = null;
+    try
+    {
+      var infoVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+      version = infoVersionAttribute?.InformationalVersion;
+    }
+    catch
+    {
+      Log.LogMessage($"Failed to read informational version attribute");
+    }
+    version ??= assemblyName.Version?.ToString();
+    Log.LogMessage($"Version: {version}");
+
+    Log.LogMessage($"Compiling release information...");
     if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(version))
     {
       Release = version.Contains('@')
             ? version   // Don't add name prefix if it's already set by the user
             : $"{name}@{version}";
     }
+#nullable disable
   }
   catch
   {
+    Log.LogWarning($"Failed to get version from {AssemblyPath}");
   }
   ]]>
       </Code>

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -96,6 +96,7 @@
       <SentryCLIBaseCommand>&quot;$(SentryCLI)&quot;</SentryCLIBaseCommand>
       <SentryCLIBaseCommand Condition="'$(SentryCLIBaseOptions.Trim())' != ''">$(SentryCLIBaseCommand) $(SentryCLIBaseOptions.Trim())</SentryCLIBaseCommand>
 
+      <SentryRelease Condition="'$(SentryRelease)' == '' And '$(SENTRY_RELEASE)' != ''">$(SENTRY_RELEASE)</SentryRelease>
       <SentryReleaseOptions Condition="'$(SentryProject)' != ''">$(SentryReleaseOptions) --project $(SentryProject)</SentryReleaseOptions>
 
       <SentrySetCommitOptions Condition="'$(SentrySetCommitOptions)' == ''">--auto</SentrySetCommitOptions>
@@ -250,7 +251,7 @@
     <Warning Condition="'$(_SentryCLIExitCode)' != '0'" Text="Sentry CLI could not upload proguard mapping." />
   </Target>
 
-  <UsingTask TaskName="SentryGetReleaseFromInformationalVersion" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+  <UsingTask TaskName="SentryGetApplicationVersion" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>
       <AssemblyPath Required="true" />
       <Release Output="true" />
@@ -267,40 +268,15 @@
 
     var assemblyName = assembly.GetName();
     var name = assemblyName.Name;
-    var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-    if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(version))
+
+    var infoVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+    var version = infoVersionAttribute?.InformationalVersion ?? assemblyName.Version?.ToString();
+    if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(version))
     {
-      Release = $"{name}@{version}";
+      Release = version.Contains('@')
+            ? version   // Don't add name prefix if it's already set by the user
+            : $"{name}@{version}";
     }
-  }
-  catch
-  {
-  }
-  ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <UsingTask TaskName="SentryGetReleaseFromAppManifest" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"
-             Condition="$(TargetFramework.Contains('ios')) Or $(TargetFramework.Contains('maccatalyst'))">
-    <ParameterGroup>
-      <AppManifestPath Required="true" />
-      <Release Output="true" />
-    </ParameterGroup>
-    <Task>
-      <Reference Include="$(_XamarinTaskAssembly)" />
-      <Using Namespace="Xamarin.MacDev"/>
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-  try
-  {
-    var plist = PDictionary.FromFile(AppManifestPath);
-
-    var packageName = plist.GetCFBundleIdentifier();
-    var packageVersion = plist.GetCFBundleShortVersionString();
-    var buildVersion = plist.GetCFBundleVersion();
-
-    Release = $"{packageName}@{packageVersion}+{buildVersion}";
   }
   catch
   {
@@ -314,25 +290,9 @@
 
     <Message Importance="High" Text="Getting Sentry Release..." />
 
-    <PropertyGroup Condition="'$(SentryRelease)' == '' And $(TargetFramework.Contains('android'))">
-      <SentryRelease>$(ApplicationId)@$(ApplicationDisplayVersion)+$(ApplicationVersion)</SentryRelease>
-    </PropertyGroup>
-
-    <SentryGetReleaseFromAppManifest AppManifestPath="$(_TemporaryAppManifest)"
-                                     Condition="'$(SentryRelease)' == '' And ($(TargetFramework.Contains('ios')) Or $(TargetFramework.Contains('maccatalyst')))">
+    <SentryGetApplicationVersion Condition="'$(SentryRelease)' == ''" AssemblyPath="$(IntermediateOutputPath)$(TargetName)$(TargetExt)">
       <Output TaskParameter="Release" PropertyName="SentryRelease" />
-    </SentryGetReleaseFromAppManifest>
-
-    <SentryGetReleaseFromInformationalVersion Condition="'$(SentryRelease)' == ''" AssemblyPath="$(IntermediateOutputPath)$(TargetName)$(TargetExt)">
-      <Output TaskParameter="Release" PropertyName="SentryRelease" />
-    </SentryGetReleaseFromInformationalVersion>
-
-    <GetAssemblyIdentity Condition="'$(SentryRelease)' == '' And '$(TargetName)' != ''" AssemblyFiles="$(IntermediateOutputPath)$(TargetName)$(TargetExt)">
-      <Output TaskParameter="Assemblies" ItemName="MainAssemblyIdentity" />
-    </GetAssemblyIdentity>
-    <PropertyGroup Condition="'$(SentryRelease)' == '' And '@(MainAssemblyIdentity)' != ''">
-      <SentryRelease>%(MainAssemblyIdentity.Name)@%(Version)</SentryRelease>
-    </PropertyGroup>
+    </SentryGetApplicationVersion>
 
     <Exec ConsoleToMSBuild="true"  Condition="'$(SentryRelease)' == ''"
           Command="sentry-cli releases propose-version">

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -37,8 +37,10 @@
       <!-- Set defaults for the Sentry properties. -->
       <SentryUploadSymbols Condition="'$(SentryUploadSymbols)' == ''">false</SentryUploadSymbols>
       <SentryUploadSources Condition="'$(SentryUploadSources)' == ''">false</SentryUploadSources>
-      <SentryCreateRelease Condition="'$(SentryCreateRelease)' == ''">false</SentryCreateRelease>
       <SentrySetCommits Condition="'$(SentrySetCommits)' == ''">false</SentrySetCommits>
+      <!-- SentryCreateRelease is implied if SentrySetCommits==true -->
+      <SentryCreateRelease Condition="'$(SentrySetCommits)' == 'true'">true</SentryCreateRelease>
+      <SentryCreateRelease Condition="'$(SentryCreateRelease)' == ''">false</SentryCreateRelease>
 
       <!-- This property controls if the Sentry CLI is to be used at all. Setting false will disable all Sentry CLI usage.
            We're explicitly skipping uploads for Sentry projects because they interfere with CLI integration test asserts. -->
@@ -95,6 +97,8 @@
       <SentryCLIBaseCommand Condition="'$(SentryCLIBaseOptions.Trim())' != ''">$(SentryCLIBaseCommand) $(SentryCLIBaseOptions.Trim())</SentryCLIBaseCommand>
 
       <SentryReleaseOptions Condition="'$(SentryProject)' != ''">$(SentryReleaseOptions) --project $(SentryProject)</SentryReleaseOptions>
+
+      <SentrySetCommitOptions Condition="'$(SentrySetCommitOptions)' == ''">--auto</SentrySetCommitOptions>
 
       <SentryCLIUploadOptions Condition="'$(SentryOrg)' != ''">$(SentryCLIUploadOptions) --org $(SentryOrg)</SentryCLIUploadOptions>
       <SentryCLIUploadOptions Condition="'$(SentryProject)' != ''">$(SentryCLIUploadOptions) --project $(SentryProject)</SentryCLIUploadOptions>
@@ -344,7 +348,16 @@
     </Exec>
   </Target>
 
-<!--    TODO: send commit details to Sentry -->
+  <!-- Send commit details to Sentry -->
+  <Target Name="_SentrySetCommits" AfterTargets="Build" DependsOnTargets="_CreateSentryRelease"
+          Condition="'$(SentryCLI)' != '' and '$(SentrySetCommits)' == 'true'">
+    <Message Importance="High" Text="Setting Sentry commits" />
+    <Exec
+      Command="$(SentryCLIBaseCommand) releases set-commits $(SentrySetCommitOptions) '$(SentryRelease)' $(SentryReleaseOptions)"
+      IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
+      <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
+    </Exec>
+  </Target>
 
   <Import Condition="'$(MSBuildProjectName)' != 'Sentry' and !$(MSBuildProjectName.StartsWith('Sentry.')) and '$(IsSentryTestProject)' == ''" Project="$(MSBuildThisFileDirectory)Sentry.Native.targets"/>
 </Project>

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -96,9 +96,7 @@
       <SentryCLIBaseCommand>&quot;$(SentryCLI)&quot;</SentryCLIBaseCommand>
       <SentryCLIBaseCommand Condition="'$(SentryCLIBaseOptions.Trim())' != ''">$(SentryCLIBaseCommand) $(SentryCLIBaseOptions.Trim())</SentryCLIBaseCommand>
 
-      <SentryRelease Condition="'$(SentryRelease)' == '' And '$(SENTRY_RELEASE)' != ''">$(SENTRY_RELEASE)</SentryRelease>
       <SentryReleaseOptions Condition="'$(SentryProject)' != ''">$(SentryReleaseOptions) --project $(SentryProject)</SentryReleaseOptions>
-
       <SentrySetCommitOptions Condition="'$(SentrySetCommitOptions)' == ''">--auto</SentrySetCommitOptions>
 
       <SentryCLIUploadOptions Condition="'$(SentryOrg)' != ''">$(SentryCLIUploadOptions) --org $(SentryOrg)</SentryCLIUploadOptions>
@@ -305,28 +303,33 @@
     </Task>
   </UsingTask>
 
+  <PropertyGroup>
+    <!-- Check if the release has been provided as an environment variable -->
+    <_SentryRelease Condition="'$(_SentryRelease)' == '' And '$(SENTRY_RELEASE)' != ''">$(SENTRY_RELEASE)</_SentryRelease>
+  </PropertyGroup>
+
   <Target Name="_GetSentryRelease" AfterTargets="DispatchToInnerBuilds;AfterBuild" Condition="'$(SentryCreateRelease)' == 'true' And '$(UseSentryCLI)' == 'true'">
 
     <Message Importance="High" Text="Getting Sentry Release..." />
 
-    <SentryGetApplicationVersion Condition="'$(SentryRelease)' == ''" AssemblyPath="$(IntermediateOutputPath)$(TargetName)$(TargetExt)">
-      <Output TaskParameter="Release" PropertyName="SentryRelease" />
+    <SentryGetApplicationVersion Condition="'$(_SentryRelease)' == ''" AssemblyPath="$(IntermediateOutputPath)$(TargetName)$(TargetExt)">
+      <Output TaskParameter="Release" PropertyName="_SentryRelease" />
     </SentryGetApplicationVersion>
 
-    <Exec ConsoleToMSBuild="true"  Condition="'$(SentryRelease)' == ''"
+    <Exec ConsoleToMSBuild="true"  Condition="'$(_SentryRelease)' == ''"
           Command="sentry-cli releases propose-version">
-      <Output TaskParameter="ConsoleOutput" PropertyName="SentryRelease"/>
+      <Output TaskParameter="ConsoleOutput" PropertyName="_SentryRelease"/>
     </Exec>
 
-    <Message Importance="High" Text="Sentry Release: $(SentryRelease)" />
+    <Message Importance="High" Text="Sentry Release: $(_SentryRelease)" />
   </Target>
 
   <!-- Set release information after the build -->
   <Target Name="_CreateSentryRelease" AfterTargets="Build" DependsOnTargets="_GetSentryRelease"
           Condition="'$(SentryCLI)' != '' and '$(SentryCreateRelease)' == 'true'">
-    <Message Importance="High" Text="Creating Sentry Release: $(SentryRelease)" />
+    <Message Importance="High" Text="Creating Sentry Release: $(_SentryRelease)" />
     <Exec
-      Command="$(SentryCLIBaseCommand) releases new '$(SentryRelease)' $(SentryReleaseOptions)"
+      Command="$(SentryCLIBaseCommand) releases new '$(_SentryRelease)' $(SentryReleaseOptions)"
       IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
     </Exec>
@@ -337,7 +340,7 @@
           Condition="'$(SentryCLI)' != '' and '$(SentrySetCommits)' == 'true'">
     <Message Importance="High" Text="Setting Sentry commits" />
     <Exec
-      Command="$(SentryCLIBaseCommand) releases set-commits $(SentrySetCommitOptions) '$(SentryRelease)' $(SentryReleaseOptions)"
+      Command="$(SentryCLIBaseCommand) releases set-commits $(SentrySetCommitOptions) '$(_SentryRelease)' $(SentryReleaseOptions)"
       IgnoreExitCode="true" ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_SentryCLIExitCode" />
     </Exec>


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3058

## Details

There are a couple of extra build properties now:
1. `SentryCreateRelease`
2. `SentrySetCommits`

### SentryCreateRelease

If you set this to true then the Sentry SDK attempts to use the Sentry CLI to automatically [create a release](https://docs.sentry.io/cli/releases/#creating-releases) when building your project. ~~The release *version* can be supplied via a separate `SentryRelease` build property. If no `SentryRelease` property is provided then~~ the SDK will infer the version automatically from the ApplicationId, AppManifest, InformationalVersion, AssembyIdentity or the commit hash.

For example:
```xml
  <PropertyGroup>
    <SentryUrl>...your Sentry URL if self-hosted, or omit this line if using sentry.io...</SentryUrl>
    <SentryOrg>...your org...</SentryOrg>
    <SentryProject>...your project...</SentryProject>
    <SentryCreateRelease>true</SentryCreateRelease>
  </PropertyGroup>
```

### SentrySetCommits

If this property is set then the Sentry SDK will automatically [associate commits with the release](https://docs.sentry.io/cli/releases/#commit-integration). By default, the SDK will set commits with the `--auto` flag but you can override this to provide whatever flags you want via the optional `SentrySetCommitOptions` property. 

For example:
```xml
  <PropertyGroup>
    <SentryUrl>...your Sentry URL if self-hosted, or omit this line if using sentry.io...</SentryUrl>
    <SentryOrg>...your org...</SentryOrg>
    <SentryProject>...your project...</SentryProject>
    <SentrySetCommits>true</SentrySetCommits>
    <SentrySetCommitOptions>--local</SentrySetCommitOptions>
  </PropertyGroup>
```
