### PR TITLE
chore: Make `samples` be standalone

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,18 +28,6 @@
   </PropertyGroup>
 
   <!--
-    Configure Sentry CLI
-    NOTE: Authentication is not set here.  Instead:
-    - In CI, `SENTRY_AUTH_TOKEN` is set as an environment variable via a GitHub Actions secret.
-    - In dev, you can either set `SENTRY_AUTH_TOKEN` manually, or you can set an auth token
-      in your ~/.sentryclirc file.  See https://docs.sentry.io/product/cli/configuration/
-
-    There is also a a `SentryAuthToken` msbuild property, but it should be used sparingly.
-    If using it, be careful that the auth token does not get committed to source control.
-  -->
-
-
-  <!--
     Note: The following platform-specific properties need to be set in both Directory.Build.props and DirectoryBuild.targets.
     TODO: Figure out how to consolidate to a single location.
   -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,16 +37,7 @@
     There is also a a `SentryAuthToken` msbuild property, but it should be used sparingly.
     If using it, be careful that the auth token does not get committed to source control.
   -->
-  <PropertyGroup>
-    <SentryOrg>sentry-sdks</SentryOrg>
-    <SentryProject>sentry-dotnet</SentryProject>
-  </PropertyGroup>
 
-  <!-- By default we'll only upload with Sentry CLI in Release configuration. -->
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <SentryUploadSymbols>true</SentryUploadSymbols>
-    <SentryUploadSources>true</SentryUploadSources>
-  </PropertyGroup>
 
   <!--
     Note: The following platform-specific properties need to be set in both Directory.Build.props and DirectoryBuild.targets.

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -6,28 +6,6 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <!--
-    This sets the default DSN for all sample projects.  Sentry employees and contractors
-    can view events at https://sentry-sdks.sentry.io/projects/sentry-dotnet.
-
-    The DSN can easily be overwritten in the sample application by the end-user.
-    The order of precedence is:
-      - SentryOptions.Dsn property set in code
-      - Sentry:Dsn set in appsettings.json or other config (where applicable)
-      - SENTRY_DSN environment variable
-      - This [Sentry.Dsn] attribute
-
-    Thus, this DSN is applied only if no other mechanism is used to set the DSN.
-
-    Note - The below works because SentryAttributes is already being converted to
-           actual attributes in src/Sentry/buildTransitive/Sentry.targets.
-  -->
-  <!-- <ItemGroup>
-    <SentryAttributes Include="Sentry.DsnAttribute">
-      <_Parameter1>https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537</_Parameter1>
-    </SentryAttributes>
-  </ItemGroup> -->
-
   <!-- Workaround for hang on compile issue.  See https://github.com/xamarin/xamarin-macios/issues/17825#issuecomment-1478568270. -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release' And '$(TargetFramework)' == 'net7.0-ios' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">
     <MtouchUseLlvm>false</MtouchUseLlvm>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -22,11 +22,11 @@
     Note - The below works because SentryAttributes is already being converted to
            actual attributes in src/Sentry/buildTransitive/Sentry.targets.
   -->
-  <ItemGroup>
+  <!-- <ItemGroup>
     <SentryAttributes Include="Sentry.DsnAttribute">
       <_Parameter1>https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537</_Parameter1>
     </SentryAttributes>
-  </ItemGroup>
+  </ItemGroup> -->
 
   <!-- Workaround for hang on compile issue.  See https://github.com/xamarin/xamarin-macios/issues/17825#issuecomment-1478568270. -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release' And '$(TargetFramework)' == 'net7.0-ios' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">

