### PR TITLE
Custom SessionReplay masks in MAUI Android apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Custom SessionReplay masks in MAUI Android apps ([#4121](https://github.com/getsentry/sentry-dotnet/pull/4121))
+
 ## 5.6.0
 
 ### Features
@@ -7,7 +13,6 @@
 - Option to disable the SentryNative integration ([#4107](https://github.com/getsentry/sentry-dotnet/pull/4107), [#4134](https://github.com/getsentry/sentry-dotnet/pull/4134))
   - To disable it, add this msbuild property: `<SentryNative>false</SentryNative>` 
 - Reintroduced experimental support for Session Replay on Android ([#4097](https://github.com/getsentry/sentry-dotnet/pull/4097))
-- Custom SessionReplay masks in MAUI Android apps ([#4121](https://github.com/getsentry/sentry-dotnet/pull/4121))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Reintroduced experimental support for Session Replay on Android ([#4097](https://github.com/getsentry/sentry-dotnet/pull/4097))
-- Custom masking for SessionReplay in MAUI Android apps ([#4121](https://github.com/getsentry/sentry-dotnet/pull/4121))
+- Custom SessionReplay masks in MAUI Android apps ([#4121](https://github.com/getsentry/sentry-dotnet/pull/4121))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Reintroduced experimental support for Session Replay on Android ([#4097](https://github.com/getsentry/sentry-dotnet/pull/4097))
+- Custom masking for SessionReplay in MAUI Android apps ([#4121](https://github.com/getsentry/sentry-dotnet/pull/4121))
 
 ### Fixes
 

--- a/samples/Sentry.Samples.Maui/MainPage.xaml
+++ b/samples/Sentry.Samples.Maui/MainPage.xaml
@@ -32,6 +32,7 @@
             <Button
                 x:Name="CounterBtn"
                 Text="Click me"
+                sentry:SessionReplay.Mask="sentry-unmask"
                 SemanticProperties.Hint="Counts the number of times you click."
                 Clicked="OnCounterClicked"
                 HorizontalOptions="Center" />

--- a/samples/Sentry.Samples.Maui/MainPage.xaml
+++ b/samples/Sentry.Samples.Maui/MainPage.xaml
@@ -32,7 +32,7 @@
             <Button
                 x:Name="CounterBtn"
                 Text="Click me"
-                sentry:SessionReplay.Mask="sentry-unmask"
+                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Hint="Counts the number of times you click."
                 Clicked="OnCounterClicked"
                 HorizontalOptions="Center" />
@@ -40,7 +40,7 @@
             <Button
                 x:Name="ThrowAndCaptureBtn"
                 Text="Throw and Capture Exception"
-                sentry:SessionReplay.Mask="sentry-unmask"
+                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Hint="Throws an exception and captures it."
                 Clicked="OnCapturedExceptionClicked"
                 HorizontalOptions="Center" />
@@ -48,7 +48,7 @@
             <Button
                 x:Name="ThrowUnhandledBtn"
                 Text="Throw Unhandled .NET Exception (Crash)"
-                sentry:SessionReplay.Mask="sentry-unmask"
+                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Hint="Throws an unhandled .NET exception, crashing the app."
                 Clicked="OnUnhandledExceptionClicked"
                 HorizontalOptions="Center" />
@@ -56,6 +56,7 @@
             <Button
                 x:Name="ThrowBackgroundUnhandledBtn"
                 Text="Throw Unhandled .NET Exception on Background Thread (Crash)"
+                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Hint="Throws an unhandled .NET exception on a background thread, crashing the app."
                 Clicked="OnBackgroundThreadUnhandledExceptionClicked"
                 HorizontalOptions="Center" />
@@ -63,7 +64,7 @@
             <Button
                 x:Name="JavaCrashBtn"
                 Text="Throw Java Exception (Crash)"
-                sentry:SessionReplay.Mask="sentry-unmask"
+                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Hint="Throws an unhandled Java exception, crashing the app."
                 Clicked="OnJavaCrashClicked"
                 HorizontalOptions="Center" />
@@ -71,7 +72,7 @@
             <Button
                 x:Name="NativeCrashBtn"
                 Text="Cause Native Crash"
-                sentry:SessionReplay.Mask="sentry-unmask"
+                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Hint="Performs an invalid native operation, crashing the app."
                 Clicked="OnNativeCrashClicked"
                 HorizontalOptions="Center" />
@@ -79,7 +80,7 @@
             <Button
                 x:Name="FeedbackBtn"
                 Text="Submit Feedback"
-                sentry:SessionReplay.Mask="sentry-unmask"
+                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Hint="Provides a form that can be used to capture open feedback from the user."
                 Clicked="OnFeedbackClicked"
                 HorizontalOptions="Center" />

--- a/samples/Sentry.Samples.Maui/MainPage.xaml
+++ b/samples/Sentry.Samples.Maui/MainPage.xaml
@@ -12,6 +12,7 @@
 
             <Image
                 Source="dotnet_bot.png"
+                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Description="Cute dot net bot waving hi to you!"
                 HeightRequest="200"
                 HorizontalOptions="Center" />
@@ -32,7 +33,6 @@
             <Button
                 x:Name="CounterBtn"
                 Text="Click me"
-                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Hint="Counts the number of times you click."
                 Clicked="OnCounterClicked"
                 HorizontalOptions="Center" />
@@ -40,7 +40,6 @@
             <Button
                 x:Name="ThrowAndCaptureBtn"
                 Text="Throw and Capture Exception"
-                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Hint="Throws an exception and captures it."
                 Clicked="OnCapturedExceptionClicked"
                 HorizontalOptions="Center" />
@@ -48,7 +47,6 @@
             <Button
                 x:Name="ThrowUnhandledBtn"
                 Text="Throw Unhandled .NET Exception (Crash)"
-                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Hint="Throws an unhandled .NET exception, crashing the app."
                 Clicked="OnUnhandledExceptionClicked"
                 HorizontalOptions="Center" />
@@ -56,7 +54,6 @@
             <Button
                 x:Name="ThrowBackgroundUnhandledBtn"
                 Text="Throw Unhandled .NET Exception on Background Thread (Crash)"
-                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Hint="Throws an unhandled .NET exception on a background thread, crashing the app."
                 Clicked="OnBackgroundThreadUnhandledExceptionClicked"
                 HorizontalOptions="Center" />
@@ -64,7 +61,6 @@
             <Button
                 x:Name="JavaCrashBtn"
                 Text="Throw Java Exception (Crash)"
-                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Hint="Throws an unhandled Java exception, crashing the app."
                 Clicked="OnJavaCrashClicked"
                 HorizontalOptions="Center" />
@@ -72,7 +68,6 @@
             <Button
                 x:Name="NativeCrashBtn"
                 Text="Cause Native Crash"
-                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Hint="Performs an invalid native operation, crashing the app."
                 Clicked="OnNativeCrashClicked"
                 HorizontalOptions="Center" />
@@ -80,7 +75,6 @@
             <Button
                 x:Name="FeedbackBtn"
                 Text="Submit Feedback"
-                sentry:SessionReplay.Mask="Unmask"
                 SemanticProperties.Hint="Provides a form that can be used to capture open feedback from the user."
                 Clicked="OnFeedbackClicked"
                 HorizontalOptions="Center" />

--- a/samples/Sentry.Samples.Maui/MainPage.xaml
+++ b/samples/Sentry.Samples.Maui/MainPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:sentry="http://schemas.sentry.io/maui"
              x:Class="Sentry.Samples.Maui.MainPage">
 
     <ScrollView>
@@ -38,6 +39,7 @@
             <Button
                 x:Name="ThrowAndCaptureBtn"
                 Text="Throw and Capture Exception"
+                sentry:SessionReplay.Mask="sentry-unmask"
                 SemanticProperties.Hint="Throws an exception and captures it."
                 Clicked="OnCapturedExceptionClicked"
                 HorizontalOptions="Center" />
@@ -45,6 +47,7 @@
             <Button
                 x:Name="ThrowUnhandledBtn"
                 Text="Throw Unhandled .NET Exception (Crash)"
+                sentry:SessionReplay.Mask="sentry-unmask"
                 SemanticProperties.Hint="Throws an unhandled .NET exception, crashing the app."
                 Clicked="OnUnhandledExceptionClicked"
                 HorizontalOptions="Center" />
@@ -59,6 +62,7 @@
             <Button
                 x:Name="JavaCrashBtn"
                 Text="Throw Java Exception (Crash)"
+                sentry:SessionReplay.Mask="sentry-unmask"
                 SemanticProperties.Hint="Throws an unhandled Java exception, crashing the app."
                 Clicked="OnJavaCrashClicked"
                 HorizontalOptions="Center" />
@@ -66,6 +70,7 @@
             <Button
                 x:Name="NativeCrashBtn"
                 Text="Cause Native Crash"
+                sentry:SessionReplay.Mask="sentry-unmask"
                 SemanticProperties.Hint="Performs an invalid native operation, crashing the app."
                 Clicked="OnNativeCrashClicked"
                 HorizontalOptions="Center" />
@@ -73,6 +78,7 @@
             <Button
                 x:Name="FeedbackBtn"
                 Text="Submit Feedback"
+                sentry:SessionReplay.Mask="sentry-unmask"
                 SemanticProperties.Hint="Provides a form that can be used to capture open feedback from the user."
                 Clicked="OnFeedbackClicked"
                 HorizontalOptions="Center" />

--- a/samples/Sentry.Samples.Maui/MauiProgram.cs
+++ b/samples/Sentry.Samples.Maui/MauiProgram.cs
@@ -29,8 +29,10 @@ public static class MauiProgram
                 // Currently experimental support is only available on Android
                 options.Native.ExperimentalOptions.SessionReplay.OnErrorSampleRate = 1.0;
                 options.Native.ExperimentalOptions.SessionReplay.SessionSampleRate = 1.0;
-                options.Native.ExperimentalOptions.SessionReplay.MaskAllImages = false;
-                options.Native.ExperimentalOptions.SessionReplay.MaskAllText = false;
+                // Mask all images and text by default.
+                // This can be overridden for individual view elements (see MainPage.xaml for an example)
+                options.Native.ExperimentalOptions.SessionReplay.MaskAllImages = true;
+                options.Native.ExperimentalOptions.SessionReplay.MaskAllText = true;
 #endif
 
                 options.SetBeforeScreenshotCapture((@event, hint) =>

--- a/samples/Sentry.Samples.Maui/MauiProgram.cs
+++ b/samples/Sentry.Samples.Maui/MauiProgram.cs
@@ -25,14 +25,17 @@ public static class MauiProgram
                 options.Debug = true;
                 options.SampleRate = 1.0F;
 
-#if ANDROID
+#if __ANDROID__
                 // Currently experimental support is only available on Android
                 options.Native.ExperimentalOptions.SessionReplay.OnErrorSampleRate = 1.0;
                 options.Native.ExperimentalOptions.SessionReplay.SessionSampleRate = 1.0;
-                // Mask all images and text by default.
-                // This can be overridden for individual view elements (see MainPage.xaml for an example)
+                // Mask all images and text by default. This can be overridden for individual view elements via the
+                // sentry:SessionReplay.Mask XML attribute (see MainPage.xaml for an example)
                 options.Native.ExperimentalOptions.SessionReplay.MaskAllImages = true;
                 options.Native.ExperimentalOptions.SessionReplay.MaskAllText = true;
+                // Alternatively the masking behaviour for entire classes of VisualElements can be configured here as
+                // an exception to the default behaviour.
+                options.Native.ExperimentalOptions.SessionReplay.UnmaskControlsOfType<Button>();
 #endif
 
                 options.SetBeforeScreenshotCapture((@event, hint) =>

--- a/samples/Sentry.Samples.Maui/Platforms/Android/MainActivity.cs
+++ b/samples/Sentry.Samples.Maui/Platforms/Android/MainActivity.cs
@@ -1,5 +1,8 @@
+#if __ANDROID__
 using Android.App;
 using Android.Content.PM;
+using Android.OS;
+#endif
 
 namespace Sentry.Samples.Maui;
 

--- a/src/Sentry.Maui/AssemblyInfo.cs
+++ b/src/Sentry.Maui/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+// XML namespaces for custom XAML elements defined in the Sentry.Maui assembly (e.g. Bindable Properties)
+[assembly: XmlnsDefinition("http://schemas.sentry.io/maui", "Sentry.Maui")]
+[assembly: Microsoft.Maui.Controls.XmlnsPrefix("http://schemas.sentry.io/maui", "sentry")]

--- a/src/Sentry.Maui/Internal/MauiButtonEventsBinder.cs
+++ b/src/Sentry.Maui/Internal/MauiButtonEventsBinder.cs
@@ -29,7 +29,6 @@ public class MauiButtonEventsBinder : IMauiElementEventBinder
         }
     }
 
-
     private void OnButtonOnClicked(object? sender, EventArgs _)
         => addBreadcrumbCallback?.Invoke(new(sender, nameof(Button.Clicked)));
 

--- a/src/Sentry.Maui/Internal/MauiEventsBinder.cs
+++ b/src/Sentry.Maui/Internal/MauiEventsBinder.cs
@@ -1,9 +1,6 @@
 using Microsoft.Extensions.Options;
 using Microsoft.Maui.Platform;
 using Sentry.Extensibility;
-#if __ANDROID__
-using View = Android.Views.View;
-#endif
 
 namespace Sentry.Maui.Internal;
 
@@ -250,13 +247,11 @@ internal class MauiEventsBinder : IMauiEventsBinder
         {
             element.Focused += OnElementOnFocused;
             element.Unfocused += OnElementOnUnfocused;
-            element.Loaded += OnElementLoaded;
         }
         else
         {
             element.Focused -= OnElementOnFocused;
             element.Unfocused -= OnElementOnUnfocused;
-            element.Loaded -= OnElementLoaded;
         }
     }
 
@@ -415,40 +410,6 @@ internal class MauiEventsBinder : IMauiEventsBinder
 
     private void OnElementOnUnfocused(object? sender, FocusEventArgs _) =>
         _hub.AddBreadcrumbForEvent(_options, sender, nameof(VisualElement.Unfocused), SystemType, RenderingCategory);
-
-    internal void OnElementLoaded(object? sender, EventArgs _)
-    {
-        if (sender is not VisualElement element)
-        {
-            _options.LogDebug("OnElementLoaded: sender is not a VisualElement");
-            return;
-        }
-
-        var handler = element.Handler;
-        if (handler is null)
-        {
-            _options.LogDebug("OnElementLoaded: element.Handler is null");
-            return;
-        }
-
-#if __ANDROID__
-        if (element.Handler?.PlatformView is not View nativeView)
-        {
-            return;
-        }
-
-        if (_options.Native.ExperimentalOptions.SessionReplay.MaskedControls.FirstOrDefault(maskType => element.GetType().IsAssignableFrom(maskType)) is not null)
-        {
-            nativeView.Tag = SessionReplayMaskMode.Mask.ToNativeTag();
-            _options.LogDebug("OnElementLoaded: Successfully set sentry-mask tag on native view");
-        }
-        else if (_options.Native.ExperimentalOptions.SessionReplay.UnmaskedControls.FirstOrDefault(unmaskType => element.GetType().IsAssignableFrom(unmaskType)) is not null)
-        {
-            nativeView.Tag = SessionReplayMaskMode.Unmask.ToNativeTag();
-            _options.LogDebug("OnElementLoaded: Successfully set sentry-unmask tag on native view");
-        }
-#endif
-    }
 
     // Shell Events
 

--- a/src/Sentry.Maui/Internal/MauiEventsBinder.cs
+++ b/src/Sentry.Maui/Internal/MauiEventsBinder.cs
@@ -1,4 +1,9 @@
 using Microsoft.Extensions.Options;
+using Microsoft.Maui.Platform;
+using Sentry.Extensibility;
+#if __ANDROID__
+using View = Android.Views.View;
+#endif
 
 namespace Sentry.Maui.Internal;
 
@@ -245,11 +250,13 @@ internal class MauiEventsBinder : IMauiEventsBinder
         {
             element.Focused += OnElementOnFocused;
             element.Unfocused += OnElementOnUnfocused;
+            element.Loaded += OnElementLoaded;
         }
         else
         {
             element.Focused -= OnElementOnFocused;
             element.Unfocused -= OnElementOnUnfocused;
+            element.Loaded -= OnElementLoaded;
         }
     }
 
@@ -408,6 +415,40 @@ internal class MauiEventsBinder : IMauiEventsBinder
 
     private void OnElementOnUnfocused(object? sender, FocusEventArgs _) =>
         _hub.AddBreadcrumbForEvent(_options, sender, nameof(VisualElement.Unfocused), SystemType, RenderingCategory);
+
+    private void OnElementLoaded(object? sender, EventArgs _)
+    {
+        if (sender is not VisualElement element)
+        {
+            _options.LogDebug("OnElementLoaded: sender is not a VisualElement");
+            return;
+        }
+
+        var handler = element.Handler;
+        if (handler is null)
+        {
+            _options.LogDebug("OnElementLoaded: element.Handler is null");
+            return;
+        }
+
+#if __ANDROID__
+        if (element.Handler?.PlatformView is not View nativeView)
+        {
+            return;
+        }
+
+        if (_options.Native.ExperimentalOptions.SessionReplay.MaskedControls.Contains(sender.GetType()))
+        {
+            nativeView.Tag = "sentry-mask";
+            _options.LogDebug("OnElementLoaded: Successfully set sentry-mask tag on native view");
+        }
+        else if (_options.Native.ExperimentalOptions.SessionReplay.UnmaskedControls.Contains(element.GetType()))
+        {
+            nativeView.Tag = "sentry-unmask";
+            _options.LogDebug("OnElementLoaded: Successfully set sentry-unmask tag on native view");
+        }
+#endif
+    }
 
     // Shell Events
 

--- a/src/Sentry.Maui/Internal/MauiEventsBinder.cs
+++ b/src/Sentry.Maui/Internal/MauiEventsBinder.cs
@@ -416,7 +416,7 @@ internal class MauiEventsBinder : IMauiEventsBinder
     private void OnElementOnUnfocused(object? sender, FocusEventArgs _) =>
         _hub.AddBreadcrumbForEvent(_options, sender, nameof(VisualElement.Unfocused), SystemType, RenderingCategory);
 
-    private void OnElementLoaded(object? sender, EventArgs _)
+    internal void OnElementLoaded(object? sender, EventArgs _)
     {
         if (sender is not VisualElement element)
         {

--- a/src/Sentry.Maui/Internal/MauiEventsBinder.cs
+++ b/src/Sentry.Maui/Internal/MauiEventsBinder.cs
@@ -437,14 +437,14 @@ internal class MauiEventsBinder : IMauiEventsBinder
             return;
         }
 
-        if (_options.Native.ExperimentalOptions.SessionReplay.MaskedControls.Contains(sender.GetType()))
+        if (_options.Native.ExperimentalOptions.SessionReplay.MaskedControls.FirstOrDefault(maskType => element.GetType().IsAssignableFrom(maskType)) is not null)
         {
-            nativeView.Tag = "sentry-mask";
+            nativeView.Tag = SessionReplayMaskMode.Mask.ToNativeTag();
             _options.LogDebug("OnElementLoaded: Successfully set sentry-mask tag on native view");
         }
-        else if (_options.Native.ExperimentalOptions.SessionReplay.UnmaskedControls.Contains(element.GetType()))
+        else if (_options.Native.ExperimentalOptions.SessionReplay.UnmaskedControls.FirstOrDefault(unmaskType => element.GetType().IsAssignableFrom(unmaskType)) is not null)
         {
-            nativeView.Tag = "sentry-unmask";
+            nativeView.Tag = SessionReplayMaskMode.Unmask.ToNativeTag();
             _options.LogDebug("OnElementLoaded: Successfully set sentry-unmask tag on native view");
         }
 #endif

--- a/src/Sentry.Maui/Internal/MauiVisualElementEventsBinder.cs
+++ b/src/Sentry.Maui/Internal/MauiVisualElementEventsBinder.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.Options;
+using Sentry.Extensibility;
+#if __ANDROID__
+using View = Android.Views.View;
+#endif
+
+namespace Sentry.Maui.Internal;
+
+/// <summary>
+/// Masks or unmasks visual elements for session replay recordings
+/// </summary>
+internal class MauiVisualElementEventsBinder : IMauiElementEventBinder
+{
+    private readonly SentryMauiOptions _options;
+
+    public MauiVisualElementEventsBinder(IOptions<SentryMauiOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    /// <inheritdoc />
+    public void Bind(VisualElement element, Action<BreadcrumbEvent> _)
+    {
+        element.Loaded += OnElementLoaded;
+    }
+
+    /// <inheritdoc />
+    public void UnBind(VisualElement element)
+    {
+        element.Loaded -= OnElementLoaded;
+    }
+
+    internal void OnElementLoaded(object? sender, EventArgs _)
+    {
+        if (sender is not VisualElement element)
+        {
+            _options.LogDebug("OnElementLoaded: sender is not a VisualElement");
+            return;
+        }
+
+        var handler = element.Handler;
+        if (handler is null)
+        {
+            _options.LogDebug("OnElementLoaded: element.Handler is null");
+            return;
+        }
+
+#if __ANDROID__
+        if (element.Handler?.PlatformView is not View nativeView)
+        {
+            return;
+        }
+
+        if (_options.Native.ExperimentalOptions.SessionReplay.MaskedControls.FirstOrDefault(maskType => element.GetType().IsAssignableFrom(maskType)) is not null)
+        {
+            nativeView.Tag = SessionReplayMaskMode.Mask.ToNativeTag();
+            _options.LogDebug("OnElementLoaded: Successfully set sentry-mask tag on native view");
+        }
+        else if (_options.Native.ExperimentalOptions.SessionReplay.UnmaskedControls.FirstOrDefault(unmaskType => element.GetType().IsAssignableFrom(unmaskType)) is not null)
+        {
+            nativeView.Tag = SessionReplayMaskMode.Unmask.ToNativeTag();
+            _options.LogDebug("OnElementLoaded: Successfully set sentry-unmask tag on native view");
+        }
+#endif
+    }
+}

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -57,6 +57,7 @@ public static class SentryMauiAppBuilderExtensions
 
         services.AddSingleton<IMauiElementEventBinder, MauiButtonEventsBinder>();
         services.AddSingleton<IMauiElementEventBinder, MauiImageButtonEventsBinder>();
+        services.AddSingleton<IMauiElementEventBinder, MauiVisualElementEventsBinder>();
         services.TryAddSingleton<IMauiEventsBinder, MauiEventsBinder>();
 
         services.AddSentry<SentryMauiOptions>();

--- a/src/Sentry.Maui/SentryMauiOptions.cs
+++ b/src/Sentry.Maui/SentryMauiOptions.cs
@@ -81,7 +81,7 @@ public class SentryMauiOptions : SentryLoggingOptions
     /// if this callback return false the capture will not take place
     /// </remarks>
     /// <code>
-    /// 
+    ///
     ///options.SetBeforeCapture((@event, hint) =>
     ///{
     ///    // Return true to capture or false to prevent the capture

--- a/src/Sentry.Maui/SessionReplay.cs
+++ b/src/Sentry.Maui/SessionReplay.cs
@@ -1,3 +1,5 @@
+
+using Sentry.Infrastructure;
 #if __ANDROID__
 using View = Android.Views.View;
 using Android.Views;
@@ -11,6 +13,9 @@ namespace Sentry.Maui;
 /// <summary>
 /// Contains custom <see cref="BindableProperty"/> definitions used to control the behaviour of the Sentry SessionReplay
 /// feature in MAUI apps.
+/// <remarks>
+/// NOTE: Session Replay is currently an experimental feature for MAUI and is subject to change.
+/// </remarks>
 /// </summary>
 public static class SessionReplay
 {
@@ -26,12 +31,12 @@ public static class SessionReplay
             propertyChanged: OnMaskChanged);
 
     /// <summary>
-    /// Gets the value of the Mask property for a view
+    /// Gets the value of the Mask property for a view.
     /// </summary>
     public static SessionReplayMaskMode GetMask(BindableObject view) => (SessionReplayMaskMode)view.GetValue(MaskProperty);
 
     /// <summary>
-    /// Sets the value of the Mask property for a view. .
+    /// Sets the value of the Mask property for a view.
     /// </summary>
     /// <param name="view">The view element to mask or unmask</param>
     /// <param name="value">The value to assign. Can be either "sentry-mask" or "sentry-unmask".</param>
@@ -50,12 +55,7 @@ public static class SessionReplay
                         return;
                     }
 
-                    nativeView.Tag = maskSetting switch
-                    {
-                        SessionReplayMaskMode.Mask => "sentry-mask",
-                        SessionReplayMaskMode.Unmask => "sentry-unmask",
-                        _ => nativeView.Tag
-                    };
+                    nativeView.Tag = maskSetting.ToNativeTag();
                 };
             }
 #endif

--- a/src/Sentry.Maui/SessionReplay.cs
+++ b/src/Sentry.Maui/SessionReplay.cs
@@ -1,0 +1,56 @@
+#if __ANDROID__
+using View = Android.Views.View;
+#endif
+
+namespace Sentry.Maui;
+
+/// <summary>
+/// Contains custom <see cref="BindableProperty"/> definitions used to control the behaviour of the Sentry SessionReplay
+/// feature in MAUI apps.
+/// </summary>
+public static class SessionReplay
+{
+    /// <summary>
+    /// Mask can be used to either unmask or mask a view.
+    /// </summary>
+    public static readonly BindableProperty MaskProperty =
+        BindableProperty.CreateAttached(
+            "Mask",
+            typeof(string),
+            typeof(SessionReplay),
+            defaultValue: "sentry-mask", // default: masked
+            propertyChanged: OnMaskChanged);
+
+    /// <summary>
+    /// Gets the value of the Mask property for a view
+    /// </summary>
+    public static string GetMask(BindableObject view) => (string)view.GetValue(MaskProperty);
+
+    /// <summary>
+    /// Sets the value of the Mask property for a view. .
+    /// </summary>
+    /// <param name="view">The view element to mask or unmask</param>
+    /// <param name="value">The value to assign. Can be either "sentry-mask" or "sentry-unmask".</param>
+    public static void SetMask(BindableObject view, string value) => view.SetValue(MaskProperty, value);
+
+    private static void OnMaskChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+#if __ANDROID__
+            if (bindable is VisualElement ve)
+            {
+                ve.HandlerChanged += (s, e) =>
+                {
+                    if (ve.Handler?.PlatformView is View nativeView && newValue is string maskSetting)
+                    {
+                        if (string.IsNullOrEmpty(maskSetting))
+                        {
+                            return;
+                        }
+                        // "sentry-unmask" if true; remove tag if false
+                        nativeView.Tag = maskSetting;
+                    }
+                };
+            }
+#endif
+    }
+}

--- a/src/Sentry.Maui/SessionReplay.cs
+++ b/src/Sentry.Maui/SessionReplay.cs
@@ -16,22 +16,22 @@ public static class SessionReplay
     public static readonly BindableProperty MaskProperty =
         BindableProperty.CreateAttached(
             "Mask",
-            typeof(string),
+            typeof(SessionReplayMaskMode),
             typeof(SessionReplay),
-            defaultValue: "sentry-mask", // default: masked
+            defaultValue: SessionReplayMaskMode.Mask,
             propertyChanged: OnMaskChanged);
 
     /// <summary>
     /// Gets the value of the Mask property for a view
     /// </summary>
-    public static string GetMask(BindableObject view) => (string)view.GetValue(MaskProperty);
+    public static SessionReplayMaskMode GetMask(BindableObject view) => (SessionReplayMaskMode)view.GetValue(MaskProperty);
 
     /// <summary>
     /// Sets the value of the Mask property for a view. .
     /// </summary>
     /// <param name="view">The view element to mask or unmask</param>
     /// <param name="value">The value to assign. Can be either "sentry-mask" or "sentry-unmask".</param>
-    public static void SetMask(BindableObject view, string value) => view.SetValue(MaskProperty, value);
+    public static void SetMask(BindableObject view, SessionReplayMaskMode value) => view.SetValue(MaskProperty, value);
 
     private static void OnMaskChanged(BindableObject bindable, object oldValue, object newValue)
     {
@@ -40,15 +40,18 @@ public static class SessionReplay
             {
                 ve.HandlerChanged += (s, e) =>
                 {
-                    if (ve.Handler?.PlatformView is View nativeView && newValue is string maskSetting)
+                    if (ve.Handler?.PlatformView is not View nativeView ||
+                        newValue is not SessionReplayMaskMode maskSetting)
                     {
-                        if (string.IsNullOrEmpty(maskSetting))
-                        {
-                            return;
-                        }
-                        // "sentry-unmask" if true; remove tag if false
-                        nativeView.Tag = maskSetting;
+                        return;
                     }
+
+                    nativeView.Tag = maskSetting switch
+                    {
+                        SessionReplayMaskMode.Mask => "sentry-mask",
+                        SessionReplayMaskMode.Unmask => "sentry-unmask",
+                        _ => nativeView.Tag
+                    };
                 };
             }
 #endif

--- a/src/Sentry.Maui/SessionReplay.cs
+++ b/src/Sentry.Maui/SessionReplay.cs
@@ -1,5 +1,9 @@
 #if __ANDROID__
 using View = Android.Views.View;
+using Android.Views;
+using Java.Lang;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
 #endif
 
 namespace Sentry.Maui;

--- a/src/Sentry.Maui/SessionReplayMaskMode.cs
+++ b/src/Sentry.Maui/SessionReplayMaskMode.cs
@@ -14,3 +14,19 @@ public enum SessionReplayMaskMode
     /// </summary>
     Unmask
 }
+
+internal static class SessionReplayMaskModeExtensions
+{
+#if __ANDROID__
+    /// <summary>
+    /// Maps from <see cref="SessionReplayMaskMode"/> to the native tag values used by the JavaSDK to mask and unmask
+    /// views. See https://docs.sentry.io/platforms/android/session-replay/privacy/#mask-by-view-instance
+    /// </summary>
+    public static string ToNativeTag(this SessionReplayMaskMode maskMode) => maskMode switch
+    {
+        SessionReplayMaskMode.Mask => "sentry-mask",
+        SessionReplayMaskMode.Unmask => "sentry-unmask",
+        _ => throw new ArgumentOutOfRangeException(nameof(maskMode), maskMode, null)
+    };
+#endif
+}

--- a/src/Sentry.Maui/SessionReplayMaskMode.cs
+++ b/src/Sentry.Maui/SessionReplayMaskMode.cs
@@ -1,0 +1,16 @@
+namespace Sentry.Maui;
+
+/// <summary>
+/// Controls the masking behaviour of the Session Replay feature.
+/// </summary>
+public enum SessionReplayMaskMode
+{
+    /// <summary>
+    /// Masks the view
+    /// </summary>
+    Mask,
+    /// <summary>
+    /// Unmasks the view
+    /// </summary>
+    Unmask
+}

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -272,6 +272,18 @@ public partial class SentryOptions
             public double? SessionSampleRate { get; set; }
             public bool MaskAllImages { get; set; } = true;
             public bool MaskAllText { get; set; } = true;
+            internal HashSet<Type> MaskedControls { get; } = [];
+            internal HashSet<Type> UnmaskedControls { get; } = [];
+
+            public void MaskControlsOfType<T>()
+            {
+                MaskedControls.Add(typeof(T));
+            }
+
+            public void UnmaskControlsOfType<T>()
+            {
+                UnmaskedControls.Add(typeof(T));
+            }
         }
 
         /// <summary>

--- a/test/Sentry.Maui.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Maui.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Maui.Hosting
+﻿[assembly: Microsoft.Maui.Controls.XmlnsDefinition("http://schemas.sentry.io/maui", "Sentry.Maui")]
+[assembly: Microsoft.Maui.Controls.XmlnsPrefix("http://schemas.sentry.io/maui", "sentry")]
+namespace Microsoft.Maui.Hosting
 {
     public static class SentryMauiAppBuilderExtensions
     {
@@ -35,6 +37,17 @@ namespace Sentry.Maui
         public bool IncludeTextInBreadcrumbs { get; set; }
         public bool IncludeTitleInBreadcrumbs { get; set; }
         public void SetBeforeScreenshotCapture(System.Func<Sentry.SentryEvent, Sentry.SentryHint, bool> beforeCapture) { }
+    }
+    public static class SessionReplay
+    {
+        public static readonly Microsoft.Maui.Controls.BindableProperty MaskProperty;
+        public static Sentry.Maui.SessionReplayMaskMode GetMask(Microsoft.Maui.Controls.BindableObject view) { }
+        public static void SetMask(Microsoft.Maui.Controls.BindableObject view, Sentry.Maui.SessionReplayMaskMode value) { }
+    }
+    public enum SessionReplayMaskMode
+    {
+        Mask = 0,
+        Unmask = 1,
     }
 }
 namespace Sentry.Maui.Internal

--- a/test/Sentry.Maui.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Maui.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Maui.Hosting
+﻿[assembly: Microsoft.Maui.Controls.XmlnsDefinition("http://schemas.sentry.io/maui", "Sentry.Maui")]
+[assembly: Microsoft.Maui.Controls.XmlnsPrefix("http://schemas.sentry.io/maui", "sentry")]
+namespace Microsoft.Maui.Hosting
 {
     public static class SentryMauiAppBuilderExtensions
     {
@@ -35,6 +37,17 @@ namespace Sentry.Maui
         public bool IncludeTextInBreadcrumbs { get; set; }
         public bool IncludeTitleInBreadcrumbs { get; set; }
         public void SetBeforeScreenshotCapture(System.Func<Sentry.SentryEvent, Sentry.SentryHint, bool> beforeCapture) { }
+    }
+    public static class SessionReplay
+    {
+        public static readonly Microsoft.Maui.Controls.BindableProperty MaskProperty;
+        public static Sentry.Maui.SessionReplayMaskMode GetMask(Microsoft.Maui.Controls.BindableObject view) { }
+        public static void SetMask(Microsoft.Maui.Controls.BindableObject view, Sentry.Maui.SessionReplayMaskMode value) { }
+    }
+    public enum SessionReplayMaskMode
+    {
+        Mask = 0,
+        Unmask = 1,
     }
 }
 namespace Sentry.Maui.Internal

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.VisualElement.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.VisualElement.cs
@@ -1,6 +1,5 @@
 using Sentry.Maui.Internal;
 using Sentry.Maui.Tests.Mocks;
-using Application = Android.App.Application;
 #if __ANDROID__
 using View = Android.Views.View;
 #endif

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.VisualElement.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.VisualElement.cs
@@ -1,5 +1,9 @@
 using Sentry.Maui.Internal;
 using Sentry.Maui.Tests.Mocks;
+using Application = Android.App.Application;
+#if __ANDROID__
+using View = Android.Views.View;
+#endif
 
 namespace Sentry.Maui.Tests;
 
@@ -46,4 +50,34 @@ public partial class MauiEventsBinderTests
         // Assert
         Assert.Single(_fixture.Scope.Breadcrumbs);
     }
+
+    [Fact]
+    public void OnElementLoaded_SenderIsNotVisualElement_LogsDebugAndReturns()
+    {
+        // Arrange
+        var element = new MockElement("element");
+
+        // Act
+        _fixture.Binder.OnElementLoaded(element, EventArgs.Empty);
+
+        // Assert
+        _fixture.Options.DiagnosticLogger.Received(1).LogDebug("OnElementLoaded: sender is not a VisualElement");
+    }
+
+    [Fact]
+    public void OnElementLoaded_HandlerIsNull_LogsDebugAndReturns()
+    {
+        // Arrange
+        var element = new MockVisualElement("element")
+        {
+            Handler = null
+        };
+
+        // Act
+        _fixture.Binder.OnElementLoaded(element, EventArgs.Empty);
+
+        // Assert
+        _fixture.Options.DiagnosticLogger.Received(1).LogDebug("OnElementLoaded: handler is null");
+    }
+
 }

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.VisualElement.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.VisualElement.cs
@@ -49,34 +49,4 @@ public partial class MauiEventsBinderTests
         // Assert
         Assert.Single(_fixture.Scope.Breadcrumbs);
     }
-
-    [Fact]
-    public void OnElementLoaded_SenderIsNotVisualElement_LogsDebugAndReturns()
-    {
-        // Arrange
-        var element = new MockElement("element");
-
-        // Act
-        _fixture.Binder.OnElementLoaded(element, EventArgs.Empty);
-
-        // Assert
-        _fixture.Options.DiagnosticLogger.Received(1).LogDebug("OnElementLoaded: sender is not a VisualElement");
-    }
-
-    [Fact]
-    public void OnElementLoaded_HandlerIsNull_LogsDebugAndReturns()
-    {
-        // Arrange
-        var element = new MockVisualElement("element")
-        {
-            Handler = null
-        };
-
-        // Act
-        _fixture.Binder.OnElementLoaded(element, EventArgs.Empty);
-
-        // Assert
-        _fixture.Options.DiagnosticLogger.Received(1).LogDebug("OnElementLoaded: handler is null");
-    }
-
 }

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.cs
@@ -18,6 +18,10 @@ public partial class MauiEventsBinderTests
             hub.When(h => h.ConfigureScope(Arg.Any<Action<Scope>>()))
                 .Do(c => c.Arg<Action<Scope>>()(Scope));
 
+            Options.Debug = true;
+            var logger = Substitute.For<IDiagnosticLogger>();
+            logger.IsEnabled(Arg.Any<SentryLevel>()).Returns(true);
+            Options.DiagnosticLogger = logger;
             var options = Microsoft.Extensions.Options.Options.Create(Options);
             Binder = new MauiEventsBinder(
                 hub,

--- a/test/Sentry.Maui.Tests/MauiVisualElementEventsBinderTests.cs
+++ b/test/Sentry.Maui.Tests/MauiVisualElementEventsBinderTests.cs
@@ -1,0 +1,59 @@
+using Sentry.Maui.Internal;
+using Sentry.Maui.Tests.Mocks;
+#if __ANDROID__
+using View = Android.Views.View;
+#endif
+
+namespace Sentry.Maui.Tests;
+
+public class MauiVisualElementEventsBinderTests
+{
+    private class Fixture
+    {
+        public MauiVisualElementEventsBinder Binder { get; }
+
+        public SentryMauiOptions Options { get; } = new();
+
+        public Fixture()
+        {
+            Options.Debug = true;
+            var logger = Substitute.For<IDiagnosticLogger>();
+            logger.IsEnabled(Arg.Any<SentryLevel>()).Returns(true);
+            Options.DiagnosticLogger = logger;
+            var options = Microsoft.Extensions.Options.Options.Create(Options);
+            Binder = new MauiVisualElementEventsBinder(options);
+        }
+    }
+
+    private readonly Fixture _fixture = new();
+
+    [Fact]
+    public void OnElementLoaded_SenderIsNotVisualElement_LogsDebugAndReturns()
+    {
+        // Arrange
+        var element = new MockElement("element");
+
+        // Act
+        _fixture.Binder.OnElementLoaded(element, EventArgs.Empty);
+
+        // Assert
+        _fixture.Options.DiagnosticLogger.Received(1).LogDebug("OnElementLoaded: sender is not a VisualElement");
+    }
+
+    [Fact]
+    public void OnElementLoaded_HandlerIsNull_LogsDebugAndReturns()
+    {
+        // Arrange
+        var element = new MockVisualElement("element")
+        {
+            Handler = null
+        };
+
+        // Act
+        _fixture.Binder.OnElementLoaded(element, EventArgs.Empty);
+
+        // Assert
+        _fixture.Options.DiagnosticLogger.Received(1).LogDebug("OnElementLoaded: handler is null");
+    }
+
+}


### PR DESCRIPTION
# Summary

Previously the SessionReplay options for Android supported either Masking everything or masking nothing:
https://github.com/getsentry/sentry-dotnet/blob/e8a65cf589aa31d4c5997760dcf8ea18b60b752b/samples/Sentry.Samples.Maui/MauiProgram.cs#L34-L35

This PR adds the ability to override those "default" masking settings one or more view elements. 

## Overriding mask settings for specific MAUI components

SDK users would do this first by adding a reference to the Sentry namespace (which gives access to Sentry specific XAML elements):
https://github.com/getsentry/sentry-dotnet/blob/e8a65cf589aa31d4c5997760dcf8ea18b60b752b/samples/Sentry.Samples.Maui/MainPage.xaml#L4

And then by specifying the `sentry:SessionReplay.Mask` for any view elements they want to explicitly mask or unmask:
https://github.com/getsentry/sentry-dotnet/blob/d51862043a7684d8fa6cbb596674ee73a253c891/samples/Sentry.Samples.Maui/MainPage.xaml#L13-L18

## Overriding mask settings for types of MAUI components

https://github.com/getsentry/sentry-dotnet/blob/d51862043a7684d8fa6cbb596674ee73a253c891/samples/Sentry.Samples.Maui/MauiProgram.cs#L36-L38

# Tests

I added a couple of almost inconsequential unit tests. It's very difficult to test these behaviours however since ultimately we're setting properties on native (Android) view elements. Create those view elements requires an [`IMauiContext`](https://stackoverflow.com/a/77556817/1182461) which really needs the view element to sit in an actual MAUI application running on Android.

I couldn't think of a practical way to access or leverage the MAUI context that would exist in our `Sentry.Maui.Device.TestApp.csproj` (I think that's gets created magically by xharness). If anyone who's more experienced with MAUI than me has any ideas about how this could be better tested, maybe we can add better test coverage in the future. 