### PR TITLE
fix: Tweak FlushOnDispose_SendsEnvelope

### DIFF
--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1753,18 +1753,19 @@ public partial class HubTests
             options.CacheDirectoryPath = cacheDirectory.Path;
         }
 
+        var hub = new Hub(options);
+        var id = hub.CaptureEvent(new SentryEvent());
+
         // Act
         // Disposing the hub should flush the client and send the envelope.
         // If caching is enabled, it should flush the cache as well.
         // Either way, the envelope should be sent.
-        using (var hub = new Hub(options))
-        {
-            hub.CaptureEvent(new SentryEvent());
-        }
+        hub.Dispose();
 
         // Assert
         await transport.Received(1)
-            .SendEnvelopeAsync(Arg.Any<Envelope>(), Arg.Any<CancellationToken>());
+            .SendEnvelopeAsync(Arg.Is<Envelope>(env => (string)env.Header["event_id"] == id.ToString()),
+                Arg.Any<CancellationToken>());
     }
 
     private static Scope GetCurrentScope(Hub hub) => hub.ScopeManager.GetCurrent().Key;


### PR DESCRIPTION
Attempts to fix #2156:
- https://github.com/getsentry/sentry-dotnet/issues/2156

This code makes use of the id returned by `CaptureEvent`. My theory is that might prevent code optimisations resulting in that code running in parallel to the assertion statement.

I also changed the code to call `Dispose` explicitly. I don't think that makes any difference tbh but it does make the method that is being tested more explicit.

#skip-changelog