### PR TITLE
Task 3690: Use [GeneratedRegex] Properties

### DIFF
--- a/src/Sentry/BuiltInSystemDiagnosticsMeters.cs
+++ b/src/Sentry/BuiltInSystemDiagnosticsMeters.cs
@@ -24,10 +24,15 @@ public static partial class BuiltInSystemDiagnosticsMeters
     /// <summary>
     /// Matches the built-in Microsoft.AspNetCore.Hosting metrics
     /// </summary>
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    public static readonly StringOrRegex MicrosoftAspNetCoreHosting = MicrosoftAspNetCoreHostingRegex;
+
+    [GeneratedRegex(MicrosoftAspNetCoreHostingPattern)]
+    private static partial Regex MicrosoftAspNetCoreHostingRegex { get; }
+#elif NET8_0
     public static readonly StringOrRegex MicrosoftAspNetCoreHosting = MicrosoftAspNetCoreHostingRegex();
 
-    [GeneratedRegex(MicrosoftAspNetCoreHostingPattern, RegexOptions.Compiled)]
+    [GeneratedRegex(MicrosoftAspNetCoreHostingPattern)]
     private static partial Regex MicrosoftAspNetCoreHostingRegex();
 #else
     public static readonly StringOrRegex MicrosoftAspNetCoreHosting = new Regex(MicrosoftAspNetCoreHostingPattern, RegexOptions.Compiled);
@@ -36,10 +41,15 @@ public static partial class BuiltInSystemDiagnosticsMeters
     /// <summary>
     /// Matches the built-in Microsoft.AspNetCore.Routing metrics
     /// </summary>
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    public static readonly StringOrRegex MicrosoftAspNetCoreRouting = MicrosoftAspNetCoreRoutingRegex;
+
+    [GeneratedRegex(MicrosoftAspNetCoreRoutingPattern)]
+    private static partial Regex MicrosoftAspNetCoreRoutingRegex { get; }
+#elif NET8_0
     public static readonly StringOrRegex MicrosoftAspNetCoreRouting = MicrosoftAspNetCoreRoutingRegex();
 
-    [GeneratedRegex(MicrosoftAspNetCoreRoutingPattern, RegexOptions.Compiled)]
+    [GeneratedRegex(MicrosoftAspNetCoreRoutingPattern)]
     private static partial Regex MicrosoftAspNetCoreRoutingRegex();
 #else
     public static readonly StringOrRegex MicrosoftAspNetCoreRouting = new Regex(MicrosoftAspNetCoreRoutingPattern, RegexOptions.Compiled);
@@ -48,10 +58,15 @@ public static partial class BuiltInSystemDiagnosticsMeters
     /// <summary>
     /// Matches the built-in Microsoft.AspNetCore.Diagnostics metrics
     /// </summary>
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    public static readonly StringOrRegex MicrosoftAspNetCoreDiagnostics = MicrosoftAspNetCoreDiagnosticsRegex;
+
+    [GeneratedRegex(MicrosoftAspNetCoreDiagnosticsPattern)]
+    private static partial Regex MicrosoftAspNetCoreDiagnosticsRegex { get; }
+#elif NET8_0
     public static readonly StringOrRegex MicrosoftAspNetCoreDiagnostics = MicrosoftAspNetCoreDiagnosticsRegex();
 
-    [GeneratedRegex(MicrosoftAspNetCoreDiagnosticsPattern, RegexOptions.Compiled)]
+    [GeneratedRegex(MicrosoftAspNetCoreDiagnosticsPattern)]
     private static partial Regex MicrosoftAspNetCoreDiagnosticsRegex();
 #else
     public static readonly StringOrRegex MicrosoftAspNetCoreDiagnostics = new Regex(MicrosoftAspNetCoreDiagnosticsPattern, RegexOptions.Compiled);
@@ -60,10 +75,15 @@ public static partial class BuiltInSystemDiagnosticsMeters
     /// <summary>
     /// Matches the built-in Microsoft.AspNetCore.RateLimiting metrics
     /// </summary>
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    public static readonly StringOrRegex MicrosoftAspNetCoreRateLimiting = MicrosoftAspNetCoreRateLimitingRegex;
+
+    [GeneratedRegex(MicrosoftAspNetCoreRateLimitingPattern)]
+    private static partial Regex MicrosoftAspNetCoreRateLimitingRegex { get; }
+#elif NET8_0
     public static readonly StringOrRegex MicrosoftAspNetCoreRateLimiting = MicrosoftAspNetCoreRateLimitingRegex();
 
