### PR TITLE
Added `dev` version suffix for non-release builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,10 @@
     <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' != 'Release'">
+    <VersionSuffix>dev</VersionSuffix>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(SolutionName)' == '.generated.NoMobile'">
     <NO_MOBILE>true</NO_MOBILE>
   </PropertyGroup>


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/2160

#skip-changelog