### PR TITLE
Removed TODO from WinUIUnhandledExceptionIntegration

### DIFF
--- a/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
+++ b/src/Sentry/Integrations/WinUIUnhandledExceptionIntegration.cs
@@ -101,7 +101,6 @@ internal class WinUIUnhandledExceptionIntegration : ISdkIntegration
         catch (Exception ex)
         {
             // If we get an exception we should let the user know how they can manually wire up the event handler.
-            // TODO: We need to create a mechanism for users to wire this up manually and document this in a separate PR
             _options.LogError(ex, "Could not attach WinUIUnhandledExceptionHandler.");
         }
     }


### PR DESCRIPTION
After investigation, this TODO item doesn't seem to make any sense.

See:
- https://github.com/getsentry/sentry-dotnet/issues/3561#issuecomment-2313969467

#skip-changelog