### PR TITLE
Bump device tests to net8.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
   -->
   <PropertyGroup>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
-    <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'ios'">10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'ios'">11.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,7 +6,7 @@
   -->
   <PropertyGroup>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
-    <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'ios'">10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'ios'">11.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>

--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -21,7 +21,7 @@ $CI = Test-Path env:CI
 Push-Location $PSScriptRoot/..
 try
 {
-    $tfm = 'net7.0-'
+    $tfm = 'net8.0-'
     $arch = (!$IsWindows -and $(uname -m) -eq 'arm64') ? 'arm64' : 'x64'
     if ($Platform -eq 'android')
     {

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -48,7 +48,7 @@
 
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="xunit" Version="2.6.5" />
+    <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="20.0.4" />
@@ -59,7 +59,7 @@
     <PackageReference Include="Verify.Xunit" Version="22.11.4" />
     <PackageReference Include="Verify.DiffPlex" Version="2.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>

--- a/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
@@ -806,7 +806,7 @@ public class SentryMiddlewareTests
         sut.PopulateScope(_fixture.HttpContext, scope);
         sut.PopulateScope(_fixture.HttpContext, scope);
 
-        Assert.Single(scope.GetAllEventProcessors().Where(c => c == customProcessor));
+        Assert.Single(scope.GetAllEventProcessors(), c => c == customProcessor);
     }
 
     [Fact]
@@ -841,7 +841,7 @@ public class SentryMiddlewareTests
         sut.PopulateScope(_fixture.HttpContext, scope);
         sut.PopulateScope(_fixture.HttpContext, scope);
 
-        Assert.Single(scope.GetAllExceptionProcessors().Where(c => c == customEventExceptionProcessor));
+        Assert.Single(scope.GetAllExceptionProcessors(), c => c == customEventExceptionProcessor);
     }
 
     [Fact]
@@ -876,6 +876,6 @@ public class SentryMiddlewareTests
         sut.PopulateScope(_fixture.HttpContext, scope);
         sut.PopulateScope(_fixture.HttpContext, scope);
 
-        Assert.Single(scope.GetAllTransactionProcessors().Where(c => c == customTransactionProcessor));
+        Assert.Single(scope.GetAllTransactionProcessors(), c => c == customTransactionProcessor);
     }
 }

--- a/test/Sentry.DiagnosticSource.Tests/Integration/SQLite/SentryDiagnosticListenerTests.cs
+++ b/test/Sentry.DiagnosticSource.Tests/Integration/SQLite/SentryDiagnosticListenerTests.cs
@@ -90,9 +90,9 @@ public class SentryDiagnosticListenerTests
         Assert.Single(spans); //1 command
 #else
         Assert.Equal(2, spans.Count); //1 query compiler, 1 command
-        Assert.Single(spans.Where(s => s.Status == SpanStatus.Ok && s.Operation == "db.query.compile"));
+        Assert.Single(spans, s => s.Status == SpanStatus.Ok && s.Operation == "db.query.compile");
 #endif
-        Assert.Single(spans.Where(s => s.Status == SpanStatus.InternalError && s.Operation == "db.query"));
+        Assert.Single(spans, s => s.Status == SpanStatus.InternalError && s.Operation == "db.query");
         Assert.All(spans, span => Assert.True(span.IsFinished));
     }
 

--- a/test/Sentry.EntityFramework.Tests/SentryQueryPerformanceListenerTests.cs
+++ b/test/Sentry.EntityFramework.Tests/SentryQueryPerformanceListenerTests.cs
@@ -210,12 +210,9 @@ public class SentryQueryPerformanceListenerTests
         // This operation will result in one reading operation and two non scalar operations.
         _fixture.Hub.Received(3).GetSpan();
         // In-memory database doesn't have a CommandText so Description is expected to be null
-        Assert.NotEmpty(_fixture.Spans.Where(
-            span => DbNonQueryKey == span.Operation && span.Description is "CREATE SCHEMA (CodeFirstDatabase(dbo.__MigrationHistory(ContextKey(Effort.string)MigrationId(Effort.string)Model(Effort.binary)ProductVersion(Effort.string))))"));
-        Assert.NotEmpty(_fixture.Spans.Where(
-            span => DbNonQueryKey == span.Operation && span.Description is null));
-        Assert.NotEmpty(_fixture.Spans.Where(
-            span => DbReaderKey == span.Operation && span.Description is null));
+        Assert.Contains(_fixture.Spans, span => DbNonQueryKey == span.Operation && span.Description is "CREATE SCHEMA (CodeFirstDatabase(dbo.__MigrationHistory(ContextKey(Effort.string)MigrationId(Effort.string)Model(Effort.binary)ProductVersion(Effort.string))))");
+        Assert.Contains(_fixture.Spans, span => DbNonQueryKey == span.Operation && span.Description is null);
+        Assert.Contains(_fixture.Spans, span => DbReaderKey == span.Operation && span.Description is null);
 
         Assert.All(_fixture.Spans, span => span.Received(1).Finish(Arg.Is<SpanStatus>(status => SpanStatus.Ok == status)));
         integration.Unregister();

--- a/test/Sentry.Hangfire.Tests/HangfireTests.cs
+++ b/test/Sentry.Hangfire.Tests/HangfireTests.cs
@@ -10,7 +10,7 @@ public class HangfireTests : IClassFixture<HangfireFixture>
     }
 
     [Fact]