-    [GeneratedRegex(MicrosoftAspNetCoreRateLimitingPattern, RegexOptions.Compiled)]
+    [GeneratedRegex(MicrosoftAspNetCoreRateLimitingPattern)]
     private static partial Regex MicrosoftAspNetCoreRateLimitingRegex();
 #else
     public static readonly StringOrRegex MicrosoftAspNetCoreRateLimiting = new Regex(MicrosoftAspNetCoreRateLimitingPattern, RegexOptions.Compiled);
@@ -72,10 +92,15 @@ public static partial class BuiltInSystemDiagnosticsMeters
     /// <summary>
     /// Matches the built-in Microsoft.AspNetCore.HeaderParsing metrics
     /// </summary>
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    public static readonly StringOrRegex MicrosoftAspNetCoreHeaderParsing = MicrosoftAspNetCoreHeaderParsingRegex;
+
+    [GeneratedRegex(MicrosoftAspNetCoreHeaderParsingPattern)]
+    private static partial Regex MicrosoftAspNetCoreHeaderParsingRegex { get; }
+#elif NET8_0
     public static readonly StringOrRegex MicrosoftAspNetCoreHeaderParsing = MicrosoftAspNetCoreHeaderParsingRegex();
 
-    [GeneratedRegex(MicrosoftAspNetCoreHeaderParsingPattern, RegexOptions.Compiled)]
+    [GeneratedRegex(MicrosoftAspNetCoreHeaderParsingPattern)]
     private static partial Regex MicrosoftAspNetCoreHeaderParsingRegex();
 #else
     public static readonly StringOrRegex MicrosoftAspNetCoreHeaderParsing = new Regex(MicrosoftAspNetCoreHeaderParsingPattern, RegexOptions.Compiled);
@@ -84,10 +109,15 @@ public static partial class BuiltInSystemDiagnosticsMeters
     /// <summary>
     /// Matches the built-in Microsoft.AspNetCore.Server.Kestrel metrics
     /// </summary>
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    public static readonly StringOrRegex MicrosoftAspNetCoreServerKestrel = MicrosoftAspNetCoreServerKestrelRegex;
+
+    [GeneratedRegex(MicrosoftAspNetCoreServerKestrelPattern)]
+    private static partial Regex MicrosoftAspNetCoreServerKestrelRegex { get; }
+#elif NET8_0
     public static readonly StringOrRegex MicrosoftAspNetCoreServerKestrel = MicrosoftAspNetCoreServerKestrelRegex();
 
-    [GeneratedRegex(MicrosoftAspNetCoreServerKestrelPattern, RegexOptions.Compiled)]
+    [GeneratedRegex(MicrosoftAspNetCoreServerKestrelPattern)]
     private static partial Regex MicrosoftAspNetCoreServerKestrelRegex();
 #else
     public static readonly StringOrRegex MicrosoftAspNetCoreServerKestrel = new Regex(MicrosoftAspNetCoreServerKestrelPattern, RegexOptions.Compiled);
@@ -96,10 +126,15 @@ public static partial class BuiltInSystemDiagnosticsMeters
     /// <summary>
     /// Matches the built-in Microsoft.AspNetCore.Http.Connections metrics
     /// </summary>
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    public static readonly StringOrRegex MicrosoftAspNetCoreHttpConnections = MicrosoftAspNetCoreHttpConnectionsRegex;
+
+    [GeneratedRegex(MicrosoftAspNetCoreHttpConnectionsPattern)]
+    private static partial Regex MicrosoftAspNetCoreHttpConnectionsRegex { get; }
+#elif NET8_0
     public static readonly StringOrRegex MicrosoftAspNetCoreHttpConnections = MicrosoftAspNetCoreHttpConnectionsRegex();
 
-    [GeneratedRegex(MicrosoftAspNetCoreHttpConnectionsPattern, RegexOptions.Compiled)]
+    [GeneratedRegex(MicrosoftAspNetCoreHttpConnectionsPattern)]
     private static partial Regex MicrosoftAspNetCoreHttpConnectionsRegex();
 #else
     public static readonly StringOrRegex MicrosoftAspNetCoreHttpConnections = new Regex(MicrosoftAspNetCoreHttpConnectionsPattern, RegexOptions.Compiled);
