### PR TITLE
fix: `FormatException` when reading `BatteryLevel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- On mobile devices, the SDK no longer throws a `FormatException` when trying to report native events ([#3485](https://github.com/getsentry/sentry-dotnet/pull/3485))
 - Race condition in `SentryMessageHandler` ([#3477](https://github.com/getsentry/sentry-dotnet/pull/3477))
 
 ## 4.9.0

--- a/src/Sentry/Protocol/Device.cs
+++ b/src/Sentry/Protocol/Device.cs
@@ -361,6 +361,8 @@ public sealed class Device : ISentryJsonSerializable, ICloneable<Device>, IUpdat
         writer.WriteStringIfNotWhiteSpace("model", Model);
         writer.WriteStringIfNotWhiteSpace("model_id", ModelId);
         writer.WriteStringIfNotWhiteSpace("arch", Architecture);
+
+        Console.WriteLine($"HUEHUEHUEHUEHUEHUE: {BatteryLevel}");
         writer.WriteNumberIfNotNull("battery_level", BatteryLevel);
         writer.WriteBooleanIfNotNull("charging", IsCharging);
         writer.WriteBooleanIfNotNull("online", IsOnline);
@@ -426,7 +428,18 @@ public sealed class Device : ISentryJsonSerializable, ICloneable<Device>, IUpdat
         var model = json.GetPropertyOrNull("model")?.GetString();
         var modelId = json.GetPropertyOrNull("model_id")?.GetString();
         var architecture = json.GetPropertyOrNull("arch")?.GetString();
-        var batteryLevel = json.GetPropertyOrNull("battery_level")?.GetInt16();
+
+        // TODO: For next mayor: Remove this and change batteryLevel from short to float
+        // The Java and Cocoa SDK report the battery as `float`
+        // Cocoa https://github.com/getsentry/sentry-cocoa/blob/e773cad622b86735f1673368414009475e4119fd/Sources/Sentry/include/SentryUIDeviceWrapper.h#L18
+        // Java  https://github.com/getsentry/sentry-java/blob/25f1ca4e1636a801c17c1662f0145f888550bce8/sentry/src/main/java/io/sentry/protocol/Device.java#L231-L233
+        short? batteryLevel = null;
+        var batteryProperty = json.GetPropertyOrNull("battery_level");
+        if (batteryProperty.HasValue)
+        {
+            batteryLevel = (short)batteryProperty.Value.GetDouble();
+        }
+
         var isCharging = json.GetPropertyOrNull("charging")?.GetBoolean();
         var isOnline = json.GetPropertyOrNull("online")?.GetBoolean();
         var orientation = json.GetPropertyOrNull("orientation")?.GetString()?.ParseEnum<DeviceOrientation>();

--- a/src/Sentry/Protocol/Device.cs
+++ b/src/Sentry/Protocol/Device.cs
@@ -427,7 +427,7 @@ public sealed class Device : ISentryJsonSerializable, ICloneable<Device>, IUpdat
         var modelId = json.GetPropertyOrNull("model_id")?.GetString();
         var architecture = json.GetPropertyOrNull("arch")?.GetString();
 
-        // TODO: For next mayor: Remove this and change batteryLevel from short to float
+        // TODO: For next major: Remove this and change batteryLevel from short to float
         // The Java and Cocoa SDK report the battery as `float`
         // Cocoa https://github.com/getsentry/sentry-cocoa/blob/e773cad622b86735f1673368414009475e4119fd/Sources/Sentry/include/SentryUIDeviceWrapper.h#L18
         // Java  https://github.com/getsentry/sentry-java/blob/25f1ca4e1636a801c17c1662f0145f888550bce8/sentry/src/main/java/io/sentry/protocol/Device.java#L231-L233

--- a/src/Sentry/Protocol/Device.cs
+++ b/src/Sentry/Protocol/Device.cs
@@ -361,8 +361,6 @@ public sealed class Device : ISentryJsonSerializable, ICloneable<Device>, IUpdat
         writer.WriteStringIfNotWhiteSpace("model", Model);
         writer.WriteStringIfNotWhiteSpace("model_id", ModelId);
         writer.WriteStringIfNotWhiteSpace("arch", Architecture);
-
-        Console.WriteLine($"HUEHUEHUEHUEHUEHUE: {BatteryLevel}");
         writer.WriteNumberIfNotNull("battery_level", BatteryLevel);
         writer.WriteBooleanIfNotNull("charging", IsCharging);
         writer.WriteBooleanIfNotNull("online", IsOnline);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dotnet/issues/3465

The mobile SDKs have `battery_level` as `float`, causing a `FormatException` when the .NET SDK tries to deserialize the event. We should remove the workaround with the next major.