### PR TITLE
Fix: ArgumentNullException in FormRequestPayloadExtractor when handling invalid form data on ASP.NET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fixed ArgumentNullException on ASP.NET in FormRequestPayloadExtractor when handling poorly structured form data ([#3734](https://github.com/getsentry/sentry-dotnet/pull/3734))
+- Fixed ArgumentNullException in FormRequestPayloadExtractor when handling invalid form data on ASP.NET ([#3734](https://github.com/getsentry/sentry-dotnet/pull/3734))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fixed ArgumentNullException on ASP.NET in FormRequestPayloadExtractor when handling poorly structured form data ([#3734](https://github.com/getsentry/sentry-dotnet/pull/3734))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.36.0 to v8.39.0 ([#3727](https://github.com/getsentry/sentry-dotnet/pull/3727))

--- a/src/Sentry/Extensibility/FormRequestPayloadExtractor.cs
+++ b/src/Sentry/Extensibility/FormRequestPayloadExtractor.cs
@@ -10,9 +10,9 @@ public class FormRequestPayloadExtractor : BaseRequestPayloadExtractor
     /// <summary>
     /// Supports <see cref="IHttpRequest"/> with content type application/x-www-form-urlencoded.
     /// </summary>
-    protected override bool IsSupported(IHttpRequest request)
-        => SupportedContentType
-            .Equals(request.ContentType, StringComparison.InvariantCulture);
+    protected override bool IsSupported(IHttpRequest request) =>
+        SupportedContentType.Equals(request.ContentType, StringComparison.InvariantCulture)
+        || (request.ContentType?.StartsWith($"{SupportedContentType};", StringComparison.InvariantCulture) == true);
 
     /// <summary>
     /// Extracts the request form data as a dictionary.

--- a/test/Sentry.AspNet.Tests/Internal/SystemWebHttpRequestTests.cs
+++ b/test/Sentry.AspNet.Tests/Internal/SystemWebHttpRequestTests.cs
@@ -1,0 +1,48 @@
+using System.Collections.Specialized;
+using Sentry.AspNet.Internal;
+
+namespace Sentry.AspNet.Tests.Internal;
+
+public class SystemWebHttpRequestTests
+{
+    [Fact]
+    public void GetFormData_GoodData_ReturnsCorrectValues()
+    {
+        // Arrange
+        var formCollection = new NameValueCollection
+        {
+            { "key1", "value1" },
+            { "key2", "value2" }
+        };
+
+        // Act
+        var form = SystemWebHttpRequest.GetFormData(formCollection).ToDict();
+
+        // Assert
+        form.Should().NotBeNull();
+        form.Should().Contain(kvp => kvp.Key == "key1" && kvp.Value.Contains("value1"));
+        form.Should().Contain(kvp => kvp.Key == "key2" && kvp.Value.Contains("value2"));
+    }
+
+    [Fact]
+    public void GetFormData_BadData_ReturnsCorrectValues()
+    {
+        // Arrange
+        var formCollection = new NameValueCollection
+        {
+            { "key1", "value1" },
+            { "key2", "value2" },
+            { null, "badkey" },
+            { "badvalue", null },
+            { null, null }
+        };
+
+        // Act
+        var form = SystemWebHttpRequest.GetFormData(formCollection).ToDict();
+
+        // Assert
+        form.Should().NotBeNull();
+        form.Should().Contain(kvp => kvp.Key == "key1" && kvp.Value.Contains("value1"));
+        form.Should().Contain(kvp => kvp.Key == "key2" && kvp.Value.Contains("value2"));
+    }
+}

--- a/test/Sentry.AspNetCore.Tests/BaseRequestPayloadExtractorTests.cs
+++ b/test/Sentry.AspNetCore.Tests/BaseRequestPayloadExtractorTests.cs
@@ -32,6 +32,7 @@ public abstract class BaseRequestPayloadExtractorTests<TExtractor>
     {
         const int originalPosition = 100;
         _ = TestFixture.Stream.Position.Returns(originalPosition);
+        TestFixture.HttpRequestCore.ContentType.Returns(SupportedContentType);
 
         var sut = TestFixture.GetSut();
 
@@ -39,6 +40,8 @@ public abstract class BaseRequestPayloadExtractorTests<TExtractor>
 
         TestFixture.Stream.Received().Position = originalPosition;
     }
+
+    protected abstract string SupportedContentType { get; }
 
     [Fact]
     public void ExtractPayload_OriginalStream_NotClosed()

--- a/test/Sentry.AspNetCore.Tests/DefaultRequestPayloadExtractorTests.cs
+++ b/test/Sentry.AspNetCore.Tests/DefaultRequestPayloadExtractorTests.cs
@@ -2,6 +2,8 @@ namespace Sentry.AspNetCore.Tests;
 
 public class DefaultRequestPayloadExtractorTests : BaseRequestPayloadExtractorTests<DefaultRequestPayloadExtractor>
 {
+    protected override string SupportedContentType => string.Empty;
+
     [Fact]
     public void ExtractPayload_StringData_ReadCorrectly()
     {

--- a/test/Sentry.AspNetCore.Tests/FormRequestPayloadExtractorTests.cs
+++ b/test/Sentry.AspNetCore.Tests/FormRequestPayloadExtractorTests.cs
@@ -8,12 +8,15 @@ public class FormRequestPayloadExtractorTests : BaseRequestPayloadExtractorTests
     public FormRequestPayloadExtractorTests()
     {
         TestFixture = new Fixture();
-        _ = TestFixture.HttpRequest.ContentType.Returns("application/x-www-form-urlencoded");
     }
 
-    [Fact]
-    public void ExtractPayload_SupportedContentType_ReadForm()
+    [Theory]
+    [InlineData("application/x-www-form-urlencoded")]
+    [InlineData("application/x-www-form-urlencoded; charset=utf-8")]
+    public void ExtractPayload_SupportedContentType_ReadForm(string contentType)
     {
+        TestFixture.HttpRequest.ContentType.Returns(contentType);
+
         var expected = new Dictionary<string, StringValues> { { "key", new StringValues("val") } };
         var f = new FormCollection(expected);
         _ = TestFixture.HttpRequestCore.Form.Returns(f);
@@ -32,7 +35,7 @@ public class FormRequestPayloadExtractorTests : BaseRequestPayloadExtractorTests
     [Fact]
     public void ExtractPayload_UnsupportedContentType_DoesNotReadStream()
     {
-        _ = TestFixture.HttpRequest.ContentType.Returns("application/json");
+        TestFixture.HttpRequest.ContentType.Returns("application/json");
 
         var sut = TestFixture.GetSut();
 

--- a/test/Sentry.AspNetCore.Tests/FormRequestPayloadExtractorTests.cs
+++ b/test/Sentry.AspNetCore.Tests/FormRequestPayloadExtractorTests.cs
@@ -5,6 +5,8 @@ namespace Sentry.AspNetCore.Tests;
 
 public class FormRequestPayloadExtractorTests : BaseRequestPayloadExtractorTests<FormRequestPayloadExtractor>
 {
+    protected override string SupportedContentType => "application/x-www-form-urlencoded";
+
     public FormRequestPayloadExtractorTests()
     {
         TestFixture = new Fixture();


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3701

### Analysis

This is handled differently in ASP.NET vs ASP.NET Core.

In ASP.NET Core, the implementation for IHttpRequest is:
https://github.com/getsentry/sentry-dotnet/blob/263961124a49c5fa8290c8721294e7fd472e7027/src/Sentry.AspNetCore/HttpRequestAdapter.cs#L16-L18

In ASP.NET the implementation is:
https://github.com/getsentry/sentry-dotnet/blob/e75d537c14ded617c99eb33f19cf4ce69ca4de36/src/Sentry.AspNet/Internal/SystemWebHttpRequest.cs#L15-L16

Seemingly it's only a problem in ASP.NET... pushing an initial PR so I can switch to my windows box for development. 