### PR TITLE
feat: Added `SentrySdk.CrashedLastRun`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Features
+
+- Added `SentrySdk.CrashedLastRun()`. Users can now retrieve the `LastRunState` ([#4025](https://github.com/getsentry/sentry-dotnet/pull/4025))
+
 ### Fixes
 
 - Using SentryOptions.Native.SuppressExcBadAccess and SentryOptions.Native.SuppressSignalAborts, users can now block duplicate errors from native due to dotnet NullReferenceExceptions - Defaults to false ([#3998](https://github.com/getsentry/sentry-dotnet/pull/3998))

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -198,6 +198,12 @@ public class DisabledHub : IHub, IDisposable
         => SentryId.Empty;
 
     /// <summary>
+    /// No-Op
+    /// </summary>
+    public CrashedLastRun CrashedLastRun()
+        => Sentry.CrashedLastRun.Unknown;
+
+    /// <summary>
     /// No-Op.
     /// </summary>
     public Task FlushAsync(TimeSpan timeout) => Task.CompletedTask;

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -288,6 +288,12 @@ public sealed class HubAdapter : IHub
         => SentrySdk.CaptureCheckIn(monitorSlug, status, sentryId, duration, scope, monitorOptions);
 
     /// <summary>
+    /// Forwards the call to <see cref="SentrySdk"/>.
+    /// </summary>
+    public CrashedLastRun CrashedLastRun()
+        => SentrySdk.CrashedLastRun();
+
+    /// <summary>
     /// Forwards the call to <see cref="SentrySdk"/>
     /// </summary>
     [DebuggerStepThrough]

--- a/src/Sentry/IHub.cs
+++ b/src/Sentry/IHub.cs
@@ -116,4 +116,11 @@ public interface IHub : ISentryClient, ISentryScopeManager
     /// <param name="configureScope">The callback to configure the scope.</param>
     /// <returns></returns>
     public SentryId CaptureEvent(SentryEvent evt, SentryHint? hint, Action<Scope> configureScope);
+
+    /// <summary>
+    /// Retrieves the crash state of the previous application run.
+    /// This indicates whether the application terminated normally or crashed.
+    /// </summary>
+    /// <returns><see cref="CrashedLastRun"/> indicating the state of the previous run.</returns>
+    public CrashedLastRun CrashedLastRun();
 }

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -679,6 +679,26 @@ internal class Hub : IHub, IDisposable
         return SentryId.Empty;
     }
 
+
+    public CrashedLastRun CrashedLastRun()
+    {
+        if (!IsEnabled)
+        {
+            return Sentry.CrashedLastRun.Unknown;
+        }
+
+        if (_options.CrashedLastRun is null)
+        {
+            _options.DiagnosticLogger?.LogDebug("The SDK does not have a 'CrashedLastRun' set. " +
+                                                "This might be due to a missing or disabled native integration.");
+            return Sentry.CrashedLastRun.Unknown;
+        }
+
+        return _options.CrashedLastRun.Invoke()
+            ? Sentry.CrashedLastRun.Crashed
+            : Sentry.CrashedLastRun.DidNotCrash;
+    }
+
     public async Task FlushAsync(TimeSpan timeout)
     {
         try

--- a/src/Sentry/LastRunState.cs
+++ b/src/Sentry/LastRunState.cs
@@ -1,0 +1,24 @@
+namespace Sentry;
+
+/// <summary>
+/// Represents the crash state of the games's previous run.
+/// Used to determine if the last execution terminated normally or crashed.
+/// </summary>
+public enum CrashedLastRun
+{
+    /// <summary>
+    /// The LastRunState is unknown. This might be due to the SDK not being initialized, native crash support
+    /// missing, or being disabled.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// The application did not crash during the last run.
+    /// </summary>
+    DidNotCrash,
+
+    /// <summary>
+    /// The application crashed during the last run.
+    /// </summary>
+    Crashed
+}

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -705,6 +705,11 @@ public static partial class SentrySdk
     public static void ResumeSession()
         => CurrentHub.ResumeSession();
 
+    /// <inheritdoc cref="IHub.CrashedLastRun"/>
+    [DebuggerStepThrough]
+    public static CrashedLastRun CrashedLastRun()
+        => CurrentHub.CrashedLastRun();
+
     /// <summary>
     /// Deliberately crashes an application, which is useful for testing and demonstration purposes.
     /// </summary>

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -75,6 +75,12 @@ namespace Sentry
         ManagedBackgroundThread = 1,
         Native = 2,
     }
+    public enum CrashedLastRun
+    {
+        Unknown = 0,
+        DidNotCrash = 1,
+        Crashed = 2,
+    }
     [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
     public class Debouncer
     {
@@ -214,6 +220,7 @@ namespace Sentry
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope);
         Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null);
         Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null);
+        Sentry.CrashedLastRun CrashedLastRun();
         void EndSession(Sentry.SessionEndStatus status = 0);
         Sentry.BaggageHeader? GetBaggage();
         Sentry.ISpan? GetSpan();
@@ -841,6 +848,7 @@ namespace Sentry
         public static System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public static Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
         public static Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
+        public static Sentry.CrashedLastRun CrashedLastRun() { }
         public static void EndSession(Sentry.SessionEndStatus status = 0) { }
         public static void Flush() { }
         public static void Flush(System.TimeSpan timeout) { }
@@ -1342,6 +1350,7 @@ namespace Sentry.Extensibility
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
         public Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
+        public Sentry.CrashedLastRun CrashedLastRun() { }
         public void Dispose() { }
         public void EndSession(Sentry.SessionEndStatus status = 0) { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
@@ -1388,6 +1397,7 @@ namespace Sentry.Extensibility
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
         public Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
+        public Sentry.CrashedLastRun CrashedLastRun() { }
         public void EndSession(Sentry.SessionEndStatus status = 0) { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
         public Sentry.BaggageHeader? GetBaggage() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -75,6 +75,12 @@ namespace Sentry
         ManagedBackgroundThread = 1,
         Native = 2,
     }
+    public enum CrashedLastRun
+    {
+        Unknown = 0,
+        DidNotCrash = 1,
+        Crashed = 2,
+    }
     [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
     public class Debouncer
     {
@@ -214,6 +220,7 @@ namespace Sentry
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope);
         Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null);
         Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null);
+        Sentry.CrashedLastRun CrashedLastRun();
         void EndSession(Sentry.SessionEndStatus status = 0);
         Sentry.BaggageHeader? GetBaggage();
         Sentry.ISpan? GetSpan();
@@ -841,6 +848,7 @@ namespace Sentry
         public static System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public static Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
         public static Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
+        public static Sentry.CrashedLastRun CrashedLastRun() { }
         public static void EndSession(Sentry.SessionEndStatus status = 0) { }
         public static void Flush() { }
         public static void Flush(System.TimeSpan timeout) { }
@@ -1342,6 +1350,7 @@ namespace Sentry.Extensibility
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
         public Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
+        public Sentry.CrashedLastRun CrashedLastRun() { }
         public void Dispose() { }
         public void EndSession(Sentry.SessionEndStatus status = 0) { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
@@ -1388,6 +1397,7 @@ namespace Sentry.Extensibility
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
         public Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
+        public Sentry.CrashedLastRun CrashedLastRun() { }
         public void EndSession(Sentry.SessionEndStatus status = 0) { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
         public Sentry.BaggageHeader? GetBaggage() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -74,6 +74,12 @@ namespace Sentry
         Managed = 0,
         ManagedBackgroundThread = 1,
     }
+    public enum CrashedLastRun
+    {
+        Unknown = 0,
+        DidNotCrash = 1,
+        Crashed = 2,
+    }
     [System.Flags]
     public enum DeduplicateMode
     {
@@ -202,6 +208,7 @@ namespace Sentry
         Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope);
         Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null);
         Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null);
