### PR TITLE
DisabledHub.StartTransaction now returns NoOpTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixes
 - On mobile devices, the SDK no longer throws a `FormatException` for `ProcessorFrequency` when trying to report native events ([#3541](https://github.com/getsentry/sentry-dotnet/pull/3541))
 
+### API Changes
+- When the Sentry SDK is disabled, `SentrySdk.StartTransaction()` now returns a `NoOpTransaction`, which avoids unnecessary memory allocations ([#3581](https://github.com/getsentry/sentry-dotnet/pull/3581))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.35.0 to v8.36.0 ([#3570](https://github.com/getsentry/sentry-dotnet/pull/3570), [#3575](https://github.com/getsentry/sentry-dotnet/pull/3575))

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -1,3 +1,4 @@
+using Sentry.Internal;
 using Sentry.Protocol.Envelopes;
 using Sentry.Protocol.Metrics;
 
@@ -47,11 +48,8 @@ public class DisabledHub : IHub, IDisposable
     /// <summary>
     /// Returns a dummy transaction.
     /// </summary>
-    public ITransactionTracer StartTransaction(
-        ITransactionContext context,
-        IReadOnlyDictionary<string, object?> customSamplingContext) =>
-        // Transactions from DisabledHub are always sampled out
-        new TransactionTracer(this, context) { IsSampled = false };
+    public ITransactionTracer StartTransaction(ITransactionContext context,
+        IReadOnlyDictionary<string, object?> customSamplingContext) => NoOpTransaction.Instance;
 
     /// <summary>
     /// No-Op.

--- a/test/Sentry.AspNet.Tests/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextExtensionsTests.cs
@@ -8,6 +8,14 @@ public class HttpContextExtensionsTests
     public void StartSentryTransaction_CreatesValidTransaction()
     {
         // Arrange
+        using var _ = SentrySdk.UseHub(new Hub(
+            new SentryOptions
+            {
+                Dsn = ValidDsn
+            },
+            Substitute.For<ISentryClient>()
+        ));
+
         var context = HttpContextBuilder.Build();
 
         // Act
@@ -69,12 +77,15 @@ public class HttpContextExtensionsTests
     public void StartSentryTransaction_SendDefaultPii_set_to_true_sets_cookies()
     {
         // Arrange
+        using var _ = SentrySdk.UseHub(new Hub(
+            new SentryOptions
+            {
+                Dsn = ValidDsn,
+                SendDefaultPii = true
+            },
+            Substitute.For<ISentryClient>()
+        ));
         var context = HttpContextBuilder.BuildWithCookies(new[] { new HttpCookie("foo", "bar") });
-
-        SentryClientExtensions.SentryOptionsForTestingOnly = new SentryOptions
-        {
-            SendDefaultPii = true
-        };
 
         // Act
         var transaction = context.StartSentryTransaction();
@@ -87,12 +98,15 @@ public class HttpContextExtensionsTests
     public void StartSentryTransaction_SendDefaultPii_set_to_true_does_not_set_cookies_if_none_found()
     {
         // Arrange
+        using var _ = SentrySdk.UseHub(new Hub(
+            new SentryOptions
+            {
+                Dsn = ValidDsn,
+                SendDefaultPii = true
+            },
+            Substitute.For<ISentryClient>()
+        ));
         var context = HttpContextBuilder.BuildWithCookies(new HttpCookie[] { });
-
-        SentryClientExtensions.SentryOptionsForTestingOnly = new SentryOptions
-        {
-            SendDefaultPii = true
-        };
 
         // Act
         var transaction = context.StartSentryTransaction();


### PR DESCRIPTION
Resolves #829 

Replaces https://github.com/getsentry/sentry-dotnet/pull/3574 (cherry picked commits to target `main` branch instead of the `version-5.0.0` branch.