### PR TITLE
NU1608 Errors on CI: Detected package version outside of dependency constraint

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -64,7 +64,8 @@ runs:
 
     - name: Install .NET Workloads
       shell: bash
-      run: >
+      run: |
+        pwd
         dotnet workload install \
           wasm-tools wasm-tools-net8 maui-android \
           ${{ runner.os == 'macOS' && 'maui-ios maui-maccatalyst maui-windows macos' || '' }} \

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "9.0.203",
-    "workloadVersion": "9.0.200",
+    "workloadVersion": "9.0.203",
     "rollForward": "disable",
     "allowPrerelease": false
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
     "version": "9.0.203",
+    "workloadVersion": "9.203.0",
     "rollForward": "disable",
     "allowPrerelease": false
   }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "9.0.203",
-    "workloadVersion": "9.203.0",
+    "workloadVersion": "9.0.200",
     "rollForward": "disable",
     "allowPrerelease": false
   }

--- a/test/Sentry.Maui.Tests/Sentry.Maui.Tests.csproj
+++ b/test/Sentry.Maui.Tests/Sentry.Maui.Tests.csproj
@@ -13,11 +13,11 @@
     <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
   </ItemGroup>
 
-  <ItemGroup  Condition="$(TargetFramework.StartsWith('net8'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
   </ItemGroup>
 
-  <ItemGroup  Condition="$(TargetFramework.StartsWith('net9'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/4154:
- https://github.com/getsentry/sentry-dotnet/issues/4154

This PR pins the version of the workloads that will be installed by [specifying a Workload Set in global.json](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-sets#use-globaljson-for-the-workload-set-version). 

The version number that goes in there was a bit mysterious to me at first. It comes from the various versions  described in [Microsoft.NET.Workloads.9.0.200](https://www.nuget.org/packages/Microsoft.NET.Workloads.9.0.200/9.203.1). Alternatively you can get a list of valid options by running `dotnet workload search version`, which on my machine yields:
> 9.0.203.1
> 9.0.203
> 9.0.202
> 9.0.201
> 9.0.200

So we want to pin `9.0.203` basically.

#skip-changelog