### PR TITLE
fix: sdk name for native on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Make `Sentry.AspNetCore.Blazor.WebAssembly` generally available. ([#3674](https://github.com/getsentry/sentry-dotnet/pull/3674))
 
+### Fixes
+
+- Events from NDK on Android will report sdk.name `sentry.native.android.dotnet` ([#3682](https://github.com/getsentry/sentry-dotnet/pull/3682))
+
 ## 4.12.1
 
 ### Fixes

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -167,7 +167,7 @@ public static partial class SentrySdk
             o.EnableExternalConfiguration = false;
             o.EnableDeduplication = false;
             o.AttachServerName = false;
-            o.NativeSdkName = "sentry.native.dotnet";
+            o.NativeSdkName = "sentry.native.android.dotnet";
 
             // These options are intentionally not expose or modified
             //o.MaxRequestBodySize   // N/A for Android apps


### PR DESCRIPTION
We append `.platform` when 'wrapping' another SDK.

`sentry.native` on Android, because of its custom unwinder and other significant changes (it's also built through sentry-java repo). Has a different SDK name:

https://github.com/getsentry/sentry-native/blob/b555a978986f882abb3161bd1c848339f9a2cc1a/include/sentry.h#L28

Resolves:
* https://github.com/getsentry/sentry-dotnet/issues/3654#issuecomment-2395681843