### PR TITLE
Ignore null value on CocoaScopeObserver.SetTag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - OTel activities that are marked as not recorded are no longer sent to Sentry ([#3890](https://github.com/getsentry/sentry-dotnet/pull/3890))
 - Unknown stack frames in profiles on .NET 8+ ([#3942](https://github.com/getsentry/sentry-dotnet/pull/3942))
 - Deduplicate profiling stack frames ([#3941](https://github.com/getsentry/sentry-dotnet/pull/3941))
+- Ignore null value on CocoaScopeObserver.SetTag ([#3948](https://github.com/getsentry/sentry-dotnet/pull/3948))
 
 ## 5.1.0
 

--- a/samples/Sentry.Samples.Ios/AppDelegate.cs
+++ b/samples/Sentry.Samples.Ios/AppDelegate.cs
@@ -30,6 +30,11 @@ public class AppDelegate : UIApplicationDelegate
             options.CacheDirectoryPath = Path.GetTempPath();
         });
 
+        SentrySdk.ConfigureScope(scope =>
+        {
+            scope.SetTag("IAmNull", null!);
+        });
+
         // create a new window instance based on the screen size
         Window = new UIWindow(UIScreen.MainScreen.Bounds);
 

--- a/samples/Sentry.Samples.Ios/AppDelegate.cs
+++ b/samples/Sentry.Samples.Ios/AppDelegate.cs
@@ -30,11 +30,6 @@ public class AppDelegate : UIApplicationDelegate
             options.CacheDirectoryPath = Path.GetTempPath();
         });
 
-        SentrySdk.ConfigureScope(scope =>
-        {
-            scope.SetTag("IAmNull", null!);
-        });
-
         // create a new window instance based on the screen size
         Window = new UIWindow(UIScreen.MainScreen.Bounds);
 

--- a/src/Sentry/Platforms/Cocoa/CocoaScopeObserver.cs
+++ b/src/Sentry/Platforms/Cocoa/CocoaScopeObserver.cs
@@ -69,7 +69,7 @@ internal sealed class CocoaScopeObserver : IScopeObserver
     {
         if (value is null)
         {
-            _options.LogDebug("Tag with key '{0}' was null.", key);
+            _options.LogDebug("Tag with key '{0}' was null. Use Unset to remove tags instead.", key);
             return;
         }
 

--- a/src/Sentry/Platforms/Cocoa/CocoaScopeObserver.cs
+++ b/src/Sentry/Platforms/Cocoa/CocoaScopeObserver.cs
@@ -67,6 +67,12 @@ internal sealed class CocoaScopeObserver : IScopeObserver
 
     public void SetTag(string key, string value)
     {
+        if (value is null)
+        {
+            _options.LogDebug("Tag with key '{0}' was null.", key);
+            return;
+        }
+
         try
         {
             SentryCocoaSdk.ConfigureScope(scope => scope.SetTagValue(value, key));

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -615,6 +615,24 @@ public class ScopeTests
 
         scope.Tags.Should().OnlyContain(pair => pair.Key == "AzFunctions" && pair.Value == "rule");
     }
+
+    [Fact]
+    public void SetTag_NullValue_DoesNotThrowArgumentNullException()
+    {
+        var scope = new Scope();
+
+        ArgumentNullException exception = null;
+        try
+        {
+            scope.SetTag("IAmNull", null);
+        }
+        catch (ArgumentNullException e)
+        {
+            exception = e;
+        }
+
+        Assert.Null(exception);
+    }
 }
 
 public static class ScopeTestExtensions


### PR DESCRIPTION
Added a null check to ignore null values, to have the same behavior as on Android. While `SetTag` doesn't allow `null` for the `value` argument, on Android it just throws a warning rather than throwing an ArgumentNullException deeper in the stack.

Fixes #3946