### PR TITLE
chore: Fix conflict when uploading test results in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: verify-test-results
+          name: ${{ runner.os }}-verify-test-results
           path: "**/*.received.*"
 
       # To save time and disk space, we only create and archive the Nuget packages when we're actually releasing.


### PR DESCRIPTION
When verify tests fail on multiple runners in CI, they all try to upload the test results using the same artifact ID, resulting in the following error:
> Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

#skip-changelog