### PR TITLE
Fix vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Resolved a potential deadlock during SDK shutdown ([#3539](https://github.com/getsentry/sentry-dotnet/pull/3539))
 
+### Dependencies
+- Bumped dependencies to resolve security vulnerabilities ([#3547])
+
 ## 4.10.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Resolved a potential deadlock during SDK shutdown ([#3539](https://github.com/getsentry/sentry-dotnet/pull/3539))
 
 ### Dependencies
+
 - Bumped dependencies to resolve security vulnerabilities ([#3547])
 
 ## 4.10.1

--- a/samples/Sentry.Samples.GenericHost/Sentry.Samples.GenericHost.csproj
+++ b/samples/Sentry.Samples.GenericHost/Sentry.Samples.GenericHost.csproj
@@ -21,6 +21,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry.Extensions.Logging\Sentry.Extensions.Logging.csproj" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <!-- https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.GraphQL.Server/Sentry.Samples.GraphQL.Server.csproj
+++ b/samples/Sentry.Samples.GraphQL.Server/Sentry.Samples.GraphQL.Server.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/src/Sentry.AspNetCore.Blazor.WebAssembly/Sentry.AspNetCore.Blazor.WebAssembly.csproj
+++ b/src/Sentry.AspNetCore.Blazor.WebAssembly/Sentry.AspNetCore.Blazor.WebAssembly.csproj
@@ -17,5 +17,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.3" />
+    <!-- https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And '$(NO_MACCATALYST)' == ''">net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And '$(NO_MACCATALYST)' == 'true'">net7.0-ios</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == 'true' And '$(NO_MACCATALYST)' == ''">net7.0-maccatalyst</TargetFrameworks>
+    <CheckEolWorkloads>false</CheckEolWorkloads>
     <IsBindingProject>true</IsBindingProject>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
     <Description>.NET Bindings for the Sentry Cocoa SDK</Description>

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And '$(NO_MACCATALYST)' == ''">net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And '$(NO_MACCATALYST)' == 'true'">net7.0-ios</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == 'true' And '$(NO_MACCATALYST)' == ''">net7.0-maccatalyst</TargetFrameworks>
+    <!-- TODO: Remove this and bump to net8.0 in the next major release -->
     <CheckEolWorkloads>false</CheckEolWorkloads>
     <IsBindingProject>true</IsBindingProject>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>

--- a/src/Sentry.Profiling/Sentry.Profiling.csproj
+++ b/src/Sentry.Profiling/Sentry.Profiling.csproj
@@ -14,6 +14,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.510501" />
+    <!-- https://github.com/advisories/GHSA-7jgj-8wvc-jh57 -->
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <!--  This triggers the build of this project and its dependencies. We don't need all of them but this is the easiest way -->
     <!--  to make sure the project builds/cleans etc in tandem with this. Packaging copies the 2 DLLs we need below -->
     <ProjectReference Include="../../modules/perfview/src/TraceEvent/TraceEvent.csproj" PrivateAssets="all" />


### PR DESCRIPTION
These vulnerabilities get reported as errors when using the version of MSBuild included in net9.0. We'll need to address them prior to supporting net9.0.

However there's no harm in addressing them earlier here in the main branch.