### PR TITLE
Prevent users building with AndroidEnableAssemblyCompression set to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Changed default value for `SentryOptions.EnableAppHangTrackingV2` to `false` ([#4042](https://github.com/getsentry/sentry-dotnet/pull/4042))
 - Missing MAUI `Shell` navigation breadcrumbs on iOS ([#4006](https://github.com/getsentry/sentry-dotnet/pull/4006))
 - Prevent application crashes when capturing screenshots on iOS ([#4069](https://github.com/getsentry/sentry-dotnet/pull/4069))
+- Prevent users from disabling AndroidEnableAssemblyCompression which leads to untrappable crash ([#4089](https://github.com/getsentry/sentry-dotnet/pull/4089))
 
 ### Dependencies
 

--- a/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
+++ b/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
@@ -9,6 +9,9 @@
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <!-- XA0119: Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.-->
     <NoWarn>$(NoWarn);XA0119</NoWarn>
+
+    <!--uncomment to test targets that block this flag-->
+    <!--<AndroidEnableAssemblyCompression>false</AndroidEnableAssemblyCompression>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
+++ b/samples/Sentry.Samples.Android/Sentry.Samples.Android.csproj
@@ -9,9 +9,6 @@
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <!-- XA0119: Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.-->
     <NoWarn>$(NoWarn);XA0119</NoWarn>
-
-    <!--uncomment to test targets that block this flag-->
-    <!--<AndroidEnableAssemblyCompression>false</AndroidEnableAssemblyCompression>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -9,6 +9,12 @@
     <SentryAttributesFile>Sentry.Attributes$(MSBuildProjectExtension.Replace('proj', ''))</SentryAttributesFile>
   </PropertyGroup>
 
+  <Target Name="_SentryEnsureAndroidEnableAssemblyCompressionDisabled"
+          Condition="$(TargetFramework.Contains('-android')) AND '$(AndroidEnableAssemblyCompression)' == 'false'"
+          BeforeTargets="ResolveAssemblyReferences;Build;Rebuild">
+    <Error Text="Android projects using Sentry cannot build using AndroidEnableAssemblyCompression = false due to a Microsoft issue.  Please follow https://github.com/dotnet/android/issues/9752" />
+  </Target>
+
   <Target Name="WriteSentryAttributes"
           Condition="$(Language) == 'VB' or $(Language) == 'C#' or $(Language) == 'F#'"
           BeforeTargets="BeforeCompile;CoreCompile"


### PR DESCRIPTION
Resolve #3920 when users set AndroidEnableAssemblyCompression to false

This issue is specific to the .NET Android SDK.  We can't detect the issue during runtime, nor can we trap it without the entire Sentry SDK having issues around missing DSN.  As such, we're implementing a target to prevent users from disabling this flag.

A few notes
- This blocks debug AND release builds with this flag set to false even though the issue is specific to it being only on release builds.  We want to notify users as early in the dev loop as possible
- This issue has only been seen in NET9, however, MAUI and mobile do not have an LTS and NET9 is considered current stable