### PR TITLE
fix: Read and send unfinished spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- When finishing a transaction, the SDK now properly sends unfinished spans ([#3533](https://github.com/getsentry/sentry-dotnet/pull/3533))
+- Unfinished spans are now correctly stored and retrieved by the CachingTransport ([#3533](https://github.com/getsentry/sentry-dotnet/pull/3533))
 
 ## 4.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- When finishing a transaction, the SDK now properly sends unfinished spans ([#3533](https://github.com/getsentry/sentry-dotnet/pull/3533))
+
 ## 4.10.0
 
 ### Features

--- a/src/Sentry/SentrySpan.cs
+++ b/src/Sentry/SentrySpan.cs
@@ -154,7 +154,7 @@ public class SentrySpan : ISpanData, ISentryJsonSerializable, ITraceContextInter
         var parentSpanId = json.GetPropertyOrNull("parent_span_id")?.Pipe(SpanId.FromJson);
         var traceId = json.GetPropertyOrNull("trace_id")?.Pipe(SentryId.FromJson) ?? SentryId.Empty;
         var startTimestamp = json.GetProperty("start_timestamp").GetDateTimeOffset();
-        var endTimestamp = json.GetProperty("timestamp").GetDateTimeOffset();
+        var endTimestamp = json.GetPropertyOrNull("timestamp")?.GetDateTimeOffset();
         var operation = json.GetPropertyOrNull("op")?.GetString() ?? "unknown";
         var description = json.GetPropertyOrNull("description")?.GetString();
         var status = json.GetPropertyOrNull("status")?.GetString()?.Replace("_", "").ParseEnum<SpanStatus>();


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/1759

With https://github.com/getsentry/relay/issues/1244 spans no longer need to be finished before sent. Without making reading the `endTimestamp` optional we end up with an error

```
System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
```