### PR TITLE
Fixed Invalid index used in Debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixes
 
 - Fixed duplicate SentryMauiEventProcessors ([#3905](https://github.com/getsentry/sentry-dotnet/pull/3905))
+- Fixed invalid string.Format index in Debug logs for the DiagnosticSource integration ([#3923](https://github.com/getsentry/sentry-dotnet/pull/3923))
 
 ### Dependencies
 

--- a/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/EFCommandDiagnosticSourceHelper.cs
+++ b/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/EFCommandDiagnosticSourceHelper.cs
@@ -34,7 +34,7 @@ internal class EFCommandDiagnosticSourceHelper : EFDiagnosticSourceHelper
                     span.Operation == Operation &&
                     TryGetCommandId(span) == commandId);
         }
-        Options.LogWarning("No correlation id found for {1}.", Operation);
+        Options.LogWarning("No correlation id found for {0}.", Operation);
         return null;
     }
 
@@ -49,6 +49,6 @@ internal class EFCommandDiagnosticSourceHelper : EFDiagnosticSourceHelper
             }
             return;
         }
-        Options.LogWarning("No correlation id can be set for {1}.", Operation);
+        Options.LogWarning("No correlation id can be set for {0}.", Operation);
     }
 }

--- a/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/EFConnectionDiagnosticSourceHelper.cs
+++ b/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/EFConnectionDiagnosticSourceHelper.cs
@@ -22,7 +22,7 @@ internal class EFConnectionDiagnosticSourceHelper : EFDiagnosticSourceHelper
                     span.Operation == Operation &&
                     TryGetConnectionId(span) == connectionId);
         }
-        Options.LogWarning("No correlation id found for {1}.", Operation);
+        Options.LogWarning("No correlation id found for {0}.", Operation);
         return null;
     }
 


### PR DESCRIPTION
Fixed  #3922 

**Changes**
Corrected the parameter index in the ``LogWarning`` call