### PR TITLE
Prevent ArgumentNullException in SentryTraceHeader Parsing

### DIFF
--- a/src/Sentry/SentryTraceHeader.cs
+++ b/src/Sentry/SentryTraceHeader.cs
@@ -40,8 +40,18 @@ public class SentryTraceHeader
         : $"{TraceId}-{SpanId}";
 
     /// <summary>
-    /// Parses <see cref="SentryTraceHeader"/> from string.
+    /// Parses a <see cref="SentryTraceHeader"/> from a string representation of the Sentry trace header.
     /// </summary>
+    /// <param name="value">
+    /// A string containing the Sentry trace header, expected to follow the format "traceId-spanId-sampled",
+    /// where "sampled" is optional.
+    /// </param>
+    /// <returns>
+    /// A <see cref="SentryTraceHeader"/> object if parsing succeeds, or <c>null</c> if the input string is null, empty, or whitespace.
+    /// </returns>
+    /// <exception cref="FormatException">
+    /// Thrown if the input string does not contain a valid trace header format, specifically if it lacks required trace ID and span ID components.
+    /// </exception>
     public static SentryTraceHeader? Parse(string value)
     {
         if (string.IsNullOrWhiteSpace(value))

--- a/src/Sentry/SentryTraceHeader.cs
+++ b/src/Sentry/SentryTraceHeader.cs
@@ -42,8 +42,13 @@ public class SentryTraceHeader
     /// <summary>
     /// Parses <see cref="SentryTraceHeader"/> from string.
     /// </summary>
-    public static SentryTraceHeader Parse(string value)
+    public static SentryTraceHeader? Parse(string value)
     {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
         var components = value.Split('-', StringSplitOptions.RemoveEmptyEntries);
         if (components.Length < 2)
         {

--- a/test/Sentry.Tests/Protocol/SentryTraceHeaderTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryTraceHeaderTests.cs
@@ -51,7 +51,7 @@ public class SentryTraceHeaderTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("  ")]
-    public void Parse_WithoutHeaderValue_ReturnsNull(string? headerValue)
+    public void Parse_WithoutHeaderValue_ReturnsNull(string headerValue)
     {
         // Act
         var header = SentryTraceHeader.Parse(headerValue);

--- a/test/Sentry.Tests/Protocol/SentryTraceHeaderTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryTraceHeaderTests.cs
@@ -46,4 +46,17 @@ public class SentryTraceHeaderTests
         header.SpanId.Should().Be(SpanId.Parse("1000000000000000"));
         header.IsSampled.Should().BeFalse();
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void Parse_WithoutHeaderValue_ReturnsNull(string? headerValue)
+    {
+        // Act
+        var header = SentryTraceHeader.Parse(headerValue);
+
+        // Assert
+        header.Should().BeNull();
+    }
 }


### PR DESCRIPTION
Hey y'all,

I recently encountered an issue where nearly every API request threw an exception after integrating Sentry with OpenTelemetry in my APIs. This issue only affected my environment, likely due to having "Just My Code" disabled in debugging options.

Upon investigation, I discovered that a null value was being passed to the `Parse` method in `SentryTraceHeader.cs`. The method was attempting to call `.Split()` on this null value, leading to an `ArgumentNullException`.

To address this, I added a null check in the `Parse` method before calling `.Split()`.