@@ -108,10 +143,15 @@ public static partial class BuiltInSystemDiagnosticsMeters
     /// <summary>
     /// Matches the built-in Microsoft.Extensions.Diagnostics.HealthChecks metrics
     /// </summary>
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    public static readonly StringOrRegex MicrosoftExtensionsDiagnosticsHealthChecks = MicrosoftExtensionsDiagnosticsHealthChecksRegex;
+
+    [GeneratedRegex(MicrosoftExtensionsDiagnosticsHealthChecksPattern)]
+    private static partial Regex MicrosoftExtensionsDiagnosticsHealthChecksRegex { get; }
+#elif NET8_0
     public static readonly StringOrRegex MicrosoftExtensionsDiagnosticsHealthChecks = MicrosoftExtensionsDiagnosticsHealthChecksRegex();
 
-    [GeneratedRegex(MicrosoftExtensionsDiagnosticsHealthChecksPattern, RegexOptions.Compiled)]
+    [GeneratedRegex(MicrosoftExtensionsDiagnosticsHealthChecksPattern)]
     private static partial Regex MicrosoftExtensionsDiagnosticsHealthChecksRegex();
 #else
     public static readonly StringOrRegex MicrosoftExtensionsDiagnosticsHealthChecks = new Regex(MicrosoftExtensionsDiagnosticsHealthChecksPattern, RegexOptions.Compiled);
@@ -120,10 +160,15 @@ public static partial class BuiltInSystemDiagnosticsMeters
     /// <summary>
     /// Matches the built-in Microsoft.Extensions.Diagnostics.ResourceMonitoring metrics
     /// </summary>
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    public static readonly StringOrRegex MicrosoftExtensionsDiagnosticsResourceMonitoring = MicrosoftExtensionsDiagnosticsResourceMonitoringRegex;
+
+    [GeneratedRegex(MicrosoftExtensionsDiagnosticsResourceMonitoringPattern)]
+    private static partial Regex MicrosoftExtensionsDiagnosticsResourceMonitoringRegex { get; }
+#elif NET8_0
     public static readonly StringOrRegex MicrosoftExtensionsDiagnosticsResourceMonitoring = MicrosoftExtensionsDiagnosticsResourceMonitoringRegex();
 
-    [GeneratedRegex(MicrosoftExtensionsDiagnosticsResourceMonitoringPattern, RegexOptions.Compiled)]
+    [GeneratedRegex(MicrosoftExtensionsDiagnosticsResourceMonitoringPattern)]
     private static partial Regex MicrosoftExtensionsDiagnosticsResourceMonitoringRegex();
 #else
     public static readonly StringOrRegex MicrosoftExtensionsDiagnosticsResourceMonitoring = new Regex(MicrosoftExtensionsDiagnosticsResourceMonitoringPattern, RegexOptions.Compiled);
@@ -132,10 +177,15 @@ public static partial class BuiltInSystemDiagnosticsMeters
     /// <summary>
     /// Matches the built-in System.Net.NameResolution metrics
     /// </summary>
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    public static readonly StringOrRegex OpenTelemetryInstrumentationRuntime = OpenTelemetryInstrumentationRuntimeRegex;
+
+    [GeneratedRegex(OpenTelemetryInstrumentationRuntimePattern)]
+    private static partial Regex OpenTelemetryInstrumentationRuntimeRegex { get; }
+#elif NET8_0
     public static readonly StringOrRegex OpenTelemetryInstrumentationRuntime = OpenTelemetryInstrumentationRuntimeRegex();
 
-    [GeneratedRegex(OpenTelemetryInstrumentationRuntimePattern, RegexOptions.Compiled)]
+    [GeneratedRegex(OpenTelemetryInstrumentationRuntimePattern)]
     private static partial Regex OpenTelemetryInstrumentationRuntimeRegex();
 #else
     public static readonly StringOrRegex OpenTelemetryInstrumentationRuntime = new Regex(OpenTelemetryInstrumentationRuntimePattern, RegexOptions.Compiled);
@@ -144,10 +194,15 @@ public static partial class BuiltInSystemDiagnosticsMeters
     /// <summary>
     /// Matches the built-in System.Net.NameResolution metrics
     /// </summary>
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    public static readonly StringOrRegex SystemNetNameResolution = SystemNetNameResolutionRegex;
+
+    [GeneratedRegex(SystemNetNameResolutionPattern)]
+    private static partial Regex SystemNetNameResolutionRegex { get; }
+#elif NET8_0
     public static readonly StringOrRegex SystemNetNameResolution = SystemNetNameResolutionRegex();
 
