### PR TITLE
feat: Added .NET8 as TFM for `Blazor.WebAssembly` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Users can now automatically create releases and associated commits via sentry-cli and MSBuild properties ([#3462](https://github.com/getsentry/sentry-dotnet/pull/3462))
+- `Sentry.AspNetCore.Blazor.WebAssembly` now targets .NET 8 specifically, allowing for proper dependency resolution ([#3501](https://github.com/getsentry/sentry-dotnet/pull/3501))
 
 ### Fixes
 

--- a/src/Sentry.AspNetCore.Blazor.WebAssembly/Sentry.AspNetCore.Blazor.WebAssembly.csproj
+++ b/src/Sentry.AspNetCore.Blazor.WebAssembly/Sentry.AspNetCore.Blazor.WebAssembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <VersionSuffix>preview.1</VersionSuffix>
     <RootNamespace>Sentry.AspNetCore.Blazor.WebAssembly</RootNamespace>
   </PropertyGroup>

--- a/src/Sentry.AspNetCore.Blazor.WebAssembly/Sentry.AspNetCore.Blazor.WebAssembly.csproj
+++ b/src/Sentry.AspNetCore.Blazor.WebAssembly/Sentry.AspNetCore.Blazor.WebAssembly.csproj
@@ -11,7 +11,11 @@
     <ProjectReference Include="..\Sentry\Sentry.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.30" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Addresses https://github.com/getsentry/sentry-dotnet/issues/2021#issuecomment-2248384178

Since the package has a dependency on `Microsoft.AspNetCore.Components.WebAssembly` adding .NET 8 as TFM allows users to resolve the actual .NET 8 dependency chain.