+        Sentry.CrashedLastRun CrashedLastRun();
         void EndSession(Sentry.SessionEndStatus status = 0);
         Sentry.BaggageHeader? GetBaggage();
         Sentry.ISpan? GetSpan();
@@ -822,6 +829,7 @@ namespace Sentry
         public static System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public static Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
         public static Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
+        public static Sentry.CrashedLastRun CrashedLastRun() { }
         public static void EndSession(Sentry.SessionEndStatus status = 0) { }
         public static void Flush() { }
         public static void Flush(System.TimeSpan timeout) { }
@@ -1323,6 +1331,7 @@ namespace Sentry.Extensibility
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
         public Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
+        public Sentry.CrashedLastRun CrashedLastRun() { }
         public void Dispose() { }
         public void EndSession(Sentry.SessionEndStatus status = 0) { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
@@ -1369,6 +1378,7 @@ namespace Sentry.Extensibility
         public System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope) { }
         public Sentry.TransactionContext ContinueTrace(Sentry.SentryTraceHeader? traceHeader, Sentry.BaggageHeader? baggageHeader, string? name = null, string? operation = null) { }
         public Sentry.TransactionContext ContinueTrace(string? traceHeader, string? baggageHeader, string? name = null, string? operation = null) { }
+        public Sentry.CrashedLastRun CrashedLastRun() { }
         public void EndSession(Sentry.SessionEndStatus status = 0) { }
         public System.Threading.Tasks.Task FlushAsync(System.TimeSpan timeout) { }
         public Sentry.BaggageHeader? GetBaggage() { }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1706,6 +1706,73 @@ public partial class HubTests
         _fixture.Client.Received().CaptureTransaction(Arg.Any<SentryTransaction>(), Arg.Any<Scope>(), Arg.Any<SentryHint>());
     }
 
