### PR TITLE
fix: MAUI Android - prevent JNI DETECTED ERROR IN APPLICATION crashes when too many events have to be processed at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes 
+
+- MAUI - Fixed `JNI DETECTED ERROR IN APPLICATION` Android crashes when multiple exceptions have to be captured in quick successions ([#3791](https://github.com/getsentry/sentry-dotnet/pull/3791))
+
+
 ## 5.0.0-alpha.1
 
 ### API Changes
@@ -24,7 +31,6 @@
 - Fixed NullReferenceException in SentryTraceHeader when parsing null or empty values ([#3757](https://github.com/getsentry/sentry-dotnet/pull/3757))
 - ArgumentNullException in FormRequestPayloadExtractor when handling invalid form data on ASP.NET ([#3734](https://github.com/getsentry/sentry-dotnet/pull/3734))
 - Crash when using NLog with FailedRequestStatusCodes options in a Maui app with Trimming enabled ([#3743](https://github.com/getsentry/sentry-dotnet/pull/3743))
-- MAUI - Fixed `JNI DETECTED ERROR IN APPLICATION` Android crashes when multiple exceptions have to be captured in quick successions ([#3791](https://github.com/getsentry/sentry-dotnet/pull/3791))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed NullReferenceException in SentryTraceHeader when parsing null or empty values ([#3757](https://github.com/getsentry/sentry-dotnet/pull/3757))
 - ArgumentNullException in FormRequestPayloadExtractor when handling invalid form data on ASP.NET ([#3734](https://github.com/getsentry/sentry-dotnet/pull/3734))
 - Crash when using NLog with FailedRequestStatusCodes options in a Maui app with Trimming enabled ([#3743](https://github.com/getsentry/sentry-dotnet/pull/3743))
+- MAUI - Fixed `JNI DETECTED ERROR IN APPLICATION` Android crashes when multiple exceptions have to be captured in quick successions ([#3791](https://github.com/getsentry/sentry-dotnet/pull/3791))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,9 @@
 - Bump Java SDK from v7.16.0 to v7.18.0 ([#3749](https://github.com/getsentry/sentry-dotnet/pull/3749), [#3771](https://github.com/getsentry/sentry-dotnet/pull/3771))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#7180)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.16.0...7.18.0)
-- Bump Native SDK from v0.7.11 to v0.7.12 ([#3731](https://github.com/getsentry/sentry-dotnet/pull/3731))
-  - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0712)
-  - [diff](https://github.com/getsentry/sentry-native/compare/0.7.11...0.7.12)
-- Bump Native SDK from v0.7.13 to v0.7.14 ([#3775](https://github.com/getsentry/sentry-dotnet/pull/3775))
-    - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0714)
-    - [diff](https://github.com/getsentry/sentry-native/compare/0.7.13...0.7.14)
+- Bump Native SDK from v0.7.11 to v0.7.15 ([#3731](https://github.com/getsentry/sentry-dotnet/pull/3731), [#3770](https://github.com/getsentry/sentry-dotnet/pull/3770), [#3775](https://github.com/getsentry/sentry-dotnet/pull/3775), [#3779](https://github.com/getsentry/sentry-dotnet/pull/3779))
+  - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0715)
+  - [diff](https://github.com/getsentry/sentry-native/compare/0.7.11...0.7.15)
 
 ## 4.13.0
 

--- a/src/Sentry.Maui/Internal/MauiDeviceData.cs
+++ b/src/Sentry.Maui/Internal/MauiDeviceData.cs
@@ -54,7 +54,7 @@ internal static class MauiDeviceData
                 logger?.LogDebug("No permission to read battery state from the device.");
             }
 
-            device.IsOnline = networkStatusListener!.Online;
+            device.IsOnline ??= networkStatusListener!.Online;
 
 #if MACCATALYST || IOS
             if (MainThread.IsMainThread)

--- a/src/Sentry.Maui/Internal/MauiDeviceData.cs
+++ b/src/Sentry.Maui/Internal/MauiDeviceData.cs
@@ -57,7 +57,7 @@ internal static class MauiDeviceData
 #if MACCATALYST || IOS
             if (MainThread.IsMainThread)
             {
-                CaptureDisplayInfo();
+                CaptureDisplayInfo(displayInfo);
             }
             else
             {
@@ -66,7 +66,7 @@ internal static class MauiDeviceData
                 // See https://learn.microsoft.com/en-us/dotnet/maui/platform-integration/device/display?view=net-maui-8.0&tabs=macios#platform-differences
                 using var resetEvent = new ManualResetEventSlim(false);
                 // ReSharper disable once AccessToDisposedClosure - not disposed until lambda completes
-                MainThread.BeginInvokeOnMainThread(() => CaptureDisplayInfo(resetEvent));
+                MainThread.BeginInvokeOnMainThread(() => CaptureDisplayInfo(displayInfo, resetEvent));
                 resetEvent.Wait();
             }
 #else
@@ -107,11 +107,8 @@ internal static class MauiDeviceData
             logger?.LogError(ex, "Error getting MAUI device information.");
         }
 
-#if MACCATALYST || IOS
-        void CaptureDisplayInfo(ManualResetEventSlim? resetEvent = null)
+        void CaptureDisplayInfo(DisplayInfo display, ManualResetEventSlim? resetEvent = null)
         {
-            // https://docs.microsoft.com/dotnet/maui/platform-integration/device/display
-            var display = DeviceDisplay.MainDisplayInfo;
             device.ScreenResolution ??= $"{(int)display.Width}x{(int)display.Height}";
             device.ScreenDensity ??= (float)display.Density;
             device.Orientation ??= display.Orientation switch
@@ -125,22 +122,5 @@ internal static class MauiDeviceData
             // ? = display.Rotation;
             resetEvent?.Set();
         }
-#else
-
-        void CaptureDisplayInfo(DisplayInfo display)
-        {
-            device.ScreenResolution ??= $"{(int)display.Width}x{(int)display.Height}";
-            device.ScreenDensity ??= (float)display.Density;
-            device.Orientation ??= display.Orientation switch
-            {
-                DisplayOrientation.Portrait => DeviceOrientation.Portrait,
-                DisplayOrientation.Landscape => DeviceOrientation.Landscape,
-                _ => null
-            };
-            // device.ScreenDpi ??= ?
-            // ? = display.RefreshRate;
-            // ? = display.Rotation;
-        }
-#endif
     }
 }

--- a/src/Sentry.Maui/Internal/MauiDeviceData.cs
+++ b/src/Sentry.Maui/Internal/MauiDeviceData.cs
@@ -6,7 +6,7 @@ namespace Sentry.Maui.Internal;
 
 internal static class MauiDeviceData
 {
-    public static void ApplyMauiDeviceData(this Device device, IDiagnosticLogger? logger)
+    public static void ApplyMauiDeviceData(this Device device, IDiagnosticLogger? logger, INetworkStatusListener? networkStatusListener)
     {
         try
         {
@@ -54,15 +54,7 @@ internal static class MauiDeviceData
                 logger?.LogDebug("No permission to read battery state from the device.");
             }
 
-            // https://docs.microsoft.com/dotnet/maui/platform-integration/communication/networking#using-connectivity
-            try
-            {
-                device.IsOnline ??= Connectivity.NetworkAccess == NetworkAccess.Internet;
-            }
-            catch (PermissionException)
-            {
-                logger?.LogDebug("No permission to read network state from the device.");
-            }
+            device.IsOnline = networkStatusListener!.Online;
 
 #if MACCATALYST || IOS
             if (MainThread.IsMainThread)

--- a/src/Sentry.Maui/Internal/MauiDeviceData.cs
+++ b/src/Sentry.Maui/Internal/MauiDeviceData.cs
@@ -6,22 +6,27 @@ namespace Sentry.Maui.Internal;
 
 internal static class MauiDeviceData
 {
-    public static void ApplyMauiDeviceData(this Device device, IDiagnosticLogger? logger, INetworkStatusListener? networkStatusListener, string deviceName, string deviceManufacturer, string deviceModel, string deviceType, bool? deviceSimulator, DevicePlatform devicePlatform, DisplayInfo displayInfo, bool supportsVibration, bool supportsAccelerometer, bool supportsGyroscope)
+    public static void ApplyMauiDeviceData(this Device device, IDiagnosticLogger? logger, INetworkStatusListener? networkStatusListener, string deviceIdiom, IDeviceInfo deviceInfo, DisplayInfo displayInfo, bool supportsVibration, bool supportsAccelerometer, bool supportsGyroscope)
     {
         try
         {
             // TODO: Add more device data where indicated
 
-            if (devicePlatform == DevicePlatform.Unknown)
+            if (deviceInfo.Platform == DevicePlatform.Unknown)
             {
                 // return early so we don't get NotImplementedExceptions (i.e., in unit tests, etc.)
                 return;
             }
-            device.Name ??= deviceName;
-            device.Manufacturer ??= deviceManufacturer;
-            device.Model ??= deviceModel;
-            device.DeviceType ??= deviceType;
-            device.Simulator = deviceSimulator;
+            device.Name ??= deviceInfo.Name;
+            device.Manufacturer ??= deviceInfo.Manufacturer;
+            device.Model ??= deviceInfo.Model;
+            device.DeviceType ??= deviceIdiom;
+            device.Simulator = deviceInfo.DeviceType switch
+            {
+                DeviceType.Virtual => true,
+                DeviceType.Physical => false,
+                _ => null
+            };
             // device.Brand ??= ?
             // device.Family ??= ?
             // device.ModelId ??= ?

--- a/src/Sentry.Maui/Internal/MauiDeviceData.cs
+++ b/src/Sentry.Maui/Internal/MauiDeviceData.cs
@@ -65,7 +65,7 @@ internal static class MauiDeviceData
                 resetEvent.Wait();
             }
 #else
-            SetDisplayInfo(displayInfo);
+            CaptureDisplayInfo(displayInfo);
 #endif
 
             device.SupportsVibration ??= supportsVibration;
@@ -120,13 +120,9 @@ internal static class MauiDeviceData
             // ? = display.Rotation;
             resetEvent?.Set();
         }
-#endif
-        
-
-        void SetDisplayInfo(DisplayInfo display, ManualResetEventSlim? resetEvent = null)
+#else
+        void CaptureDisplayInfo(DisplayInfo display)
         {
-            // https://docs.microsoft.com/dotnet/maui/platform-integration/device/display
-            //var display = DeviceDisplay.MainDisplayInfo;
             device.ScreenResolution ??= $"{(int)display.Width}x{(int)display.Height}";
             device.ScreenDensity ??= (float)display.Density;
             device.Orientation ??= display.Orientation switch
@@ -138,7 +134,7 @@ internal static class MauiDeviceData
             // device.ScreenDpi ??= ?
             // ? = display.RefreshRate;
             // ? = display.Rotation;
-            resetEvent?.Set();
         }
+#endif
     }
 }

--- a/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
@@ -31,14 +31,14 @@ internal class SentryMauiEventProcessor : ISentryEventProcessor
         _deviceSupportsGyroscope = Gyroscope.IsSupported;
 #endif
 
-#if IOS
+#if MACCATALYST || IOS
         if (MainThread.IsMainThread)
         {
 #endif
         // https://docs.microsoft.com/dotnet/maui/platform-integration/device/information
         _deviceInfo = DeviceInfo.Current;
         _deviceIdiom = _deviceInfo.Idiom.ToString();
-#if IOS
+#if MACCATALYST || IOS
         }
         else
         {

--- a/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
@@ -17,7 +17,7 @@ internal class SentryMauiEventProcessor : ISentryEventProcessor
     {
         @event.Sdk.Name = Constants.SdkName;
         @event.Sdk.Version = Constants.SdkVersion;
-        @event.Contexts.Device.ApplyMauiDeviceData(_options.DiagnosticLogger);
+        @event.Contexts.Device.ApplyMauiDeviceData(_options.DiagnosticLogger, _options.NetworkStatusListener);
         @event.Contexts.OperatingSystem.ApplyMauiOsData(_options.DiagnosticLogger);
         @event.Contexts.App.InForeground = InForeground;
 

--- a/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
@@ -12,12 +12,7 @@ internal class SentryMauiEventProcessor : ISentryEventProcessor
     private readonly bool _deviceSupportsAccelerometer;
     private readonly bool _deviceSupportsGyroscope;
     private readonly IDeviceInfo _deviceInfo;
-    private readonly string _deviceDeviceType;
-    private readonly DevicePlatform _devicePlatform;
-    private readonly bool? _deviceSimulator;
-    private readonly string _deviceName;
-    private readonly string _deviceManufacturer;
-    private readonly string _deviceModel;
+    private readonly string _deviceIdiom;
 
     public SentryMauiEventProcessor(SentryMauiOptions options)
     {
@@ -36,18 +31,8 @@ internal class SentryMauiEventProcessor : ISentryEventProcessor
 
         // https://docs.microsoft.com/dotnet/maui/platform-integration/device/information
         _deviceInfo = DeviceInfo.Current;
+        _deviceIdiom = _deviceInfo.Idiom.ToString();
 
-        _deviceName = _deviceInfo.Name;
-        _deviceManufacturer = _deviceInfo.Manufacturer;
-        _deviceModel = _deviceInfo.Model;
-        _deviceDeviceType = _deviceInfo.Idiom.ToString();
-        _devicePlatform = _deviceInfo.Platform;
-        _deviceSimulator = _deviceInfo.DeviceType switch
-        {
-            DeviceType.Virtual => true,
-            DeviceType.Physical => false,
-            _ => null
-        };
     }
 
     public SentryEvent Process(SentryEvent @event)
@@ -58,12 +43,8 @@ internal class SentryMauiEventProcessor : ISentryEventProcessor
         // Apply Device Data
         @event.Contexts.Device.ApplyMauiDeviceData(_options.DiagnosticLogger,
                                                    _options.NetworkStatusListener,
-                                                   _deviceName,
-                                                   _deviceManufacturer,
-                                                   _deviceModel,
-                                                   _deviceDeviceType,
-                                                   _deviceSimulator,
-                                                   _devicePlatform,
+                                                   _deviceIdiom,
+                                                   _deviceInfo,
                                                    _displayInfo,
                                                    _deviceSupportsVibration,
                                                    _deviceSupportsAccelerometer,

--- a/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
@@ -21,6 +21,7 @@ internal class SentryMauiEventProcessor : ISentryEventProcessor
         // https://docs.microsoft.com/dotnet/maui/platform-integration/device/display
         _displayInfo = DeviceDisplay.MainDisplayInfo;
 
+#if !PLATFORM_NEUTRAL
 
         // https://docs.microsoft.com/dotnet/maui/platform-integration/device/vibrate
         _deviceSupportsVibration = Vibration.Default.IsSupported;
@@ -28,6 +29,7 @@ internal class SentryMauiEventProcessor : ISentryEventProcessor
         // https://docs.microsoft.com/dotnet/maui/platform-integration/device/sensors
         _deviceSupportsAccelerometer = Accelerometer.IsSupported;
         _deviceSupportsGyroscope = Gyroscope.IsSupported;
+#endif
 
         // https://docs.microsoft.com/dotnet/maui/platform-integration/device/information
         _deviceInfo = DeviceInfo.Current;

--- a/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
@@ -5,19 +5,69 @@ namespace Sentry.Maui.Internal;
 internal class SentryMauiEventProcessor : ISentryEventProcessor
 {
     public static bool? InForeground { get; set; }
+    private readonly DisplayInfo _displayInfo;
 
     private readonly SentryMauiOptions _options;
+    private readonly bool _deviceSupportsVibration;
+    private readonly bool _deviceSupportsAccelerometer;
+    private readonly bool _deviceSupportsGyroscope;
+    private readonly IDeviceInfo _deviceInfo;
+    private readonly string _deviceDeviceType;
+    private readonly DevicePlatform _devicePlatform;
+    private readonly bool? _deviceSimulator;
+    private readonly string _deviceName;
+    private readonly string _deviceManufacturer;
+    private readonly string _deviceModel;
 
     public SentryMauiEventProcessor(SentryMauiOptions options)
     {
         _options = options;
+
+        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/display
+        _displayInfo = DeviceDisplay.MainDisplayInfo;
+
+
+        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/vibrate
+        _deviceSupportsVibration = Vibration.Default.IsSupported;
+
+        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/sensors
+        _deviceSupportsAccelerometer = Accelerometer.IsSupported;
+        _deviceSupportsGyroscope = Gyroscope.IsSupported;
+
+        // https://docs.microsoft.com/dotnet/maui/platform-integration/device/information
+        _deviceInfo = DeviceInfo.Current;
+
+        _deviceName = _deviceInfo.Name;
+        _deviceManufacturer = _deviceInfo.Manufacturer;
+        _deviceModel = _deviceInfo.Model;
+        _deviceDeviceType = _deviceInfo.Idiom.ToString();
+        _devicePlatform = _deviceInfo.Platform;
+        _deviceSimulator = _deviceInfo.DeviceType switch
+        {
+            DeviceType.Virtual => true,
+            DeviceType.Physical => false,
+            _ => null
+        };
     }
 
     public SentryEvent Process(SentryEvent @event)
     {
         @event.Sdk.Name = Constants.SdkName;
         @event.Sdk.Version = Constants.SdkVersion;
-        @event.Contexts.Device.ApplyMauiDeviceData(_options.DiagnosticLogger, _options.NetworkStatusListener);
+
+        // Apply Device Data
+        @event.Contexts.Device.ApplyMauiDeviceData(_options.DiagnosticLogger,
+                                                   _options.NetworkStatusListener,
+                                                   _deviceName,
+                                                   _deviceManufacturer,
+                                                   _deviceModel,
+                                                   _deviceDeviceType,
+                                                   _deviceSimulator,
+                                                   _devicePlatform,
+                                                   _displayInfo,
+                                                   _deviceSupportsVibration,
+                                                   _deviceSupportsAccelerometer,
+                                                   _deviceSupportsGyroscope);
         @event.Contexts.OperatingSystem.ApplyMauiOsData(_options.DiagnosticLogger);
         @event.Contexts.App.InForeground = InForeground;
 

--- a/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiEventProcessor.cs
@@ -8,9 +8,9 @@ internal class SentryMauiEventProcessor : ISentryEventProcessor
     private readonly DisplayInfo _displayInfo;
 
     private readonly SentryMauiOptions _options;
-    private readonly bool _deviceSupportsVibration;
-    private readonly bool _deviceSupportsAccelerometer;
-    private readonly bool _deviceSupportsGyroscope;
+    private readonly bool _deviceSupportsVibration = false;
+    private readonly bool _deviceSupportsAccelerometer = false;
+    private readonly bool _deviceSupportsGyroscope = false;
     private readonly IDeviceInfo _deviceInfo;
     private readonly string _deviceIdiom;
 

--- a/test/Sentry.Maui.Tests/SentryMauiEventProcessStressTests.cs
+++ b/test/Sentry.Maui.Tests/SentryMauiEventProcessStressTests.cs
@@ -1,0 +1,92 @@
+using Microsoft.Extensions.Options;
+#if ANDROID
+using Sentry.Android;
+using Sentry.JavaSdk.Protocol;
+#endif
+
+namespace Sentry.Maui.Tests;
+
+public class SentryMauiEventProcessStressTests
+{
+    private class Fixture
+    {
+        public MauiAppBuilder Builder { get; }
+        public FakeTransport Transport { get; private set; } = new FakeTransport();
+        public InMemoryDiagnosticLogger Logger { get; private set; } = new InMemoryDiagnosticLogger();
+
+        public Fixture()
+        {
+            var builder = MauiApp.CreateBuilder();
+            builder.Services.AddSingleton(Substitute.For<IApplication>());
+
+            builder.Services.Configure<SentryMauiOptions>(options =>
+            {
+                options.Transport = Transport;
+                options.Dsn = ValidDsn;
+                options.AttachScreenshot = false; //Disable the screenshot attachment to have the logcat as primary attachment
+                options.Debug = true;
+                options.DiagnosticLogger = Logger;
+                options.AutoSessionTracking = false; //Get rid of session envelope for easier Assert
+                options.CacheDirectoryPath = null;   //Do not wrap our FakeTransport with a caching transport
+                options.FlushTimeout = TimeSpan.FromSeconds(10);
+            });
+            Builder = builder;
+        }
+    }
+
+    private readonly Fixture _fixture = new();
+
+#if ANDROID
+    [Fact]
+    public async void CaptureExceptions()
+    {
+        var builder = _fixture.Builder.UseSentry(options =>
+        {
+            options.Debug = false;
+            options.AutoSessionTracking = true;
+            options.IsGlobalModeEnabled = false;
+            options.StackTraceMode = StackTraceMode.Enhanced;
+            options.DiagnosticLevel = SentryLevel.Debug;
+            options.TracesSampleRate = 1.0;
+            options.SampleRate = 1.0F;
+            options.MaxBreadcrumbs = 200;
+            options.CreateElementEventsBreadcrumbs = false;
+            options.IncludeBackgroundingStateInBreadcrumbs = false;
+            options.IncludeTextInBreadcrumbs = false;
+            options.IncludeTitleInBreadcrumbs = false;
+            options.SendDefaultPii = false;
+            options.AttachScreenshot = false;
+        });
+
+        // Arrange
+        var processor = Substitute.For<ISentryEventProcessorWithHint>();
+        using var app = builder.Build();
+        SentryHint hint = null;
+        var options = app.Services.GetRequiredService<IOptions<SentryMauiOptions>>().Value;
+        var scope = new Scope(options);
+
+        // Act
+        processor.Process(Arg.Any<SentryEvent>(), Arg.Do<SentryHint>(h => hint = h)).Returns(new SentryEvent());
+        options.AddEventProcessor(processor);
+
+        _ = new SentryClient(options).CaptureEvent(new SentryEvent(), scope);
+        var logCount = 200;
+        List<SentryId> eventIds = new List<SentryId>();
+        List<Task> tasks = new List<Task>();
+
+        for (int i = 0; i < logCount; i++)
+        {
+            tasks.Add(Task.Run(() =>
+            {
+                eventIds.Add(SentrySdk.CaptureException(new NotImplementedException("Sample Exception " + i)));
+            }));
+        }
+        await Task.WhenAll(tasks);
+
+        var envelopes = _fixture.Transport.GetSentEnvelopes().Where(e => eventIds.Contains(e.TryGetEventId()?? new SentryId()));
+
+        // Assert
+        envelopes.Should().NotBeEmpty("eventIds.Count: {0} ", eventIds.Count);
+    }
+#endif
+}


### PR DESCRIPTION
This PR offers a fix for #3627.
When calling SentrySdk SentrySdk.CaptureException(ex) in multiple tight successions, Android apps would crash with a JNI DETECTED ERROR IN APPLICATION error message.