### PR TITLE
Prevent package downgrade for Maui packages

### DIFF
--- a/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
+++ b/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks />
     <TargetFrameworks Condition="'$(NO_ANDROID)' == ''">$(TargetFrameworks);net8.0-android34.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net8.0-ios17.0</TargetFrameworks>
+    <UseMaui>true</UseMaui>
     <!-- Currently broken on .NET 7, see
       - https://github.com/dotnet/maui/issues/18573
       - https://developercommunity.visualstudio.com/t/MAUI0000:-SystemMissingMethodException:/10505327?sort=newest&ftype=problem
@@ -64,9 +65,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.83" />
-    <PackageReference Include="Microsoft.Maui.Core" Version="8.0.83" />
-    <PackageReference Include="Microsoft.Maui.Essentials" Version="8.0.83" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+    <PackageReference Include="Microsoft.Maui.Core" Version="$(MauiVersion)" />
+    <PackageReference Include="Microsoft.Maui.Essentials" Version="$(MauiVersion)" />
 
     <!-- https://github.com/advisories/GHSA-5f2m-466j-3848 -->
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />


### PR DESCRIPTION
Addresses issue we're seeing in multiple PR branches:

```
/Users/runner/work/sentry-dotnet/sentry-dotnet/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj : error NU1605: Warning As Error: Detected package downgrade: Microsoft.Maui.Controls from 8.0.100 to 8.0.83. Reference the package directly from the project to select a different version.  [/Users/runner/work/sentry-dotnet/sentry-dotnet/Sentry-CI-Build-macOS.slnf]
/Users/runner/work/sentry-dotnet/sentry-dotnet/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj : error NU1605:  Sentry.Maui.Device.TestApp -> Sentry.Maui.Tests -> Microsoft.Maui.Controls (>= 8.0.100)  [/Users/runner/work/sentry-dotnet/sentry-dotnet/Sentry-CI-Build-macOS.slnf]
/Users/runner/work/sentry-dotnet/sentry-dotnet/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj : error NU1605:  Sentry.Maui.Device.TestApp -> Microsoft.Maui.Controls (>= 8.0.83) [/Users/runner/work/sentry-dotnet/sentry-dotnet/Sentry-CI-Build-macOS.slnf]
  Failed to restore /Users/runner/work/sentry-dotnet/sentry-dotnet/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj (in 11.56 sec).
```

#skip-changelog