### PR TITLE
Don't strip symbols for device tests

### DIFF
--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -60,7 +60,7 @@ try
     if ($Build)
     {
         # We disable AOT for device tests: https://github.com/nsubstitute/NSubstitute/issues/834
-        dotnet build -f $tfm -c Release -p:EnableAot=false test/Sentry.Maui.Device.TestApp
+        dotnet build -f $tfm -c Release -p:EnableAot=false -p:NoSymbolStrip=true test/Sentry.Maui.Device.TestApp
         if ($LASTEXITCODE -ne 0)
         {
             throw 'Failed to build Sentry.Maui.Device.TestApp'


### PR DESCRIPTION
When we run into issues running device tests, this makes it easier to make sense of any stack traces accompanying errors. 

#skip-changelog