### PR TITLE
target net9 on gcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Target `net9.0` on Sentry.Google.Cloud.Functions to avoid conflict with Sentry.AspNetCore ([#4039](https://github.com/getsentry/sentry-dotnet/pull/4039))
+
 ## 5.4.0
 
 ### Enhancements

--- a/src/Sentry.Google.Cloud.Functions/Sentry.Google.Cloud.Functions.csproj
+++ b/src/Sentry.Google.Cloud.Functions/Sentry.Google.Cloud.Functions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <PackageTags>$(PackageTags);GCP;Google Cloud Functions</PackageTags>
     <Description>Official Google Cloud Functions integration for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
   </PropertyGroup>
@@ -14,7 +14,13 @@
   <ItemGroup>
     <ProjectReference Include="..\Sentry.AspNetCore\Sentry.AspNetCore.csproj" />
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Sentry.Google.Cloud.Functions.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Google.Cloud.Functions.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -1,0 +1,10 @@
+﻿namespace Google.Cloud.Functions.Framework
+{
+    public class SentryStartup : Google.Cloud.Functions.Hosting.FunctionsStartup
+    {
+        public SentryStartup() { }
+        public override void Configure(Microsoft.AspNetCore.Hosting.WebHostBuilderContext context, Microsoft.AspNetCore.Builder.IApplicationBuilder app) { }
+        public override void ConfigureLogging(Microsoft.AspNetCore.Hosting.WebHostBuilderContext context, Microsoft.Extensions.Logging.ILoggingBuilder logging) { }
+        public override void ConfigureServices(Microsoft.AspNetCore.Hosting.WebHostBuilderContext context, Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+    }
+}

--- a/test/Sentry.Google.Cloud.Functions.Tests/Sentry.Google.Cloud.Functions.Tests.csproj
+++ b/test/Sentry.Google.Cloud.Functions.Tests/Sentry.Google.Cloud.Functions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Sentry.MauiTrimTest/Platforms/MacCatalyst/Program.cs
+++ b/test/Sentry.MauiTrimTest/Platforms/MacCatalyst/Program.cs
@@ -1,4 +1,4 @@
-﻿using ObjCRuntime;
+using ObjCRuntime;
 using UIKit;
 
 namespace Sentry.MauiTrimTest;


### PR DESCRIPTION

```
Error NU1605 : Warning As Error: Detected package downgrade: Microsoft.Extensions.Configuration.Binder from 9.0.0 to 8.0.0. Reference the package directly from the project to select a different version. 
 Sentaur.Leaderboard.AntiCheat -> Sentry.Google.Cloud.Functions 5.4.0 -> Sentry.AspNetCore 5.4.0 -> Microsoft.Extensions.Configuration.Binder (>= 9.0.0) 
 Sentaur.Leaderboard.AntiCheat -> Sentry.Google.Cloud.Functions 5.4.0 -> Microsoft.Extensions.Configuration.Binder (>= 8.0.0)
```

Many papercuts when trying to spare targeting the latest on some packages.

I had stuff like this in the past and settled on bumping everything. Somehow went back into "lets skip less important packages" but truth is that it's painful if you add multiple Sentry packages to the same app.