### PR TITLE
Set PollingNetworkStatusListener as the default NetworkStatusListener

### DIFF
--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -1298,9 +1298,7 @@ public class SentryOptions
                 UriFormat.Unescaped)
         );
 
-#if PLATFORM_NEUTRAL
         NetworkStatusListener = new PollingNetworkStatusListener(this);
-#endif
     }
 
     /// <summary>


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3510

#skip-changelog