### PR TITLE
remove build-tools workaround

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -28,18 +28,6 @@ runs:
       with:
         log-accepted-android-sdk-licenses: false
 
-    # https://github.com/actions/runner-images/issues/10814
-    - name: Workaround build-tools issue
-      if: runner.os == 'macOS'
-      shell: bash
-      run: |
-        curl https://dl.google.com/android/repository/build-tools_r35_macosx.zip > $ANDROID_HOME/build-tools_r35_macosx.zip
-        cd $ANDROID_HOME
-        mkdir -p build-tools
-        unzip build-tools_r35_macosx.zip
-        mv android-15 build-tools/35.0.0
-        cd -
-
     - name: Set Java Version
       uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
Seems it's not needed anymore (based on [this PR](https://github.com/getsentry/sentry-dotnet/pull/4187/files))

#skip-changelog