### PR TITLE
fix: Marked `SentrySdk.Metrics` as obsolete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### API Changes
+
+- The `SentrySdk.Metrics` module is deprecated and will be removed in the next major release. 
+  Sentry will reject all metrics sent after October 7, 2024.
+  Learn more: https://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-to-Metrics  ([#3619](https://github.com/getsentry/sentry-dotnet/pull/3619))
+
 ### Features
 
 - All exceptions are now added as breadcrumbs on future events. Previously this was only the case for exceptions captured via the `Sentry.SeriLog` or `Sentry.Extensions.Logging` integrations. ([#3584](https://github.com/getsentry/sentry-dotnet/pull/3584))

--- a/samples/Sentry.Samples.Console.Metrics/Program.cs
+++ b/samples/Sentry.Samples.Console.Metrics/Program.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Obsolete Warning
 using System.Diagnostics.Metrics;
 using System.Text.RegularExpressions;
 
@@ -137,3 +138,4 @@ internal static class Program
         System.Console.WriteLine($"GET {url} {result.StatusCode}");
     }
 }
+#pragma warning restore CS0618

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -288,6 +288,9 @@ public sealed class HubAdapter : IHub
         => SentrySdk.FlushAsync(timeout);
 
     /// <inheritdoc cref="IMetricAggregator"/>
