### PR TITLE
Add `DisableSentryNative` build property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Option to disable the SentryNative integration ([#4107](https://github.com/getsentry/sentry-dotnet/pull/4107))
+
 ### Fixes
 
 - Prevent users from disabling AndroidEnableAssemblyCompression which leads to untrappable crash ([#4089](https://github.com/getsentry/sentry-dotnet/pull/4089))

--- a/src/Sentry/Platforms/Native/SentryNative.cs
+++ b/src/Sentry/Platforms/Native/SentryNative.cs
@@ -7,6 +7,11 @@ namespace Sentry;
 internal static class SentryNative
 {
 #if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    // FeatureSwitchDefinition should help with trimming disabled code.
+    // This way, `SentryNative.IsEnabled` should be treated as a compile-time constant for trimmed apps.
+    [FeatureSwitchDefinition("Sentry.Native.IsEnabled")]
+#endif
     internal static bool IsEnabled => !AppContext.TryGetSwitch("Sentry.Native.IsEnabled", out var isEnabled) || isEnabled;
 
     internal static bool IsAvailable { get; }

--- a/src/Sentry/Platforms/Native/SentryNative.cs
+++ b/src/Sentry/Platforms/Native/SentryNative.cs
@@ -7,11 +7,13 @@ namespace Sentry;
 internal static class SentryNative
 {
 #if NET8_0_OR_GREATER
+    internal static bool IsEnabled => !AppContext.TryGetSwitch("Sentry.Native.IsEnabled", out var isEnabled) || isEnabled;
+
     internal static bool IsAvailable { get; }
 
     static SentryNative()
     {
-        IsAvailable = AotHelper.IsTrimmed && !SentryRuntime.Current.IsBrowserWasm();
+        IsAvailable = IsEnabled && AotHelper.IsTrimmed && !SentryRuntime.Current.IsBrowserWasm();
     }
 #else
     // This is a compile-time const so that the irrelevant code is removed during compilation.

--- a/src/Sentry/Platforms/Native/SentryNative.cs
+++ b/src/Sentry/Platforms/Native/SentryNative.cs
@@ -7,18 +7,23 @@ namespace Sentry;
 internal static class SentryNative
 {
 #if NET8_0_OR_GREATER
+    // Should be in-sync with Sentry.Native.targets const.
+    private const string SentryNativeIsEnabledSwitchName = "Sentry.Native.IsEnabled";
+
+    private static readonly bool IsAvailableCore;
+
 #if NET9_0_OR_GREATER
     // FeatureSwitchDefinition should help with trimming disabled code.
     // This way, `SentryNative.IsEnabled` should be treated as a compile-time constant for trimmed apps.
-    [FeatureSwitchDefinition("Sentry.Native.IsEnabled")]
+    [FeatureSwitchDefinition(SentryNativeIsEnabledSwitchName)]
 #endif
-    internal static bool IsEnabled => !AppContext.TryGetSwitch("Sentry.Native.IsEnabled", out var isEnabled) || isEnabled;
+    private static bool IsEnabled => !AppContext.TryGetSwitch(SentryNativeIsEnabledSwitchName, out var isEnabled) || isEnabled;
 
-    internal static bool IsAvailable { get; }
+    internal static bool IsAvailable => IsEnabled && IsAvailableCore;
 
     static SentryNative()
     {
-        IsAvailable = IsEnabled && AotHelper.IsTrimmed && !SentryRuntime.Current.IsBrowserWasm();
+        IsAvailableCore = AotHelper.IsTrimmed && !SentryRuntime.Current.IsBrowserWasm();
     }
 #else
     // This is a compile-time const so that the irrelevant code is removed during compilation.

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <!-- When user sets <DisableSentryNative>true</DisableSentryNative> in their project -->
-    <!-- SentryNative.IsEnabled should result in runtime constant for trimmed applications -->
+    <!-- SentryNative.IsEnabled should result in compile-time constant for trimmed applications -->
     <!-- Effectively disabling native library -->
     <RuntimeHostConfigurationOption Include="Sentry.Native.IsEnabled"
                                     Condition="'$(DisableSentryNative)' != 'true'"

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -8,6 +8,16 @@
   Note:Target framework conditions should be kept synchronized with src/Sentry/buildTransitive/Sentry.Native.targets -->
 <Project>
 
+  <ItemGroup>
+    <!-- When user sets <DisableSentryNative>true</DisableSentryNative> in their project -->
+    <!-- SentryNative.IsEnabled should result in runtime constant for trimmed applications -->
+    <!-- Effectively disabling native library -->
+    <RuntimeHostConfigurationOption Include="Sentry.Native.IsEnabled"
+                                    Condition="'$(DisableSentryNative)' != 'true'"
+                                    Value="true"
+                                    Trim="true" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- net8.0 or greater -->
     <FrameworkSupportsNative Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe')">true</FrameworkSupportsNative>

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -11,6 +11,8 @@
   <PropertyGroup>
     <!-- net8.0 or greater -->
     <FrameworkSupportsNative Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe')">true</FrameworkSupportsNative>
+    <!-- Make it opt-out -->
+    <FrameworkSupportsNative Condition="'$(DisableSentryNative)' == 'true'">false</FrameworkSupportsNative>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(FrameworkSupportsNative)' == 'true' and '$(RuntimeIdentifier)' == 'win-x64'">


### PR DESCRIPTION
This PR adds a new `DisableSentryNative` build property, allowing to opt-out from linking and using Sentry.Native on .NET 8+ builds. By default, `DisableSentryNative` is false, so old behavior is kept unchanged.

Two main changes of this PR:
1. `DirectPInvoke`/`NativeLibrary` are only set when `DisableSentryNative` is false. 
2. `SentryNative.IsAvailable` returns false, if `DisableSentryNative` was set to true.

Runtime switches (`RuntimeHostConfigurationOption` and `AppContext.TryGetSwitch`) were used to pass build property to the runtime library. `FeatureSwitchDefinition` used should make this switch into a compile-time variable.

Closes https://github.com/getsentry/sentry-dotnet/issues/4102

NOTE: while it should work, I haven't tested the build yet. Need to figure out how to prepare a local build with native bits and everything included.
