### PR TITLE
build(deps): bump Polyfill from 1.23.0 to 1.32.0

### DIFF
--- a/src/Sentry.Analyzers/Sentry.Analyzers.csproj
+++ b/src/Sentry.Analyzers/Sentry.Analyzers.csproj
@@ -24,7 +24,7 @@
       https://github.com/SimonCropp/Polyfill
     -->
     <ItemGroup>
-      <PackageReference Include="Polyfill" Version="1.23.0" PrivateAssets="all" />
+      <PackageReference Include="Polyfill" Version="1.32.0" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -75,7 +75,7 @@
     https://github.com/SimonCropp/Polyfill
   -->
   <ItemGroup>
-    <PackageReference Include="Polyfill" Version="1.23.0" PrivateAssets="all" />
+    <PackageReference Include="Polyfill" Version="1.32.0" PrivateAssets="all" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
from https://github.com/getsentry/sentry-dotnet/pull/4158#discussion_r2069147588

for PR #4158

`Polyfill v1.32.0` includes `System.Diagnostics.CodeAnalysis.ExperimentalAttribute`.

Alternatively, we could update to a later version of _Polyfill_ as well, or the current latest version.
Where e.g. `v1.34.0` includes the `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler` which the compiler then chooses for _interpolated strings_. This should have a positive effect on performance when using _interpolated strings_ in our codebase targeting TFMs less than `net6.0`.

Updating Polyfill in a this PR separately in order to run tests in an isolated fashion because the compiler may pick up new types that now become (internally) accessible.