### PR TITLE
fix: cocoa bindings generated code line endings

### DIFF
--- a/scripts/generate-cocoa-bindings.ps1
+++ b/scripts/generate-cocoa-bindings.ps1
@@ -147,8 +147,8 @@ internal enum SentryTransactionNameSource : long
 }
 '@
 
-$Text += "`r`n$SentryLevel"
-$Text += "`r`n$SentryTransactionNameSource"
+$Text += "`n$SentryLevel"
+$Text += "`n$SentryTransactionNameSource"
 
 # Add header and output file
 $Text = "$Header`n`n$Text"
@@ -296,7 +296,7 @@ interface SentryId
 }
 '@
 
-$Text += "`r`n$SentryId"
+$Text += "`n$SentryId"
 
 # Add header and output file
 $Text = "$Header`n`n$Text"

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -91,7 +91,7 @@
   <!-- Generate bindings -->
   <Target Name="_GenerateSentryCocoaBindings" AfterTargets="SetupCocoaSDK"
           Condition="$([MSBuild]::IsOSPlatform('OSX')) and Exists('$(SentryCocoaFrameworkHeaders)')"
-          Inputs="../../modules/sentry-cocoa.properties"
+          Inputs="../../modules/sentry-cocoa.properties;../../scripts/generate-cocoa-bindings.ps1"
           Outputs="ApiDefinitions.cs;StructsAndEnums.cs">
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="_InnerGenerateSentryCocoaBindings" Properties="TargetFramework=once" />
   </Target>


### PR DESCRIPTION
Fixes line endings in the generated code

on macOS git diff says warning: in the working copy of 'src/Sentry.Bindings.Cocoa/ApiDefinitions.cs', CRLF will be replaced by LF the next time Git touches it 


#skip-changelog