+    [Obsolete("The SentrySdk.Metrics module is deprecated and will be removed in the next major release. " +
+              "Sentry will reject all metrics sent after October 7, 2024." +
+              "Learn more: https://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-to-Metrics")]
     public IMetricAggregator Metrics
         => SentrySdk.Metrics;
 

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -659,9 +659,7 @@ internal class Hub : IHub, IMetricHub, IDisposable
 
         try
         {
-            Metrics.FlushAsync().ContinueWith(_ =>
-                CurrentClient.FlushAsync(_options.ShutdownTimeout).ConfigureAwait(false).GetAwaiter().GetResult()
-            ).ConfigureAwait(false).GetAwaiter().GetResult();
+            CurrentClient.FlushAsync(_options.ShutdownTimeout).ConfigureAwait(false).GetAwaiter().GetResult();
         }
         catch (Exception e)
         {

--- a/src/Sentry/Internal/SystemDiagnosticsMetricsListener.cs
+++ b/src/Sentry/Internal/SystemDiagnosticsMetricsListener.cs
@@ -11,10 +11,13 @@ internal class SystemDiagnosticsMetricsListener : IDisposable
 
     internal readonly MeterListener _sentryListener = new();
 
+#pragma warning disable CS0618 // Obsolete Warning
     private SystemDiagnosticsMetricsListener(ExperimentalMetricsOptions metricsOptions)
         : this(metricsOptions, () => SentrySdk.Metrics)
+#pragma warning restore CS0618
     {
     }
+
 
     /// <summary>
     /// Overload for testing purposes - allows us to supply a mock IMetricAggregator

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -668,6 +668,9 @@ public static partial class SentrySdk
         => CurrentHub.ContinueTrace(traceHeader, baggageHeader, name, operation);
 
     /// <inheritdoc cref="IMetricAggregator"/>
+    [Obsolete("The SentrySdk.Metrics module is deprecated and will be removed in the next major release. " +
+              "Sentry will reject all metrics sent after October 7, 2024." +
+              "Learn more: https://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-to-Metrics")]
     public static IMetricAggregator Metrics
         => CurrentHub.Metrics;
 

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -783,6 +783,10 @@ namespace Sentry
     {
         public static bool IsEnabled { get; }
         public static Sentry.SentryId LastEventId { get; }
+        [System.Obsolete("The SentrySdk.Metrics module is deprecated and will be removed in the next major " +
+            "release. Sentry will reject all metrics sent after October 7, 2024.Learn more: h" +
+            "ttps://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-" +
+            "to-Metrics")]
         public static Sentry.IMetricAggregator Metrics { get; }
         public static void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
@@ -1322,6 +1326,10 @@ namespace Sentry.Extensibility
         public static readonly Sentry.Extensibility.HubAdapter Instance;
         public bool IsEnabled { get; }
         public Sentry.SentryId LastEventId { get; }
+        [System.Obsolete("The SentrySdk.Metrics module is deprecated and will be removed in the next major " +
+            "release. Sentry will reject all metrics sent after October 7, 2024.Learn more: h" +
+            "ttps://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-" +
+            "to-Metrics")]
         public Sentry.IMetricAggregator Metrics { get; }
         public void AddBreadcrumb(string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public void AddBreadcrumb(Sentry.Infrastructure.ISystemClock clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -783,6 +783,10 @@ namespace Sentry
     {
         public static bool IsEnabled { get; }
         public static Sentry.SentryId LastEventId { get; }
+        [System.Obsolete("The SentrySdk.Metrics module is deprecated and will be removed in the next major " +
+            "release. Sentry will reject all metrics sent after October 7, 2024.Learn more: h" +
+            "ttps://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-" +
+            "to-Metrics")]
         public static Sentry.IMetricAggregator Metrics { get; }
         public static void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
@@ -1322,6 +1326,10 @@ namespace Sentry.Extensibility
         public static readonly Sentry.Extensibility.HubAdapter Instance;
         public bool IsEnabled { get; }
         public Sentry.SentryId LastEventId { get; }
+        [System.Obsolete("The SentrySdk.Metrics module is deprecated and will be removed in the next major " +
+            "release. Sentry will reject all metrics sent after October 7, 2024.Learn more: h" +
+            "ttps://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-" +
+            "to-Metrics")]
         public Sentry.IMetricAggregator Metrics { get; }
         public void AddBreadcrumb(string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public void AddBreadcrumb(Sentry.Infrastructure.ISystemClock clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -785,6 +785,10 @@ namespace Sentry
     {
         public static bool IsEnabled { get; }
         public static Sentry.SentryId LastEventId { get; }
+        [System.Obsolete("The SentrySdk.Metrics module is deprecated and will be removed in the next major " +
+            "release. Sentry will reject all metrics sent after October 7, 2024.Learn more: h" +
+            "ttps://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-" +
+            "to-Metrics")]
         public static Sentry.IMetricAggregator Metrics { get; }
         public static void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
@@ -1324,6 +1328,10 @@ namespace Sentry.Extensibility
         public static readonly Sentry.Extensibility.HubAdapter Instance;
         public bool IsEnabled { get; }
         public Sentry.SentryId LastEventId { get; }
+        [System.Obsolete("The SentrySdk.Metrics module is deprecated and will be removed in the next major " +
+            "release. Sentry will reject all metrics sent after October 7, 2024.Learn more: h" +
+            "ttps://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-" +
+            "to-Metrics")]
         public Sentry.IMetricAggregator Metrics { get; }
         public void AddBreadcrumb(string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public void AddBreadcrumb(Sentry.Infrastructure.ISystemClock clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -780,6 +780,10 @@ namespace Sentry
     {
         public static bool IsEnabled { get; }
         public static Sentry.SentryId LastEventId { get; }
+        [System.Obsolete("The SentrySdk.Metrics module is deprecated and will be removed in the next major " +
+            "release. Sentry will reject all metrics sent after October 7, 2024.Learn more: h" +
+            "ttps://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-" +
+            "to-Metrics")]
         public static Sentry.IMetricAggregator Metrics { get; }
         public static void AddBreadcrumb(Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
@@ -1319,6 +1323,10 @@ namespace Sentry.Extensibility
         public static readonly Sentry.Extensibility.HubAdapter Instance;
         public bool IsEnabled { get; }
         public Sentry.SentryId LastEventId { get; }
+        [System.Obsolete("The SentrySdk.Metrics module is deprecated and will be removed in the next major " +
+            "release. Sentry will reject all metrics sent after October 7, 2024.Learn more: h" +
+            "ttps://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-" +
+            "to-Metrics")]
         public Sentry.IMetricAggregator Metrics { get; }
         public void AddBreadcrumb(string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public void AddBreadcrumb(Sentry.Infrastructure.ISystemClock clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }


### PR DESCRIPTION
Relates to Metrics Deprecation https://github.com/getsentry/sentry-dotnet/issues/3597

While marking the API as obsolete I also removed the shutdown flushing. I think it's fairly low risk and it fixes the deadlocking situation in https://github.com/getsentry/sentry-unity/issues/1779

