### PR TITLE
chore(deps): update Java SDK to v8.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 - Bump CLI from v2.42.2 to v2.43.0 ([#4036](https://github.com/getsentry/sentry-dotnet/pull/4036), [#4049](https://github.com/getsentry/sentry-dotnet/pull/4049), [#4060](https://github.com/getsentry/sentry-dotnet/pull/4060), [#4062](https://github.com/getsentry/sentry-dotnet/pull/4062))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2430)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.42.2...2.43.0)
+- Bump Java SDK from v7.20.1 to v8.6.0 ([#4075](https://github.com/getsentry/sentry-dotnet/pull/4075))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#860)
+  - [diff](https://github.com/getsentry/sentry-java/compare/7.20.1...8.6.0)
 
 ## 5.4.0
 

--- a/integration-test/cli.Tests.ps1
+++ b/integration-test/cli.Tests.ps1
@@ -165,7 +165,7 @@ Describe 'MAUI' -ForEach @(
             'maui-app.pdb'
         )
         $result.ScriptOutput | Should -AnyElementMatch 'Uploaded a total of 1 new mapping files'
-        $result.ScriptOutput | Should -AnyElementMatch 'Found 17 debug information files \(1 with embedded sources\)'
+        $result.ScriptOutput | Should -AnyElementMatch 'Found 25 debug information files \(1 with embedded sources\)'
     }
 
     It "uploads symbols and sources for an iOS build" -Skip:(!$IsMacOS) {

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -3,8 +3,9 @@
     <TargetFrameworks>net8.0-android34.0</TargetFrameworks>
     <!-- BG8605 and BG8606 happen because there's a missing androidx.lifecycle dependency, but we don't need it here.  (The native Android Sentry SDK will use it if it exists.) -->
     <NoWarn>$(NoWarn);BG8605;BG8606</NoWarn>
-    <SentryAndroidSdkVersion>7.20.1</SentryAndroidSdkVersion>
+    <SentryAndroidSdkVersion>8.6.0</SentryAndroidSdkVersion>
     <SentryAndroidSdkDirectory>$(BaseIntermediateOutputPath)sdks\Sentry\Android\$(SentryAndroidSdkVersion)\</SentryAndroidSdkDirectory>
+    <SentryNativeNdkVersion></SentryNativeNdkVersion>
     <Description>.NET Bindings for the Sentry Android SDK</Description>
   </PropertyGroup>
 
@@ -40,7 +41,7 @@
     <AndroidNativeLibrary Include="..\..\lib\sentrysupplemental\bin\x86_64\libsentrysupplemental.so" Abi="x86_64" />
   </ItemGroup>
 
-  <Target Name="DownloadSentryAndroidSdk" BeforeTargets="CollectPackageReferences">
+  <Target Name="DownloadSentryAndroidSdk" BeforeTargets="ResolveAssemblyReferences">
     <DownloadFile
       SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-core/$(SentryAndroidSdkVersion)/sentry-android-core-$(SentryAndroidSdkVersion).aar"
       DestinationFolder="$(SentryAndroidSdkDirectory)"
@@ -59,6 +60,40 @@
       Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-$(SentryAndroidSdkVersion).jar')"
       Retries="3"
     />
+    <!-- Download the POM file -->
+    <DownloadFile
+      SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-ndk/$(SentryAndroidSdkVersion)/sentry-android-ndk-$(SentryAndroidSdkVersion).pom"
+      DestinationFolder="$(SentryAndroidSdkDirectory)"
+      Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).pom')"
+      Retries="3"
+    />
+    
+    <!-- Read the POM file and extract the sentry-native-ndk version -->
+    <XmlPeek
+      XmlInputPath="$(SentryAndroidSdkDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).pom"
+      Query="//*[local-name()='dependency' and .//*[local-name()='artifactId' and text()='sentry-native-ndk']]/*[local-name()='version']/text()"
+      Condition="Exists('$(SentryAndroidSdkDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).pom')">
+      <Output TaskParameter="Result" PropertyName="SentryNativeNdkVersion" />
+    </XmlPeek>
+    
+    <Message Text="Found Sentry Native NDK version: $(SentryNativeNdkVersion)" Importance="high" 
+             Condition="'$(SentryNativeNdkVersion)' != ''" />
+    
+    <!-- Download the sentry-native-ndk dependency if version was found -->
+    <DownloadFile
+      SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-native-ndk/$(SentryNativeNdkVersion)/sentry-native-ndk-$(SentryNativeNdkVersion).aar"
+      DestinationFolder="$(SentryAndroidSdkDirectory)"
+      Condition="'$(SentryNativeNdkVersion)' != '' And !Exists('$(SentryAndroidSdkDirectory)sentry-native-ndk-$(SentryNativeNdkVersion).aar')"
+      Retries="3"
+    />
+    
+    <!-- Create an item for the downloaded sentry-native-ndk -->
+    <ItemGroup Condition="'$(SentryNativeNdkVersion)' != ''">
+      <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-native-ndk-$(SentryNativeNdkVersion).aar" />
+    </ItemGroup>
   </Target>
+
+  <!-- Add support for XmlPeek task -->
+  <UsingTask TaskName="XmlPeek" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
 
 </Project>

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -5,6 +5,7 @@
     <NoWarn>$(NoWarn);BG8605;BG8606</NoWarn>
     <SentryAndroidSdkVersion>8.6.0</SentryAndroidSdkVersion>
     <SentryAndroidSdkDirectory>$(BaseIntermediateOutputPath)sdks\Sentry\Android\$(SentryAndroidSdkVersion)\</SentryAndroidSdkDirectory>
+    <!-- This gets resolved by the DownloadSentryAndroidSdk target -->
     <SentryNativeNdkVersion></SentryNativeNdkVersion>
     <Description>.NET Bindings for the Sentry Android SDK</Description>
   </PropertyGroup>
@@ -41,7 +42,7 @@
     <AndroidNativeLibrary Include="..\..\lib\sentrysupplemental\bin\x86_64\libsentrysupplemental.so" Abi="x86_64" />
   </ItemGroup>
 
-  <Target Name="DownloadSentryAndroidSdk" BeforeTargets="ResolveAssemblyReferences">
+  <Target Name="DownloadSentryAndroidSdk" BeforeTargets="CollectPackageReferences">
     <DownloadFile
       SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-core/$(SentryAndroidSdkVersion)/sentry-android-core-$(SentryAndroidSdkVersion).aar"
       DestinationFolder="$(SentryAndroidSdkDirectory)"
@@ -60,7 +61,7 @@
       Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-$(SentryAndroidSdkVersion).jar')"
       Retries="3"
     />
-    <!-- Download the POM file -->
+    <!-- The native-ndk exists outside of the android-ndk now. We're downloading the POM file to get the version of the native-ndk. -->
     <DownloadFile
       SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-ndk/$(SentryAndroidSdkVersion)/sentry-android-ndk-$(SentryAndroidSdkVersion).pom"
       DestinationFolder="$(SentryAndroidSdkDirectory)"
@@ -68,7 +69,6 @@
       Retries="3"
     />
     
-    <!-- Read the POM file and extract the sentry-native-ndk version -->
     <XmlPeek
       XmlInputPath="$(SentryAndroidSdkDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).pom"
       Query="//*[local-name()='dependency' and .//*[local-name()='artifactId' and text()='sentry-native-ndk']]/*[local-name()='version']/text()"
@@ -76,10 +76,6 @@
       <Output TaskParameter="Result" PropertyName="SentryNativeNdkVersion" />
     </XmlPeek>
     
-    <Message Text="Found Sentry Native NDK version: $(SentryNativeNdkVersion)" Importance="high" 
-             Condition="'$(SentryNativeNdkVersion)' != ''" />
-    
-    <!-- Download the sentry-native-ndk dependency if version was found -->
     <DownloadFile
       SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-native-ndk/$(SentryNativeNdkVersion)/sentry-native-ndk-$(SentryNativeNdkVersion).aar"
       DestinationFolder="$(SentryAndroidSdkDirectory)"
@@ -87,13 +83,11 @@
       Retries="3"
     />
     
-    <!-- Create an item for the downloaded sentry-native-ndk -->
+    <!-- Since we're reading the version from the POM file, we need to create an item for the downloaded sentry-native-ndk -->
     <ItemGroup Condition="'$(SentryNativeNdkVersion)' != ''">
       <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-native-ndk-$(SentryNativeNdkVersion).aar" />
     </ItemGroup>
   </Target>
 
-  <!-- Add support for XmlPeek task -->
   <UsingTask TaskName="XmlPeek" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
-
 </Project>

--- a/src/Sentry.Bindings.Android/Transforms/Metadata.xml
+++ b/src/Sentry.Bindings.Android/Transforms/Metadata.xml
@@ -90,13 +90,8 @@
     This API uses FrameMetrics, which requires Android >= 24.0.  We currently target Android >= 21.0 which is the minimum supported by MAUI.
     AndroidProfiler is dependant on SentryFrameMetricsCollector
   -->
-  <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='SpanFrameMetricsCollector']/*" />
   <remove-node path="/api/package[@name='io.sentry.android.core.internal.util']/*[starts-with(@name,'SentryFrameMetricsCollector')]" />
   <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='AndroidProfiler']/*" />
-  <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='AndroidContinuousProfiler']/*" />
-
-  <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='SentryAndroidOptions']/method[@name='getFrameMetricsCollector']" />
-  <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='SentryAndroidOptions']/method[@name='setFrameMetricsCollector']" />
 
   <!-- Remove problematic classes for profiling that create a stack overflow during code generation, which appears as:
       error MSB6006: "dotnet" exited with code 134
@@ -113,7 +108,7 @@
   -->
   <remove-node path="/api/package[@name='io.sentry']/interface[@name='BackfillingEventProcessor']" />
   <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='AnrV2EventProcessor']" />
-
+  
   <!--
     SentryEvent.serialize() expects an parameter which implements IObjectWriter.
     JsonObjectWriter implements IObjectWriter in Java, but somehow this is not reflected in the generated binding.
@@ -153,4 +148,11 @@
   <remove-node path="/api/package[@name='io.sentry.exception']/class[@name='SentryEnvelopeException']" />
   <remove-node path="/api/package[@name='io.sentry.exception']/class[@name='SentryHttpClientException']" />
   <remove-node path="/api/package[@name='io.sentry.vendor.gson.stream']/class[@name='MalformedJsonException']" />
+
+  <!-- Remove CombinedContextsView.PutAll method due to conflicts when attempting to overwrite a method with the same name. -->
+  <remove-node path="/api/package[@name='io.sentry']/class[@name='CombinedContextsView']/method[@name='putAll']" />
+  <!-- Remove ISentryLifecycleToken.Close method due to conflicts with IAutoCloseable.Close due to having the same name. -->
+  <remove-node path="/api/package[@name='io.sentry']/interface[@name='ISentryLifecycleToken']/method[@name='close']" />
+  <!-- Remove QueueFile. The `.iterator` method has nullability issues -->
+  <remove-node path="/api/package[@name='io.sentry.cache.tape']/class[@name='QueueFile']" />
 </metadata>

--- a/src/Sentry.Bindings.Android/Transforms/Metadata.xml
+++ b/src/Sentry.Bindings.Android/Transforms/Metadata.xml
@@ -115,7 +115,6 @@
   <remove-node path="/api/package[@name='io.sentry']/class[@name='OutboxSender']" />
   <remove-node path="/api/package[@name='io.sentry.cache']/class[@name='EnvelopeCache']" />
   <remove-node path="/api/package[@name='io.sentry.android.core.cache']/class[@name='AndroidEnvelopeCache']" />
-  <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='TempSensorBreadcrumbsIntegration']" />
   <remove-node path="/api/package[@name='io.sentry.android.core.internal.gestures']" />
   <remove-node path="/api/package[@name='io.sentry.android.core.performance']" />
 

--- a/src/Sentry.Bindings.Android/Transforms/Metadata.xml
+++ b/src/Sentry.Bindings.Android/Transforms/Metadata.xml
@@ -64,8 +64,22 @@
   <attr path="/api/package[@name='io.sentry']/interface[@name='ObjectReader']/method[@name='dateOrNull']" name="visibility">internal</attr>
 
 
-    <!-- Fix missing compareTo(Object) methods on classes extending SentryDate. -->
+  <!-- Fix missing compareTo(Object) methods on classes extending SentryDate. -->
   <add-node path="/api/package[@name='io.sentry']/class[@extends='io.sentry.SentryDate']">
+    <method name="compareTo" return="int" abstract="false" native="false" synchronized="false" static="false" final="false" deprecated="not deprecated" visibility="public">
+        <parameter name="p0" type="java.lang.Object" />
+    </method>
+  </add-node>
+
+  <!-- Fix missing compareTo(Object) method for EventProcessorAndOrder-->
+  <add-node path="/api/package[@name='io.sentry.internal.eventprocessor']/class[@name='EventProcessorAndOrder']">
+    <method name="compareTo" return="int" abstract="false" native="false" synchronized="false" static="false" final="false" deprecated="not deprecated" visibility="public">
+        <parameter name="p0" type="java.lang.Object" />
+    </method>
+  </add-node>
+
+  <!-- Fix missing compareTo(Object) method for Breadcrumb -->
+  <add-node path="/api/package[@name='io.sentry']/class[@name='Breadcrumb']">
     <method name="compareTo" return="int" abstract="false" native="false" synchronized="false" static="false" final="false" deprecated="not deprecated" visibility="public">
         <parameter name="p0" type="java.lang.Object" />
     </method>
@@ -76,8 +90,20 @@
     This API uses FrameMetrics, which requires Android >= 24.0.  We currently target Android >= 21.0 which is the minimum supported by MAUI.
     AndroidProfiler is dependant on SentryFrameMetricsCollector
   -->
+  <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='SpanFrameMetricsCollector']/*" />
   <remove-node path="/api/package[@name='io.sentry.android.core.internal.util']/*[starts-with(@name,'SentryFrameMetricsCollector')]" />
   <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='AndroidProfiler']/*" />
+  <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='AndroidContinuousProfiler']/*" />
+
+  <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='SentryAndroidOptions']/method[@name='getFrameMetricsCollector']" />
+  <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='SentryAndroidOptions']/method[@name='setFrameMetricsCollector']" />
+
+  <!-- Remove problematic classes for profiling that create a stack overflow during code generation, which appears as:
+      error MSB6006: "dotnet" exited with code 134
+  -->
+  <remove-node path="/api/package[@name='io.sentry']/class[@name='ProfileChunk']" />
+  <remove-node path="/api/package[@name='io.sentry']/class[@name='ProfilingTraceData']" />
+  <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='AndroidProfiler']" />
 
   <!--
     The BackfillingEventProcessor interface creates a stack overflow during code generation, which appears as:
@@ -120,7 +146,7 @@
 
   <remove-node path="/api/package[starts-with(@name,'io.sentry')]/*/method[@name='clone' and count(parameter)=0]" />
   <remove-node path="/api/package[starts-with(@name,'io.sentry')]/class/implements[@name='io.sentry.JsonDeserializer']" />
-  <remove-node path="/api/package[@name='io.sentry.vendor.gson.stream']/class[@name='JsonToken']/field[@name='NAME']" />>
+  <remove-node path="/api/package[@name='io.sentry.vendor.gson.stream']/class[@name='JsonToken']/field[@name='NAME']" />
 
   <remove-node path="/api/package[@name='io.sentry.exception']/class[@name='ExceptionMechanismException']" />
   <remove-node path="/api/package[@name='io.sentry.exception']/class[@name='InvalidSentryTraceHeaderException']" />


### PR DESCRIPTION
Superseds https://github.com/getsentry/sentry-dotnet/pull/3911

The `sentry-native` NDK stuff [was moved](https://github.com/getsentry/sentry-java/pull/3189) from `sentry-java` to `sentry-native` and is no longer part of `android-ndk`. `sentry-native-ndk` has its own version and is now a dependency. This means we need to:
1. Download the accompanying `.pom` file for `android-ndk` from Maven
2. Read the dependency version
3. Download the correct version of `sentry-native-ndk`. 