### PR TITLE
Resolve Processors from ServiceProvider for Background Services in ASP.NET Core

### DIFF
--- a/src/Sentry.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/ApplicationBuilderExtensions.cs
@@ -39,6 +39,10 @@ internal static class ApplicationBuilderExtensions
             {
                 o.UseStackTraceFactory(stackTraceFactory);
             }
+
+            o.AddEventProcessorProvider(() => app.ApplicationServices.GetNonScoped<ISentryEventProcessor>());
+            o.AddExceptionProcessorProvider(() => app.ApplicationServices.GetNonScoped<ISentryEventExceptionProcessor>());
+            o.AddTransactionProcessorProvider(() => app.ApplicationServices.GetNonScoped<ISentryTransactionProcessor>());
         }
 
         var lifetime = app.ApplicationServices.GetService<IHostApplicationLifetime>();

--- a/src/Sentry.AspNetCore/LifetimeServiceResolver.cs
+++ b/src/Sentry.AspNetCore/LifetimeServiceResolver.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Sentry.AspNetCore;
+
+internal class LifetimeServiceResolver(IServiceCollection services)
+{
+    public IEnumerable<T> GetServices<T>(IServiceProvider provider,
+        params ServiceLifetime[] lifetimes)
+    {
+        return Factories<T>(lifetimes)
+            .Select(factory => factory(provider));
+    }
+
+    private IEnumerable<Func<IServiceProvider,T>> Factories<T>(ServiceLifetime[] lifetimes)
+    {
+        foreach (var descriptor in services)
+        {
+            if (descriptor.ServiceType != typeof(T) || !lifetimes.Contains(descriptor.Lifetime))
+            {
+                continue;
+            }
+            if (descriptor.ImplementationInstance is not null)
+            {
+                yield return _ => (T)descriptor.ImplementationInstance;
+            }
+            if (descriptor.ImplementationFactory is not null)
+            {
+                yield return provider => (T)descriptor.ImplementationFactory(provider);
+            }
+            if (descriptor.ImplementationType is not null)
+            {
+                yield return provider => (T)ActivatorUtilities.GetServiceOrCreateInstance(provider, descriptor.ImplementationType);
+            }
+        }
+    }
+}

--- a/src/Sentry.AspNetCore/LifetimeServiceResolver.cs
+++ b/src/Sentry.AspNetCore/LifetimeServiceResolver.cs
@@ -11,7 +11,7 @@ internal class LifetimeServiceResolver(IServiceCollection services)
             .Select(factory => factory(provider));
     }
 
