### PR TITLE
Fixed length of scrubbed DebugImage.CodeId in Verify outputs

### DIFF
--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
@@ -71,7 +71,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: .../Sentry.NLog.Tests.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../Sentry.NLog.Tests.dll
               }
             ],

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
@@ -71,7 +71,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: .../Sentry.NLog.Tests.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../Sentry.NLog.Tests.dll
               }
             ],

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
@@ -71,7 +71,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: .../Sentry.NLog.Tests.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../Sentry.NLog.Tests.dll
               }
             ],

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.Mono4_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.Mono4_0.verified.txt
@@ -71,7 +71,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: .../Sentry.NLog.Tests.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../Sentry.NLog.Tests.dll
               }
             ],

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet6_0.verified.txt
@@ -237,7 +237,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: .../Sentry.Serilog.Tests.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../Sentry.Serilog.Tests.dll
               }
             ],

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet7_0.verified.txt
@@ -237,7 +237,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: .../Sentry.Serilog.Tests.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../Sentry.Serilog.Tests.dll
               }
             ],

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
@@ -237,7 +237,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: .../Sentry.Serilog.Tests.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../Sentry.Serilog.Tests.dll
               }
             ],

--- a/test/Sentry.Testing/VerifyExtensions.cs
+++ b/test/Sentry.Testing/VerifyExtensions.cs
@@ -92,7 +92,7 @@ public static class VerifyExtensions
             obj.DebugChecksum = ScrubAlphaNum(obj.DebugChecksum);
             obj.DebugFile = ScrubPath(obj.DebugFile);
             obj.CodeFile = ScrubPath(obj.CodeFile);
-            obj.CodeId = ScrubAlphaNum(obj.CodeId);
+            obj.CodeId = obj.CodeId is null ? "null" : "______________";
             writer.Serialize(JToken.FromObject(obj));
         }
     }

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet6_0.verified.txt
@@ -79,7 +79,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: .../Sentry.Tests.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../Sentry.Tests.dll
               },
               {
@@ -89,7 +89,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: xunit.execution.dotnet.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../xunit.execution.dotnet.dll
               },
               {
@@ -99,7 +99,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: xunit.core.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../xunit.core.dll
               }
             ],

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet7_0.verified.txt
@@ -79,7 +79,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: .../Sentry.Tests.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../Sentry.Tests.dll
               },
               {
@@ -89,7 +89,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: xunit.execution.dotnet.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../xunit.execution.dotnet.dll
               },
               {
@@ -99,7 +99,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: xunit.core.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../xunit.core.dll
               }
             ],

--- a/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/HubTests.CaptureEvent_ActiveTransaction_UnhandledExceptionTransactionEndedAsCrashed.DotNet8_0.verified.txt
@@ -79,7 +79,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: .../Sentry.Tests.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../Sentry.Tests.dll
               },
               {
@@ -89,7 +89,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: xunit.execution.dotnet.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../xunit.execution.dotnet.dll
               },
               {
@@ -99,7 +99,7 @@
                 DebugId: ________-____-____-____-____________-________,
                 DebugChecksum: ______:________________________________________________________________,
                 DebugFile: xunit.core.pdb,
-                CodeId: _____________,
+                CodeId: ______________,
                 CodeFile: .../xunit.core.dll
               }
             ],


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3467

#skip-changelog