### PR TITLE
Add Exception HResult to mechanism data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - User Feedback can now be captured without errors/exceptions. Note that these APIs replace the older UserFeedback APIs, which have now been marked as obsolete (and will be removed in a future major version bump) ([#3981](https://github.com/getsentry/sentry-dotnet/pull/3981))
+- Exception.HResult is now included in the mechanism data for all exceptions ([#4029](https://github.com/getsentry/sentry-dotnet/pull/4029))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Exception.HResult is now included in the mechanism data for all exceptions ([#4029](https://github.com/getsentry/sentry-dotnet/pull/4029))
+
 ## 5.3.0
 
 ### Features
 
 - User Feedback can now be captured without errors/exceptions. Note that these APIs replace the older UserFeedback APIs, which have now been marked as obsolete (and will be removed in a future major version bump) ([#3981](https://github.com/getsentry/sentry-dotnet/pull/3981))
-- Exception.HResult is now included in the mechanism data for all exceptions ([#4029](https://github.com/getsentry/sentry-dotnet/pull/4029))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## 5.4.0
+## Unreleased
 
 ### Features
 
 - Exception.HResult is now included in the mechanism data for all exceptions ([#4029](https://github.com/getsentry/sentry-dotnet/pull/4029))
+
+## 5.4.0
+
+### Enhancements
+
 - Profiling: improve performance by subscribing only to necessary CLR events ([#3970](https://github.com/getsentry/sentry-dotnet/pull/3970))
 
 ### Fixes

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -199,6 +199,9 @@ internal class MainExceptionProcessor : ISentryEventExceptionProcessor
             exception.Data.Remove(Mechanism.DescriptionKey);
         }
 
+        // Add HResult to mechanism data before adding exception data, so that it can be overridden.
+        mechanism.Data["HResult"] = $"0x{exception.HResult:X8}";
+
         // Copy remaining exception data to mechanism data.
         foreach (var key in exception.Data.Keys.OfType<string>())
         {

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet8_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet8_0.verified.txt
@@ -10,7 +10,15 @@
       SentryExceptions: [
         {
           Type: System.Exception,
-          Value: my exception
+          Value: my exception,
+          Mechanism: {
+            Type: generic,
+            Synthetic: false,
+            IsExceptionGroup: false,
+            Data: {
+              HResult: 0x80131500
+            }
+          }
         }
       ],
       Level: error,

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet9_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet9_0.verified.txt
@@ -10,7 +10,15 @@
       SentryExceptions: [
         {
           Type: System.Exception,
-          Value: my exception
+          Value: my exception,
+          Mechanism: {
+            Type: generic,
+            Synthetic: false,
+            IsExceptionGroup: false,
+            Data: {
+              HResult: 0x80131500
+            }
+          }
         }
       ],
       Level: error,

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.Net4_8.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.Net4_8.verified.txt
@@ -10,7 +10,15 @@
       SentryExceptions: [
         {
           Type: System.Exception,
-          Value: my exception
+          Value: my exception,
+          Mechanism: {
+            Type: generic,
+            Synthetic: false,
+            IsExceptionGroup: false,
+            Data: {
+              HResult: 0x80131500
+            }
+          }
         }
       ],
       Level: error,

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsSqlAsync.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsSqlAsync.verified.txt
@@ -10,7 +10,15 @@
       SentryExceptions: [
         {
           Type: System.Exception,
-          Value: my exception
+          Value: my exception,
+          Mechanism: {
+            Type: generic,
+            Synthetic: false,
+            IsExceptionGroup: false,
+            Data: {
+              HResult: 0x80131500
+            }
+          }
         }
       ],
       Level: error,

--- a/test/Sentry.EntityFramework.Tests/IntegrationTests.Simple.verified.txt
+++ b/test/Sentry.EntityFramework.Tests/IntegrationTests.Simple.verified.txt
@@ -10,7 +10,15 @@
       SentryExceptions: [
         {
           Type: System.Exception,
-          Value: my exception
+          Value: my exception,
+          Mechanism: {
+            Type: generic,
+            Synthetic: false,
+            IsExceptionGroup: false,
+            Data: {
+              HResult: 0x80131500
+            }
+          }
         }
       ],
       Level: error,

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
@@ -59,7 +59,10 @@
                   Type: generic,
                   Handled: true,
                   Synthetic: false,
-                  IsExceptionGroup: false
+                  IsExceptionGroup: false,
+                  Data: {
+                    HResult: 0x80131500
+                  }
                 }
               }
             ],

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet9_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.DotNet9_0.verified.txt
@@ -59,7 +59,10 @@
                   Type: generic,
                   Handled: true,
                   Synthetic: false,
-                  IsExceptionGroup: false
+                  IsExceptionGroup: false,
+                  Data: {
+                    HResult: 0x80131500
+                  }
                 }
               }
             ],

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.Mono4_0.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.Mono4_0.verified.txt
@@ -59,7 +59,10 @@
                   Type: generic,
                   Handled: true,
                   Synthetic: false,
-                  IsExceptionGroup: false
+                  IsExceptionGroup: false,
+                  Data: {
+                    HResult: 0x80131500
+                  }
                 }
               }
             ],

--- a/test/Sentry.NLog.Tests/IntegrationTests.Simple.Net4_8.verified.txt
+++ b/test/Sentry.NLog.Tests/IntegrationTests.Simple.Net4_8.verified.txt
@@ -59,7 +59,10 @@
                   Type: generic,
                   Handled: true,
                   Synthetic: false,
-                  IsExceptionGroup: false
+                  IsExceptionGroup: false,
+                  Data: {
+                    HResult: 0x80131500
+                  }
                 }
               }
             ],

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet8_0.verified.txt
@@ -224,7 +224,8 @@
                   Synthetic: false,
                   IsExceptionGroup: false,
                   Data: {
-                    details: Do work always throws.
+                    details: Do work always throws.,
+                    HResult: 0x80131500
                   }
                 }
               }

--- a/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet9_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/IntegrationTests.Simple.DotNet9_0.verified.txt
@@ -224,7 +224,8 @@
                   Synthetic: false,
                   IsExceptionGroup: false,
                   Data: {
-                    details: Do work always throws.
+                    details: Do work always throws.,
+                    HResult: 0x80131500
                   }
                 }
               }

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate.verified.txt
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate.verified.txt
@@ -8,7 +8,10 @@
       Synthetic: false,
       IsExceptionGroup: false,
       ExceptionId: 2,
-      ParentId: 0
+      ParentId: 0,
+      Data: {
+        HResult: 0x80131500
+      }
     }
   },
   {
@@ -20,7 +23,10 @@
       Synthetic: false,
       IsExceptionGroup: false,
       ExceptionId: 1,
-      ParentId: 0
+      ParentId: 0,
+      Data: {
+        HResult: 0x80131500
+      }
     }
   },
   {
@@ -33,7 +39,8 @@
       IsExceptionGroup: true,
       ExceptionId: 0,
       Data: {
-        foo: bar
+        foo: bar,
+        HResult: 0x80131500
       }
     }
   }


### PR DESCRIPTION
Resolves #3939

### Example

This is an example of the event that gets captured by the Sentry.Samples.Console.Basic demo. You can see the `HResult` along with the other mechanism data at the bottom of the screenshot:
<img width="616" alt="image" src="https://github.com/user-attachments/assets/73fe2b22-2651-470e-bc2b-b00d0121e500" />
