### PR TITLE
Add SentryOptions.DisableSentryHttpMessageHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added `SentryOptions.DisableSentryHttpMessageHandler` ([#3879](https://github.com/getsentry/sentry-dotnet/pull/3879))
+
 ## 5.0.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Added `SentryOptions.DisableSentryHttpMessageHandler` ([#3879](https://github.com/getsentry/sentry-dotnet/pull/3879))
+- Added `SentryOptions.DisableSentryHttpMessageHandler`. Useful if you're using `OpenTelemetry.Instrumentation.Http` and ending up with duplicate spans. ([#3879](https://github.com/getsentry/sentry-dotnet/pull/3879))
 
 ## 5.0.1
 

--- a/src/Sentry.Extensions.Logging/SentryHttpMessageHandlerBuilderFilter.cs
+++ b/src/Sentry.Extensions.Logging/SentryHttpMessageHandlerBuilderFilter.cs
@@ -14,7 +14,8 @@ internal class SentryHttpMessageHandlerBuilderFilter : IHttpMessageHandlerBuilde
         handlerBuilder =>
         {
             var hub = _getHub();
-            if (!handlerBuilder.AdditionalHandlers.Any(h => h is SentryHttpMessageHandler))
+            var enableHandler = hub.GetSentryOptions()?.DisableSentryHttpMessageHandler == false;
+            if (enableHandler && !handlerBuilder.AdditionalHandlers.Any(h => h is SentryHttpMessageHandler))
             {
                 handlerBuilder.AdditionalHandlers.Add(
                     new SentryHttpMessageHandler(hub)

--- a/src/Sentry/BindableSentryOptions.cs
+++ b/src/Sentry/BindableSentryOptions.cs
@@ -48,6 +48,7 @@ internal partial class BindableSentryOptions
     public TimeSpan? AutoSessionTrackingInterval { get; set; }
     public bool? AutoSessionTracking { get; set; }
     public bool? UseAsyncFileIO { get; set; }
+    public bool? DisableSentryHttpMessageHandler { get; set; }
     public bool? JsonPreserveReferences { get; set; }
     public bool? EnableSpotlight { get; set; }
     public string? SpotlightUrl { get; set; }
@@ -94,6 +95,7 @@ internal partial class BindableSentryOptions
         options.AutoSessionTrackingInterval = AutoSessionTrackingInterval ?? options.AutoSessionTrackingInterval;
         options.AutoSessionTracking = AutoSessionTracking ?? options.AutoSessionTracking;
         options.UseAsyncFileIO = UseAsyncFileIO ?? options.UseAsyncFileIO;
+        options.DisableSentryHttpMessageHandler = DisableSentryHttpMessageHandler ?? options.DisableSentryHttpMessageHandler;
         options.JsonPreserveReferences = JsonPreserveReferences ?? options.JsonPreserveReferences;
         options.EnableSpotlight = EnableSpotlight ?? options.EnableSpotlight;
         options.SpotlightUrl = SpotlightUrl ?? options.SpotlightUrl;

--- a/src/Sentry/SentryHttpMessageHandler.cs
+++ b/src/Sentry/SentryHttpMessageHandler.cs
@@ -5,7 +5,8 @@ using Sentry.Internal.OpenTelemetry;
 namespace Sentry;
 
 /// <summary>
-/// Special HTTP message handler that can be used to propagate Sentry headers and other contextual information.
+/// Special HTTP message handler that can be used to propagate Sentry headers and other contextual information. Will
+/// also create events for failed requests if <see cref="SentryOptions.CaptureFailedRequests"/> is enabled.
 /// </summary>
 public class SentryHttpMessageHandler : SentryMessageHandler
 {

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -1067,6 +1067,14 @@ public class SentryOptions
     internal Instrumenter Instrumenter { get; set; } = Instrumenter.Sentry;
 
     /// <summary>
+    /// <para>
+    /// Set to `true` to prevents Sentry from automatically registering <see cref="SentryHttpMessageHandler"/>.
+    /// </para>
+    /// <para>Defaults to `false`. Should be set to `true` when using the OpenTelemetry.Instrumentation.Http.</para>
+    /// </summary>
+    public bool DisableSentryHttpMessageHandler { get; set; } = false;
+
+    /// <summary>
     /// Adds a <see cref="JsonConverter"/> to be used when serializing or deserializing
     /// objects to JSON with this SDK.  For example, when custom context data might use
     /// a data type that requires custom serialization logic.

--- a/test/Sentry.Extensions.Logging.Tests/SentryHttpMessageHandlerBuilderFilterTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryHttpMessageHandlerBuilderFilterTests.cs
@@ -4,9 +4,13 @@ namespace Sentry.Extensions.Logging.Tests;
 
 public class SentryHttpMessageHandlerBuilderFilterTests
 {
-    [Fact]
+    [SkippableFact]
     public void Configure_HandlerEnabled_ShouldAddSentryHttpMessageHandler()
     {
+#if __ANDROID__
+        Skip.If(true, "Can't create proxies for classes without parameterless constructors on Android");
+#endif
+
         // Arrange
         var hub = Substitute.For<IHub>();
         SentryClientExtensions.SentryOptionsForTestingOnly = new SentryOptions { DisableSentryHttpMessageHandler = false };
@@ -24,9 +28,13 @@ public class SentryHttpMessageHandlerBuilderFilterTests
         handlerBuilder.AdditionalHandlers.Should().ContainSingle(h => h is SentryHttpMessageHandler);
     }
 
-    [Fact]
+    [SkippableFact]
     public void Configure_HandlerDisabled_ShouldNotAddSentryHttpMessageHandler()
     {
+#if __ANDROID__
+        Skip.If(true, "Can't create proxies for classes without parameterless constructors on Android");
+#endif
+
         // Arrange
         var hub = Substitute.For<IHub>();
         SentryClientExtensions.SentryOptionsForTestingOnly = new SentryOptions { DisableSentryHttpMessageHandler = true };

--- a/test/Sentry.Extensions.Logging.Tests/SentryHttpMessageHandlerBuilderFilterTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryHttpMessageHandlerBuilderFilterTests.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Http;
+
+namespace Sentry.Extensions.Logging.Tests;
+
+public class SentryHttpMessageHandlerBuilderFilterTests
+{
+    [Fact]
+    public void Configure_HandlerEnabled_ShouldAddSentryHttpMessageHandler()
+    {
+        // Arrange
+        var hub = Substitute.For<IHub>();
+        SentryClientExtensions.SentryOptionsForTestingOnly = new SentryOptions { DisableSentryHttpMessageHandler = false };
+
+        var filter = new SentryHttpMessageHandlerBuilderFilter(() => hub);
+        var handlerBuilder = Substitute.For<HttpMessageHandlerBuilder>();
+        handlerBuilder.AdditionalHandlers.Returns(new List<DelegatingHandler>());
+        Action<HttpMessageHandlerBuilder> next = _ => { };
+
+        // Act
+        var configure = filter.Configure(next);
+        configure(handlerBuilder);
+
+        // Assert
+        handlerBuilder.AdditionalHandlers.Should().ContainSingle(h => h is SentryHttpMessageHandler);
+    }
+
+    [Fact]
+    public void Configure_HandlerDisabled_ShouldNotAddSentryHttpMessageHandler()
+    {
+        // Arrange
+        var hub = Substitute.For<IHub>();
+        SentryClientExtensions.SentryOptionsForTestingOnly = new SentryOptions { DisableSentryHttpMessageHandler = true };
+
+        var filter = new SentryHttpMessageHandlerBuilderFilter(() => hub);
+        var handlerBuilder = Substitute.For<HttpMessageHandlerBuilder>();
+        handlerBuilder.AdditionalHandlers.Returns(new List<DelegatingHandler>());
+        Action<HttpMessageHandlerBuilder> next = _ => { };
+
+        // Act
+        var configure = filter.Configure(next);
+        configure(handlerBuilder);
+
+        // Assert
+        handlerBuilder.AdditionalHandlers.Should().NotContain(h => h is SentryHttpMessageHandler);
+    }
+}

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -664,6 +664,7 @@ namespace Sentry
         public Sentry.SentryLevel DiagnosticLevel { get; set; }
         public Sentry.Extensibility.IDiagnosticLogger? DiagnosticLogger { get; set; }
         public bool DisableFileWrite { get; set; }
+        public bool DisableSentryHttpMessageHandler { get; set; }
         public string? Distribution { get; set; }
         public string? Dsn { get; set; }
         public bool EnableScopeSync { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -664,6 +664,7 @@ namespace Sentry
         public Sentry.SentryLevel DiagnosticLevel { get; set; }
         public Sentry.Extensibility.IDiagnosticLogger? DiagnosticLogger { get; set; }
         public bool DisableFileWrite { get; set; }
+        public bool DisableSentryHttpMessageHandler { get; set; }
         public string? Distribution { get; set; }
         public string? Dsn { get; set; }
         public bool EnableScopeSync { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -651,6 +651,7 @@ namespace Sentry
         public Sentry.SentryLevel DiagnosticLevel { get; set; }
         public Sentry.Extensibility.IDiagnosticLogger? DiagnosticLogger { get; set; }
         public bool DisableFileWrite { get; set; }
+        public bool DisableSentryHttpMessageHandler { get; set; }
         public string? Distribution { get; set; }
         public string? Dsn { get; set; }
         public bool EnableScopeSync { get; set; }


### PR DESCRIPTION
Addresses the duplicate trace problem described in https://github.com/getsentry/sentry-dotnet/issues/3843:
- https://github.com/getsentry/sentry-dotnet/issues/3843#issuecomment-2579087325

Essentially we allow SDK users to disable the `SentryHttpMessageHandler` if they are already using the `OpenTelemetry.Instrumentation.Http` package to trace outbound requests... to avoid duplicate instrumentation.  

This PR does not address any issues around YARP - that would require separate exploration.