### PR TITLE
ci: Alpine Linux Docker image (musl)

### DIFF
--- a/.github/alpine/Dockerfile
+++ b/.github/alpine/Dockerfile
@@ -1,0 +1,42 @@
+# docker build --build-arg BASE=alpine:3.21
+ARG BASE=alpine:latest
+FROM ${BASE}
+
+RUN apk update
+
+# common
+RUN apk add bash build-base cmake curl git icu lsb-release-minimal sudo tar wget
+
+# sentry-native
+RUN apk add curl-dev libunwind-dev libunwind-static linux-headers openssl-dev zlib-dev xz-dev
+
+# sentry-dotnet
+RUN apk add grpc-plugins openjdk11 powershell
+ENV PROTOBUF_PROTOC=/usr/bin/protoc
+ENV GRPC_PROTOC_PLUGIN=/usr/bin/grpc_csharp_plugin
+RUN pwsh -Command Install-Module Pester -Scope AllUsers -Force
+
+# mono (3.22+)
+RUN if ! apk add mono; then \
+    sed -i.bak 's|/v3\.[0-9]\+|/edge|g' /etc/apk/repositories && \
+    cat /etc/apk/repositories && \
+    apk update && \
+    apk add --no-cache mono && \
+    mv /etc/apk/repositories.bak /etc/apk/repositories && \
+    apk update; \
+  fi
+RUN mono --version
+
+# runner
+RUN addgroup runner
+RUN adduser -S -u 1001 -h /home/runner -G runner runner
+RUN mkdir -p /home/runner /__e /__w /__w/_temp /__w/_actions /__w/_tool
+RUN chown -R runner:runner /home/runner /__e /__w
+RUN ln -s /__w /home/runner/work
+RUN echo "runner ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/runner
+RUN chmod 0440 /etc/sudoers.d/runner
+RUN chmod -R 777 /opt
+RUN chmod -R 777 /usr/share
+USER runner
+WORKDIR /__w
+ENTRYPOINT ["/bin/bash"]

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -1,0 +1,38 @@
+name: Build Alpine Linux Docker image
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/alpine/*'
+
+jobs:
+  build:
+    name: Build sentry-dotnet-alpine:${{ matrix.version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "3.21"
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build ghcr.io/${{ github.repository_owner }}/sentry-dotnet-alpine:${{ matrix.version }}
+        run: docker build --build-arg BASE=alpine:${{ matrix.version }} -t ghcr.io/${{ github.repository_owner }}/sentry-dotnet-alpine:${{ matrix.version }} .
+        working-directory: .github/alpine
+
+      - name: Push ghcr.io/${{ github.repository_owner }}/sentry-dotnet-alpine:${{ matrix.version }}
+        run: docker push ghcr.io/${{ github.repository_owner }}/sentry-dotnet-alpine:${{ matrix.version }}
+        working-directory: .github/alpine


### PR DESCRIPTION
This PR adds a workflow for building an Alpine Linux Docker image tailored for the CI workflows in sentry-dotnet, which is a prerequisite for testing `linux-musl-x64` in:
- https://github.com/getsentry/sentry-dotnet/pull/4188

### Background

The Alpine Linux Docker image is bare bones (< 5MB!) and requires quite a bit of boilerplate to make it usable even for basic CI workflows:
- `git` must be installed before `actions/checkout`
- `tar` must be installed before `actions/cache`
- `bash` must be installed before any `shell: bash` steps
- ...

Furthermore, the ready-made runner images come with a wide range of pre-installed development packages and tools missing in the vanilla Alpine Linux image. Last but not least, various `setup-xxx` actions rely on relaxed system permissions (`chmod 777 -R /opt /usr/share`), and the integration test composite action requires a runner-like structure.

### Notes

- The workflow requires `packages: write` permission to push to ghcr.io.
- This action only needs to be triggered once, but has a trigger on `.github/alpine` should the `Dockerfile` ever need adjustments.