### PR TITLE
fix: MAUI sample crash in .NET 9

### DIFF
--- a/samples/Sentry.Samples.Maui/App.xaml.cs
+++ b/samples/Sentry.Samples.Maui/App.xaml.cs
@@ -9,7 +9,6 @@ public partial class App
 
     protected override Window CreateWindow(IActivationState activationState)
     {
-        Windows[0].Page = new AppShell();
-        return base.CreateWindow(activationState);
+        return new Window(new AppShell());
     }
 }


### PR DESCRIPTION
This is a simple fix for the issue (#3794) that prevents the sample MAUI app from running without crashing.

#skip-changelog