### PR TITLE
Remove duplicate Sentry.Bindings.Android.targets from NuGet package

### DIFF
--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -12,8 +12,11 @@
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\README.md" />
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="" />
+    <!--
+    Normally we'd put this in a TFM specific directory, however this package only targets one TFM:
+      https://learn.microsoft.com/en-us/nuget/concepts/msbuild-props-and-targets
+    -->
     <None Include="$(MSBuildThisFileDirectory)build/Sentry.Bindings.Android.targets" Pack="true" PackagePath="build/Sentry.Bindings.Android.targets" />
-    <None Include="$(MSBuildThisFileDirectory)build/Sentry.Bindings.Android.targets" Pack="true" PackagePath="build/$(TargetFramework)$(TargetPlatformVersion)/Sentry.Bindings.Android.targets" />
     <None Include="$(MSBuildThisFileDirectory)sentry-proguard.cfg" Pack="true" PackagePath="" />
     <PackageReference Remove="SIL.ReleaseTasks" />
   </ItemGroup>


### PR DESCRIPTION
Will hopefully resolve:
- https://github.com/NuGet/Home/issues/13957

For reference, also see:
- https://github.com/getsentry/publish/issues/4649#issuecomment-2496227672

#skip-changelog