### PR TITLE
Ensure mechanism data is not fully overwritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Fixes
 - Ensure user exception data is not removed by AspNetCoreExceptionProcessor ([#4016](https://github.com/getsentry/sentry-dotnet/pull/4106))
-
 - Prevent users from disabling AndroidEnableAssemblyCompression which leads to untrappable crash ([#4089](https://github.com/getsentry/sentry-dotnet/pull/4089))
 
 ## 5.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- Ensure user exception data is not removed by AspNetCoreExceptionProcessor ([#4016](https://github.com/getsentry/sentry-dotnet/pull/4106))
+
 ## 5.5.0
 
 ### Features

--- a/src/Sentry.AspNetCore/AspNetCoreExceptionProcessor.cs
+++ b/src/Sentry.AspNetCore/AspNetCoreExceptionProcessor.cs
@@ -14,11 +14,9 @@ internal class AspNetCoreExceptionProcessor : ISentryEventExceptionProcessor
             {
                 foreach (var ex in @event.SentryExceptions)
                 {
-                    ex.Mechanism = new Mechanism
-                    {
-                        Type = "ExceptionHandlerMiddleware",
-                        Handled = false
-                    };
+                    ex.Mechanism ??= new Mechanism();
+                    ex.Mechanism.Type = "ExceptionHandlerMiddleware";
+                    ex.Mechanism.Handled = false;
                 }
             }
         }

--- a/test/Sentry.AspNetCore.Tests/AspNetCoreExceptionProcessorTests.cs
+++ b/test/Sentry.AspNetCore.Tests/AspNetCoreExceptionProcessorTests.cs
@@ -1,0 +1,44 @@
+namespace Sentry.AspNetCore.Tests;
+
+public class AspNetCoreExceptionProcessorTests
+{
+    private readonly AspNetCoreExceptionProcessor _sut = new();
+
+    [Fact]
+    public void Process_Event()
+    {
+        var @event = new SentryEvent();
+        @event.Logger = "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware";
+
+        _sut.Process(null!, @event);
+
+        foreach (var ex in @event.SentryExceptions)
+        {
+            ex.Mechanism.Should().NotBeNull();
+            ex.Mechanism.Type.Should().Be("ExceptionHandlerMiddleware");
+            ex.Mechanism.Handled.Should().BeFalse();
+        }
+    }
+
+
+    [Fact]
+    public void Process_ShouldNotOverwriteMechanism()
+    {
+        var @event = new SentryEvent();
+        var mechanism = new Mechanism();
+        mechanism.Data.Add("key", "value");
+
+        @event.SentryExceptions = [new SentryException
+        {
+            Mechanism = mechanism
+        }];
+        @event.Logger = "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware";
+
+        _sut.Process(null!, @event);
+
+        var mech = @event.SentryExceptions.First().Mechanism;
+        mech.Should().NotBeNull();
+        mech.Data.First().Key.Should().Be("key");
+        mech.Data.First().Value.Should().Be("value");
+    }
+}


### PR DESCRIPTION
Resolves #4027 

ASP.NET Core's AspNetCoreExceptionProcessor was overwriting the Mechanism and thereby clearing any exception data that may have been recorded.  