### PR TITLE
Only use MarshalManagedExceptionMode.UnwindNativeCode when building for Mono on net8.0 and earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - .NET on iOS: Add experimental EnableAppHangTrackingV2 configuration flag to the options binding SDK ([#3877](https://github.com/getsentry/sentry-dotnet/pull/3877))
 - Added `SentryOptions.DisableSentryHttpMessageHandler`. Useful if you're using `OpenTelemetry.Instrumentation.Http` and ending up with duplicate spans. ([#3879](https://github.com/getsentry/sentry-dotnet/pull/3879))
 
+### Fixes
+
+- Use MarshalManagedExceptionMode.Default on CoreCLR ([#3912](https://github.com/getsentry/sentry-dotnet/pull/3912))
+
 ### Dependencies
 
 - Bump Native SDK from v0.7.17 to v0.7.18 ([#3891](https://github.com/getsentry/sentry-dotnet/pull/3891))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- Use MarshalManagedExceptionMode.Default on CoreCLR ([#3912](https://github.com/getsentry/sentry-dotnet/pull/3912))
+- MarshalManagedExceptionMode.Default is now used when capturing native exceptions in AOT compiled iOS applications, making native stack traces more readable ([#3912](https://github.com/getsentry/sentry-dotnet/pull/3912))
 
 ### Dependencies
 

--- a/src/Sentry.Bindings.Cocoa/buildTransitive/Sentry.Bindings.Cocoa.targets
+++ b/src/Sentry.Bindings.Cocoa/buildTransitive/Sentry.Bindings.Cocoa.targets
@@ -52,13 +52,11 @@
   <!--
    Ensure the AppDomain.CurrentDomain.UnhandledException gets triggered - see:
     https://github.com/xamarin/xamarin-macios/issues/15252
-   Not supported on the CoreCLR - see:
-    https://github.com/xamarin/xamarin-macios/blob/0a81da28e4217624a54ccb83541e1eb8ba651fca/runtime/runtime.m#L2480-L2491
 
-   The condition is a bit hacky - it relies on:
-    https://github.com/xamarin/xamarin-macios/blob/0ab074390689880fe9269804a0156341d30251f6/dotnet/targets/Xamarin.Shared.Sdk.targets#L1004-L1006
+   Not supported on the CoreCLR or NativeAOT - see:
+    https://github.com/xamarin/xamarin-macios/blob/0a81da28e4217624a54ccb83541e1eb8ba651fca/runtime/runtime.m#L2480-L2491
   -->
-  <PropertyGroup Condition="'$(_XamarinRuntime)' != 'CoreCLR'">
+  <PropertyGroup Condition="'$(UseMonoRuntime)' == 'true'">
     <MtouchExtraArgs>--marshal-managed-exceptions=unwindnativecode</MtouchExtraArgs>
   </PropertyGroup>
 

--- a/src/Sentry.Bindings.Cocoa/buildTransitive/Sentry.Bindings.Cocoa.targets
+++ b/src/Sentry.Bindings.Cocoa/buildTransitive/Sentry.Bindings.Cocoa.targets
@@ -49,4 +49,17 @@
     </ItemGroup>
   </Target>
 
+  <!--
+   Ensure the AppDomain.CurrentDomain.UnhandledException gets triggered - see:
+    https://github.com/xamarin/xamarin-macios/issues/15252
+   Not supported on the CoreCLR - see:
+    https://github.com/xamarin/xamarin-macios/blob/0a81da28e4217624a54ccb83541e1eb8ba651fca/runtime/runtime.m#L2480-L2491
+
+   The condition is a bit hacky - it relies on:
+    https://github.com/xamarin/xamarin-macios/blob/0ab074390689880fe9269804a0156341d30251f6/dotnet/targets/Xamarin.Shared.Sdk.targets#L1004-L1006
+  -->
+  <PropertyGroup Condition="'$(_XamarinRuntime)' != 'CoreCLR'">
+    <MtouchExtraArgs>--marshal-managed-exceptions=unwindnativecode</MtouchExtraArgs>
+  </PropertyGroup>
+
 </Project>

--- a/src/Sentry/Platforms/Cocoa/SentrySdk.cs
+++ b/src/Sentry/Platforms/Cocoa/SentrySdk.cs
@@ -1,6 +1,8 @@
 using Sentry.Cocoa;
 using Sentry.Cocoa.Extensions;
 using Sentry.Extensibility;
+using Sentry.Internal;
+using Sentry.PlatformAbstractions;
 
 // ReSharper disable once CheckNamespace
 namespace Sentry;
@@ -10,10 +12,10 @@ public static partial class SentrySdk
     private static void InitSentryCocoaSdk(SentryOptions options)
     {
         options.LogDebug("Initializing native SDK");
-        // Workaround for https://github.com/xamarin/xamarin-macios/issues/15252
         ObjCRuntime.Runtime.MarshalManagedException += (_, args) =>
         {
-            args.ExceptionMode = ObjCRuntime.MarshalManagedExceptionMode.UnwindNativeCode;
+            // This MAY be overriden in Sentry.Bindings.Cocoa.targets
+            options.LogDebug($"MarshalManagedExceptionMode: {args.ExceptionMode}");
         };
 
         // Set default release and distribution


### PR DESCRIPTION
May resolve https://github.com/getsentry/sentry-dotnet/issues/3280:
- https://github.com/getsentry/sentry-dotnet/issues/3280

Ideally we'd get customers to test this though as I've had extreme difficulty reproducing the stack traces referred to.