### PR TITLE
WIP: Unsampled Transactions to reduce memory pressure

### DIFF
--- a/src/Sentry/Internal/NoOpSpan.cs
+++ b/src/Sentry/Internal/NoOpSpan.cs
@@ -13,10 +13,10 @@ internal class NoOpSpan : ISpan
     {
     }
 
-    public SpanId SpanId => SpanId.Empty;
+    public virtual SpanId SpanId => SpanId.Empty;
     public SpanId? ParentSpanId => SpanId.Empty;
-    public SentryId TraceId => SentryId.Empty;
-    public bool? IsSampled => default;
+    public virtual SentryId TraceId => SentryId.Empty;
+    public virtual bool? IsSampled => default;
     public IReadOnlyDictionary<string, string> Tags => ImmutableDictionary<string, string>.Empty;
     public IReadOnlyDictionary<string, object?> Extra => ImmutableDictionary<string, object?>.Empty;
     public IReadOnlyDictionary<string, object?> Data => ImmutableDictionary<string, object?>.Empty;
@@ -24,7 +24,7 @@ internal class NoOpSpan : ISpan
     public DateTimeOffset? EndTimestamp => default;
     public bool IsFinished => default;
 
-    public string Operation
+    public virtual string Operation
     {
         get => string.Empty;
         set { }
@@ -42,21 +42,21 @@ internal class NoOpSpan : ISpan
         set { }
     }
 
-    public ISpan StartChild(string operation) => this;
+    public virtual ISpan StartChild(string operation) => this;
 
-    public void Finish()
+    public virtual void Finish()
     {
     }
 
-    public void Finish(SpanStatus status)
+    public virtual void Finish(SpanStatus status)
     {
     }
 
-    public void Finish(Exception exception, SpanStatus status)
+    public virtual void Finish(Exception exception, SpanStatus status)
     {
     }
 
-    public void Finish(Exception exception)
+    public virtual void Finish(Exception exception)
     {
     }
 
@@ -76,7 +76,7 @@ internal class NoOpSpan : ISpan
     {
     }
 
-    public SentryTraceHeader GetTraceHeader() => SentryTraceHeader.Empty;
+    public virtual SentryTraceHeader GetTraceHeader() => SentryTraceHeader.Empty;
 
     public IReadOnlyDictionary<string, Measurement> Measurements => ImmutableDictionary<string, Measurement>.Empty;
 

--- a/src/Sentry/Internal/NoOpTransaction.cs
+++ b/src/Sentry/Internal/NoOpTransaction.cs
@@ -7,13 +7,13 @@ internal class NoOpTransaction : NoOpSpan, ITransactionTracer
 {
     public new static ITransactionTracer Instance { get; } = new NoOpTransaction();
 
-    private NoOpTransaction()
+    protected NoOpTransaction()
     {
     }
 
     public SdkVersion Sdk => SdkVersion.Instance;
 
-    public string Name
+    public virtual string Name
     {
         get => string.Empty;
         set { }
@@ -87,7 +87,7 @@ internal class NoOpTransaction : NoOpSpan, ITransactionTracer
         set { }
     }
 
-    public IReadOnlyCollection<ISpan> Spans => ImmutableList<ISpan>.Empty;
+    public virtual IReadOnlyCollection<ISpan> Spans => ImmutableList<ISpan>.Empty;
 
     public IReadOnlyCollection<Breadcrumb> Breadcrumbs => ImmutableList<Breadcrumb>.Empty;
 

--- a/src/Sentry/Internal/UnsampledTransaction.cs
+++ b/src/Sentry/Internal/UnsampledTransaction.cs
@@ -76,7 +76,7 @@ internal sealed class UnsampledTransaction : NoOpTransaction
         return span;
     }
 
-    private  class UnsampledSpan(UnsampledTransaction transaction) : NoOpSpan
+    private class UnsampledSpan(UnsampledTransaction transaction) : NoOpSpan
     {
         public override ISpan StartChild(string operation) => transaction.StartChild(operation);
     }

--- a/src/Sentry/Internal/UnsampledTransaction.cs
+++ b/src/Sentry/Internal/UnsampledTransaction.cs
@@ -1,0 +1,83 @@
+using Sentry.Extensibility;
+
+namespace Sentry.Internal;
+
+/// <summary>
+/// We know already, when starting a transaction, whether it's going to be sampled or not. When it's not sampled, we can
+/// avoid lots of unecessary processing. The only thing we need to track is the number of spans that would have been
+/// created (the client reports detailing discarded events includes this detail).
+/// </summary>
+internal sealed class UnsampledTransaction : NoOpTransaction
+{
+    // Although it's a little bit wasteful to create separate individual class instances here when all we're going to
+    // report to sentry is the span count (in the client report), SDK users may refer to things like
+    // `ITransaction.Spans.Count`, so we create an actual collection
+    private readonly ConcurrentBag<ISpan> _spans = [];
+    private readonly IHub _hub;
+    private readonly ITransactionContext _context;
+    private readonly SentryOptions? _options;
+
+    public UnsampledTransaction(IHub hub, ITransactionContext context)
+    {
+        _hub = hub;
+        _options = _hub.GetSentryOptions();
+        _options?.LogDebug("Starting unsampled transaction");
+        _context = context;
+    }
+
+    internal DynamicSamplingContext? DynamicSamplingContext { get; set; }
+
+    public override IReadOnlyCollection<ISpan> Spans => _spans;
+
+    public override SpanId SpanId => _context.SpanId;
+    public override SentryId TraceId => _context.TraceId;
+    public override bool? IsSampled => false;
+
+    public override string Name
+    {
+        get => _context.Name;
+        set { }
+    }
+
+    public override string Operation
+    {
+        get => _context.Operation;
+        set { }
+    }
+
+    public override void Finish()
+    {
+        _options?.LogDebug("Finishing unsampled transaction");
+
+        // Clear the transaction from the scope
+        _hub.ConfigureScope(scope => scope.ResetTransaction(this));
+
+        // Record the discarded events
+        var spanCount = Spans.Count + 1; // 1 for each span + 1 for the transaction itself
+        _options?.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.SampleRate, DataCategory.Transaction);
+        _options?.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.SampleRate, DataCategory.Span, spanCount);
+
+        _options?.LogDebug("Finished unsampled transaction");
+    }
+
+    public override void Finish(SpanStatus status) => Finish();
+
+    public override void Finish(Exception exception, SpanStatus status) => Finish();
+
+    public override void Finish(Exception exception) => Finish();
+
+    /// <inheritdoc />
+    public override SentryTraceHeader GetTraceHeader() => new(TraceId, SpanId, IsSampled);
+
+    public override ISpan StartChild(string operation)
+    {
+        var span = new UnsampledSpan(this);
+        _spans.Add(span);
+        return span;
+    }
+
+    private  class UnsampledSpan(UnsampledTransaction transaction) : NoOpSpan
+    {
+        public override ISpan StartChild(string operation) => transaction.StartChild(operation);
+    }
+}


### PR DESCRIPTION
WIP... really needs to be done after https://github.com/getsentry/sentry-dotnet/pull/3951 gets merged as it's fiddling with the same sections of code (and needs to take into account the sample_rand etc. as well). 

Not sure if this is worth finishing since we eventually plan to get rid of transactions entirely. 