### PR TITLE
Allow WinUI 3 unhandled exception handler to be registered manually

### DIFF
--- a/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
@@ -56,7 +56,14 @@ internal class WinUIUnhandledExceptionIntegration : ISdkIntegration
         _options = options;
 
         // Hook the main event handler
-        AttachEventHandler();
+        if (options.AttachWinUIUnhandledExceptionHandler is {} manualAttachmentCallback)
+        {
+            manualAttachmentCallback(WinUIUnhandledExceptionHandler);
+        }
+        else
+        {
+            AttachEventHandlerViaReflection();
+        }
     }
 
     private static Assembly? GetWinUIAssembly()
@@ -84,7 +91,7 @@ internal class WinUIUnhandledExceptionIntegration : ISdkIntegration
     /// </summary>
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = AotHelper.SuppressionJustification)]
     [UnconditionalSuppressMessage("Trimming", "IL2075:\'this\' argument does not satisfy \'DynamicallyAccessedMembersAttribute\' in call to target method. The return value of the source method does not have matching annotations.", Justification = AotHelper.SuppressionJustification)]
-    private void AttachEventHandler()
+    private void AttachEventHandlerViaReflection()
     {
         try
         {
@@ -142,5 +149,10 @@ internal class WinUIUnhandledExceptionIntegration : ISdkIntegration
         }
     }
 }
+
+/// <summary>
+/// Delegate for Sentry's WinUI UnhandledException event handler.
+/// </summary>
+public delegate void SentryWinUIUnhandledExceptionEventHandler(object sender, object e);
 
 #endif

--- a/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
@@ -56,7 +56,7 @@ internal class WinUIUnhandledExceptionIntegration : ISdkIntegration
         _options = options;
 
         // Hook the main event handler
-        if (options.AttachWinUIUnhandledExceptionHandler is {} manualAttachmentCallback)
+        if (options.AttachWinUIUnhandledExceptionHandler is { } manualAttachmentCallback)
         {
             manualAttachmentCallback(WinUIUnhandledExceptionHandler);
         }

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -1682,6 +1682,31 @@ public class SentryOptions
     /// </summary>
     public void DisableWinUiUnhandledExceptionIntegration()
         => RemoveDefaultIntegration(DefaultIntegrations.WinUiUnhandledExceptionIntegration);
+
+    /// <summary>
+    /// <para>Callback action that can be used to attach Sentry's WinUI unhandled exception handler.</para>
+    /// <para>
+    /// When Trimming is enabled Sentry is unable to use reflection to automatically registering its unhandled
+    /// exception handler, in WinUI 3 applications. In such cases, you will need to manually attach Sentry's unhandled
+    /// exception handler when initializing the Sentry SDK (see sample code below).
+    /// </para>
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// public App()
+    /// {
+    ///     SentrySdk.Init(options =>
+    ///     {
+    ///         /* ...other Sentry options */
+    ///         options.AttachWinUIUnhandledExceptionHandler = (SentryWinUIUnhandledExceptionEventHandler handler)
+    ///             => this.UnhandledException += (o, e) => handler(o, e);
+    ///     });
+    ///
+    ///     this.InitializeComponent();
+    /// }
+    /// </code>
+    /// </example>
+    public Action<SentryWinUIUnhandledExceptionEventHandler>? AttachWinUIUnhandledExceptionHandler { get; set; }
 #endif
 
 #if NET8_0_OR_GREATER


### PR DESCRIPTION
Experimenting with a solution for:
- https://github.com/getsentry/sentry-dotnet/issues/3561