### PR TITLE
feat(release): Replace release bot with GH app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,22 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Release a new version: ${{ github.event.inputs.version }}'
     steps:
+      - name: Get auth token
+        id: token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        with:
+          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_RELEASE_PAT }}
+          token: ${{ steps.token.outputs.token }}
           fetch-depth: 0
 
       - name: Prepare release ${{ github.event.inputs.version }}
         uses: getsentry/action-prepare-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}


### PR DESCRIPTION
More details: https://www.notion.so/sentry/DACI-Replace-GitHub-bot-accounts-with-GitHub-Apps-getsentry-release-15109965d1204a91b9be71c49e8b66e0?pvs=4

#skip-changelog