### PR TITLE
Fixed: processing spans after SDK is closed (OTel and ASP.NET Core)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- When using OTel and ASP.NET Core the SDK could try to process OTel spans after the SDK had been closed ([#3726](https://github.com/getsentry/sentry-dotnet/pull/3726))
+
 ## 4.12.2
 
 ### Features

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -83,6 +83,14 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
     /// <inheritdoc />
     public override void OnStart(Activity data)
     {
+        if (!_hub.IsEnabled)
+        {
+            // This would be unusual... it might happen if the SDK is closed while the processor is still running and
+            // we receive new telemetry. In this case, we can't log anything because our logger is disabled, so we just
+            // swallow it
+            return;
+        }
+
         if (data.ParentSpanId != default && _map.TryGetValue(data.ParentSpanId, out var mappedParent))
         {
             // Explicit ParentSpanId of another activity that we have already mapped
@@ -165,6 +173,14 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
     /// <inheritdoc />
     public override void OnEnd(Activity data)
     {
+        if (!_hub.IsEnabled)
+        {
+            // This would be unusual... it might happen if the SDK is closed while the processor is still running and
+            // we receive new telemetry. In this case, we can't log anything because our logger is disabled, so we just
+            // swallow it
+            return;
+        }
+
         // Make a dictionary of the attributes (aka "tags") for faster lookup when used throughout the processor.
         var attributes = data.TagObjects.ToDict();
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3724

Fixes and issue when using ASP.NET Core and OpenTelemetry instrumentation, where the SDK might be closed before the last OpenTelemetry spans get fully processed by the `SentrySpanProcessor`.

## Problem

When the AppBuilderExtensions initialise the SDK a lifetime callback is also registered to close the SDK when the app shuts down:
https://github.com/getsentry/sentry-dotnet/blob/e382fb080102cf654f86566cd53816b208746e62/src/Sentry.AspNetCore/ApplicationBuilderExtensions.cs#L45

However this can be called before all telemetry events are received/processed by the `SentrySpanProcessor`, which was then trying to create new spans for that telemetry using a disabled hub.

## Solution

The OnEnd and OnStart events for the SentrySpanProcessor now check to see whether the hub is still active before doing any work.