### PR TITLE
Don't resend envelopes that get rejected by the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - OTel activities that are marked as not recorded are no longer sent to Sentry ([#3890](https://github.com/getsentry/sentry-dotnet/pull/3890))
+- Fixed envelopes with oversized attachments getting stuck in __processing ([#3938](https://github.com/getsentry/sentry-dotnet/pull/3938))
 
 ## 5.1.0
 

--- a/src/Sentry/Internal/DiscardReason.cs
+++ b/src/Sentry/Internal/DiscardReason.cs
@@ -7,6 +7,7 @@ internal readonly struct DiscardReason : IEnumeration<DiscardReason>
     public static DiscardReason CacheOverflow = new("cache_overflow");
     public static DiscardReason EventProcessor = new("event_processor");
     public static DiscardReason NetworkError = new("network_error");
+    public static DiscardReason SendError = new("send_error");
     public static DiscardReason QueueOverflow = new("queue_overflow");
     public static DiscardReason RateLimitBackoff = new("ratelimit_backoff");
     public static DiscardReason SampleRate = new("sample_rate");

--- a/src/Sentry/Internal/DiscardReason.cs
+++ b/src/Sentry/Internal/DiscardReason.cs
@@ -4,10 +4,10 @@ internal readonly struct DiscardReason : IEnumeration<DiscardReason>
 {
     // See https://develop.sentry.dev/sdk/client-reports/ for list
     public static DiscardReason BeforeSend = new("before_send");
+    public static DiscardReason BufferOverflow = new("buffer_overflow");
     public static DiscardReason CacheOverflow = new("cache_overflow");
     public static DiscardReason EventProcessor = new("event_processor");
     public static DiscardReason NetworkError = new("network_error");
-    public static DiscardReason SendError = new("send_error");
     public static DiscardReason QueueOverflow = new("queue_overflow");
     public static DiscardReason RateLimitBackoff = new("ratelimit_backoff");
     public static DiscardReason SampleRate = new("sample_rate");

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -300,12 +300,21 @@ internal class CachingTransport : ITransport, IDisposable
         }
     }
 
-    private static bool IsNetworkError(Exception exception) =>
+    private static bool IsNetworkUnavailableError(Exception exception) =>
         exception switch
         {
+            // TODO: Could we make this more specific? Lots of these errors are unrelated to network availability.
             HttpRequestException or WebException or IOException or SocketException => true,
             _ => false
         };
+
+    private static bool IsRejectedByServer(Exception ex)
+    {
+        // When envelopes are too big, the server will reset the connection as soon as the maximum size is exceeded
+        // (it doesn't wait for us to finish sending the whole envelope).
+        return ex is SocketException { ErrorCode: 32 /* Broken pipe */ }
+            || (ex.InnerException is { } innerException && IsRejectedByServer(ex.InnerException));
+    }
 
     private async Task InnerProcessCacheAsync(string file, CancellationToken cancellation)
     {
@@ -346,8 +355,15 @@ internal class CachingTransport : ITransport, IDisposable
                         // Let the worker catch, log, wait a bit and retry.
                         throw;
                     }
-                    catch (Exception ex) when (IsNetworkError(ex))
+                    catch (Exception ex) when (IsRejectedByServer(ex))
                     {
+                        _options.ClientReportRecorder.RecordDiscardedEvents(DiscardReason.SendError, envelope);
+                        _options.LogError(ex, "Failed to send cached envelope: {0}. The envelope is likely too big and will be discarded.", file);
+                    }
+                    catch (Exception ex) when (IsNetworkUnavailableError(ex))
+                    {
+                        // TODO: Envelopes could end up in an infinite loop here. We should consider implementing some
+                        // kind backoff strategy and a retry limit... then drop the envelopes if the limit is exceeded.
                         if (_options.NetworkStatusListener is PollingNetworkStatusListener pollingListener)
                         {
                             pollingListener.Online = false;

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -313,7 +313,7 @@ internal class CachingTransport : ITransport, IDisposable
         // When envelopes are too big, the server will reset the connection as soon as the maximum size is exceeded
         // (it doesn't wait for us to finish sending the whole envelope).
         return ex is SocketException { ErrorCode: 32 /* Broken pipe */ }
-            || (ex.InnerException is { } innerException && IsRejectedByServer(ex.InnerException));
+            || (ex.InnerException is { } innerException && IsRejectedByServer(innerException));
     }
 
     private async Task InnerProcessCacheAsync(string file, CancellationToken cancellation)
@@ -357,7 +357,7 @@ internal class CachingTransport : ITransport, IDisposable
                     }
                     catch (Exception ex) when (IsRejectedByServer(ex))
                     {
-                        _options.ClientReportRecorder.RecordDiscardedEvents(DiscardReason.SendError, envelope);
+                        _options.ClientReportRecorder.RecordDiscardedEvents(DiscardReason.BufferOverflow, envelope);
                         _options.LogError(ex, "Failed to send cached envelope: {0}. The envelope is likely too big and will be discarded.", file);
                     }
                     catch (Exception ex) when (IsNetworkUnavailableError(ex))

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -712,6 +712,43 @@ public class CachingTransportTests
     }
 
     [Fact]
+    public async Task FlushAsync_RejectedByServer_DiscardsEnvelope()
+    {
+        // Arrange
+        var listener = Substitute.For<INetworkStatusListener>();
+        listener.Online.Returns(_ => true);
+
+        using var cacheDirectory = new TempDirectory();
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            DiagnosticLogger = _logger,
+            Debug = true,
+            CacheDirectoryPath = cacheDirectory.Path,
+            NetworkStatusListener = listener,
+            ClientReportRecorder = Substitute.For<IClientReportRecorder>()
+        };
+
+        using var envelope = Envelope.FromEvent(new SentryEvent());
+
+        var innerTransport = Substitute.For<ITransport>();
+        innerTransport.SendEnvelopeAsync(Arg.Any<Envelope>(), Arg.Any<CancellationToken>())
+            .Returns(_ => throw new SocketException(32 /* Bad pipe exception */));
+        await using var transport = CachingTransport.Create(innerTransport, options, startWorker: false);
+
+        // Act
+        await transport.SendEnvelopeAsync(envelope);
+        await transport.FlushAsync();
+
+        // Assert
+        foreach (var item in envelope.Items)
+        {
+            options.ClientReportRecorder.Received(1)
+                .RecordDiscardedEvent(DiscardReason.SendError, item.DataCategory);
+        }
+    }
+
+    [Fact]
     public async Task DoesntWriteSentAtHeaderToCacheFile()
     {
         // Arrange

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -744,7 +744,7 @@ public class CachingTransportTests
         foreach (var item in envelope.Items)
         {
             options.ClientReportRecorder.Received(1)
-                .RecordDiscardedEvent(DiscardReason.SendError, item.DataCategory);
+                .RecordDiscardedEvent(DiscardReason.BufferOverflow, item.DataCategory);
         }
     }
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/3804:
- https://github.com/getsentry/sentry-dotnet/issues/3804

# Windows

Interestingly, on Windows the connection closes gracefully and we get a nice orderly response code back from the server that we can process:
> Error: HttpTransport: Sentry rejected the envelope '1c7a93c84b124a8395e982d97670e6a3'. Status code: RequestEntityTooLarge. Error detail: 413 Payload Too Large .

This PR may actually be working around an issue in the .NET Runtime on macOS then.