### PR TITLE
feat: Observe transaction on scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+## Features
+
+- When setting a transaction on the scope, the SDK will attempt to sync the transaction's trace with the SDK on the native layer ([#4153](https://github.com/getsentry/sentry-dotnet/pull/4153)) 
+
 ## 5.6.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 5.6.0
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Features
 
-- When setting a transaction on the scope, the SDK will attempt to sync the transaction's trace with the SDK on the native layer ([#4153](https://github.com/getsentry/sentry-dotnet/pull/4153)) 
+- When setting a transaction on the scope, the SDK will attempt to sync the transaction's trace context with the SDK on the native layer. Finishing a transaction will now also start a new trace ([#4153](https://github.com/getsentry/sentry-dotnet/pull/4153)) 
 - Added `CaptureFeedback` overload with `configureScope` parameter ([#4073](https://github.com/getsentry/sentry-dotnet/pull/4073))
 - Custom SessionReplay masks in MAUI Android apps ([#4121](https://github.com/getsentry/sentry-dotnet/pull/4121))
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>5.5.1</VersionPrefix>
+    <VersionPrefix>5.6.0</VersionPrefix>
     <LangVersion>13</LangVersion>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -392,8 +392,13 @@ public class TransactionTracer : IBaseTracer, ITransactionTracer
         EndTimestamp ??= _stopwatch.CurrentDateTimeOffset;
         _options?.LogDebug("Finished Transaction {0}.", SpanId);
 
-        // Clear the transaction from the scope
-        _hub.ConfigureScope(scope => scope.ResetTransaction(this));
+        // Clear the transaction from the scope and regenerate the Propagation Context
+        // We do this so new events don't have a trace context that is "older" than the transaction that just finished
+        _hub.ConfigureScope(scope =>
+        {
+            scope.ResetTransaction(this);
+            scope.SetPropagationContext(new SentryPropagationContext());
+        });
 
         // Client decides whether to discard this transaction based on sampling
         _hub.CaptureTransaction(new SentryTransaction(this));

--- a/test/Sentry.Tests/Protocol/SentryTransactionTests.cs
+++ b/test/Sentry.Tests/Protocol/SentryTransactionTests.cs
@@ -567,6 +567,30 @@ public class SentryTransactionTests
     }
 
     [Fact]
+    public void Finish_ResetsScopeAndSetsNewPropagationContext()
+    {
+        // Arrange
+        var hub = Substitute.For<IHub>();
+        var transaction = new TransactionTracer(hub, "test name", "test op");
+
+        Action<Scope> capturedAction = null;
+        hub.ConfigureScope(Arg.Do<Action<Scope>>(action => capturedAction = action));
+
+        // Act
+        transaction.Finish();
+
+        // Assert
+        hub.Received(1).ConfigureScope(Arg.Any<Action<Scope>>());
+
+        capturedAction.Should().NotBeNull(); // Sanity Check
+        var mockScope = Substitute.For<Scope>();
+        capturedAction(mockScope);
+
+        mockScope.Received(1).ResetTransaction(transaction);
+        mockScope.Received(1).SetPropagationContext(Arg.Any<SentryPropagationContext>());
+    }
+
+    [Fact]
     public void ISpan_GetTransaction_FromTransaction()
     {
         // Arrange

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -326,16 +326,14 @@ public class ScopeTests
             ScopeObserver = observer,
             EnableScopeSync = enableScopeSync
         });
-        // First set a transaction
         var transaction = new TransactionTracer(DisabledHub.Instance, "test-transaction", "op");
         scope.Transaction = transaction;
-
-        // Clear received calls to observer
-        observer.ClearReceivedCalls();
 
         var expectedTraceId = scope.PropagationContext.TraceId;
         var expectedSpanId = scope.PropagationContext.SpanId;
         var expectedCount = enableScopeSync ? 1 : 0;
+
+        observer.ClearReceivedCalls();
 
         // Act
         scope.Transaction = null;
@@ -359,12 +357,11 @@ public class ScopeTests
         var transaction = new TransactionTracer(DisabledHub.Instance, "test-transaction", "op");
         scope.Transaction = transaction;
 
-        // Clear received calls to observer
-        observer.ClearReceivedCalls();
-
         var expectedTraceId = scope.PropagationContext.TraceId;
         var expectedSpanId = scope.PropagationContext.SpanId;
         var expectedCount = enableScopeSync ? 1 : 0;
+
+        observer.ClearReceivedCalls();
 
         // Act
         scope.ResetTransaction(transaction);
@@ -389,7 +386,6 @@ public class ScopeTests
         var differentTransaction = new TransactionTracer(DisabledHub.Instance, "different", "op");
         scope.Transaction = transaction;
 
-        // Clear received calls to observer
         observer.ClearReceivedCalls();
 
         // Act

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -290,6 +290,115 @@ public class ScopeTests
         scope.Span.Should().Be(secondSpan);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Transaction_Set_ObserverSetsTraceIfEnabled(bool enableScopeSync)
+    {
+        // Arrange
+        var observer = Substitute.For<IScopeObserver>();
+        var scope = new Scope(new SentryOptions
+        {
+            ScopeObserver = observer,
+            EnableScopeSync = enableScopeSync
+        });
+        var transaction = new TransactionTracer(DisabledHub.Instance, "test-transaction", "op");
+        var expectedTraceId = transaction.TraceId;
+        var expectedSpanId = transaction.SpanId;
+        var expectedCount = enableScopeSync ? 1 : 0;
+
+        // Act
+        scope.Transaction = transaction;
+
+        // Assert
+        observer.Received(expectedCount).SetTrace(Arg.Is(expectedTraceId), Arg.Is(expectedSpanId));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Transaction_SetToNull_ObserverSetsTraceFromPropagationContextIfEnabled(bool enableScopeSync)
+    {
+        // Arrange
+        var observer = Substitute.For<IScopeObserver>();
+        var scope = new Scope(new SentryOptions
+        {
+            ScopeObserver = observer,
+            EnableScopeSync = enableScopeSync
+        });
+        // First set a transaction
+        var transaction = new TransactionTracer(DisabledHub.Instance, "test-transaction", "op");
+        scope.Transaction = transaction;
+
+        // Clear received calls to observer
+        observer.ClearReceivedCalls();
+
+        var expectedTraceId = scope.PropagationContext.TraceId;
+        var expectedSpanId = scope.PropagationContext.SpanId;
+        var expectedCount = enableScopeSync ? 1 : 0;
+
+        // Act
+        scope.Transaction = null;
+
+        // Assert
+        observer.Received(expectedCount).SetTrace(Arg.Is(expectedTraceId), Arg.Is(expectedSpanId));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ResetTransaction_MatchingTransaction_ObserverSetsTraceFromPropagationContextIfEnabled(bool enableScopeSync)
+    {
+        // Arrange
+        var observer = Substitute.For<IScopeObserver>();
+        var scope = new Scope(new SentryOptions
+        {
+            ScopeObserver = observer,
+            EnableScopeSync = enableScopeSync
+        });
+        var transaction = new TransactionTracer(DisabledHub.Instance, "test-transaction", "op");
+        scope.Transaction = transaction;
+
+        // Clear received calls to observer
+        observer.ClearReceivedCalls();
+
+        var expectedTraceId = scope.PropagationContext.TraceId;
+        var expectedSpanId = scope.PropagationContext.SpanId;
+        var expectedCount = enableScopeSync ? 1 : 0;
+
+        // Act
+        scope.ResetTransaction(transaction);
+
+        // Assert
+        observer.Received(expectedCount).SetTrace(Arg.Is(expectedTraceId), Arg.Is(expectedSpanId));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ResetTransaction_NonMatchingTransaction_ObserverNotCalled(bool enableScopeSync)
+    {
+        // Arrange
+        var observer = Substitute.For<IScopeObserver>();
+        var scope = new Scope(new SentryOptions
+        {
+            ScopeObserver = observer,
+            EnableScopeSync = enableScopeSync
+        });
+        var transaction = new TransactionTracer(DisabledHub.Instance, "test-transaction", "op");
+        var differentTransaction = new TransactionTracer(DisabledHub.Instance, "different", "op");
+        scope.Transaction = transaction;
+
+        // Clear received calls to observer
+        observer.ClearReceivedCalls();
+
+        // Act
+        scope.ResetTransaction(differentTransaction);
+
+        // Assert
+        observer.DidNotReceive().SetTrace(Arg.Any<SentryId>(), Arg.Any<SpanId>());
+    }
+
     [Fact]
     public void AddAttachment_AddAttachments()
     {


### PR DESCRIPTION
### Problem Statement

Underlying SDKs should be able to observe changes to the transaction, so they use the same trace context.

### Proposal

1. Leverage the existing `SetTrace` and call it whenever a transaction gets set/unset on the scope.
2. When the transaction finishes, the trace context needs to be updated again. Since there is no active transaction, this falls back to the propagation context. To preserve some sort of "time continuity", and not have new events contain a trace ID that is "older" than the transaction that just finished, the propagation context gets regenerated.



