### PR TITLE
Removed RunAsyncVoid method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Client reports now include dropped spans ([#3463](https://github.com/getsentry/sentry-dotnet/pull/3463))
 
+### API Changes
+
+- Removed SentrySdk.RunAsyncVoid ([#3466](https://github.com/getsentry/sentry-dotnet/pull/3466))
+
 ## 4.8.1
 
 ### Fixes

--- a/samples/Sentry.Samples.Maui/MainPage.xaml
+++ b/samples/Sentry.Samples.Maui/MainPage.xaml
@@ -70,13 +70,6 @@
                 Clicked="OnNativeCrashClicked"
                 HorizontalOptions="Center" />
 
-            <Button
-                x:Name="AsyncVoidCrashBtn"
-                Text="Capture an exception from an async void method"
-                SemanticProperties.Hint="Throws an exception in an async void event handler."
-                Clicked="OnAsyncVoidCrashClicked"
-                HorizontalOptions="Center" />
-
         </VerticalStackLayout>
     </ScrollView>
 

--- a/samples/Sentry.Samples.Maui/MainPage.xaml.cs
+++ b/samples/Sentry.Samples.Maui/MainPage.xaml.cs
@@ -88,21 +88,6 @@ public partial class MainPage
 #endif
     }
 
-    private void OnAsyncVoidCrashClicked(object sender, EventArgs e)
-    {
-        var client = new HttpClient(new FlakyMessageHandler());
-
-        // You can use RunAsyncVoid to call async methods safely from within MAUI event handlers.
-        SentrySdk.RunAsyncVoid(
-            async () => await client.GetAsync("https://amostunreliablewebsite.net/"),
-            ex => _logger.LogWarning(ex, "Error fetching data")
-        );
-
-        // This is an example of the same, omitting any exception handler callback. In this case, the default exception
-        // handler will be used, which simply captures any exceptions and sends these to Sentry
-        SentrySdk.RunAsyncVoid(async () => await client.GetAsync("https://amostunreliablewebsite.net/"));
-    }
-
     private class FlakyMessageHandler : DelegatingHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -692,37 +692,6 @@ public static partial class SentrySdk
         => CurrentHub.ResumeSession();
 
     /// <summary>
-    /// Runs an `async void` method safely.
-    /// </summary>
-    /// <param name="task">Typically either a method group or an async lambda that executes some async void code</param>
-    /// <param name="handler">
-    /// An optional callback that will be run if an exception is thrown. If no callback is provided then by default the
-    /// exception will be captured and sent to Sentry.
-    /// </param>
-    /// <example>
-    /// <code>
-    /// SentrySdk.RunAsyncVoid(async () => await MyAsyncMethod(), ex => Console.WriteLine(ex.Message));
-    /// </code>
-    /// </example>
-    public static void RunAsyncVoid(Action task, Action<Exception>? handler = null)
-    {
-        var syncCtx = SynchronizationContext.Current;
-        try
-        {
-            handler ??= DefaultExceptionHandler;
-            SynchronizationContext.SetSynchronizationContext(new ExceptionHandlingSynchronizationContext(handler, syncCtx));
-            task();
-        }
-        finally
-        {
-            SynchronizationContext.SetSynchronizationContext(syncCtx);
-        }
-        return;
-
-        void DefaultExceptionHandler(Exception ex) => CaptureException(ex);
-    }
-
-    /// <summary>
     /// Deliberately crashes an application, which is useful for testing and demonstration purposes.
     /// </summary>
     /// <remarks>

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -827,7 +827,6 @@ namespace Sentry
         public static System.IDisposable PushScope() { }
         public static System.IDisposable PushScope<TState>(TState state) { }
         public static void ResumeSession() { }
-        public static void RunAsyncVoid(System.Action task, System.Action<System.Exception>? handler = null) { }
         public static void StartSession() { }
         public static Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context) { }
         public static Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -827,7 +827,6 @@ namespace Sentry
         public static System.IDisposable PushScope() { }
         public static System.IDisposable PushScope<TState>(TState state) { }
         public static void ResumeSession() { }
-        public static void RunAsyncVoid(System.Action task, System.Action<System.Exception>? handler = null) { }
         public static void StartSession() { }
         public static Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context) { }
         public static Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -829,7 +829,6 @@ namespace Sentry
         public static System.IDisposable PushScope() { }
         public static System.IDisposable PushScope<TState>(TState state) { }
         public static void ResumeSession() { }
-        public static void RunAsyncVoid(System.Action task, System.Action<System.Exception>? handler = null) { }
         public static void StartSession() { }
         public static Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context) { }
         public static Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -824,7 +824,6 @@ namespace Sentry
         public static System.IDisposable PushScope() { }
         public static System.IDisposable PushScope<TState>(TState state) { }
         public static void ResumeSession() { }
-        public static void RunAsyncVoid(System.Action task, System.Action<System.Exception>? handler = null) { }
         public static void StartSession() { }
         public static Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context) { }
         public static Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }


### PR DESCRIPTION
After further testing, we can't find any use case for this extension method so we're removing it from the SDK.

Technically this is a breaking change. Alternatively, we could mark it obsolete instead and remove it in the next major release but it's highly improbably that anyone is using this method.