### PR TITLE
Revert "Session Replay: Recording on Android (#3552)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### API Changes
+
+- Temporarily removed experimental Session Replay support ([#3827](https://github.com/getsentry/sentry-dotnet/pull/3827))
+
 ### Fixes
 - Fixed JNI Error when accessing Android device data from multiple threads ([#3802](https://github.com/getsentry/sentry-dotnet/pull/3802))
 

--- a/samples/Sentry.Samples.Maui/MauiProgram.cs
+++ b/samples/Sentry.Samples.Maui/MauiProgram.cs
@@ -25,14 +25,6 @@ public static class MauiProgram
                 options.Debug = true;
                 options.SampleRate = 1.0F;
 
-#if ANDROID
-                // Currently experimental support is only available on Android
-                options.Native.ExperimentalOptions.SessionReplay.OnErrorSampleRate = 1.0;
-                options.Native.ExperimentalOptions.SessionReplay.SessionSampleRate = 1.0;
-                options.Native.ExperimentalOptions.SessionReplay.MaskAllImages = false;
-                options.Native.ExperimentalOptions.SessionReplay.MaskAllText = false;
-#endif
-
                 options.SetBeforeScreenshotCapture((@event, hint) =>
                 {
                     Console.WriteLine("screenshot about to be captured.");
@@ -41,6 +33,7 @@ public static class MauiProgram
                     return true;
                 });
             })
+
             .ConfigureFonts(fonts =>
             {
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -33,7 +33,6 @@
     <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-$(SentryAndroidSdkVersion).jar" />
     <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-android-core-$(SentryAndroidSdkVersion).aar" />
     <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).aar" />
-    <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-android-replay-$(SentryAndroidSdkVersion).aar" />
     <AndroidLibrary Include="..\..\lib\sentry-android-supplemental\bin\sentry-android-supplemental.jar" />
     <AndroidNativeLibrary Include="..\..\lib\sentrysupplemental\bin\arm64-v8a\libsentrysupplemental.so" Abi="arm64-v8a" />
     <AndroidNativeLibrary Include="..\..\lib\sentrysupplemental\bin\armeabi-v7a\libsentrysupplemental.so" Abi="armeabi-v7a" />
@@ -52,12 +51,6 @@
       SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-ndk/$(SentryAndroidSdkVersion)/sentry-android-ndk-$(SentryAndroidSdkVersion).aar"
       DestinationFolder="$(SentryAndroidSdkDirectory)"
       Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).aar')"
-      Retries="3"
-    />
-    <DownloadFile
-      SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-replay/$(SentryAndroidSdkVersion)/sentry-android-replay-$(SentryAndroidSdkVersion).aar"
-      DestinationFolder="$(SentryAndroidSdkDirectory)"
-      Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-android-replay-$(SentryAndroidSdkVersion).aar')"
       Retries="3"
     />
     <DownloadFile

--- a/src/Sentry.Bindings.Android/Transforms/Metadata.xml
+++ b/src/Sentry.Bindings.Android/Transforms/Metadata.xml
@@ -118,8 +118,6 @@
   <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='TempSensorBreadcrumbsIntegration']" />
   <remove-node path="/api/package[@name='io.sentry.android.core.internal.gestures']" />
   <remove-node path="/api/package[@name='io.sentry.android.core.performance']" />
-  <remove-node path="/api/package[@name='io.sentry.android.replay.viewhierarchy']" />
-  <remove-node path="/api/package[@name='io.sentry.android.replay.util']" />
 
   <remove-node path="/api/package[starts-with(@name,'io.sentry')]/*/method[@name='clone' and count(parameter)=0]" />
   <remove-node path="/api/package[starts-with(@name,'io.sentry')]/class/implements[@name='io.sentry.JsonDeserializer']" />

--- a/src/Sentry/Platforms/Android/BindableNativeSentryOptions.cs
+++ b/src/Sentry/Platforms/Android/BindableNativeSentryOptions.cs
@@ -1,5 +1,4 @@
 // ReSharper disable once CheckNamespace
-
 namespace Sentry;
 
 internal partial class BindableSentryOptions
@@ -35,20 +34,7 @@ internal partial class BindableSentryOptions
         public TimeSpan? ReadTimeout { get; set; }
         public bool? EnableTracing { get; set; }
         public bool? EnableBeforeSend { get; set; }
-        public NativeExperimentalOptions ExperimentalOptions { get; set; } = new();
 
-        internal class NativeExperimentalOptions
-        {
-            public NativeSentryReplayOptions SessionReplay { get; set; } = new();
-        }
-
-        internal class NativeSentryReplayOptions
-        {
-            public double? OnErrorSampleRate { get; set; }
-            public double? SessionSampleRate { get; set; }
-            public bool RedactAllImages { get; set; }
-            public bool RedactAllText { get; set; }
-        }
         public void ApplyTo(SentryOptions.NativeOptions options)
         {
             options.AnrEnabled = AnrEnabled ?? options.AnrEnabled;
@@ -75,21 +61,6 @@ internal partial class BindableSentryOptions
             options.ReadTimeout = ReadTimeout ?? options.ReadTimeout;
             options.EnableTracing = EnableTracing ?? options.EnableTracing;
             options.EnableBeforeSend = EnableBeforeSend ?? options.EnableBeforeSend;
-
-            if (ExperimentalOptions.SessionReplay.OnErrorSampleRate is { } errorSampleRate)
-            {
-#pragma warning disable CA1422
-                options.ExperimentalOptions.SessionReplay.OnErrorSampleRate = errorSampleRate;
-#pragma warning restore CA1422
-            }
-            if (ExperimentalOptions.SessionReplay.SessionSampleRate is { } sessionSampleRate)
-            {
-#pragma warning disable CA1422
-                options.ExperimentalOptions.SessionReplay.SessionSampleRate = sessionSampleRate;
-#pragma warning restore CA1422
-            }
-            ExperimentalOptions.SessionReplay.RedactAllText = options.ExperimentalOptions.SessionReplay.MaskAllText;
-            ExperimentalOptions.SessionReplay.RedactAllImages = options.ExperimentalOptions.SessionReplay.MaskAllImages;
         }
     }
 }

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -1,5 +1,4 @@
 // ReSharper disable once CheckNamespace
