### PR TITLE
fix: Intermittent error installing Android SDKs when running integration tests

### DIFF
--- a/integration-test/cli.Tests.ps1
+++ b/integration-test/cli.Tests.ps1
@@ -144,15 +144,6 @@ Describe 'MAUI' -ForEach @(
         }
 
         AddPackageReference $name 'Sentry.Maui'
-
-        if (Test-Path env:CI)
-        {
-            dotnet build $name/$name.csproj -t:InstallAndroidDependencies -f:$framework-android$androidTpv -p:AcceptAndroidSDKLicenses=True -p:AndroidSdkPath="/usr/local/lib/android/sdk/" | ForEach-Object { Write-Host $_ }
-            if ($LASTEXITCODE -ne 0)
-            {
-                throw "Failed to install android dependencies."
-            }
-        }
     }
 
     It "uploads symbols and sources for an Android build" {


### PR DESCRIPTION
Fixes intermittent error installing Android SDKs when running integration tests:
```
RuntimeException: Failed to install android dependencies.
  at <ScriptBlock>, /Users/runner/work/sentry-dotnet/sentry-dotnet/integration-test/cli.Tests.ps1:153
```

We shouldn't need to run this build target manually as part of the environment setup anymore.

#skip-changelog