### PR TITLE
Only regenerate the cocoa bindings when they change

### DIFF
--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -91,6 +91,7 @@
   <!-- Generate bindings -->
   <Target Name="_GenerateSentryCocoaBindings" AfterTargets="SetupCocoaSDK"
           Condition="$([MSBuild]::IsOSPlatform('OSX')) and Exists('$(SentryCocoaFrameworkHeaders)')"
+          Inputs="../../modules/sentry-cocoa.properties"
           Outputs="ApiDefinitions.cs;StructsAndEnums.cs">
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="_InnerGenerateSentryCocoaBindings" Properties="TargetFramework=once" />
   </Target>


### PR DESCRIPTION
Currently the `ApiDefinitions.cs` and `StructsAndEnums.cs` files are being regenerated every time the `src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj` project is built... changing the timestamp on these and showing as "changes" that aren't really changes in git. 

This PR uses the [MS Build Incremental Build](https://learn.microsoft.com/en-us/visualstudio/msbuild/how-to-build-incrementally) features to ensure these files only get regenerated if/when the CocoaSDK version changes. 

#skip-changelog