--- a/samples/Sentry.Samples.Android/MainActivity.cs
+++ b/samples/Sentry.Samples.Android/MainActivity.cs
@@ -7,19 +7,19 @@ public class MainActivity : Activity
 {
     protected override void OnCreate(Bundle? savedInstanceState)
     {
-        SentrySdk.Init(o =>
+        SentrySdk.Init(options =>
         {
-            o.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
-            o.SendDefaultPii = true; // adds the user's IP address automatically
+            options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+            options.SendDefaultPii = true; // adds the user's IP address automatically
 
             // Android specific .NET features are under the Android properties:
-            o.Android.LogCatIntegration = LogCatIntegrationType.Errors; // Get logcat logs for both handled and unhandled errors; default is unhandled only
-            o.Android.LogCatMaxLines = 1000; // Defaults to 1000
+            options.Android.LogCatIntegration = LogCatIntegrationType.Errors; // Get logcat logs for both handled and unhandled errors; default is unhandled only
+            options.Android.LogCatMaxLines = 1000; // Defaults to 1000
 
             // All the native Android SDK options are available below
             // https://docs.sentry.io/platforms/android/configuration/
             // Enable Native Android SDK ANR detection
-            o.Native.AnrEnabled = true;
+            options.Native.AnrEnabled = true;
         });
 
         // Here's an example of adding custom scope information.

--- a/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
+++ b/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
@@ -27,6 +27,8 @@
     In a real app, you probably only want to do this on Release builds.
   -->
   <PropertyGroup>
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
     <SentryUploadSources>true</SentryUploadSources>
     <SentryUploadSymbols>true</SentryUploadSymbols>
     <!-- Use ProGuard (R8), and upload mapping to Sentry-->

--- a/samples/Sentry.Samples.AspNetCore.Basic/Program.cs
+++ b/samples/Sentry.Samples.AspNetCore.Basic/Program.cs
@@ -1,16 +1,16 @@
 var builder = WebApplication.CreateBuilder(args);
 
-builder.WebHost.UseSentry(o =>
+builder.WebHost.UseSentry(options =>
 {
     // A DSN is required.  You can set it here, or in configuration, or in an environment variable.
-    o.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+    options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
 
     // Enable Sentry performance monitoring
-    o.TracesSampleRate = 1.0;
+    options.TracesSampleRate = 1.0;
 
 #if DEBUG
     // Log debug information about the Sentry SDK
-    o.Debug = true;
+    options.Debug = true;
 #endif
 });
 

--- a/samples/Sentry.Samples.AspNetCore.Basic/Sentry.Samples.AspNetCore.Basic.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Basic/Sentry.Samples.AspNetCore.Basic.csproj
@@ -4,6 +4,14 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+    <SentryCreateRelease>true</SentryCreateRelease>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.AspNetCore\Sentry.AspNetCore.csproj" />
   </ItemGroup>

--- a/samples/Sentry.Samples.AspNetCore.Basic/Sentry.Samples.AspNetCore.Basic.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Basic/Sentry.Samples.AspNetCore.Basic.csproj
@@ -10,6 +10,7 @@
     <SentryUploadSymbols>true</SentryUploadSymbols>
     <SentryUploadSources>true</SentryUploadSources>
     <SentryCreateRelease>true</SentryCreateRelease>
+    <SentrySetCommits>true</SentrySetCommits>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.AspNetCore.Blazor.Server/Sentry.Samples.AspNetCore.Blazor.Server.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Server/Sentry.Samples.AspNetCore.Blazor.Server.csproj
@@ -5,6 +5,15 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+    <SentryCreateRelease>true</SentryCreateRelease>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.AspNetCore.Blazor.WebAssembly\Sentry.AspNetCore.Blazor.WebAssembly.csproj" />
     <ProjectReference Include="..\..\src\Sentry.AspNetCore\Sentry.AspNetCore.csproj" />

--- a/samples/Sentry.Samples.AspNetCore.Blazor.Server/Sentry.Samples.AspNetCore.Blazor.Server.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Server/Sentry.Samples.AspNetCore.Blazor.Server.csproj
@@ -12,6 +12,7 @@
     <SentryUploadSymbols>true</SentryUploadSymbols>
     <SentryUploadSources>true</SentryUploadSources>
     <SentryCreateRelease>true</SentryCreateRelease>
+    <SentrySetCommits>true</SentrySetCommits>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Sentry.Samples.AspNetCore.Blazor.Wasm.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Sentry.Samples.AspNetCore.Blazor.Wasm.csproj
@@ -11,6 +11,7 @@
     <SentryUploadSymbols>true</SentryUploadSymbols>
     <SentryUploadSources>true</SentryUploadSources>
     <SentryCreateRelease>true</SentryCreateRelease>
+    <SentrySetCommits>true</SentrySetCommits>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Sentry.Samples.AspNetCore.Blazor.Wasm.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Wasm/Sentry.Samples.AspNetCore.Blazor.Wasm.csproj
@@ -5,6 +5,14 @@
     <RunAOTCompilation>true</RunAOTCompilation>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+    <SentryCreateRelease>true</SentryCreateRelease>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.3"/>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.3" PrivateAssets="all"/>

--- a/samples/Sentry.Samples.AspNetCore.Grpc/Sentry.Samples.AspNetCore.Grpc.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Grpc/Sentry.Samples.AspNetCore.Grpc.csproj
@@ -12,10 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Sentry.AspNetCore.Grpc\Sentry.AspNetCore.Grpc.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Protobuf Include="Proto\sample.proto" GrpcServices="Server" />
   </ItemGroup>
 
@@ -23,6 +19,17 @@
     <Content Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sentry.AspNetCore.Grpc\Sentry.AspNetCore.Grpc.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.AspNetCore.Mvc/Sentry.Samples.AspNetCore.Mvc.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Mvc/Sentry.Samples.AspNetCore.Mvc.csproj
@@ -7,6 +7,13 @@
     <RootNamespace>Samples.AspNetCore.Mvc</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.AspNetCore\Sentry.AspNetCore.csproj" />
   </ItemGroup>

--- a/samples/Sentry.Samples.AspNetCore.Serilog/Sentry.Samples.AspNetCore.Serilog.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Serilog/Sentry.Samples.AspNetCore.Serilog.csproj
@@ -10,6 +10,13 @@
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.AspNetCore\Sentry.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Sentry.Serilog\Sentry.Serilog.csproj" />

--- a/samples/Sentry.Samples.Aws.Lambda.AspNetCoreServer/Sentry.Samples.Aws.Lambda.AspNetCoreServer.csproj
+++ b/samples/Sentry.Samples.Aws.Lambda.AspNetCoreServer/Sentry.Samples.Aws.Lambda.AspNetCoreServer.csproj
@@ -4,13 +4,23 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.3.0" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.7" />
   </ItemGroup>
+
   <ItemGroup>
     <Folder Include="Controllers" />
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.AspNetCore\Sentry.AspNetCore.csproj" />
   </ItemGroup>

--- a/samples/Sentry.Samples.Azure.Functions.Worker/Program.cs
+++ b/samples/Sentry.Samples.Azure.Functions.Worker/Program.cs
@@ -6,8 +6,9 @@ var host = new HostBuilder()
     {
         builder.UseSentry(host, options =>
         {
+            options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
             options.TracesSampleRate = 1.0;
-            // options.Debug = true;
+            options.Debug = true;
         });
     })
     .Build();

--- a/samples/Sentry.Samples.Azure.Functions.Worker/Sentry.Samples.Azure.Functions.Worker.csproj
+++ b/samples/Sentry.Samples.Azure.Functions.Worker/Sentry.Samples.Azure.Functions.Worker.csproj
@@ -21,7 +21,14 @@
         <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
     </ItemGroup>
 
-    <ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
+  <ItemGroup>
       <!-- TODO: Replace with a package reference -->
       <ProjectReference Include="..\..\src\Sentry.Azure.Functions.Worker\Sentry.Azure.Functions.Worker.csproj" />
     </ItemGroup>

--- a/samples/Sentry.Samples.Console.Basic/Program.cs
+++ b/samples/Sentry.Samples.Console.Basic/Program.cs
@@ -14,10 +14,9 @@ using System.Net.Http;
 
 SentrySdk.Init(options =>
 {
-    // TODO: Configure a Sentry Data Source Name (DSN).
+    // You can set here in code, or you can set it in the SENTRY_DSN environment variable.
     // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
-    // You can set it in the SENTRY_DSN environment variable, or you can set it in code here.
-    options.Dsn = "... Your DSN ...";
+    options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
 
     // When debug is enabled, the Sentry client will emit detailed debugging information to the console.
     // This might be helpful, or might interfere with the normal operation of your application.

--- a/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
+++ b/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
@@ -40,6 +40,13 @@
     To associate commits with releases
     See https://docs.sentry.io/cli/releases/#commit-integration
     -->
+    <SentrySetCommits>true</SentrySetCommits>
+    <SentrySetCommitOptions>--local</SentrySetCommitOptions>
+
+    <!--
+    To associate commits with releases
+    See https://docs.sentry.io/cli/releases/#commit-integration
+    -->
 <!--    <SentrySetCommits>true</SentrySetCommits>-->
 <!--    <SentrySetCommitOptions>&#45;&#45;local</SentrySetCommitOptions>-->
   </PropertyGroup>

--- a/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
+++ b/samples/Sentry.Samples.Console.Basic/Sentry.Samples.Console.Basic.csproj
@@ -13,26 +13,36 @@
 
   <PropertyGroup>
     <!--
-    We set the SentryOrg and SentryProject globally in our root Directory.Build.props.
-    In your own project, uncomment the following block and set the values for your Sentry configuration.
-    Also note, these options do nothing if you are not authenticated.
-    See https://docs.sentry.io/platforms/dotnet/configuration/msbuild/
+    Note, these options do nothing if you are not authenticated.
+    See https://docs.sentry.io/platforms/dotnet/configuration/msbuild/#authentication
     -->
     <!--
     <SentryUrl>...your Sentry URL if self-hosted, or omit this line if using sentry.io...</SentryUrl>
-    <SentryOrg>...your org...</SentryOrg>
-    <SentryProject>...your project...</SentryProject>
     -->
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
 
     <!--
     After the above properties are configured, you can use the following features.
-    Uploading sources to Sentry during the build will enable Source Context in the Sentry issue details page.
     Uploading symbols to Sentry will enable server-side symbolication (i.e. when the PDB is not present at runtime, or for AOT published programs).
+    Uploading sources to Sentry during the build will enable Source Context in the Sentry issue details page.
     -->
-    <SentryUploadSources>true</SentryUploadSources>
     <SentryUploadSymbols>true</SentryUploadSymbols>
-  </PropertyGroup>
+    <SentryUploadSources>true</SentryUploadSources>
 
+    <!--
+    You can automatically create releases via sentry-cli and control their creation via these properties
+    See https://docs.sentry.io/cli/releases/#creating-releases
+    -->
+    <SentryCreateRelease>true</SentryCreateRelease>
+
+    <!--
+    To associate commits with releases
+    See https://docs.sentry.io/cli/releases/#commit-integration
+    -->
+<!--    <SentrySetCommits>true</SentrySetCommits>-->
+<!--    <SentrySetCommitOptions>&#45;&#45;local</SentrySetCommitOptions>-->
+  </PropertyGroup>
 
   <!-- In your own project, this would be a PackageReference to the latest version of Sentry. -->
   <ItemGroup>
@@ -41,6 +51,7 @@
   <ItemGroup>
     <TrimmerRootAssembly Include="Sentry" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>

--- a/samples/Sentry.Samples.Console.Customized/Program.cs
+++ b/samples/Sentry.Samples.Console.Customized/Program.cs
@@ -15,32 +15,31 @@ internal static class Program
         });
 
         // Enable the SDK
-        using (SentrySdk.Init(o =>
+        using (SentrySdk.Init(options =>
         {
-            // A Sentry Data Source Name (DSN) is required.
+            // You can set here in code, or you can set it in the SENTRY_DSN environment variable.
             // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
-            // You can set it in the SENTRY_DSN environment variable, or you can set it in code here.
-            // o.Dsn = "... Your DSN ...";
+            options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
 
             // Send stack trace for events that were not created from an exception
             // e.g: CaptureMessage, log.LogDebug, log.LogInformation ...
-            o.AttachStacktrace = true;
+            options.AttachStacktrace = true;
 
             // Sentry won't consider code from namespace LibraryX.* as part of the app code and will hide it from the stacktrace by default
             // To see the lines from non `AppCode`, select `Full`. Will include non App code like System.*, Microsoft.* and LibraryX.*
-            o.AddInAppExclude("LibraryX.");
+            options.AddInAppExclude("LibraryX.");
 
             // Before excluding all prefixed 'LibraryX.', any stack trace from a type namespaced 'LibraryX.Core' will be considered InApp.
-            o.AddInAppInclude("LibraryX.Core");
+            options.AddInAppInclude("LibraryX.Core");
 
             // Send personal identifiable information like the username logged on to the computer and machine name
-            o.SendDefaultPii = true;
+            options.SendDefaultPii = true;
 
             // To enable event sampling, uncomment:
             // o.SampleRate = 0.5f; // Randomly drop (don't send to Sentry) half of events
 
             // Modifications to event before it goes out. Could replace the event altogether
-            o.SetBeforeSend((@event, _) =>
+            options.SetBeforeSend((@event, _) =>
                 {
                     // Drop an event altogether:
                     if (@event.Tags.ContainsKey("SomeTag"))
@@ -53,7 +52,7 @@ internal static class Program
             );
 
             // Allows inspecting and modifying, returning a new or simply rejecting (returning null)
-            o.SetBeforeBreadcrumb((crumb, hint) =>
+            options.SetBeforeBreadcrumb((crumb, hint) =>
             {
                 // Don't add breadcrumbs with message containing:
                 if (crumb.Message?.Contains("bad breadcrumb") == true)
@@ -72,34 +71,34 @@ internal static class Program
             });
 
             // Ignore exception by its type:
-            o.AddExceptionFilterForType<XsltCompileException>();
+            options.AddExceptionFilterForType<XsltCompileException>();
 
             // Configure the background worker which sends events to sentry:
             // Wait up to 5 seconds before shutdown while there are events to send.
-            o.ShutdownTimeout = TimeSpan.FromSeconds(5);
+            options.ShutdownTimeout = TimeSpan.FromSeconds(5);
 
             // Enable SDK logging with Debug level
-            o.Debug = true;
+            options.Debug = true;
             // To change the verbosity, use:
-            // o.DiagnosticLevel = SentryLevel.Info;
+            // options.DiagnosticLevel = SentryLevel.Info;
             // To use a custom logger:
-            // o.DiagnosticLogger = ...
+            // options.DiagnosticLogger = ...
 
             // Using a proxy:
-            o.HttpProxy = null; //new WebProxy("https://localhost:3128");
+            options.HttpProxy = null; //new WebProxy("https://localhost:3128");
 
             // Example customizing the HttpMessageHandlers created
-            o.CreateHttpMessageHandler = () => new HttpClientHandler
+            options.CreateHttpMessageHandler = () => new HttpClientHandler
             {
                 ServerCertificateCustomValidationCallback = (_, certificate, _, _) =>
                     !certificate.Archived
             };
 
             // Access to the HttpClient created to serve the SentryClint
-            o.ConfigureClient = client => client.DefaultRequestHeaders.TryAddWithoutValidation("CustomHeader", new[] { "my value" });
+            options.ConfigureClient = client => client.DefaultRequestHeaders.TryAddWithoutValidation("CustomHeader", new[] { "my value" });
 
             // Control/override how to apply the State object into the scope
-            o.SentryScopeStateProcessor = new MyCustomerScopeStateProcessor();
+            options.SentryScopeStateProcessor = new MyCustomerScopeStateProcessor();
         }))
         {
             // Ignored by its type due to the setting above

--- a/samples/Sentry.Samples.Console.Customized/Sentry.Samples.Console.Customized.csproj
+++ b/samples/Sentry.Samples.Console.Customized/Sentry.Samples.Console.Customized.csproj
@@ -5,6 +5,39 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+    Note, these options do nothing if you are not authenticated.
+    See https://docs.sentry.io/platforms/dotnet/configuration/msbuild/#authentication
+    -->
+    <!--
+    <SentryUrl>...your Sentry URL if self-hosted, or omit this line if using sentry.io...</SentryUrl>
+    -->
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+
+    <!--
+    After the above properties are configured, you can use the following features.
+    Uploading symbols to Sentry will enable server-side symbolication (i.e. when the PDB is not present at runtime, or for AOT published programs).
+    Uploading sources to Sentry during the build will enable Source Context in the Sentry issue details page.
+    -->
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+
+    <!--
+    You can automatically create releases via sentry-cli and control their creation via these properties
+    See https://docs.sentry.io/cli/releases/#creating-releases
+    -->
+    <SentryCreateRelease>true</SentryCreateRelease>
+
+    <!--
+    To associate commits with releases
+    See https://docs.sentry.io/cli/releases/#commit-integration
+    -->
+    <!--    <SentrySetCommits>true</SentrySetCommits>-->
+    <!--    <SentrySetCommitOptions>&#45;&#45;local</SentrySetCommitOptions>-->
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>

--- a/samples/Sentry.Samples.Console.Metrics/Program.cs
+++ b/samples/Sentry.Samples.Console.Metrics/Program.cs
@@ -19,9 +19,9 @@ internal static class Program
         // Enable the SDK
         using (SentrySdk.Init(options =>
                {
-                   options.Dsn =
-                       // NOTE: ADD YOUR OWN DSN BELOW so you can see the events in your own Sentry account
-                       "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+                   // You can set here in code, or you can set it in the SENTRY_DSN environment variable.
+                   // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+                   options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
 
                    options.Debug = true;
                    options.StackTraceMode = StackTraceMode.Enhanced;

--- a/samples/Sentry.Samples.Console.Metrics/Sentry.Samples.Console.Metrics.csproj
+++ b/samples/Sentry.Samples.Console.Metrics/Sentry.Samples.Console.Metrics.csproj
@@ -1,12 +1,45 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup>
+      <OutputType>Exe</OutputType>
+      <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-    </ItemGroup>
+  <PropertyGroup>
+    <!--
+    Note, these options do nothing if you are not authenticated.
+    See https://docs.sentry.io/platforms/dotnet/configuration/msbuild/#authentication
+    -->
+    <!--
+    <SentryUrl>...your Sentry URL if self-hosted, or omit this line if using sentry.io...</SentryUrl>
+    -->
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+
+    <!--
+    After the above properties are configured, you can use the following features.
+    Uploading symbols to Sentry will enable server-side symbolication (i.e. when the PDB is not present at runtime, or for AOT published programs).
+    Uploading sources to Sentry during the build will enable Source Context in the Sentry issue details page.
+    -->
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+
+    <!--
+    You can automatically create releases via sentry-cli and control their creation via these properties
+    See https://docs.sentry.io/cli/releases/#creating-releases
+    -->
+    <SentryCreateRelease>true</SentryCreateRelease>
+
+    <!--
+    To associate commits with releases
+    See https://docs.sentry.io/cli/releases/#commit-integration
+    -->
+    <!--    <SentrySetCommits>true</SentrySetCommits>-->
+    <!--    <SentrySetCommitOptions>&#45;&#45;local</SentrySetCommitOptions>-->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.Console.Native/Program.cs
+++ b/samples/Sentry.Samples.Console.Native/Program.cs
@@ -5,10 +5,9 @@
 // Initialize the Sentry SDK.  (It is not necessary to dispose it.)
 SentrySdk.Init(options =>
 {
-    // A Sentry Data Source Name (DSN) is required.
+    // You can set here in code, or you can set it in the SENTRY_DSN environment variable.
     // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
-    // You can set it in the SENTRY_DSN environment variable, or you can set it in code here.
-    // options.Dsn = "... Your DSN ...";
+    options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
 
     // When debug is enabled, the Sentry client will emit detailed debugging information to the console.
     // This might be helpful, or might interfere with the normal operation of your application.

--- a/samples/Sentry.Samples.Console.Native/Sentry.Samples.Console.Native.csproj
+++ b/samples/Sentry.Samples.Console.Native/Sentry.Samples.Console.Native.csproj
@@ -4,30 +4,41 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <PublishAot>true</PublishAot>
   </PropertyGroup>
 
   <PropertyGroup>
     <!--
-    We set the SentryOrg and SentryProject globally in our root Directory.Build.props.
-    In your own project, uncomment the following block and set the values for your Sentry configuration.
-    Also note, these options do nothing if you are not authenticated.
-    See https://docs.sentry.io/platforms/dotnet/configuration/msbuild/
+    Note, these options do nothing if you are not authenticated.
+    See https://docs.sentry.io/platforms/dotnet/configuration/msbuild/#authentication
     -->
     <!--
     <SentryUrl>...your Sentry URL if self-hosted, or omit this line if using sentry.io...</SentryUrl>
-    <SentryOrg>...your org...</SentryOrg>
-    <SentryProject>...your project...</SentryProject>
     -->
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
 
     <!--
     After the above properties are configured, you can use the following features.
-    Uploading sources to Sentry during the build will enable Source Context in the Sentry issue details page.
     Uploading symbols to Sentry will enable server-side symbolication (i.e. when the PDB is not present at runtime, or for AOT published programs).
+    Uploading sources to Sentry during the build will enable Source Context in the Sentry issue details page.
     -->
-    <SentryUploadSources>true</SentryUploadSources>
     <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+
+    <!--
+    You can automatically create releases via sentry-cli and control their creation via these properties
+    See https://docs.sentry.io/cli/releases/#creating-releases
+    -->
+    <SentryCreateRelease>true</SentryCreateRelease>
+
+    <!--
+    To associate commits with releases
+    See https://docs.sentry.io/cli/releases/#commit-integration
+    -->
+    <!--    <SentrySetCommits>true</SentrySetCommits>-->
+    <!--    <SentrySetCommitOptions>&#45;&#45;local</SentrySetCommitOptions>-->
   </PropertyGroup>
 
   <!-- In your own project, this would be a PackageReference to the latest version of Sentry. -->

--- a/samples/Sentry.Samples.Console.Profiling/Program.cs
+++ b/samples/Sentry.Samples.Console.Profiling/Program.cs
@@ -8,9 +8,9 @@ internal static class Program
         // Enable the SDK
         using (SentrySdk.Init(options =>
         {
-            options.Dsn =
-                // NOTE: ADD YOUR OWN DSN BELOW so you can see the events in your own Sentry account
-                "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+            // You can set here in code, or you can set it in the SENTRY_DSN environment variable.
+            // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+            options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
 
             options.Debug = true;
             // options.AutoSessionTracking = true;

--- a/samples/Sentry.Samples.Console.Profiling/Sentry.Samples.Console.Profiling.csproj
+++ b/samples/Sentry.Samples.Console.Profiling/Sentry.Samples.Console.Profiling.csproj
@@ -5,6 +5,39 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+    Note, these options do nothing if you are not authenticated.
+    See https://docs.sentry.io/platforms/dotnet/configuration/msbuild/#authentication
+    -->
+    <!--
+    <SentryUrl>...your Sentry URL if self-hosted, or omit this line if using sentry.io...</SentryUrl>
+    -->
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+
+    <!--
+    After the above properties are configured, you can use the following features.
+    Uploading symbols to Sentry will enable server-side symbolication (i.e. when the PDB is not present at runtime, or for AOT published programs).
+    Uploading sources to Sentry during the build will enable Source Context in the Sentry issue details page.
+    -->
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+
+    <!--
+    You can automatically create releases via sentry-cli and control their creation via these properties
+    See https://docs.sentry.io/cli/releases/#creating-releases
+    -->
+    <SentryCreateRelease>true</SentryCreateRelease>
+
+    <!--
+    To associate commits with releases
+    See https://docs.sentry.io/cli/releases/#commit-integration
+    -->
+    <!--    <SentrySetCommits>true</SentrySetCommits>-->
+    <!--    <SentrySetCommitOptions>&#45;&#45;local</SentrySetCommitOptions>-->
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <ProjectReference Include="..\..\src\Sentry.Profiling\Sentry.Profiling.csproj" />

--- a/samples/Sentry.Samples.EntityFramework/Program.cs
+++ b/samples/Sentry.Samples.EntityFramework/Program.cs
@@ -2,14 +2,17 @@ using System.ComponentModel.DataAnnotations;
 using System.Data.Common;
 using System.Data.Entity;
 
-using var _ = SentrySdk.Init(o =>
+using var _ = SentrySdk.Init(options =>
 {
-    o.Debug = true; // To see SDK logs on the console
-    o.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
-    o.TracesSampleRate = 1.0;
+    // You can set here in code, or you can set it in the SENTRY_DSN environment variable.
+    // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+    options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+
+    options.Debug = true; // To see SDK logs on the console
+    options.TracesSampleRate = 1.0;
 
     // Add the EntityFramework integration to the SentryOptions of your app startup code:
-    o.AddEntityFramework();
+    options.AddEntityFramework();
 });
 
 var dbConnection = Effort.DbConnectionFactory.CreateTransient();

--- a/samples/Sentry.Samples.EntityFramework/Sentry.Samples.EntityFramework.csproj
+++ b/samples/Sentry.Samples.EntityFramework/Sentry.Samples.EntityFramework.csproj
@@ -5,6 +5,13 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.EntityFramework\Sentry.EntityFramework.csproj" />
 

--- a/samples/Sentry.Samples.GenericHost/Sentry.Samples.GenericHost.csproj
+++ b/samples/Sentry.Samples.GenericHost/Sentry.Samples.GenericHost.csproj
@@ -11,6 +11,13 @@
     </None>
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />

--- a/samples/Sentry.Samples.Google.Cloud.Functions/Sentry.Samples.Google.Cloud.Functions.csproj
+++ b/samples/Sentry.Samples.Google.Cloud.Functions/Sentry.Samples.Google.Cloud.Functions.csproj
@@ -7,13 +7,23 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
-    <ProjectReference Include="..\..\src\Sentry.Google.Cloud.Functions\Sentry.Google.Cloud.Functions.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <None Update="*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sentry.Google.Cloud.Functions\Sentry.Google.Cloud.Functions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.GraphQL.Client.Http/Program.cs
+++ b/samples/Sentry.Samples.GraphQL.Client.Http/Program.cs
@@ -11,7 +11,10 @@ using GraphQL.Client.Serializer.SystemTextJson;
 
 SentrySdk.Init(options =>
 {
-    // options.Dsn = "... Your DSN ...";
+    // You can set here in code, or you can set it in the SENTRY_DSN environment variable.
+    // // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+    options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+
     options.CaptureFailedRequests = true;
     options.SendDefaultPii = true;
     options.TracesSampleRate = 1.0;

--- a/samples/Sentry.Samples.GraphQL.Client.Http/Sentry.Samples.GraphQL.Client.Http.csproj
+++ b/samples/Sentry.Samples.GraphQL.Client.Http/Sentry.Samples.GraphQL.Client.Http.csproj
@@ -1,17 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+  <PropertyGroup>
+      <OutputType>Exe</OutputType>
+      <TargetFramework>net8.0</TargetFramework>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="GraphQL" Version="7.6.0" />
     <PackageReference Include="GraphQL.Client" Version="6.0.0" />
     <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="6.0.0" />
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />

--- a/samples/Sentry.Samples.GraphQL.Server/Program.cs
+++ b/samples/Sentry.Samples.GraphQL.Server/Program.cs
@@ -39,14 +39,16 @@ public static class Program
                     .AddSentry() // <-- Ensure telemetry is sent to Sentry
                 );
 
-        builder.WebHost.UseSentry(o =>
+        builder.WebHost.UseSentry(options =>
         {
-            // A DSN is required.  You can set it here, or in configuration, or in an environment variable.
-            // o.Dsn = "...Your DSN Here...";
-            o.TracesSampleRate = 1.0;
-            o.Debug = true;
-            o.SendDefaultPii = true;
-            o.UseOpenTelemetry(); // <-- Configure Sentry to use OpenTelemetry trace information
+            // You can set here in code, or you can set it in the SENTRY_DSN environment variable.
+            // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+            options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+
+            options.TracesSampleRate = 1.0;
+            options.Debug = true;
+            options.SendDefaultPii = true;
+            options.UseOpenTelemetry(); // <-- Configure Sentry to use OpenTelemetry trace information
         });
 
         builder.Services

--- a/samples/Sentry.Samples.GraphQL.Server/Sentry.Samples.GraphQL.Server.csproj
+++ b/samples/Sentry.Samples.GraphQL.Server/Sentry.Samples.GraphQL.Server.csproj
@@ -20,6 +20,13 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.5" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.AspNetCore\Sentry.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Sentry.OpenTelemetry\Sentry.OpenTelemetry.csproj" />

--- a/samples/Sentry.Samples.Hangfire/Sentry.Samples.Hangfire.csproj
+++ b/samples/Sentry.Samples.Hangfire/Sentry.Samples.Hangfire.csproj
@@ -12,6 +12,13 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.12" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.Hangfire\Sentry.Hangfire.csproj" />
   </ItemGroup>

--- a/samples/Sentry.Samples.Hangfire/appsettings.json
+++ b/samples/Sentry.Samples.Hangfire/appsettings.json
@@ -26,10 +26,14 @@
     }
   },
   "Logging": {
+    "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Default": "Trace"
     }
   },
-  "AllowedHosts": "*"
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http2"
+    }
+  }
 }

--- a/samples/Sentry.Samples.Ios/AppDelegate.cs
+++ b/samples/Sentry.Samples.Ios/AppDelegate.cs
@@ -12,17 +12,17 @@ public class AppDelegate : UIApplicationDelegate
     public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
     {
         // Init the Sentry SDK
-        SentrySdk.Init(o =>
+        SentrySdk.Init(options =>
         {
-            o.Debug = true;
-            o.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
-            o.TracesSampleRate = 1.0;
-            o.ProfilesSampleRate = 1.0;
+            options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+            options.Debug = true;
+            options.TracesSampleRate = 1.0;
+            options.ProfilesSampleRate = 1.0;
 
             // All the native iOS SDK options are available below
             // https://docs.sentry.io/platforms/apple/guides/ios/configuration/
             // Enable Native iOS SDK App Hangs detection
-            o.Native.EnableAppHangTracking = true;
+            options.Native.EnableAppHangTracking = true;
         });
 
         // create a new window instance based on the screen size

--- a/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
+++ b/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
@@ -10,29 +10,36 @@
     <PublishAot>true</PublishAot>
   </PropertyGroup>
 
-  <!--
-    In a real project, use the PackageReference and set the version to the latest release.
-    Use that instead of the ProjectReference.
-  -->
+  <PropertyGroup>
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
 
-  <ItemGroup>
-    <!-- <PackageReference Include="Sentry" Version="..." /> -->
-    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-  </ItemGroup>
-
-  <!--
-    To run on a device, you need to set the CodesignEntitlements property.
-  -->
+  <!-- To run on a device, you need to set the CodesignEntitlements property. -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
 
   <!--
-    For this demo app, let's upload sources and symbols to Sentry on every build, regardless of configuration.
-    In a real app, you probably only want to do this on Release builds.
+    In a real project, use the PackageReference and set the version to the latest release.
+    Use that instead of the ProjectReference.
+  -->
+
+  <!--
+  For this demo app, let's upload sources and symbols to Sentry on every build, regardless of configuration.
+  In a real app, you probably only want to do this on Release builds.
   -->
   <PropertyGroup>
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
     <SentryUploadSources>true</SentryUploadSources>
     <SentryUploadSymbols>true</SentryUploadSymbols>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- <PackageReference Include="Sentry" Version="..." /> -->
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
+  </ItemGroup>
 </Project>

--- a/samples/Sentry.Samples.Log4Net/Sentry.Samples.Log4Net.csproj
+++ b/samples/Sentry.Samples.Log4Net/Sentry.Samples.Log4Net.csproj
@@ -6,6 +6,13 @@
     <Version>3.5.234</Version>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.Log4Net\Sentry.Log4Net.csproj" />
   </ItemGroup>

--- a/samples/Sentry.Samples.ME.Logging/Program.cs
+++ b/samples/Sentry.Samples.ME.Logging/Program.cs
@@ -4,25 +4,26 @@ using Sentry.Extensions.Logging;
 using var loggerFactory = LoggerFactory.Create(builder =>
 {
     builder.AddConsole();
-    builder.AddSentry(o =>
+    builder.AddSentry(options =>
     {
-        // Set to true to SDK debugging to see the internal messages through the logging library.
-        o.Debug = false;
-        // Configure the level of Sentry internal logging
-        o.DiagnosticLevel = SentryLevel.Debug;
+        options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
 
-        o.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
-        o.MaxBreadcrumbs = 150; // Increasing from default 100
-        o.Release = "e386dfd"; // If not set here, SDK looks for it on main assembly's AssemblyInformationalVersion and AssemblyVersion
+        // Set to true to SDK debugging to see the internal messages through the logging library.
+        options.Debug = false;
+        // Configure the level of Sentry internal logging
+        options.DiagnosticLevel = SentryLevel.Debug;
+
+        options.MaxBreadcrumbs = 150; // Increasing from default 100
+        options.Release = "e386dfd"; // If not set here, SDK looks for it on main assembly's AssemblyInformationalVersion and AssemblyVersion
 
         // Optionally configure options: The default values are:
-        o.MinimumBreadcrumbLevel = LogLevel.Information; // It requires at least this level to store breadcrumb
-        o.MinimumEventLevel = LogLevel.Error; // This level or above will result in event sent to Sentry
+        options.MinimumBreadcrumbLevel = LogLevel.Information; // It requires at least this level to store breadcrumb
+        options.MinimumEventLevel = LogLevel.Error; // This level or above will result in event sent to Sentry
 
         // Don't keep as a breadcrumb or send events for messages of level less than Critical with exception of type DivideByZeroException
-        o.AddLogEntryFilter((_, level, _, exception) => level < LogLevel.Critical && exception is DivideByZeroException);
+        options.AddLogEntryFilter((_, level, _, exception) => level < LogLevel.Critical && exception is DivideByZeroException);
 
-        o.ConfigureScope(s => s.SetTag("RootScope", "sent with all events"));
+        options.ConfigureScope(s => s.SetTag("RootScope", "sent with all events"));
     });
 });
 var logger = loggerFactory.CreateLogger<Program>();

--- a/samples/Sentry.Samples.ME.Logging/Sentry.Samples.ME.Logging.csproj
+++ b/samples/Sentry.Samples.ME.Logging/Sentry.Samples.ME.Logging.csproj
@@ -6,10 +6,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-  </ItemGroup>
 </Project>

--- a/samples/Sentry.Samples.MacCatalyst/AppDelegate.cs
+++ b/samples/Sentry.Samples.MacCatalyst/AppDelegate.cs
@@ -12,10 +12,10 @@ public class AppDelegate : UIApplicationDelegate
     public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
     {
         // Init the Sentry SDK
-        SentrySdk.Init(o =>
+        SentrySdk.Init(options =>
         {
-            o.Debug = true;
-            o.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+            options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+            options.Debug = true;
         });
 
         // create a new window instance based on the screen size

--- a/samples/Sentry.Samples.MacCatalyst/Sentry.Samples.MacCatalyst.csproj
+++ b/samples/Sentry.Samples.MacCatalyst/Sentry.Samples.MacCatalyst.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net8.0-maccatalyst</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -8,15 +9,12 @@
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 
-  <!--
-    In a real project, use the PackageReference and set the version to the latest release.
-    Use that instead of the ProjectReference.
-  -->
-
-  <ItemGroup>
-    <!-- <PackageReference Include="Sentry" Version="..." /> -->
-    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
-  </ItemGroup>
+  <PropertyGroup>
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
 
   <!--
     Use the arm64 runtime when building on arm64, and the x64 runtime when building on x64 Macs.
@@ -32,9 +30,20 @@
     For this demo app, let's upload sources and symbols to Sentry on every build, regardless of configuration.
     In a real app, you probably only want to do this on Release builds.
   -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
     <SentryUploadSources>true</SentryUploadSources>
     <SentryUploadSymbols>true</SentryUploadSymbols>
   </PropertyGroup>
+
+  <!--
+    In a real project, use the PackageReference and set the version to the latest release.
+    Use that instead of the ProjectReference.
+  -->
+  <ItemGroup>
+    <!-- <PackageReference Include="Sentry" Version="..." /> -->
+    <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.MacOS/AppDelegate.cs
+++ b/samples/Sentry.Samples.MacOS/AppDelegate.cs
@@ -6,11 +6,11 @@ public class AppDelegate : NSApplicationDelegate
     public override void DidFinishLaunching(NSNotification notification)
     {
         // Init the Sentry SDK
-        SentrySdk.Init(o =>
+        SentrySdk.Init(options =>
         {
-            o.Debug = true;
-            o.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
-            o.TracesSampleRate = 1.0;
+            options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+            options.Debug = true;
+            options.TracesSampleRate = 1.0;
         });
     }
 }

--- a/samples/Sentry.Samples.MacOS/Sentry.Samples.MacOS.csproj
+++ b/samples/Sentry.Samples.MacOS/Sentry.Samples.MacOS.csproj
@@ -11,21 +11,23 @@
   </PropertyGroup>
 
   <!--
+    For this demo app, let's upload sources and symbols to Sentry on every build, regardless of configuration.
+    In a real app, you probably only want to do this on Release builds.
+  -->
+  <PropertyGroup>
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
+  <!--
     In a real project, use the PackageReference and set the version to the latest release.
     Use that instead of the ProjectReference.
   -->
-
   <ItemGroup>
     <!-- <PackageReference Include="Sentry" Version="..." /> -->
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
   </ItemGroup>
 
-  <!--
-    For this demo app, let's upload sources and symbols to Sentry on every build, regardless of configuration.
-    In a real app, you probably only want to do this on Release builds.
-  -->
-  <PropertyGroup>
-    <SentryUploadSources>true</SentryUploadSources>
-    <SentryUploadSymbols>true</SentryUploadSymbols>
-  </PropertyGroup>
 </Project>

--- a/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
+++ b/samples/Sentry.Samples.Maui/Sentry.Samples.Maui.csproj
@@ -40,14 +40,18 @@
       It is not strictly necessary, but makes the demo sligtly cleaner.
     -->
     <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
 
     <!--
-      For this demo app, let's upload sources and symbols to Sentry on every build, regardless of configuration.
-      In a real app, you probably only want to do this on Release builds.
+    For this demo app, let's upload sources and symbols to Sentry on every build, regardless of configuration.
+    In a real app, you probably only want to do this on Release builds.
     -->
-    <SentryUploadSources>true</SentryUploadSources>
     <SentryUploadSymbols>true</SentryUploadSymbols>
-
+    <SentryUploadSources>true</SentryUploadSources>
   </PropertyGroup>
 
   <!--

--- a/samples/Sentry.Samples.NLog/Program.cs
+++ b/samples/Sentry.Samples.NLog/Program.cs
@@ -104,26 +104,26 @@ public static class Program
         // Other overloads exist, for example, configure the SDK with only the DSN or no parameters at all.
         var config = LogManager.Configuration = new LoggingConfiguration();
         _ = config
-            .AddSentry(o =>
+            .AddSentry(options =>
             {
-                o.Layout = "${message}";
-                o.BreadcrumbLayout = "${logger}: ${message}"; // Optionally specify a separate format for breadcrumbs
-
-                o.MinimumBreadcrumbLevel = LogLevel.Debug; // Debug and higher are stored as breadcrumbs (default is Info)
-                o.MinimumEventLevel = LogLevel.Error; // Error and higher is sent as event (default is Error)
-
                 // If DSN is not set, the SDK will look for an environment variable called SENTRY_DSN. If
                 // nothing is found, SDK is disabled.
-                o.Dsn = DsnSample;
+                options.Dsn = DsnSample;
 
-                o.AttachStacktrace = true;
-                o.SendDefaultPii = true; // Send Personal Identifiable information like the username of the user logged in to the device
+                options.Layout = "${message}";
+                options.BreadcrumbLayout = "${logger}: ${message}"; // Optionally specify a separate format for breadcrumbs
 
-                o.IncludeEventDataOnBreadcrumbs = true; // Optionally include event properties with breadcrumbs
-                o.ShutdownTimeoutSeconds = 5;
+                options.MinimumBreadcrumbLevel = LogLevel.Debug; // Debug and higher are stored as breadcrumbs (default is Info)
+                options.MinimumEventLevel = LogLevel.Error; // Error and higher is sent as event (default is Error)
+
+                options.AttachStacktrace = true;
+                options.SendDefaultPii = true; // Send Personal Identifiable information like the username of the user logged in to the device
+
+                options.IncludeEventDataOnBreadcrumbs = true; // Optionally include event properties with breadcrumbs
+                options.ShutdownTimeoutSeconds = 5;
 
                 //Optionally specify user properties via NLog (here using MappedDiagnosticsLogicalContext as an example)
-                o.User = new SentryNLogUser
+                options.User = new SentryNLogUser
                 {
                     Id = "${scopeproperty:item=id}",
                     Username = "${scopeproperty:item=username}",
@@ -135,7 +135,7 @@ public static class Program
                     },
                 };
 
-                o.AddTag("logger", "${logger}");  // Send the logger name as a tag
+                options.AddTag("logger", "${logger}");  // Send the logger name as a tag
 
                 // Other configuration
             });

--- a/samples/Sentry.Samples.NLog/Sentry.Samples.NLog.csproj
+++ b/samples/Sentry.Samples.NLog/Sentry.Samples.NLog.csproj
@@ -6,16 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.2.4" />
-    <ProjectReference Include="..\..\src\Sentry.NLog\Sentry.NLog.csproj">
-      <Private>true</Private>
-    </ProjectReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="NLog.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="5.2.4" />
+    <ProjectReference Include="..\..\src\Sentry.NLog\Sentry.NLog.csproj">
+      <Private>true</Private>
+    </ProjectReference>
+  </ItemGroup>
+  
 </Project>

--- a/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Program.cs
+++ b/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Program.cs
@@ -38,7 +38,10 @@ builder.Services.AddOpenTelemetry()
 
 builder.WebHost.UseSentry(options =>
 {
-    // options.Dsn = "...Your DSN...";
+    // You can set here in code, or you can set it in the SENTRY_DSN environment variable, or the config.
+    // // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+    options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+
     options.Debug = builder.Environment.IsDevelopment();
     options.SendDefaultPii = true;
     options.TracesSampleRate = 1.0;

--- a/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Sentry.Samples.OpenTelemetry.AspNetCore.csproj
+++ b/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Sentry.Samples.OpenTelemetry.AspNetCore.csproj
@@ -13,6 +13,13 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.AspNetCore\Sentry.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Sentry.OpenTelemetry\Sentry.OpenTelemetry.csproj" />

--- a/samples/Sentry.Samples.OpenTelemetry.Console/Program.cs
+++ b/samples/Sentry.Samples.OpenTelemetry.Console/Program.cs
@@ -14,12 +14,13 @@ var activitySource = new ActivitySource("Sentry.Samples.OpenTelemetry.Console");
 
 SentrySdk.Init(options =>
 {
-    // TODO: Replace the DSN below with your own. You can find this value in your Sentry project settings.
-    // https://docs.sentry.io/product/sentry-basics/concepts/dsn-explainer/#where-to-find-your-dsn
-    options.Dsn = "... Your DSN ...";
+    // You can set here in code, or you can set it in the SENTRY_DSN environment variable.
+    // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+    options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+
+    options.Debug = true;
     options.TracesSampleRate = 1.0;
     options.UseOpenTelemetry(); // <-- Configure Sentry to use OpenTelemetry trace information
-    options.Debug = true;
 });
 
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()

--- a/samples/Sentry.Samples.OpenTelemetry.Console/README.md
+++ b/samples/Sentry.Samples.OpenTelemetry.Console/README.md
@@ -17,7 +17,7 @@ SentrySdk.Init(o =>
 {
     options.Dsn = "...Your DSN...";
     options.TracesSampleRate = 1.0;
-    o.UseOpenTelemetry(); // <-- Configure Sentry to use OpenTelemetry trace information
+    options.UseOpenTelemetry(); // <-- Configure Sentry to use OpenTelemetry trace information
 });
 ```
 

--- a/samples/Sentry.Samples.OpenTelemetry.Console/Sentry.Samples.OpenTelemetry.Console.csproj
+++ b/samples/Sentry.Samples.OpenTelemetry.Console/Sentry.Samples.OpenTelemetry.Console.csproj
@@ -12,6 +12,13 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
   <!-- In your own project, this would be a PackageReference to the latest version of Sentry. -->
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />

--- a/samples/Sentry.Samples.Serilog/Program.cs
+++ b/samples/Sentry.Samples.Serilog/Program.cs
@@ -12,19 +12,21 @@ internal static class Program
             .MinimumLevel.Debug()
             .WriteTo.Console()
             // Other overloads exist, for example, configure the SDK with only the DSN or no parameters at all.
-            .WriteTo.Sentry(o =>
+            .WriteTo.Sentry(options =>
             {
+                // You can set here in code, or you can set it in the SENTRY_DSN environment variable.
+                // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+                options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
+
                 // Debug and higher are stored as breadcrumbs (default os Information)
-                o.MinimumBreadcrumbLevel = LogEventLevel.Debug;
+                options.MinimumBreadcrumbLevel = LogEventLevel.Debug;
                 // Error and higher is sent as event (default is Error)
-                o.MinimumEventLevel = LogEventLevel.Error;
-                // If DSN is not set, the SDK will look for an environment variable called SENTRY_DSN. If nothing is found, SDK is disabled.
-                o.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537";
-                o.AttachStacktrace = true;
+                options.MinimumEventLevel = LogEventLevel.Error;
+                options.AttachStacktrace = true;
                 // send PII like the username of the user logged in to the device
-                o.SendDefaultPii = true;
+                options.SendDefaultPii = true;
                 // Optional Serilog text formatter used to format LogEvent to string. If TextFormatter is set, FormatProvider is ignored.
-                o.TextFormatter = new MessageTemplateTextFormatter("[{MyTaskId}] {Message}");
+                options.TextFormatter = new MessageTemplateTextFormatter("[{MyTaskId}] {Message}");
                 // Other configuration
             })
             .CreateLogger();

--- a/samples/Sentry.Samples.Serilog/Sentry.Samples.Serilog.csproj
+++ b/samples/Sentry.Samples.Serilog/Sentry.Samples.Serilog.csproj
@@ -11,6 +11,13 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <SentryOrg>sentry-sdks</SentryOrg>
+    <SentryProject>sentry-dotnet</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryUploadSources>true</SentryUploadSources>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.Serilog\Sentry.Serilog.csproj" />
   </ItemGroup>


### PR DESCRIPTION
The idea is to make our `samples` be as standalone and without any automagic as possible.
This makes it easier to copy sample projects, drop provided repro-projects in there, and change the package import from a nuget package to the `.csproj`.


#skip-changelog