### PR TITLE
chore: Upload build logs even for failed builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,7 @@ jobs:
         run: dotnet build Sentry-CI-Build-${{ runner.os }}.slnf -c Release --no-restore --nologo -v:minimal -flp:logfile=build.log -p:CopyLocalLockFileAssemblies=true -bl:build.binlog
 
       - name: Upload build logs
+        if: ${{ steps.build.outcome != 'skipped' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-build-logs


### PR DESCRIPTION
Previous build logs were captured as artefacts only if the build step succeeded.

This change means we capture build logs even for failed builds.

#skip-changelog