### PR TITLE
fix: wait for profiling session shutdown

### DIFF
--- a/src/Sentry.Profiling/SampleProfilerSession.cs
+++ b/src/Sentry.Profiling/SampleProfilerSession.cs
@@ -17,14 +17,16 @@ internal class SampleProfilerSession : IDisposable
     private readonly IDiagnosticLogger? _logger;
     private readonly SentryStopwatch _stopwatch;
     private bool _stopped = false;
+    private Task _processing;
 
-    private SampleProfilerSession(SentryStopwatch stopwatch, EventPipeSession session, TraceLogEventSource eventSource, IDiagnosticLogger? logger)
+    private SampleProfilerSession(SentryStopwatch stopwatch, EventPipeSession session, TraceLogEventSource eventSource, Task processing, IDiagnosticLogger? logger)
     {
         _session = session;
         _logger = logger;
         _eventSource = eventSource;
         _sampleEventParser = new SampleProfilerTraceEventParser(_eventSource);
         _stopwatch = stopwatch;
+        _processing = processing;
     }
 
     // Exposed only for benchmarks.
@@ -86,7 +88,7 @@ internal class SampleProfilerSession : IDisposable
             var eventSource = TraceLog.CreateFromEventPipeSession(session, TraceLog.EventPipeRundownConfiguration.Enable(client));
 
             // Process() blocks until the session is stopped so we need to run it on a separate thread.
-            Task.Factory.StartNew(eventSource.Process, TaskCreationOptions.LongRunning)
+            var processing = Task.Factory.StartNew(eventSource.Process, TaskCreationOptions.LongRunning)
                 .ContinueWith(_ =>
                 {
                     if (_.Exception?.InnerException is { } e)
@@ -95,7 +97,7 @@ internal class SampleProfilerSession : IDisposable
                     }
                 }, TaskContinuationOptions.OnlyOnFaulted);
 
-            return new SampleProfilerSession(stopWatch, session, eventSource, logger);
+            return new SampleProfilerSession(stopWatch, session, eventSource, processing, logger);
         }
         catch (Exception ex)
         {
@@ -128,6 +130,7 @@ internal class SampleProfilerSession : IDisposable
             {
                 _stopped = true;
                 _session.Stop();
+                _processing.Wait();
                 _session.Dispose();
                 _eventSource.Dispose();
             }


### PR DESCRIPTION
This was reproducible on Linux in our tests, although they did not fail:

```
error: There is no currently active test.
    Test: Sentry.Profiling.Tests.SamplingTransactionProfilerTests.EventPipeSession_ReceivesExpectedCLREvents
    Message: [Warning 00:00:01.05]: Error during sampler profiler EventPipeSession processing.
    Exception: System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'Microsoft.Diagnostics.NETCore.Client.ExposedSocketNetworkStream'.
   at System.Net.Sockets.NetworkStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at FastSerialization.IOStreamStreamReader.Fill(Int32 minimum) in /home/ivan/dev/sentry-dotnet/modules/perfview/src/FastSerialization/StreamReaderWriter.cs:line 872
   at FastSerialization.MemoryStreamReader.ReadByte() in /home/ivan/dev/sentry-dotnet/modules/perfview/src/FastSerialization/StreamReaderWriter.cs:line 79
   at FastSerialization.Deserializer.ReadTag() in /home/ivan/dev/sentry-dotnet/modules/perfview/src/FastSerialization/FastSerialization.cs:line 2139
   at FastSerialization.Deserializer.FindEndTag(SerializationType type, IFastSerializable objectBeingDeserialized) in /home/ivan/dev/sentry-dotnet/modules/perfview/src/FastSerialization/FastSerialization.cs:line 2037
   at FastSerialization.Deserializer.ReadObjectDefinition(Tags tag, StreamLabel objectLabel) in /home/ivan/dev/sentry-dotnet/modules/perfview/src/FastSerialization/FastSerialization.cs:line 1964
   at FastSerialization.Deserializer.ReadObject() in /home/ivan/dev/sentry-dotnet/modules/perfview/src/FastSerialization/FastSerialization.cs:line 1411
   at Microsoft.Diagnostics.Tracing.EventPipeEventSource.Process() in /home/ivan/dev/sentry-dotnet/modules/perfview/src/TraceEvent/EventPipe/EventPipeEventSource.cs:line 160
   at Microsoft.Diagnostics.Tracing.Etlx.TraceLogEventSource.Process() in /home/ivan/dev/sentry-dotnet/modules/perfview/src/TraceEvent/TraceLog.cs:line 4519
   at System.Threading.Tasks.Task`1.InnerInvoke()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)

```

#skip-changelog