### PR TITLE
Prevent NullReferenceException in SentryTraceHeader Parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,13 @@
 
 ### Fixes
 
-- Fixed ArgumentNullException in FormRequestPayloadExtractor when handling invalid form data on ASP.NET ([#3734](https://github.com/getsentry/sentry-dotnet/pull/3734))
+- Fixed NullReferenceException in SentryTraceHeader when parsing null or empty values ([#3757](https://github.com/getsentry/sentry-dotnet/pull/3757))
 
 ## Unreleased
 
 ### Fixes
 
-- Fixed NullReferenceException in SentryTraceHeader when parsing null or empty values ([#3757](https://github.com/getsentry/sentry-dotnet/pull/3757))
+- Fixed ArgumentNullException in FormRequestPayloadExtractor when handling invalid form data on ASP.NET ([#3734](https://github.com/getsentry/sentry-dotnet/pull/3734))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@
 
 ### Fixes
 
-- Fixed ArgumentNullException in FormRequestPayloadExtractor when handling invalid form data on ASP.NET ([#3734](https://github.com/getsentry/sentry-dotnet/pull/3734))
 - Fixed NullReferenceException in SentryTraceHeader when parsing null or empty values ([#3757](https://github.com/getsentry/sentry-dotnet/pull/3757))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Added support for `.NET 9` (preview) ([#3699](https://github.com/getsentry/sentry-dotnet/pull/3699))
 - libsentrysupplemental.so now supports 16 KB page sizes on Android ([#3723](https://github.com/getsentry/sentry-dotnet/pull/3723))
 
+### Fixes
+
+- Fixed ArgumentNullException in FormRequestPayloadExtractor when handling invalid form data on ASP.NET ([#3734](https://github.com/getsentry/sentry-dotnet/pull/3734))
+
 ## Unreleased
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Fixes
 
 - Fixed ArgumentNullException in FormRequestPayloadExtractor when handling invalid form data on ASP.NET ([#3734](https://github.com/getsentry/sentry-dotnet/pull/3734))
+- Fixed NullReferenceException in SentryTraceHeader when parsing null or empty values ([#3757](https://github.com/getsentry/sentry-dotnet/pull/3757))
 
 ### Dependencies
 

--- a/src/Sentry/SentryTraceHeader.cs
+++ b/src/Sentry/SentryTraceHeader.cs
@@ -40,10 +40,25 @@ public class SentryTraceHeader
         : $"{TraceId}-{SpanId}";
 
     /// <summary>
-    /// Parses <see cref="SentryTraceHeader"/> from string.
+    /// Parses a <see cref="SentryTraceHeader"/> from a string representation of the Sentry trace header.
     /// </summary>
-    public static SentryTraceHeader Parse(string value)
+    /// <param name="value">
+    /// A string containing the Sentry trace header, expected to follow the format "traceId-spanId-sampled",
+    /// where "sampled" is optional.
+    /// </param>
+    /// <returns>
+    /// A <see cref="SentryTraceHeader"/> object if parsing succeeds, or <c>null</c> if the input string is null, empty, or whitespace.
+    /// </returns>
+    /// <exception cref="FormatException">
+    /// Thrown if the input string does not contain a valid trace header format, specifically if it lacks required trace ID and span ID components.
+    /// </exception>
+    public static SentryTraceHeader? Parse(string value)
     {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
         var components = value.Split('-', StringSplitOptions.RemoveEmptyEntries);
         if (components.Length < 2)
         {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet6_0.verified.txt
@@ -911,7 +911,7 @@ namespace Sentry
         public Sentry.SpanId SpanId { get; }
         public Sentry.SentryId TraceId { get; }
         public override string ToString() { }
-        public static Sentry.SentryTraceHeader Parse(string value) { }
+        public static Sentry.SentryTraceHeader? Parse(string value) { }
     }
     public class SentryTransaction : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet7_0.verified.txt
@@ -911,7 +911,7 @@ namespace Sentry
         public Sentry.SpanId SpanId { get; }
         public Sentry.SentryId TraceId { get; }
         public override string ToString() { }
-        public static Sentry.SentryTraceHeader Parse(string value) { }
+        public static Sentry.SentryTraceHeader? Parse(string value) { }
     }
     public class SentryTransaction : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -913,7 +913,7 @@ namespace Sentry
         public Sentry.SpanId SpanId { get; }
         public Sentry.SentryId TraceId { get; }
         public override string ToString() { }
-        public static Sentry.SentryTraceHeader Parse(string value) { }
+        public static Sentry.SentryTraceHeader? Parse(string value) { }
     }
     public class SentryTransaction : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -913,7 +913,7 @@ namespace Sentry
         public Sentry.SpanId SpanId { get; }
         public Sentry.SentryId TraceId { get; }
         public override string ToString() { }
-        public static Sentry.SentryTraceHeader Parse(string value) { }
+        public static Sentry.SentryTraceHeader? Parse(string value) { }
     }
     public class SentryTransaction : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -908,7 +908,7 @@ namespace Sentry
         public Sentry.SpanId SpanId { get; }
         public Sentry.SentryId TraceId { get; }
         public override string ToString() { }
-        public static Sentry.SentryTraceHeader Parse(string value) { }
+        public static Sentry.SentryTraceHeader? Parse(string value) { }
     }
     public class SentryTransaction : Sentry.IEventLike, Sentry.IHasExtra, Sentry.IHasTags, Sentry.ISentryJsonSerializable, Sentry.ISpanData, Sentry.ITransactionContext, Sentry.ITransactionData, Sentry.Protocol.ITraceContext
     {

--- a/test/Sentry.Tests/Protocol/SentryTraceHeaderTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryTraceHeaderTests.cs
@@ -46,4 +46,17 @@ public class SentryTraceHeaderTests
         header.SpanId.Should().Be(SpanId.Parse("1000000000000000"));
         header.IsSampled.Should().BeFalse();
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void Parse_WithoutHeaderValue_ReturnsNull(string headerValue)
+    {
+        // Act
+        var header = SentryTraceHeader.Parse(headerValue);
+
+        // Assert
+        header.Should().BeNull();
+    }
 }


### PR DESCRIPTION
Hey y'all,

I recently encountered an issue where nearly every API request threw an exception after integrating Sentry with OpenTelemetry in my APIs. This issue only affected my environment, likely due to having **Just My Code** disabled in debugging options.

Upon investigation, I discovered that a null value was being passed to the `Parse` method in `SentryTraceHeader.cs`. The method was attempting to call `.Split()` on this null value, leading to an `NullReferenceException`.

To address this, I added a null check in the `Parse` method before calling `.Split()`.

Please review the changes when you have a chance and let me know if there are any additional adjustments or improvements you’d like to see. Thank you!

---

Moved from [PR](https://github.com/getsentry/sentry-dotnet/pull/3745)