### PR TITLE
fix: Android - prevent `JNI DETECTED ERROR IN APPLICATION` crashes when too many events have to be processed at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed NullReferenceException in SentryTraceHeader when parsing null or empty values ([#3757](https://github.com/getsentry/sentry-dotnet/pull/3757))
 - ArgumentNullException in FormRequestPayloadExtractor when handling invalid form data on ASP.NET ([#3734](https://github.com/getsentry/sentry-dotnet/pull/3734))
 - Crash when using NLog with FailedRequestStatusCodes options in a Maui app with Trimming enabled ([#3743](https://github.com/getsentry/sentry-dotnet/pull/3743))
+- Fixed `JNI DETECTED ERROR IN APPLICATION` Android crashes when multiple exceptions have to be captured in quick successions ([#3781](https://github.com/getsentry/sentry-dotnet/pull/3781))
 
 ### Dependencies
 


### PR DESCRIPTION
This PR offers a fix for #3627. 
When calling SentrySdk `SentrySdk.CaptureException(ex)` in multiple tight successions, Android apps would crash with a `JNI DETECTED ERROR IN APPLICATION` error message.

This is unique to Android, as the issue was not reproducible on iOS.

*still need to add tests*