### PR TITLE
fix: Bumped `System.Text.Json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bump Java SDK from v7.14.0 to v7.15.0 ([#3670](https://github.com/getsentry/sentry-dotnet/pull/3670))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#7150)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.14.0...7.15.0)
+- Bumped `System.Text.Json` from v6.0.8 to v6.0.10 ([#3704](https://github.com/getsentry/sentry-dotnet/pull/3704))
 
 ## 4.12.1
 

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -82,7 +82,7 @@
 
   <!-- Ensure at least version 6 of System.Text.Json so we have JsonSerializationContext available -->
   <ItemGroup Condition="!$(TargetFramework.StartsWith('net6')) and !$(TargetFramework.StartsWith('net7')) and !$(TargetFramework.StartsWith('net8'))">
-    <PackageReference Include="System.Text.Json" Version="6.0.8" >
+    <PackageReference Include="System.Text.Json" Version="6.0.10" >
   <!--
     Ignoring the vulnerability warning: https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
     The app can/should pin to the latest version. We will bump once a patch on v6 (still LTS until Nov 24) is out


### PR DESCRIPTION
I'm not sure what dependabot's issue is that it's not doing that on its own but here we are.

Addresses: https://github.com/getsentry/sentry-dotnet/security/dependabot/16

Version `6.0.10` is out.