### PR TITLE
Revert signal handler chaining order (PR #3694)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - .NET Mobile: Disable and made obsolete the iOS Watchdog termination feature which is based on heuristics that don't work in .NET ([#3867](https://github.com/getsentry/sentry-dotnet/pull/3867))
-
+- NullReferenceExceptions causing application crashes in AOT compiled applications (PR #3694) ([#3871](https://github.com/getsentry/sentry-dotnet/pull/3871))
 
 ### Dependencies
 

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -60,7 +60,7 @@ public static partial class SentrySdk
             o.ServerName = options.ServerName;
             o.SessionTrackingIntervalMillis = (long)options.AutoSessionTrackingInterval.TotalMilliseconds;
             o.ShutdownTimeoutMillis = (long)options.ShutdownTimeout.TotalMilliseconds;
-            o.SetNativeHandlerStrategy(JavaSdk.Android.Core.NdkHandlerStrategy.SentryHandlerStrategyChainAtStart);
+            o.SetNativeHandlerStrategy(JavaSdk.Android.Core.NdkHandlerStrategy.SentryHandlerStrategyDefault);
 
             if (options.CacheDirectoryPath is { } cacheDirectoryPath)
             {


### PR DESCRIPTION
Fixes app crashes from NullReferenceExceptions even when these are caught/handled, if Sentry Native is being used. See:
- https://github.com/getsentry/sentry-dotnet/issues/3861