### PR TITLE
chore: Comment why `format-code` runs on `macos-latest`

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -44,5 +44,6 @@ runs:
           wasm-tools maui-android \
           ${{ runner.os == 'macOS' && 'maui-ios maui-maccatalyst maui-windows macos' || '' }} \
           ${{ runner.os == 'Windows' && 'maui-windows' || '' }} \
+          ${{ runner.os == 'Linux' && 'ios' || '' }} \
           --temp-dir "${{ runner.temp }}" \
           --skip-sign-check

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -44,6 +44,5 @@ runs:
           wasm-tools maui-android \
           ${{ runner.os == 'macOS' && 'maui-ios maui-maccatalyst maui-windows macos' || '' }} \
           ${{ runner.os == 'Windows' && 'maui-windows' || '' }} \
-          ${{ runner.os == 'Linux' && 'ios' || '' }} \
           --temp-dir "${{ runner.temp }}" \
           --skip-sign-check

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   format-code:
     name: Format Code
-    runs-on: ubuntu-latest
+    # Running on 'macos' because Linux is missing the `ios` workload
+    # See: https://github.com/dotnet/runtime/issues/85505
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   format-code:
     name: Format Code
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
We're currently forced to run on macos for `format-code` because restoring the workloads on `Ubuntu` causes errors for `Sentry.Samples.Ios.csproj`, `Sentry.Samples.MacCatalyst.csproj`, and `Sentry.Samples.MacOS.csproj`:

```
The project depends on the following workload packs that do not exist in any of the workloads available in this installation: Microsoft.iOS.Sdk.net8.0_18.0
You may need to build the project on another operating system or architecture, or update the .NET SDK. 
```


#skip-changelog