+    [Fact]
+    public void GetLastRunState_WithoutInit_ReturnsUnknown()
+    {
+        // Make sure SDK is closed
+        SentrySdk.Close();
+
+        // Act
+        var result = SentrySdk.CrashedLastRun();
+
+        // Assert
+        Assert.Equal(CrashedLastRun.Unknown, result);
+    }
+
+    [Fact]
+    public void GetLastRunState_WhenCrashed_ReturnsCrashed()
+    {
+        // Arrange
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            CrashedLastRun = () => true // Mock crashed state
+        };
+
+        // Act
+        SentrySdk.Init(options);
+        var result = SentrySdk.CrashedLastRun();
+
+        // Assert
+        Assert.Equal(CrashedLastRun.Crashed, result);
+    }
+
+    [Fact]
+    public void GetLastRunState_WhenNotCrashed_ReturnsDidNotCrash()
+    {
+        // Arrange
+        var options = new SentryOptions()
+        {
+            Dsn = ValidDsn,
+            CrashedLastRun = () => false // Mock non-crashed state
+        };
+
+        // Act
+        SentrySdk.Init(options);
+        var result = SentrySdk.CrashedLastRun();
+
+        // Assert
+        Assert.Equal(CrashedLastRun.DidNotCrash, result);
+    }
+
+    [Fact]
+    public void GetLastRunState_WithNullDelegate_ReturnsUnknown()
+    {
+        // Arrange
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            CrashedLastRun = null // Explicitly set to null
+        };
+
+        // Act
+        SentrySdk.Init(options);
+        var result = SentrySdk.CrashedLastRun();
+
+        // Assert
+        Assert.Equal(CrashedLastRun.Unknown, result);
+    }
+
     [SkippableTheory]
     [InlineData(false)]
     [InlineData(true)]


### PR DESCRIPTION
This came up through user feedback looking for functionality similar to AppCenter's `Crashes.GetLastSessionCrashReportAsync()`.

Snippet on how to consume the API
```
// This assumes that the SDK is already initialized and that he SDK has already set 
// up the native scope sync - it will return `Unknown` otherwise
var lastRunState = SentrySdk.CrashedLastRun();

switch (lastRunState)
{
    case Sentry.LastRunState.Crashed:
        // Perform recovery actions or show user message.
        break;
        
    case Sentry.LastRunState.DidNotCrash:
        // Operate normally
        break;
        
    case Sentry.LastRunState.Unknown:
        // The SDK was either not initialized or does not have access to the native layer
        break;
}
```

Also resolves https://github.com/getsentry/sentry-unity/issues/741