### PR TITLE
Fix UWP Net Native compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix UWP Net Native compilation ([#4085](https://github.com/getsentry/sentry-dotnet/pull/4085))
+
 ## 5.5.0
 
 ### Features

--- a/src/Sentry/Internal/FnvHash.cs
+++ b/src/Sentry/Internal/FnvHash.cs
@@ -10,34 +10,39 @@ namespace Sentry.Internal;
 /// </remarks>
 internal struct FnvHash
 {
-    public FnvHash()
+    // Provide a constructor that takes a parameter (so it’s not the default one).
+    // This lets you explicitly set your initial hash code:
+    public FnvHash(int _)
     {
+        _hashCode = Offset;
     }
 
     private const int Offset = unchecked((int)2166136261);
     private const int Prime = 16777619;
 
-    private int HashCode { get; set; } = Offset;
+    // Field (no initializer here—set it in the constructor)
+    private int _hashCode;
 
     private void Combine(byte data)
     {
         unchecked
         {
-            HashCode ^= data;
-            HashCode *= Prime;
+            _hashCode ^= data;
+            _hashCode *= Prime;
         }
     }
 
-    private static int ComputeHash(byte[] data)
+    private static int ComputeHashInternal(byte[] data)
     {
-        var result = new FnvHash();
+        // Create FnvHash via the constructor, which initializes _hashCode to Offset
+        var result = new FnvHash(0);
         foreach (var b in data)
         {
             result.Combine(b);
         }
-
-        return result.HashCode;
+        return result._hashCode;
     }
 
-    public static int ComputeHash(string data) => ComputeHash(Encoding.UTF8.GetBytes(data));
+    public static int ComputeHash(string data)
+        => ComputeHashInternal(Encoding.UTF8.GetBytes(data));
 }

--- a/src/Sentry/Internal/FnvHash.cs
+++ b/src/Sentry/Internal/FnvHash.cs
@@ -5,44 +5,23 @@ namespace Sentry.Internal;
 ///
 /// See https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV_hash_parameters
 /// </summary>
-/// <remarks>
-/// We use a struct to avoid heap allocations.
-/// </remarks>
-internal struct FnvHash
+internal static class FnvHash
 {
-    // Provide a constructor that takes a parameter (so it’s not the default one).
-    // This lets you explicitly set your initial hash code:
-    public FnvHash(int _)
-    {
-        _hashCode = Offset;
-    }
-
     private const int Offset = unchecked((int)2166136261);
     private const int Prime = 16777619;
 
-    // Field (no initializer here—set it in the constructor)
-    private int _hashCode;
-
-    private void Combine(byte data)
+    internal static int ComputeHash(string input)
     {
-        unchecked
+        var hashCode = Offset;
+        foreach (var b in Encoding.UTF8.GetBytes(input))
         {
-            _hashCode ^= data;
-            _hashCode *= Prime;
+            unchecked
+            {
+                hashCode ^= b;
+                hashCode *= Prime;
+            }
         }
-    }
 
-    private static int ComputeHashInternal(byte[] data)
-    {
-        // Create FnvHash via the constructor, which initializes _hashCode to Offset
-        var result = new FnvHash(0);
-        foreach (var b in data)
-        {
-            result.Combine(b);
-        }
-        return result._hashCode;
+        return hashCode;
     }
-
-    public static int ComputeHash(string data)
-        => ComputeHashInternal(Encoding.UTF8.GetBytes(data));
 }


### PR DESCRIPTION
Sentry DotNet since version 5.2.0 (and until the most recent 5.5.0) can't be used in UWP projects because they fail to compile with following error:

`Sentry : Gatekeeper error GK0018 : GK0018 Value type 'Sentry.Internal.FnvHash' has an explicit default constructor which is unsupported. Use an initialization function instead.`

This happens with .NET Native compilation and static analysis enabled. Versions 5.1.1 and older aren't producing this issue as they don't contain FnvHash struct.

Similar error was solved in the past with other objects: https://github.com/getsentry/sentry-dotnet/pull/2415

Please test my changes before merging. As a customer, I want this issue quickly fixed, so I am helping you. However, I don't want to spend hours getting compilation of sentry working and testing it within my package. 💯 Thank you for your understanding.