### PR TITLE
Pin iOS 18.0 in Samples and Test apps

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Pin the Xcode Version
       if: runner.os == 'macOS'
       shell: bash
-      run: sudo xcode-select --switch /Applications/Xcode_16.2.app
+      run: sudo xcode-select --switch /Applications/Xcode_16.3.app
 
     # Needed for Android SDK setup step
     - uses: actions/setup-java@v3

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Pin the Xcode Version
       if: runner.os == 'macOS'
       shell: bash
-      run: sudo xcode-select --switch /Applications/Xcode_16.3.app
+      run: sudo xcode-select --switch /Applications/Xcode_16.3_Release_Candidate_2.app
 
     # Needed for Android SDK setup step
     - uses: actions/setup-java@v3

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Pin the Xcode Version
       if: runner.os == 'macOS'
       shell: bash
-      run: sudo xcode-select --switch /Applications/Xcode_16.3_Release_Candidate_2.app
+      run: sudo xcode-select --switch /Applications/Xcode_16.2.app
 
     # Needed for Android SDK setup step
     - uses: actions/setup-java@v3

--- a/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
+++ b/samples/Sentry.Samples.Ios/Sentry.Samples.Ios.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetPlatformVersion>18</TargetPlatformVersion>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>

--- a/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
+++ b/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
@@ -4,7 +4,8 @@
     <TargetFrameworks></TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_ANDROID)' == ''">$(TargetFrameworks);net8.0-android;net9.0-android</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net8.0-ios;net9.0-ios</TargetFrameworks>
-    <!-- Pin target iOS version so that our tests don't break when new versions of Xcode are released ('net8.0-ios' floats up otherwise) -->
+    <!-- Pin target iOS version so that our tests don't break when new versions of Xcode are released.
+      'net8.0-ios' resolves the latest version of the iOS SDK otherwise. -->
     <TargetPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">18</TargetPlatformVersion>
     <UseMaui>true</UseMaui>
     <!-- Currently broken on .NET 7, see

--- a/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
+++ b/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
@@ -4,8 +4,10 @@
     <TargetFrameworks></TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_ANDROID)' == ''">$(TargetFrameworks);net8.0-android;net9.0-android</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net8.0-ios;net9.0-ios</TargetFrameworks>
-    <TargetPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">18</TargetPlatformVersion>
-    <TargetPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">35</TargetPlatformVersion>
+    <TargetPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-ios'">17</TargetPlatformVersion>
+    <TargetPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-ios'">18</TargetPlatformVersion>
+    <TargetPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-android'">34</TargetPlatformVersion>
+    <TargetPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-android'">35</TargetPlatformVersion>
     <UseMaui>true</UseMaui>
     <!-- Currently broken on .NET 7, see
       - https://github.com/dotnet/maui/issues/18573

--- a/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
+++ b/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks></TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_ANDROID)' == ''">$(TargetFrameworks);net8.0-android;net9.0-android</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net8.0-ios;net9.0-ios</TargetFrameworks>
+    <TargetPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">18</TargetPlatformVersion>
+    <TargetPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">35</TargetPlatformVersion>
     <UseMaui>true</UseMaui>
     <!-- Currently broken on .NET 7, see
       - https://github.com/dotnet/maui/issues/18573

--- a/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
+++ b/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
@@ -4,10 +4,8 @@
     <TargetFrameworks></TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_ANDROID)' == ''">$(TargetFrameworks);net8.0-android;net9.0-android</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net8.0-ios;net9.0-ios</TargetFrameworks>
-    <TargetPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-ios'">17</TargetPlatformVersion>
-    <TargetPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-ios'">18</TargetPlatformVersion>
-    <TargetPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-android'">34</TargetPlatformVersion>
-    <TargetPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-android'">35</TargetPlatformVersion>
+    <!-- Pin target iOS version so that our tests don't break when new versions of Xcode are released ('net8.0-ios' floats up otherwise) -->
+    <TargetPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">18</TargetPlatformVersion>
     <UseMaui>true</UseMaui>
     <!-- Currently broken on .NET 7, see
       - https://github.com/dotnet/maui/issues/18573


### PR DESCRIPTION
Pinning `TargetPlatformVersion` 18.0 for iOS targets in samples and test apps so that our builds are deterministic. Otherwise they break frequently when new versions of Xcode/Microsoft.iOS are released. 

For example the error from [this build run](https://github.com/getsentry/sentry-dotnet/actions/runs/14363626452/job/40271121336?pr=4084):
> ILLINK : error MT0180: This version of Microsoft.iOS requires the iOS 18.4 SDK (shipped with Xcode 16.3). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options > Linker Behavior (to try to avoid the new APIs). [/Users/runner/work/sentry-dotnet/sentry-dotnet/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj::TargetFramework=net9.0-ios]

#skip-changelog