### PR TITLE
Detect Sentry Java SDK dependencies during build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Sentry Java SDK dependencies are now detected and included in the Android bindings ([#4079](https://github.com/getsentry/sentry-dotnet/pull/4079))
+
 ## 5.5.0
 
 ### Features
@@ -563,7 +569,6 @@ Unable to load DLL sentry-native or one of its dependencies
 ### Fixes
 
 - Dynamic Sampling Context not propagated correctly for HttpClient spans ([#3208](https://github.com/getsentry/sentry-dotnet/pull/3208))
-- Sentry Java SDK dependencies are now detected and included in the Android bindings ([#4079](https://github.com/getsentry/sentry-dotnet/pull/4079))
 
 ## 4.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,6 +563,7 @@ Unable to load DLL sentry-native or one of its dependencies
 ### Fixes
 
 - Dynamic Sampling Context not propagated correctly for HttpClient spans ([#3208](https://github.com/getsentry/sentry-dotnet/pull/3208))
+- Sentry Java SDK dependencies are now detected and included in the Android bindings ([#4079](https://github.com/getsentry/sentry-dotnet/pull/4079))
 
 ## 4.2.0
 

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+<!--    <TargetFrameworks>net8.0-android34.0</TargetFrameworks>-->
     <TargetFrameworks>net8.0-android34.0;net9.0-android35.0</TargetFrameworks>
-    <!-- BG8605 and BG8606 happen because there's a missing androidx.lifecycle dependency, but we don't need it here.  (The native Android Sentry SDK will use it if it exists.) -->
-    <NoWarn>$(NoWarn);BG8605;BG8606</NoWarn>
     <SentryAndroidSdkVersion>7.20.1</SentryAndroidSdkVersion>
-    <SentryAndroidSdkDirectory>$(BaseIntermediateOutputPath)sdks\Sentry\Android\$(SentryAndroidSdkVersion)\</SentryAndroidSdkDirectory>
+    <SentryAndroidSdkDirectory>$(BaseIntermediateOutputPath)sdks\$(TargetFramework)\Sentry\Android\$(SentryAndroidSdkVersion)\</SentryAndroidSdkDirectory>
     <Description>.NET Bindings for the Sentry Android SDK</Description>
   </PropertyGroup>
 
@@ -47,16 +46,56 @@
     <InternalsVisibleTo Include="Sentry.Maui.Tests" PublicKey="$(SentryPublicKey)" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
+    <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-$(SentryAndroidSdkVersion).jar" />
+    <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-android-core-$(SentryAndroidSdkVersion).aar" />
+    <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).aar" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net8'))">
     <!-- AndroidMavenLibrary include format is {GroupId}:{ArtifactId} -->
-    <AndroidMavenLibrary Include="io.sentry:sentry" Version="$(SentryAndroidSdkVersion)" />
+    <AndroidLibrary
+      Include="$(SentryAndroidSdkDirectory)sentry-$(SentryAndroidSdkVersion).jar"
+      Manifest="$(SentryAndroidSdkDirectory)sentry-$(SentryAndroidSdkVersion).pom"
+      JavaArtifact="io.sentry:sentry:$(SentryAndroidSdkVersion)"
+    />
     <AndroidMavenLibrary Include="io.sentry:sentry-android-core" Version="$(SentryAndroidSdkVersion)" />
     <AndroidMavenLibrary Include="io.sentry:sentry-android-ndk" Version="$(SentryAndroidSdkVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <AndroidLibrary Include="..\..\lib\sentry-android-supplemental\bin\sentry-android-supplemental.jar" />
     <AndroidNativeLibrary Include="..\..\lib\sentrysupplemental\bin\arm64-v8a\libsentrysupplemental.so" Abi="arm64-v8a" />
     <AndroidNativeLibrary Include="..\..\lib\sentrysupplemental\bin\armeabi-v7a\libsentrysupplemental.so" Abi="armeabi-v7a" />
     <AndroidNativeLibrary Include="..\..\lib\sentrysupplemental\bin\x86\libsentrysupplemental.so" Abi="x86" />
     <AndroidNativeLibrary Include="..\..\lib\sentrysupplemental\bin\x86_64\libsentrysupplemental.so" Abi="x86_64" />
   </ItemGroup>
+
+  <Target Name="DownloadSentryAndroidSdk" BeforeTargets="CollectPackageReferences">
+    <DownloadFile
+      SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-core/$(SentryAndroidSdkVersion)/sentry-android-core-$(SentryAndroidSdkVersion).aar"
+      DestinationFolder="$(SentryAndroidSdkDirectory)"
+      Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-android-core-$(SentryAndroidSdkVersion).aar') And $(TargetFramework.StartsWith('net8'))"
+      Retries="3"
+    />
+    <DownloadFile
+      SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-ndk/$(SentryAndroidSdkVersion)/sentry-android-ndk-$(SentryAndroidSdkVersion).aar"
+      DestinationFolder="$(SentryAndroidSdkDirectory)"
+      Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).aar') And $(TargetFramework.StartsWith('net8'))"
+      Retries="3"
+    />
+    <DownloadFile
+      SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry/$(SentryAndroidSdkVersion)/sentry-$(SentryAndroidSdkVersion).jar"
+      DestinationFolder="$(SentryAndroidSdkDirectory)"
+      Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-$(SentryAndroidSdkVersion).jar')"
+      Retries="3"
+    />
+    <DownloadFile
+      SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry/$(SentryAndroidSdkVersion)/sentry-$(SentryAndroidSdkVersion).pom"
+      DestinationFolder="$(SentryAndroidSdkDirectory)"
+      Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-$(SentryAndroidSdkVersion).pom') And !$(TargetFramework.StartsWith('net8'))"
+      Retries="3"
+    />
+  </Target>
 
 </Project>

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android34.0</TargetFrameworks>
+    <TargetFrameworks>net8.0-android34.0;net9.0-android35.0;</TargetFrameworks>
     <!-- BG8605 and BG8606 happen because there's a missing androidx.lifecycle dependency, but we don't need it here.  (The native Android Sentry SDK will use it if it exists.) -->
     <NoWarn>$(NoWarn);BG8605;BG8606</NoWarn>
     <SentryAndroidSdkVersion>7.20.1</SentryAndroidSdkVersion>
@@ -30,35 +30,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-$(SentryAndroidSdkVersion).jar" />
-    <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-android-core-$(SentryAndroidSdkVersion).aar" />
-    <AndroidLibrary Include="$(SentryAndroidSdkDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).aar" />
+    <!-- AndroidMavenLibrary include format is {GroupId}:{ArtifactId} -->
+    <AndroidMavenLibrary Include="io.sentry:sentry" Version="$(SentryAndroidSdkVersion)" />
+    <AndroidMavenLibrary Include="io.sentry:sentry-android-core" Version="$(SentryAndroidSdkVersion)" />
+    <AndroidMavenLibrary Include="io.sentry:sentry-android-ndk" Version="$(SentryAndroidSdkVersion)" />
     <AndroidLibrary Include="..\..\lib\sentry-android-supplemental\bin\sentry-android-supplemental.jar" />
     <AndroidNativeLibrary Include="..\..\lib\sentrysupplemental\bin\arm64-v8a\libsentrysupplemental.so" Abi="arm64-v8a" />
     <AndroidNativeLibrary Include="..\..\lib\sentrysupplemental\bin\armeabi-v7a\libsentrysupplemental.so" Abi="armeabi-v7a" />
     <AndroidNativeLibrary Include="..\..\lib\sentrysupplemental\bin\x86\libsentrysupplemental.so" Abi="x86" />
     <AndroidNativeLibrary Include="..\..\lib\sentrysupplemental\bin\x86_64\libsentrysupplemental.so" Abi="x86_64" />
   </ItemGroup>
-
-  <Target Name="DownloadSentryAndroidSdk" BeforeTargets="CollectPackageReferences">
-    <DownloadFile
-      SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-core/$(SentryAndroidSdkVersion)/sentry-android-core-$(SentryAndroidSdkVersion).aar"
-      DestinationFolder="$(SentryAndroidSdkDirectory)"
-      Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-android-core-$(SentryAndroidSdkVersion).aar')"
-      Retries="3"
-    />
-    <DownloadFile
-      SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry-android-ndk/$(SentryAndroidSdkVersion)/sentry-android-ndk-$(SentryAndroidSdkVersion).aar"
-      DestinationFolder="$(SentryAndroidSdkDirectory)"
-      Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-android-ndk-$(SentryAndroidSdkVersion).aar')"
-      Retries="3"
-    />
-    <DownloadFile
-      SourceUrl="https://repo1.maven.org/maven2/io/sentry/sentry/$(SentryAndroidSdkVersion)/sentry-$(SentryAndroidSdkVersion).jar"
-      DestinationFolder="$(SentryAndroidSdkDirectory)"
-      Condition="!Exists('$(SentryAndroidSdkDirectory)sentry-$(SentryAndroidSdkVersion).jar')"
-      Retries="3"
-    />
-  </Target>
 
 </Project>

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -19,6 +19,11 @@
     <None Include="$(MSBuildThisFileDirectory)build/Sentry.Bindings.Android.targets" Pack="true" PackagePath="build/Sentry.Bindings.Android.targets" />
     <None Include="$(MSBuildThisFileDirectory)sentry-proguard.cfg" Pack="true" PackagePath="" />
     <PackageReference Remove="SIL.ReleaseTasks" />
+
+    <!-- Dependencies for AndroidMavenLibrary references   -->
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.8.7.2" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common.Java8" Version="2.8.7.2" />
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.15.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android34.0;net9.0-android35.0;</TargetFrameworks>
+    <TargetFrameworks>net8.0-android34.0;net9.0-android35.0</TargetFrameworks>
     <!-- BG8605 and BG8606 happen because there's a missing androidx.lifecycle dependency, but we don't need it here.  (The native Android Sentry SDK will use it if it exists.) -->
     <NoWarn>$(NoWarn);BG8605;BG8606</NoWarn>
     <SentryAndroidSdkVersion>7.20.1</SentryAndroidSdkVersion>
@@ -19,11 +19,24 @@
     <None Include="$(MSBuildThisFileDirectory)build/Sentry.Bindings.Android.targets" Pack="true" PackagePath="build/Sentry.Bindings.Android.targets" />
     <None Include="$(MSBuildThisFileDirectory)sentry-proguard.cfg" Pack="true" PackagePath="" />
     <PackageReference Remove="SIL.ReleaseTasks" />
+  </ItemGroup>
 
-    <!-- Dependencies for AndroidMavenLibrary references   -->
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.8.7.2" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common.Java8" Version="2.8.7.2" />
-    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.15.0.2" />
+  <!-- Dependencies for AndroidMavenLibrary references -->
+  <!-- Note: versions match what was shipped with net8.0-android34.0 in MAUI -->
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.6.1.3" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common.Java8" Version="2.6.1.3" />
+    <!-- MAUI 8 references this version indirectly via Xamarin.AndroidX.SwipeRefreshLayout (>= 1.1.0.14)   -->
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.10.1.2" />
+  </ItemGroup>
+
+  <!-- Dependencies for AndroidMavenLibrary references -->
+  <!-- Note: versions match what was shipped with net9.0-android35.0 in MAUI -->
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.8.5.1" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common.Java8" Version="2.8.5.1" />
+    <!-- MAUI 9 references this version indirectly via Xamarin.AndroidX.SwipeRefreshLayout (>= 1.1.0.24)   -->
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.13.1.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves Java dependencies for all of the existing Maven repositories we depend on. 

Relates to:
- https://github.com/getsentry/sentry-dotnet/issues/3755#issuecomment-2555847331 

To fix that particular issue, we need to add an `AndroidMavenLibrary` reference to the `sentry-android-replay` ArtefactId when implementing:
- https://github.com/getsentry/sentry-dotnet/issues/4080 

# Summary

.NET 9 adds some features that allow us to [detect Java dependencies](https://learn.microsoft.com/en-us/dotnet/android/binding-libs/advanced-concepts/java-dependency-verification), with build warnings for any that are missing 🎉 

Previously we downloaded java/aar files for Sentry's Java SDK from Maven and then referenced these directly with `AndroidLibrary` XML tags. The new features in .NET 9 allow us to include a Manifest/POM file when referencing *.java files (the POM file is what describes the dependencies of the java library) or to reference maven repositories directly with `AndroidMavenLibrary` tags which takes care of downloading the java and POM files and referencing these.

## Solution

For all of this to work, `Sentry.Bindings.Android.csproj` has to target `net9.0-android`. So I've added a net9 target and it turns out we were missing various dependencies:
```
1>Xamarin.Android.Bindings.JavaDependencyVerification.targets(27,5): Error XA4242 : Java dependency 'androidx.lifecycle:lifecycle-process:2.2.0' is not satisfied. Microsoft maintains the NuGet package 'Xamarin.AndroidX.Lifecycle.Process' that could fulfill this dependency.
1>Xamarin.Android.Bindings.JavaDependencyVerification.targets(27,5): Error XA4242 : Java dependency 'androidx.lifecycle:lifecycle-common-java8:2.2.0' is not satisfied. Microsoft maintains the NuGet package 'Xamarin.AndroidX.Lifecycle.Common.Java8' that could fulfill this dependency.
1>Xamarin.Android.Bindings.JavaDependencyVerification.targets(27,5): Error XA4242 : Java dependency 'androidx.core:core:1.3.2' is not satisfied. Microsoft maintains the NuGet package 'Xamarin.AndroidX.Core' that could fulfill this dependency.
```

Although the tooling only identifies these when targeting net9, I believe we were missing the same dependencies when targeting net8.0. This may explain various "missing class" errors that users have been reporting at runtime. 

In addition to adding the tooling to ensure we get appropriate warnings then, this PR also [includes appropriate versions of the missing libraries](https://github.com/getsentry/sentry-dotnet/blob/18d17b2b5374973d9df4798955a1a5befc6ed00d/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj#L23-L39).

# References
- https://learn.microsoft.com/en-us/dotnet/android/binding-libs/advanced-concepts/android-maven-library
- https://learn.microsoft.com/en-us/dotnet/android/binding-libs/advanced-concepts/resolving-java-dependencies