### PR TITLE
fix: MSB4185: The function "IsWindows" on type "System.OperatingSystem" is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Work around iOS SHA1 bug ([#4143](https://github.com/getsentry/sentry-dotnet/pull/4143))
+- Fixes build error when building .NET Framwork applications using Sentry 5.6.0: `MSB4185 :The function "IsWindows" on type "System.OperatingSystem" is not available` ([#4160](https://github.com/getsentry/sentry-dotnet/pull/4160))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixes
 
 - Work around iOS SHA1 bug ([#4143](https://github.com/getsentry/sentry-dotnet/pull/4143))
-- Fixes build error when building .NET Framwork applications using Sentry 5.6.0: `MSB4185 :The function "IsWindows" on type "System.OperatingSystem" is not available` ([#4160](https://github.com/getsentry/sentry-dotnet/pull/4160))
+- Fixes build error when building .NET Framework applications using Sentry 5.6.0: `MSB4185 :The function "IsWindows" on type "System.OperatingSystem" is not available` ([#4160](https://github.com/getsentry/sentry-dotnet/pull/4160))
 
 ### Dependencies
 

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -15,7 +15,7 @@
     <Error Text="Android projects using Sentry cannot build using AndroidEnableAssemblyCompression = false due to a Microsoft issue.  Please follow https://github.com/dotnet/android/issues/9752" />
   </Target>
 
-  <ItemGroup Condition="$([System.OperatingSystem]::IsWindows())">
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <!-- See: https://github.com/getsentry/sentry-dotnet/pull/4111 -->
     <LinkerArg Include="/NODEFAULTLIB:MSVCRT" />
   </ItemGroup>


### PR DESCRIPTION
Resolves #4141:
- https://github.com/getsentry/sentry-dotnet/issues/4141

When building .NET Framework applications, only whitelisted `System.*` property function invocations (e.g., `System.OperatingSystem.IsWindows()` are allowed).

This PR avoid using an unlisted functions in the transitive build targets.