### PR TITLE
chore: Increase date range for MIT licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2024 Sentry
+Copyright (c) 2018-2025 Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
It's 2025 now.

#skip-changelog