### PR TITLE
fix: Update request size thresholds to match other SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Redact Authorization headers before sending events to Sentry ([#4164](https://github.com/getsentry/sentry-dotnet/pull/4164))
 - Remove Strong Naming from Sentry.Hangfire ([#4099](https://github.com/getsentry/sentry-dotnet/pull/4099))
-- Update request size thresholds to match other SDKs ([#4177](https://github.com/getsentry/sentry-dotnet/pull/4177))
+- Increase `RequestSize.Small` threshold from 1 kB to 4 kB to match other SDKs ([#4177](https://github.com/getsentry/sentry-dotnet/pull/4177))
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Redact Authorization headers before sending events to Sentry ([#4164](https://github.com/getsentry/sentry-dotnet/pull/4164))
+- Update request size thresholds to match other SDKs ([#4177](https://github.com/getsentry/sentry-dotnet/pull/4177))
 
 ### Features
 

--- a/src/Sentry.AspNetCore.Grpc/ProtobufRequestExtractionDispatcher.cs
+++ b/src/Sentry.AspNetCore.Grpc/ProtobufRequestExtractionDispatcher.cs
@@ -46,7 +46,7 @@ public class ProtobufRequestExtractionDispatcher : IProtobufRequestPayloadExtrac
 
         switch (size)
         {
-            case RequestSize.Small when request.ContentLength < 1_000:
+            case RequestSize.Small when request.ContentLength < 4_000:
             case RequestSize.Medium when request.ContentLength < 10_000:
             case RequestSize.Always:
                 _options.Log(SentryLevel.Debug,

--- a/src/Sentry/Extensibility/RequestBodyExtractionDispatcher.cs
+++ b/src/Sentry/Extensibility/RequestBodyExtractionDispatcher.cs
@@ -42,7 +42,7 @@ public class RequestBodyExtractionDispatcher : IRequestPayloadExtractor
 
         switch (size)
         {
-            case RequestSize.Small when request.ContentLength < 1_000:
+            case RequestSize.Small when request.ContentLength < 4_000:
             case RequestSize.Medium when request.ContentLength < 10_000:
             case RequestSize.Always:
                 _options.LogDebug("Attempting to read request body of size: {0}, configured max: {1}.",

--- a/test/Sentry.Tests/Extensibility/RequestBodyExtractionDispatcherTests.cs
+++ b/test/Sentry.Tests/Extensibility/RequestBodyExtractionDispatcherTests.cs
@@ -51,10 +51,10 @@ public class RequestBodyExtractionDispatcherTests
 
     [Theory]
     [InlineData(RequestSize.None, 1, false)]
-    [InlineData(RequestSize.Small, 999, true)]
-    [InlineData(RequestSize.Small, 10_000, false)]
+    [InlineData(RequestSize.Small, 3_999, true)]
+    [InlineData(RequestSize.Small, 4_000, false)]
     [InlineData(RequestSize.Medium, 9999, true)]
-    [InlineData(RequestSize.Medium, 100_000, false)]
+    [InlineData(RequestSize.Medium, 10_000, false)]
     [InlineData(RequestSize.Always, int.MaxValue, true)] // 2 GB event? No problem...
     public void ExtractPayload_RequestSizeSmall_ContentLength(RequestSize requestSize, int contentLength, bool readBody)
     {


### PR DESCRIPTION
Changed the threshold for small request bodies from 1k to 4k to align with other SDKs (per [the docs](https://docs.sentry.io/platforms/dotnet/guides/aspnetcore/configuration/options/#max-request-body-size)).