### PR TITLE
Fixed duplicate SentryMauiEventProcessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- Fixed duplicate SentryMauiOptions registration ([#3905](https://github.com/getsentry/sentry-dotnet/pull/3905))
+- Fixed duplicate SentryMauiEventProcessors ([#3905](https://github.com/getsentry/sentry-dotnet/pull/3905))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - .NET on iOS: Add experimental EnableAppHangTrackingV2 configuration flag to the options binding SDK ([#3877](https://github.com/getsentry/sentry-dotnet/pull/3877))
 - Added `SentryOptions.DisableSentryHttpMessageHandler`. Useful if you're using `OpenTelemetry.Instrumentation.Http` and ending up with duplicate spans. ([#3879](https://github.com/getsentry/sentry-dotnet/pull/3879))
 
+### Fixes
+
+- Fixed duplicate SentryMauiOptions registration ([#3905](https://github.com/getsentry/sentry-dotnet/pull/3905))
+
 ### Dependencies
 
 - Bump Native SDK from v0.7.17 to v0.7.18 ([#3891](https://github.com/getsentry/sentry-dotnet/pull/3891))

--- a/src/Sentry.Maui/Internal/SentryMauiOptionsSetup.cs
+++ b/src/Sentry.Maui/Internal/SentryMauiOptionsSetup.cs
@@ -15,7 +15,7 @@ internal class SentryMauiOptionsSetup : IConfigureOptions<SentryMauiOptions>
     public SentryMauiOptionsSetup(IConfiguration config)
     {
         ArgumentNullException.ThrowIfNull(config);
-        _config = config;
+        _config = config.GetSection("Sentry");
     }
 
     public void Configure(SentryMauiOptions options)

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -55,7 +55,6 @@ public static class SentryMauiAppBuilderExtensions
         services.AddLogging();
         services.AddSingleton<ILoggerProvider, SentryMauiLoggerProvider>();
         services.AddSingleton<IMauiInitializeService, SentryMauiInitializer>();
-        services.AddSingleton<IConfigureOptions<SentryMauiOptions>, SentryMauiOptionsSetup>();
         services.AddSingleton<Disposer>();
         services.TryAddSingleton<IMauiEventsBinder, MauiEventsBinder>();
 

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -44,7 +44,6 @@ public static class SentryMauiAppBuilderExtensions
     {
         var services = builder.Services;
 
-        services.AddSingleton<IConfigureOptions<SentryMauiOptions>, SentryMauiOptionsSetup>();
         if (configureOptions != null)
         {
             services.Configure(configureOptions);
@@ -53,6 +52,7 @@ public static class SentryMauiAppBuilderExtensions
         services.AddLogging();
         services.AddSingleton<ILoggerProvider, SentryMauiLoggerProvider>();
         services.AddSingleton<IMauiInitializeService, SentryMauiInitializer>();
+        services.AddSingleton<IConfigureOptions<SentryMauiOptions>, SentryMauiOptionsSetup>();
         services.AddSingleton<Disposer>();
         services.TryAddSingleton<IMauiEventsBinder, MauiEventsBinder>();
 

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -44,9 +44,7 @@ public static class SentryMauiAppBuilderExtensions
     {
         var services = builder.Services;
 
-        var section = builder.Configuration.GetSection("Sentry");
-        services.AddSingleton<IConfigureOptions<SentryMauiOptions>>(_ => new SentryMauiOptionsSetup(section));
-
+        services.AddSingleton<IConfigureOptions<SentryMauiOptions>, SentryMauiOptionsSetup>();
         if (configureOptions != null)
         {
             services.Configure(configureOptions);

--- a/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.cs
+++ b/test/Sentry.Maui.Tests/SentryMauiAppBuilderExtensionsTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Options;
 using Sentry.Internal.Http;
+using Sentry.Maui.Internal;
 using MauiConstants = Sentry.Maui.Internal.Constants;
 
 namespace Sentry.Maui.Tests;
@@ -28,6 +29,24 @@ public partial class SentryMauiAppBuilderExtensionsTests
     }
 
     private readonly Fixture _fixture = new();
+
+    [Fact]
+    public void UseSentry_RegistersEventProcessorOnlyOnce()
+    {
+        // Arrange
+        var builder = _fixture.Builder;
+        builder.Services.Configure<SentryMauiOptions>(options =>
+        {
+            options.Dsn = ValidDsn;
+        });
+
+        // Act
+        using var app = builder.UseSentry().Build();
+
+        // Assert
+        var options = app.Services.GetRequiredService<IOptions<SentryMauiOptions>>().Value;
+        options.EventProcessors.Should().ContainSingle(t => t.Type == typeof(SentryMauiEventProcessor));
+    }
 
     [Fact]
     public void CanUseSentry_WithConfigurationOnly()


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3894:
- https://github.com/getsentry/sentry-dotnet/issues/3894

## Note

Config bindings for appsettings.json files don't come out of the box with MAUI. To verify these work, they have to be [wired up manually](https://montemagno.com/dotnet-maui-appsettings-json-configuration/). 