### PR TITLE
fix: Sentry.Native.targets

### DIFF
--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -7,21 +7,21 @@
 
   Note:Target framework conditions should be kept synchronized with src/Sentry/buildTransitive/Sentry.Native.targets -->
 <Project>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net8')) and '$(OutputType)' == 'Exe' And '$(RuntimeIdentifier)' == 'win-x64'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8')) and ('$(OutputType)' == 'Exe' Or '$(OutputType)' == 'WinExe') And '$(RuntimeIdentifier)' == 'win-x64'">
     <DirectPInvoke Include="sentry-native" />
     <NativeLibrary Include="$(MSBuildThisFileDirectory)..\sentry-native\win-x64\sentry-native.lib" />
     <NativeLibrary Include="dbghelp.lib" />
     <NativeLibrary Include="winhttp.lib" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net8')) and '$(OutputType)' == 'Exe' And '$(RuntimeIdentifier)' == 'linux-x64'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8')) and ('$(OutputType)' == 'Exe' Or '$(OutputType)' == 'WinExe') And '$(RuntimeIdentifier)' == 'linux-x64'">
     <DirectPInvoke Include="sentry-native" />
     <NativeLibrary Include="$(MSBuildThisFileDirectory)..\sentry-native\linux-x64\libsentry-native.a" />
     <!-- See: https://github.com/dotnet/runtime/issues/97414 -->
     <NativeSystemLibrary Include="curl" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net8')) and '$(OutputType)' == 'Exe' And ('$(RuntimeIdentifier)' == 'osx-x64' or '$(RuntimeIdentifier)' == 'osx-arm64')">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8')) and ('$(OutputType)' == 'Exe' Or '$(OutputType)' == 'WinExe') And ('$(RuntimeIdentifier)' == 'osx-x64' or '$(RuntimeIdentifier)' == 'osx-arm64')">
     <DirectPInvoke Include="sentry-native" />
     <NativeLibrary Include="$(MSBuildThisFileDirectory)..\sentry-native\osx\libsentry-native.a" />
     <NativeSystemLibrary Include="curl" />


### PR DESCRIPTION
I've updated the conditions to include both 'Exe' and 'WinExe' for the OutputType.

This is necessary because:

  1. When `OutputType` is set to `Exe`, it is automatically changed to `WinExe` for WPF and Windows Forms apps that target any framework version, including .NET Framework. (see this [Breaking Change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/5.0/automatically-infer-winexe-output-type)).

  2. Avalonia uses 'WinExe' when targeting every platform (not just Windows).
  
Previously, when AOT compiling a WinForms or Avalonia app, sentry-native couldn't be found.

This change ensures that sentry-native is correctly linked for these types of applications during AOT compilation, fixing https://github.com/getsentry/sentry-dotnet/issues/3484#issuecomment-2254925496

Here is an Avalonia app that has been AOT compiled using Sentry Native successfully 

<img width="576" alt="Screenshot 2024-07-31 at 11 37 48 AM" src="https://github.com/user-attachments/assets/9222bb31-bcf3-44e7-ab7b-3b6ce9f579c5">

