### PR TITLE
Skip flaky test (EventPipeSession_ReceivesExpectedCLREvents)

### DIFF
--- a/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs
+++ b/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs
@@ -184,8 +184,9 @@ public class SamplingTransactionProfilerTests
     [SkippableFact]
     public async Task EventPipeSession_ReceivesExpectedCLREvents()
     {
-        SampleProfilerSession? session = null;
-        SkipIfFailsInCI(() => session = SampleProfilerSession.StartNew(_testOutputLogger));
+        Skip.If(TestEnvironment.IsGitHubActions, "Flaky on CI");
+
+        var session = SampleProfilerSession.StartNew(_testOutputLogger);
         using (session)
         {
             var eventsReceived = new HashSet<string>();
@@ -193,7 +194,6 @@ public class SamplingTransactionProfilerTests
 
             var loadedMethods = new HashSet<string>();
             session!.EventSource.Clr.MethodLoadVerbose += (MethodLoadUnloadVerboseTraceData ev) => loadedMethods.Add(ev.MethodName);
-
 
             await session.WaitForFirstEventAsync(CancellationToken.None);
             var limitMs = 50;


### PR DESCRIPTION
#skip-changelog

EventPipeSession_ReceivesExpectedCLREvents is flaky in CI. 

Example error:
```
Error: Assert.Contains() Failure: Item not found in set
Set:       [".ctor", "set_Target", "AwaitUnsafeOnCompleted", "GetStateMachineBox", "get_Context", ···]
Not found: "MethodToBeLoaded"

  Failed Sentry.Profiling.Tests.SamplingTransactionProfilerTests.EventPipeSession_ReceivesExpectedCLREvents [1 s]
  Error Message:
   Assert.Contains() Failure: Item not found in set
Set:       [".ctor", "set_Target", "AwaitUnsafeOnCompleted", "GetStateMachineBox", "get_Context", ···]
Not found: "MethodToBeLoaded"
  Stack Trace:
     at Sentry.Profiling.Tests.SamplingTransactionProfilerTests.EventPipeSession_ReceivesExpectedCLREvents() in /Users/runner/work/sentry-dotnet/sentry-dotnet/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs:line 209
--- End of stack trace from previous location ---
  Standard Output Messages:
 [Debug 00:00:00.93]: Sleeping... time remaining: 250 ms
 [Debug 00:00:01.03]: Sleeping... time remaining: 152 ms
 [Debug 00:00:01.03]: Profiling is being cut-of after 50 ms because the transaction takes longer than that.
 [Debug 00:00:01.15]: Sleeping... time remaining: 27 ms
 [Debug 00:00:01.17]: Profiler has been stopped and has received all the samples up to the end time.
 [Debug 00:00:01.18]: Sleeping... time remaining: 250 ms
 [Debug 00:00:01.28]: Sleeping... time remaining: 151 ms
 [Debug 00:00:01.43]: Sleeping... time remaining: 4 ms
 [Warning 00:00:01.62]: Error during sampler profiler session shutdown.
     Exception: System.AggregateException: One or more errors occurred. (A task was canceled.)
  ---> System.Threading.Tasks.TaskCanceledException: A task was canceled.
    at System.Threading.Tasks.Task.GetExceptions(Boolean includeTaskCanceledExceptions)
    at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
    at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
    at System.Threading.Tasks.Task.Wait()
    at Sentry.Profiling.SampleProfilerSession.Stop() in /_/src/Sentry.Profiling/SampleProfilerSession.cs:line 135
    at Sentry.Profiling.SampleProfilerSession.Dispose() in /_/src/Sentry.Profiling/SampleProfilerSession.cs:line 146
    at Sentry.Profiling.Tests.SamplingTransactionProfilerTests.EventPipeSession_ReceivesExpectedCLREvents() in /Users/runner/work/sentry-dotnet/sentry-dotnet/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs:line 209
    at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)
    at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
    at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
    at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext()
    at Xunit.Sdk.AsyncTestSyncContext.<>c__DisplayClass7_0.<Post>b__0() in /_/src/xunit.execution/Sdk/AsyncTestSyncContext.cs:line 58
    at Xunit.Sdk.XunitWorkerThread.<>c.<QueueUserWorkItem>b__5_0(Object _) in /_/src/common/XunitWorkerThread.cs:line 37
    at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
    at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
    at System.Threading.Thread.StartCallback()
 --- End of stack trace from previous location ---
 
    --- End of inner exception stack trace ---
    at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
    at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
    at System.Threading.Tasks.Task.Wait()
    at Sentry.Profiling.SampleProfilerSession.Stop() in /_/src/Sentry.Profiling/SampleProfilerSession.cs:line 135
```