### PR TITLE
MauiAppBuilderExtensions Benchmarks - DO NOT MERGE

### DIFF
--- a/benchmarks/Sentry.Benchmarks/BenchmarkDotNet.Artifacts/results/MvvmBenchmarks-report-github.md
+++ b/benchmarks/Sentry.Benchmarks/BenchmarkDotNet.Artifacts/results/MvvmBenchmarks-report-github.md
@@ -1,0 +1,15 @@
+```
+
+BenchmarkDotNet v0.13.12, macOS 15.4.1 (24E263) [Darwin 24.4.0]
+Apple M2 Max, 1 CPU, 12 logical and 12 physical cores
+.NET SDK 9.0.203
+  [Host]     : .NET 9.0.4 (9.0.425.16305), Arm64 RyuJIT AdvSIMD
+  DefaultJob : .NET 9.0.4 (9.0.425.16305), Arm64 RyuJIT AdvSIMD
+
+
+```
+| Method           | ResolveOptionsWithServiceProvider | Mean     | Error   | StdDev   | Gen0    | Gen1   | Allocated |
+|----------------- |---------------------------------- |---------:|--------:|---------:|--------:|-------:|----------:|
+| **&#39;Build MAUI App&#39;** | **Directly**                          | **470.8 μs** | **9.02 μs** |  **9.65 μs** | **11.7188** | **2.9297** |  **99.25 KB** |
+| **&#39;Build MAUI App&#39;** | **ServiceProvider**                   | **473.6 μs** | **8.73 μs** | **13.85 μs** | **11.7188** | **2.9297** |  **98.66 KB** |
+| **&#39;Build MAUI App&#39;** | **InvokeConfigOptions**               | **462.0 μs** | **8.84 μs** | **10.18 μs** | **11.7188** | **2.9297** |  **98.74 KB** |

