### PR TITLE
ci: change updater PR strategy to update

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -26,5 +26,6 @@ jobs:
     with:
       name: ${{ matrix.name }}
       path: ${{ matrix.path }}
+      pr-strategy: update
     secrets:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}


### PR DESCRIPTION
The default (which was the previous behaviour when the udpater was created) creates new branch & PR for every release.

The "update" strategy updates a single PR per dependency.