### PR TITLE
fix: MSVCRT build warning on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Prevent users from disabling AndroidEnableAssemblyCompression which leads to untrappable crash ([#4089](https://github.com/getsentry/sentry-dotnet/pull/4089))
+- MSVCRT build warning on Windows ([#4111](https://github.com/getsentry/sentry-dotnet/pull/4111))
 
 ## 5.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixes
 
 - Prevent users from disabling AndroidEnableAssemblyCompression which leads to untrappable crash ([#4089](https://github.com/getsentry/sentry-dotnet/pull/4089))
-- MSVCRT build warning on Windows ([#4111](https://github.com/getsentry/sentry-dotnet/pull/4111))
+- Fixed MSVCRT build warning on Windows ([#4111](https://github.com/getsentry/sentry-dotnet/pull/4111))
 
 ## 5.5.1
 

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -16,7 +16,7 @@
   </Target>
 
   <ItemGroup Condition="$([System.OperatingSystem]::IsWindows())">
-    <!-- See: https://github.com/getsentry/sentry-dotnet/issues/3928 -->
+    <!-- See: https://github.com/getsentry/sentry-dotnet/pull/4111 -->
     <LinkerArg Include="/NODEFAULTLIB:MSVCRT" />
   </ItemGroup>
 

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -15,6 +15,11 @@
     <Error Text="Android projects using Sentry cannot build using AndroidEnableAssemblyCompression = false due to a Microsoft issue.  Please follow https://github.com/dotnet/android/issues/9752" />
   </Target>
 
+  <ItemGroup>
+    <!-- See: https://github.com/getsentry/sentry-dotnet/issues/3928 -->
+    <LinkerArg Include="/NODEFAULTLIB:MSVCRT" />
+  </ItemGroup>
+
   <Target Name="WriteSentryAttributes"
           Condition="$(Language) == 'VB' or $(Language) == 'C#' or $(Language) == 'F#'"
           BeforeTargets="BeforeCompile;CoreCompile"

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -15,7 +15,7 @@
     <Error Text="Android projects using Sentry cannot build using AndroidEnableAssemblyCompression = false due to a Microsoft issue.  Please follow https://github.com/dotnet/android/issues/9752" />
   </Target>
 
-  <ItemGroup>
+  <ItemGroup Condition="$([System.OperatingSystem]::IsWindows())">
     <!-- See: https://github.com/getsentry/sentry-dotnet/issues/3928 -->
     <LinkerArg Include="/NODEFAULTLIB:MSVCRT" />
   </ItemGroup>


### PR DESCRIPTION
Fixes `LNK4098` linker warning when compiling applications using AOT on windows.

Resolves #3928 :
- https://github.com/getsentry/sentry-dotnet/issues/3928