### PR TITLE
use ubuntu-latest-4-cores on heavy workloads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ env:
 jobs:
   build-sentry-native:
     name: sentry-native (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, windows, macos]
+        os: [ubuntu-latest-4-cores, windows-latest, macos-latest]
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           enableCrossOsArchive: true
 
       - name: Free Disk Space (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: contains(matrix.os,'ubuntu')
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           android: true
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest-4-cores, windows-latest, macos-latest]
 
     steps:
       - name: Cancel Previous Runs
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest-4-cores, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -27,7 +27,7 @@ jobs:
         run: dotnet tool install -g dotnet-format
 
       - name: Format Code
-        # We're excluding `./**/*OptionsSetup.cs` from the format because the tool struggles with 
+        # We're excluding `./**/*OptionsSetup.cs` from the format because the tool struggles with
         # source generators
         run: dotnet format Sentry.sln --no-restore --exclude ./modules --exclude ./**/*OptionsSetup.cs
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8c6cbc01-f9ce-4a25-8a18-910d1587921a)

Looking at the large runner [here](https://github.com/getsentry/sentry-dotnet/actions/runners), looks like we need to use the right name

The goal is not to add `ubuntu-latest-4-cores` everywhere, but add to things that run on Linux that are slow to run

#skip-changelog