-
 namespace Sentry;
 
 public partial class SentryOptions
@@ -261,21 +260,5 @@ public partial class SentryOptions
         /// be stripped away during the round-tripping between the two SDKs.  Use with caution.
         /// </remarks>
         public bool EnableBeforeSend { get; set; } = false;
-        public class NativeExperimentalOptions
-        {
-            public NativeSentryReplayOptions SessionReplay { get; set; } = new();
-        }
-
-        public class NativeSentryReplayOptions
-        {
-            public double? OnErrorSampleRate { get; set; }
-            public double? SessionSampleRate { get; set; }
-            public bool MaskAllImages { get; set; } = true;
-            public bool MaskAllText { get; set; } = true;
-        }
-        /// <summary>
-        /// ExperimentalOptions
-        /// </summary>
-        public NativeExperimentalOptions ExperimentalOptions { get; set; } = new();
     }
 }

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -132,13 +132,6 @@ public static partial class SentrySdk
             options.Native.InAppExcludes?.ForEach(o.AddInAppExclude);
             options.Native.InAppIncludes?.ForEach(o.AddInAppInclude);
 
-            o.Experimental.SessionReplay.OnErrorSampleRate =
-                (JavaDouble?)options.Native.ExperimentalOptions.SessionReplay.OnErrorSampleRate;
-            o.Experimental.SessionReplay.SessionSampleRate =
-                (JavaDouble?)options.Native.ExperimentalOptions.SessionReplay.SessionSampleRate;
-            o.Experimental.SessionReplay.SetMaskAllImages(options.Native.ExperimentalOptions.SessionReplay.MaskAllImages);
-            o.Experimental.SessionReplay.SetMaskAllText(options.Native.ExperimentalOptions.SessionReplay.MaskAllText);
-
             // These options are intentionally set and not exposed for modification
             o.EnableExternalConfiguration = false;
             o.EnableDeduplication = false;

--- a/test/Sentry.Tests/Platforms/Android/BindableNativeOptionsTests.cs
+++ b/test/Sentry.Tests/Platforms/Android/BindableNativeOptionsTests.cs
@@ -5,11 +5,6 @@ namespace Sentry.Tests.Platforms.Android;
 
 public class BindableNativeOptionsTests : BindableTests<SentryOptions.NativeOptions>
 {
-    public BindableNativeOptionsTests()
-        : base(nameof(BindableSentryOptions.NativeOptions.ExperimentalOptions))
-    {
-    }
-
     [Fact]
     public void BindableProperties_MatchOptionsProperties()
     {


### PR DESCRIPTION
This reverts commit ad807953572d76b1990c0964fd467e4394ebeaf1.

Removing Replay temporarily until we can work out why this prevents our Android integration from functioning correctly. See:
- https://github.com/getsentry/sentry-dotnet/issues/3755#issuecomment-2476030976

We should reintroduce Replay in a new PR that also resolves the problem above. 