--- a/benchmarks/Sentry.Benchmarks/BenchmarkDotNet.Artifacts/results/MvvmBenchmarks-report-github.md
+++ b/benchmarks/Sentry.Benchmarks/BenchmarkDotNet.Artifacts/results/MvvmBenchmarks-report-github.md
@@ -8,8 +8,8 @@ Apple M2 Max, 1 CPU, 12 logical and 12 physical cores
 
 
 ```
-| Method           | ResolveOptionsWithServiceProvider | Mean     | Error   | StdDev   | Gen0    | Gen1   | Allocated |
-|----------------- |---------------------------------- |---------:|--------:|---------:|--------:|-------:|----------:|
-| **&#39;Build MAUI App&#39;** | **Directly**                          | **470.8 μs** | **9.02 μs** |  **9.65 μs** | **11.7188** | **2.9297** |  **99.25 KB** |
-| **&#39;Build MAUI App&#39;** | **ServiceProvider**                   | **473.6 μs** | **8.73 μs** | **13.85 μs** | **11.7188** | **2.9297** |  **98.66 KB** |
-| **&#39;Build MAUI App&#39;** | **InvokeConfigOptions**               | **462.0 μs** | **8.84 μs** | **10.18 μs** | **11.7188** | **2.9297** |  **98.74 KB** |
+| Method           | ResolveOptionsWithServiceProvider | Mean     | Error    | StdDev   | Median   | Gen0    | Gen1   | Allocated |
+|----------------- |---------------------------------- |---------:|---------:|---------:|---------:|--------:|-------:|----------:|
+| **&#39;Build MAUI App&#39;** | **Directly**                          | **494.3 μs** | **19.62 μs** | **53.38 μs** | **476.0 μs** | **12.6953** | **2.9297** | **105.13 KB** |
+| **&#39;Build MAUI App&#39;** | **ServiceProvider**                   | **488.1 μs** |  **8.56 μs** | **12.55 μs** | **486.6 μs** | **15.6250** | **3.9063** | **129.52 KB** |
+| **&#39;Build MAUI App&#39;** | **InvokeConfigOptions**               | **499.5 μs** |  **9.93 μs** | **22.21 μs** | **501.9 μs** | **12.6953** | **3.9063** | **110.23 KB** |

--- a/benchmarks/Sentry.Benchmarks/MvvmBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/MvvmBenchmarks.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+using Sentry;
+using Sentry.Maui;
+
+public class MvvmBenchmarks
+{
+    private MauiAppBuilder AppBuilder;
+
+    [Params(RegisterEventBinderMethod.ServiceProvider, RegisterEventBinderMethod.InvokeConfigOptions, RegisterEventBinderMethod.Directly)]
+    public RegisterEventBinderMethod ResolveOptionsWithServiceProvider;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        AppBuilder = MauiApp.CreateBuilder()
+            // This adds Sentry to your Maui application
+            .UseSentry(options =>
+            {
+                // The DSN is the only required option.
+                options.Dsn = DsnSamples.ValidDsn;
+                // Automatically create traces for async relay commands in the MVVM Community Toolkit
+                options.AddCommunityToolkitIntegration();
+            }, ResolveOptionsWithServiceProvider);
+    }
+
+    [Benchmark(Description = "Build MAUI App")]
+    public void BuildMauiAppBenchmark()
+    {
+        AppBuilder.Build();
+    }
+}

--- a/benchmarks/Sentry.Benchmarks/MvvmBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/MvvmBenchmarks.cs
@@ -4,15 +4,13 @@ using Sentry.Maui;
 
 public class MvvmBenchmarks
 {
-    private MauiAppBuilder AppBuilder;
-
     [Params(RegisterEventBinderMethod.ServiceProvider, RegisterEventBinderMethod.InvokeConfigOptions, RegisterEventBinderMethod.Directly)]
     public RegisterEventBinderMethod ResolveOptionsWithServiceProvider;
 
-    [GlobalSetup]
-    public void Setup()
+    [Benchmark(Description = "Build MAUI App")]
+    public void BuildMauiAppBenchmark()
     {
-        AppBuilder = MauiApp.CreateBuilder()
+        var appBuilder = MauiApp.CreateBuilder()
             // This adds Sentry to your Maui application
             .UseSentry(options =>
             {
@@ -21,11 +19,6 @@ public class MvvmBenchmarks
                 // Automatically create traces for async relay commands in the MVVM Community Toolkit
                 options.AddCommunityToolkitIntegration();
             }, ResolveOptionsWithServiceProvider);
-    }
-
-    [Benchmark(Description = "Build MAUI App")]
-    public void BuildMauiAppBenchmark()
-    {
-        AppBuilder.Build();
+        appBuilder.Build();
     }
 }

--- a/benchmarks/Sentry.Benchmarks/Sentry.Benchmarks.csproj
+++ b/benchmarks/Sentry.Benchmarks/Sentry.Benchmarks.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <UseMaui>true</UseMaui>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Sentry.Maui.CommunityToolkit.Mvvm\Sentry.Maui.CommunityToolkit.Mvvm.csproj" />
+    <ProjectReference Include="..\..\src\Sentry.Maui\Sentry.Maui.csproj" />
     <ProjectReference Include="..\..\src\Sentry\Sentry.csproj" />
     <ProjectReference Include="..\..\src\Sentry.Profiling\Sentry.Profiling.csproj" />
     <ProjectReference Include="..\..\test\Sentry.Testing\Sentry.Testing.csproj" />


### PR DESCRIPTION
Not to be merged... this is just to investigate the performance implications of various different techniques for initialising the Sentry.Maui integration. 

Third round of benchmarks, I realised much of what we wanted to measure was being hidden in the `[GlobalSetup]` for the Benchmark test. I moved all of this into the test itself (so that it would be properly measured) 

Results of the latest benchmarks:
| Method           | ResolveOptionsWithServiceProvider | Mean     | Error    | StdDev   | Median   | Gen0    | Gen1   | Allocated |
|----------------- |---------------------------------- |---------:|---------:|---------:|---------:|--------:|-------:|----------:|
| 'Build MAUI App' | Directly                          | 494.3 us | 19.62 us | 53.38 us | 476.0 us | 12.6953 | 2.9297 | 105.13 KB |                                                     
| 'Build MAUI App' | ServiceProvider                   | 488.1 us |  8.56 us | 12.55 us | 486.6 us | 15.6250 | 3.9063 | 129.52 KB |
| 'Build MAUI App' | InvokeConfigOptions               | 499.5 us |  9.93 us | 22.21 us | 501.9 us | 12.6953 | 3.9063 | 110.23 KB |

This time round, the winner actually appears to be the existing code (as surprising as that may be).

Overall, the difference between all 3 solutions is less than 12 millionths of a second (running on a Macbook with an M2 processor). Even assuming we're running on a device that is 1000 times slower, that amounts to approximately ~10 ms.