### PR TITLE
Workaround flaky SSL connection installing Android SDKs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,7 +220,14 @@ jobs:
         uses: ./.github/actions/buildnative
 
       - name: Install Android SDKs
+        id: installandroidsdks
+        continue-on-error: true
         if: runner.os == 'macOS'
+        run: |
+          dotnet build src/Sentry/Sentry.csproj -t:InstallAndroidDependencies -f:net8.0-android34.0 -p:AcceptAndroidSDKLicenses=True -p:AndroidSdkPath="/usr/local/lib/android/sdk/"
+
+      - name: Install Android SDKs (retry)
+        if: steps.installandroidsdks.outcome=='failure' && runner.os == 'macOS'
         run: |
           dotnet build src/Sentry/Sentry.csproj -t:InstallAndroidDependencies -f:net8.0-android34.0 -p:AcceptAndroidSDKLicenses=True -p:AndroidSdkPath="/usr/local/lib/android/sdk/"
 


### PR DESCRIPTION
In our GitHub Actions we're trying to install the android sdks by running:
```
dotnet build src/Sentry/Sentry.csproj -t:InstallAndroidDependencies -f:net8.0-android34.0 -p:AcceptAndroidSDKLicenses=True -p:AndroidSdkPath="/usr/local/lib/android/sdk/"
```

This command often fails to download the necessary dependencies due to SSL certificate errors:
> /Users/runner/.dotnet/packs/Microsoft.Android.Sdk.Darwin/34.0.145/tools/Xamarin.Installer.Common.targets(12,3): error : Failed to download Xamarin Repository manifest from https://aka.ms/AndroidManifestFeed/d17-12. System.AggregateException: One or more errors occurred. (The SSL connection could not be established, see inner exception.) [/Users/runner/work/sentry-dotnet/sentry-dotnet/src/Sentry/Sentry.csproj::TargetFramework=net8.0-android34.0]

When this happens, we have to manually rerun the job, which is painful. 

This PR simply retries that command once, if it fails the first time... so some basic **_resilience_**. 

#skip-changelog