-    [GeneratedRegex(SystemNetNameResolutionPattern, RegexOptions.Compiled)]
+    [GeneratedRegex(SystemNetNameResolutionPattern)]
     private static partial Regex SystemNetNameResolutionRegex();
 #else
     public static readonly StringOrRegex SystemNetNameResolution = new Regex(SystemNetNameResolutionPattern, RegexOptions.Compiled);
@@ -156,10 +211,15 @@ public static partial class BuiltInSystemDiagnosticsMeters
     /// <summary>
     /// Matches the built-in <see cref="System.Net.Http"/> metrics
     /// </summary>
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    public static readonly StringOrRegex SystemNetHttp = SystemNetHttpRegex;
+
+    [GeneratedRegex(SystemNetHttpPattern)]
+    private static partial Regex SystemNetHttpRegex { get; }
+#elif NET8_0
     public static readonly StringOrRegex SystemNetHttp = SystemNetHttpRegex();
 
-    [GeneratedRegex(SystemNetHttpPattern, RegexOptions.Compiled)]
+    [GeneratedRegex(SystemNetHttpPattern)]
     private static partial Regex SystemNetHttpRegex();
 #else
     public static readonly StringOrRegex SystemNetHttp = new Regex(SystemNetHttpPattern, RegexOptions.Compiled);

--- a/src/Sentry/Internal/OriginHelper.cs
+++ b/src/Sentry/Internal/OriginHelper.cs
@@ -5,12 +5,15 @@ internal static partial class OriginHelper
     internal const string Manual = "manual";
     private const string ValidOriginPattern = @"^(auto|manual)(\.[\w]+){0,3}$";
 
-#if NET8_0_OR_GREATER
-    [GeneratedRegex(ValidOriginPattern, RegexOptions.Compiled)]
-    private static partial Regex ValidOriginRegEx();
-    private static readonly Regex ValidOrigin = ValidOriginRegEx();
+#if NET9_0_OR_GREATER
+    [GeneratedRegex(ValidOriginPattern)]
+    private static partial Regex ValidOrigin { get; }
+#elif NET8_0
+    [GeneratedRegex(ValidOriginPattern)]
+    private static partial Regex ValidOriginRegex();
+    private static readonly Regex ValidOrigin = ValidOriginRegex();
 #else
-    private static readonly Regex ValidOrigin = new (ValidOriginPattern, RegexOptions.Compiled);
+    private static readonly Regex ValidOrigin = new(ValidOriginPattern, RegexOptions.Compiled);
 #endif
 
     public static bool IsValidOrigin(string? value) => value == null || ValidOrigin.IsMatch(value);


### PR DESCRIPTION
This is meant to address #3690

As you can see, this doesn't really clean things up -- mainly to preserve regex source generation for `net8.0` (_Option 1_).

If we're fine using dynamic regex compilation at runtime for `net8.0` (_Option 2_) things get much simpler but it may come with performance changes.

<details>
  <summary>OriginHelper.cs (As-is)</summary>

```csharp
#if NET8_0_OR_GREATER 
     [GeneratedRegex(ValidOriginPattern, RegexOptions.Compiled)] 
     private static partial Regex ValidOriginRegEx(); 
     private static readonly Regex ValidOrigin = ValidOriginRegEx(); 
 #else 
     private static readonly Regex ValidOrigin = new (ValidOriginPattern, RegexOptions.Compiled); 
 #endif 

```

</details>

<details>
  <summary>OriginHelper.cs (Option 1)</summary>

```csharp
#if NET9_0_OR_GREATER
    [GeneratedRegex(ValidOriginPattern)]
    private static partial Regex ValidOrigin { get; }
#elif NET8_0
    [GeneratedRegex(ValidOriginPattern)]
    private static partial Regex ValidOriginRegex();
    private static readonly Regex ValidOrigin = ValidOriginRegex();
#else
    private static readonly Regex ValidOrigin = new(ValidOriginPattern, RegexOptions.Compiled);
#endif

```

</details>

<details>
  <summary>OriginHelper.cs (Option 2)</summary>

```csharp
#if NET9_0_OR_GREATER
    [GeneratedRegex(ValidOriginPattern)]
    private static partial Regex ValidOrigin { get; }
#else
    private static readonly Regex ValidOrigin = new(ValidOriginPattern, RegexOptions.Compiled);
#endif

```

</details>

Thoughts?

#skip-changelog