### PR TITLE
fix: Ensure span ids are 16 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 - Fixed JNI Error when accessing Android device data from multiple threads ([#3802](https://github.com/getsentry/sentry-dotnet/pull/3802))
+- Fix "System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'idData')" error propagating OpenTelemetry span ids ([#3850](https://github.com/getsentry/sentry-dotnet/pull/3850))
 
 ### Dependencies
 

--- a/src/Sentry/SpanId.cs
+++ b/src/Sentry/SpanId.cs
@@ -41,7 +41,7 @@ public readonly struct SpanId : IEquatable<SpanId>, ISentryJsonSerializable
     public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(_value);
 
     /// <inheritdoc />
-    public override string ToString() => _value.ToString("x8");
+    public override string ToString() => _value.ToString("x8").PadLeft(16, '0');
 
     /// <summary>
     /// Generates a new Sentry ID.

--- a/test/Sentry.Tests/Protocol/Context/TraceTests.cs
+++ b/test/Sentry.Tests/Protocol/Context/TraceTests.cs
@@ -85,4 +85,15 @@ public class TraceTests
         Assert.Equal(trace.SpanId, clone.SpanId);
         Assert.Equal(trace.TraceId, clone.TraceId);
     }
+
+    [Fact]
+    public void SpanId_LeadingZero_ToStringValid()
+    {
+        // Arrange
+        const string spanIdInput = "0ecd6f15f72015cb";
+        var spanId = new SpanId(spanIdInput);
+
+        // Assert
+        Assert.Equal(spanIdInput, spanId.ToString());
+    }
 }


### PR DESCRIPTION
Storing span ids as longs causes leading zeroes to be lost. This restores them.