### PR TITLE
fix: rename `DisableSentryNative` to `SentryNative`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Option to disable the SentryNative integration ([#4107](https://github.com/getsentry/sentry-dotnet/pull/4107))
+- Option to disable the SentryNative integration ([#4107](https://github.com/getsentry/sentry-dotnet/pull/4107), [#4134](https://github.com/getsentry/sentry-dotnet/pull/4134))
 - Reintroduced experimental support for Session Replay on Android ([#4097](https://github.com/getsentry/sentry-dotnet/pull/4097))
 
 ### Fixes

--- a/src/Sentry/Platforms/Native/SentryNative.cs
+++ b/src/Sentry/Platforms/Native/SentryNative.cs
@@ -14,7 +14,7 @@ internal static class SentryNative
 
 #if NET9_0_OR_GREATER
     // FeatureSwitchDefinition should help with trimming disabled code.
-    // This way, `Sentry.Native.IsEnabled` should be treated as a compile-time constant for trimmed apps.
+    // This way, `SentryNative.IsEnabled` should be treated as a compile-time constant for trimmed apps.
     [FeatureSwitchDefinition(SentryNativeIsEnabledSwitchName)]
 #endif
     private static bool IsEnabled => !AppContext.TryGetSwitch(SentryNativeIsEnabledSwitchName, out var isEnabled) || isEnabled;

--- a/src/Sentry/Platforms/Native/SentryNative.cs
+++ b/src/Sentry/Platforms/Native/SentryNative.cs
@@ -14,7 +14,7 @@ internal static class SentryNative
 
 #if NET9_0_OR_GREATER
     // FeatureSwitchDefinition should help with trimming disabled code.
-    // This way, `SentryNative.IsEnabled` should be treated as a compile-time constant for trimmed apps.
+    // This way, `Sentry.Native.IsEnabled` should be treated as a compile-time constant for trimmed apps.
     [FeatureSwitchDefinition(SentryNativeIsEnabledSwitchName)]
 #endif
     private static bool IsEnabled => !AppContext.TryGetSwitch(SentryNativeIsEnabledSwitchName, out var isEnabled) || isEnabled;

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <!-- When user sets <SentryNative>false</SentryNative> or <SentryNative>disable</SentryNative> in their project -->
-    <!-- SentryNative.IsEnabled should result in compile-time constant for trimmed applications -->
+    <!-- Sentry.Native.IsEnabled should result in compile-time constant for trimmed applications -->
     <!-- Effectively disabling native library -->
     <RuntimeHostConfigurationOption Include="Sentry.Native.IsEnabled"
                                     Condition="'$(SentryNative)' != 'false' and '$(SentryNative)' != 'disable'"

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <!-- When user sets <SentryNative>false</SentryNative> or <SentryNative>disable</SentryNative> in their project -->
-    <!-- Sentry.Native.IsEnabled should result in compile-time constant for trimmed applications -->
+    <!-- SentryNative.IsEnabled should result in compile-time constant for trimmed applications -->
     <!-- Effectively disabling native library -->
     <RuntimeHostConfigurationOption Include="Sentry.Native.IsEnabled"
                                     Condition="'$(SentryNative)' != 'false' and '$(SentryNative)' != 'disable'"

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -9,11 +9,11 @@
 <Project>
 
   <ItemGroup>
-    <!-- When user sets <DisableSentryNative>true</DisableSentryNative> in their project -->
+    <!-- When user sets <SentryNative>false</SentryNative> or <SentryNative>disable</SentryNative> in their project -->
     <!-- SentryNative.IsEnabled should result in compile-time constant for trimmed applications -->
     <!-- Effectively disabling native library -->
     <RuntimeHostConfigurationOption Include="Sentry.Native.IsEnabled"
-                                    Condition="'$(DisableSentryNative)' != 'true'"
+                                    Condition="'$(SentryNative)' != 'false' and '$(SentryNative)' != 'disable'"
                                     Value="true"
                                     Trim="true" />
   </ItemGroup>
@@ -22,7 +22,7 @@
     <!-- net8.0 or greater -->
     <FrameworkSupportsNative Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe')">true</FrameworkSupportsNative>
     <!-- Make it opt-out -->
-    <FrameworkSupportsNative Condition="'$(DisableSentryNative)' == 'true'">false</FrameworkSupportsNative>
+    <FrameworkSupportsNative Condition="'$(SentryNative)' == 'false' or '$(SentryNative)' == 'disable'">false</FrameworkSupportsNative>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(FrameworkSupportsNative)' == 'true' and '$(RuntimeIdentifier)' == 'win-x64'">


### PR DESCRIPTION
follow-up to #4107

- Rename unreleased MSBuild property from `DisableSentryNative` to `SentryNative`
  - to keep all Sentry-related MSBuild properties prefixed with `Sentry..`
- Change the value to opt-out from `true` to `false`|`disable`
  - similar to `SentryImplicitUsings`, also an opt-out
  - opposite to `ImplicitUsings`, which is an opt-in
- Keep disabling native libraries as explicit opt-out