### PR TITLE
chore: Bump to dotnet SDK 9.0.203

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -60,7 +60,7 @@ runs:
       with:
         dotnet-version: |
           8.0.x
-          9.0.202
+          9.0.203
 
     - name: Install .NET Workloads
       shell: bash

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.202",
+    "version": "9.0.203",
     "rollForward": "disable",
     "allowPrerelease": false
   }


### PR DESCRIPTION
Bump the .NET SDK version to 9.0.203. Possibly impacts https://github.com/getsentry/sentry-dotnet/issues/3915. See:
- https://github.com/getsentry/sentry-dotnet/issues/3915#issuecomment-2800227556

#skip-changelog