### PR TITLE
Fixes "Failed to persist session" error on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fixed "Failed to persist session" error on iOS ([#3655](https://github.com/getsentry/sentry-dotnet/pull/3655))
+
 ### Dependencies
 
 - Bump CLI from v2.36.5 to v2.36.6 ([#3647](https://github.com/getsentry/sentry-dotnet/pull/3647))

--- a/src/Sentry/GlobalSessionManager.cs
+++ b/src/Sentry/GlobalSessionManager.cs
@@ -76,10 +76,9 @@ internal class GlobalSessionManager : ISessionManager
                 return;
             }
 
-            using var writer = new Utf8JsonWriter(file);
-
             try
             {
+                using var writer = new Utf8JsonWriter(file);
                 persistedSessionUpdate.WriteTo(writer, _options.DiagnosticLogger);
                 writer.Flush();
             }


### PR DESCRIPTION
Fixes #3653

Ideally we'd be able to reproduce this in a unit test to prevent a regression.

Regardless, it looks like there might be a timing issue where sometimes the writer tries to do something with the file after `File.Dispose()` has been called. I've moved the writer inside the try block to ensure `writer.Dispose()` is called before `file.Dispose()`, which should avoid the problem.