-    public async void ExecuteJobWithAttribute_CapturesCheckInInProgressAndOkWithDuration()
+    public async Task ExecuteJobWithAttribute_CapturesCheckInInProgressAndOkWithDuration()
     {
         var sentryId = SentryId.Create();
         _fixture.Hub.CaptureCheckIn(Arg.Any<string>(), Arg.Any<CheckInStatus>()).Returns(sentryId);
@@ -29,7 +29,7 @@ public class HangfireTests : IClassFixture<HangfireFixture>
     }
 
     [Fact]
-    public async void ExecuteJobWithException_CapturesCheckInInProgressAndErrorWithDuration()
+    public async Task ExecuteJobWithException_CapturesCheckInInProgressAndErrorWithDuration()
     {
         var sentryId = SentryId.Create();
         _fixture.Hub.CaptureCheckIn(Arg.Any<string>(), Arg.Any<CheckInStatus>()).Returns(sentryId);
@@ -50,7 +50,7 @@ public class HangfireTests : IClassFixture<HangfireFixture>
     }
 
     [Fact]
-    public async void ExecuteJobWithoutAttribute_DoesNotCapturesCheckInButLogs()
+    public async Task ExecuteJobWithoutAttribute_DoesNotCapturesCheckInButLogs()
     {
         var sentryId = SentryId.Create();
         _fixture.Hub.CaptureCheckIn(Arg.Any<string>(), Arg.Any<CheckInStatus>()).Returns(sentryId);

--- a/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
+++ b/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks />
-    <TargetFrameworks Condition="'$(NO_ANDROID)' == ''">$(TargetFrameworks);net7.0-android</TargetFrameworks>
-    <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="'$(NO_ANDROID)' == ''">$(TargetFrameworks);net8.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net8.0-ios</TargetFrameworks>
     <!-- Currently broken on .NET 7, see
       - https://github.com/dotnet/maui/issues/18573
       - https://developercommunity.visualstudio.com/t/MAUI0000:-SystemMissingMethodException:/10505327?sort=newest&ftype=problem
@@ -70,8 +70,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DeviceRunners.XHarness.Maui" Version="0.1.0-preview.1" />
-    <PackageReference Include="DeviceRunners.XHarness.Xunit" Version="0.1.0-preview.1" />
+    <PackageReference Include="DeviceRunners.XHarness.Maui" Version="0.1.0-preview.2" />
+    <PackageReference Include="DeviceRunners.XHarness.Xunit" Version="0.1.0-preview.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
@@ -51,7 +51,7 @@ public partial class MainExceptionProcessorTests
 
         sut.Process(exp, evt);
 
-        Assert.Single(evt.SentryExceptions!.Where(p => p.Mechanism?.Handled == null));
+        Assert.Single(evt.SentryExceptions!, p => p.Mechanism?.Handled == null);
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public partial class MainExceptionProcessorTests
 
         sut.Process(exp, evt);
 
-        Assert.Single(evt.SentryExceptions!.Where(p => p.Mechanism?.Handled == false));
+        Assert.Single(evt.SentryExceptions!, p => p.Mechanism?.Handled == false);
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public partial class MainExceptionProcessorTests
 
         sut.Process(exp, evt);
 
-        Assert.Single(evt.SentryExceptions!.Where(p => p.Mechanism?.Handled == true));
+        Assert.Single(evt.SentryExceptions!, p => p.Mechanism?.Handled == true);
     }
 
     [Fact]
@@ -91,7 +91,7 @@ public partial class MainExceptionProcessorTests
 
         sut.Process(exp, evt);
 
-        Assert.Single(evt.SentryExceptions!.Where(p => p.Mechanism?.Handled == true));
+        Assert.Single(evt.SentryExceptions!, p => p.Mechanism?.Handled == true);
     }
 
     [Fact]

--- a/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
+++ b/test/Sentry.Tests/Internals/SentryStackTraceFactoryTests.cs
@@ -52,7 +52,7 @@ public partial class SentryStackTraceFactoryTests
     [Theory]
     [InlineData(StackTraceMode.Original, "AsyncWithWait_StackTrace { <lambda> }")]
     [InlineData(StackTraceMode.Enhanced, "void SentryStackTraceFactoryTests.AsyncWithWait_StackTrace(StackTraceMode mode, string method)+() => { }")]
-    public async void AsyncWithWait_StackTrace(StackTraceMode mode, string method)
+    public async Task AsyncWithWait_StackTrace(StackTraceMode mode, string method)
     {
         _fixture.SentryOptions.StackTraceMode = mode;
         _fixture.SentryOptions.AttachStacktrace = true;

--- a/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
@@ -568,7 +568,7 @@ public class EnvelopeTests
     }
 
     [Fact]
-    public async void AsyncSerialization_EnvelopeWithThrowingItem_DoesntThrow()
+    public async Task AsyncSerialization_EnvelopeWithThrowingItem_DoesntThrow()
     {
         // Arrange
         using var envelope = new Envelope(


### PR DESCRIPTION
Attempt to bump the device tests to net8.0 using the DeviceRunners NuGet package. Around 227 tests fail with issues relating to CastleProxy. 

At this stage, the only thing left is to try to create a minimal repro of this, outside the Sentry repo, so that we can submit an issue to the CastleProxy team. 