-    private IEnumerable<Func<IServiceProvider,T>> Factories<T>(ServiceLifetime[] lifetimes)
+    private IEnumerable<Func<IServiceProvider, T>> Factories<T>(ServiceLifetime[] lifetimes)
     {
         foreach (var descriptor in services)
         {

--- a/src/Sentry.AspNetCore/SentryMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryMiddleware.cs
@@ -239,6 +239,8 @@ internal class SentryMiddleware : IMiddleware
 
     internal void PopulateScope(HttpContext context, Scope scope)
     {
+        // Singleton and Transient processors might already have been registered in the ApplicationBuilderExtensions.
+        // Here we ensure any Scoped processors are also resolved
         scope.AddEventProcessors(_eventProcessors.Except(scope.GetAllEventProcessors()));
         scope.AddExceptionProcessors(_eventExceptionProcessors.Except(scope.GetAllExceptionProcessors()));
         scope.AddTransactionProcessors(_transactionProcessors.Except(scope.GetAllTransactionProcessors()));

--- a/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
@@ -103,7 +103,8 @@ public static class SentryWebHostBuilderExtensions
         });
 
         _ = builder.ConfigureServices(c => _ =
-            c.AddTransient<IStartupFilter, SentryStartupFilter>()
+            c.AddSingleton(new LifetimeServiceResolver(c))
+             .AddTransient<IStartupFilter, SentryStartupFilter>()
              .AddTransient<IStartupFilter, SentryTracingStartupFilter>()
              .AddTransient<SentryMiddleware>()
         );

--- a/src/Sentry.AspNetCore/ServiceProviderExtensions.cs
+++ b/src/Sentry.AspNetCore/ServiceProviderExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Sentry.AspNetCore;
+
+internal static class ServiceProviderExtensions
+{
+    public static IEnumerable<T> GetServices<T>(this IServiceProvider serviceProvider, ServiceLifetime[] lifetimes) =>
+        serviceProvider
+            .GetRequiredService<LifetimeServiceResolver>()
+            .GetServices<T>(serviceProvider, lifetimes);
+
+    public static IEnumerable<T> GetNonScoped<T>(this IServiceProvider serviceProvider) =>
+        serviceProvider
+            .GetRequiredService<LifetimeServiceResolver>()
+            .GetServices<T>(serviceProvider, [ServiceLifetime.Singleton, ServiceLifetime.Transient]);
+}

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -1538,7 +1538,7 @@ public class SentryOptions
     {
         if (TransactionProcessors == null)
         {
-            TransactionProcessors = new() { processor };
+            TransactionProcessors = [processor];
         }
         else
         {

--- a/test/Sentry.AspNetCore.Tests/LifetimeSpecificServiceResolversTests.cs
+++ b/test/Sentry.AspNetCore.Tests/LifetimeSpecificServiceResolversTests.cs
@@ -5,11 +5,11 @@ namespace Sentry.AspNetCore.Tests;
 
 public class LifetimeSpecificServiceResolversTests
 {
-    private interface IMyInterface {}
-    private class ServiceA : IMyInterface {}
-    private class ServiceB: IMyInterface {}
-    private class ServiceC : IMyInterface {}
-    private class ServiceD : IMyInterface {}
+    private interface IMyInterface { }
+    private class ServiceA : IMyInterface { }
+    private class ServiceB : IMyInterface { }
+    private class ServiceC : IMyInterface { }
+    private class ServiceD : IMyInterface { }
 
     private class ServiceE(Foo foo) : IMyInterface
     {

--- a/test/Sentry.AspNetCore.Tests/LifetimeSpecificServiceResolversTests.cs
+++ b/test/Sentry.AspNetCore.Tests/LifetimeSpecificServiceResolversTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Sentry.AspNetCore.Tests;
+
+public class LifetimeSpecificServiceResolversTests
+{
+    private interface IMyInterface {}
+    private class ServiceA : IMyInterface {}
+    private class ServiceB: IMyInterface {}
+    private class ServiceC : IMyInterface {}
+    private class ServiceD : IMyInterface {}
+
+    private class ServiceE(Foo foo) : IMyInterface
+    {
+        public void Foo() => foo.Bar();
+    }
+
+    private class Foo
+    {
+        public void Bar() => Console.WriteLine("bar");
+    }
+
+    [Fact]
+    public void ShouldResolveSingletonDependencies()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+
+        // Register services with various lifetimes
+        serviceCollection.AddSingleton<IMyInterface>(new ServiceA());
+        serviceCollection.AddTransient<IMyInterface, ServiceB>();
+        serviceCollection.AddSingleton<IMyInterface>(_ => new ServiceC());
+
+        serviceCollection.AddSingleton(new LifetimeServiceResolver(serviceCollection));
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        // Act
+        var instances = serviceProvider
+            .GetServices<IMyInterface>([ServiceLifetime.Singleton])
+            .ToArray();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            instances.Length.Should().Be(2);
+            instances.Should().Contain(x => x.GetType() == typeof(ServiceA));
+            instances.Should().Contain(x => x.GetType() == typeof(ServiceC));
+        }
+    }
+
+    [Fact]
+    public void ShouldResolveTransientDependencies()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+
+        // Register services with various lifetimes
+        serviceCollection.AddTransient<IMyInterface, ServiceA>();
+        serviceCollection.AddScoped<IMyInterface>(_ => new ServiceB());
+        serviceCollection.AddTransient<IMyInterface>(_ => new ServiceC());
+        serviceCollection.AddSingleton<IMyInterface>(new ServiceD());
+
+        serviceCollection.AddSingleton(new LifetimeServiceResolver(serviceCollection));
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        // Act
+        var instances = serviceProvider
+            .GetServices<IMyInterface>([ServiceLifetime.Transient])
+            .ToArray();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            instances.Length.Should().Be(2);
+            instances.Should().Contain(x => x.GetType() == typeof(ServiceA));
+            instances.Should().Contain(x => x.GetType() == typeof(ServiceC));
+        }
+    }
+
+    [Fact]
+    public void ShouldResolveScopedDependencies()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+
+        // Register services with various lifetimes
+        serviceCollection.AddScoped<Foo>();
+        serviceCollection.AddScoped<IMyInterface, ServiceE>();
+        serviceCollection.AddScoped<IMyInterface>(_ => new ServiceB());
+        serviceCollection.AddTransient<IMyInterface>(_ => new ServiceC());
+        serviceCollection.AddSingleton<IMyInterface>(new ServiceD());
+
+        serviceCollection.AddSingleton(new LifetimeServiceResolver(serviceCollection));
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        // Act
+        var instances = serviceProvider
+            .GetServices<IMyInterface>([ServiceLifetime.Scoped])
+            .ToArray();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            instances.Length.Should().Be(2);
+            instances.Should().Contain(x => x.GetType() == typeof(ServiceE));
+            instances.Should().Contain(x => x.GetType() == typeof(ServiceB));
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/orgs/getsentry/projects/181/views/1?pane=issue&itemId=45150310

Currently WIP (sharing for comment).

It kind of works. I need to find a way to deduplicate these since the `Except` that is used currently only compares object references (which is too specific):
https://github.com/getsentry/sentry-dotnet/blob/30bb7b444dd8a6bfee4c06a03931e6391bf9bee6/src/Sentry.AspNetCore/SentryMiddleware.cs#L244-L246