### PR TITLE
release: 5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 5.6.0
 
 ### Features
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>5.5.1</VersionPrefix>
+    <VersionPrefix>5.6.0</VersionPrefix>
     <LangVersion>13</LangVersion>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
Release done outside craft because of issues with dotnet versioning

On NuGet already: https://www.nuget.org/packages/Sentry/5.6.0

see:
* https://github.com/getsentry/publish/issues/5421

#skip-changelog