### PR TITLE
Fix iOS device tests when running on Arm64 host machines

### DIFF
--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -45,6 +45,8 @@ try
     {
         $tfm += 'ios'
         $group = 'apple'
+        # Always use x64 on iOS, since arm64 doesn't support JIT, which is required for tests using NSubstitute
+        $arch = 'x64'
         $buildDir = $CI ? 'bin' : "test/Sentry.Maui.Device.TestApp/bin/Release/$tfm/iossimulator-$arch"
         $envValue = $CI ? 'true' : 'false'
         $arguments = @(

--- a/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
+++ b/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
@@ -50,11 +50,12 @@
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
 
     <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'android'      And '$(OSArchitecture)' == 'Arm64'">android-arm64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'ios'          And '$(OSArchitecture)' == 'Arm64'">iossimulator-arm64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'  And '$(OSArchitecture)' == 'Arm64'">maccatalyst-arm64</RuntimeIdentifier>
-
     <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'android'      And '$(OSArchitecture)' == 'x64'">android-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'ios'          And '$(OSArchitecture)' == 'x64'">iossimulator-x64</RuntimeIdentifier>
+
+    <!-- On iOS we always target x64 since Arm64 doesn't support JIT, which is required by tests using NSubstitute   -->
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'ios'">iossimulator-x64</RuntimeIdentifier>
+
+    <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'  And '$(OSArchitecture)' == 'Arm64'">maccatalyst-arm64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == 'maccatalyst'  And '$(OSArchitecture)' == 'x64'">maccatalyst-x64</RuntimeIdentifier>
   </PropertyGroup>
 


### PR DESCRIPTION
Tweaked the device tests so that these always use x64 when running on iOS (even if the host machine is running Arm64). This is necessary because the Arm64 runtime doesn't support JIT, which is required by the Castle DynamicProxy used under the hood by any of our tests that leverage NSubstitute. When running against the Arm64 runtime, all of those tests would fail.

See [this discord conversation](https://discord.com/channels/732297728826277939/1298876194552549458/1298974102383497277) for details.

#skip-changelog