### PR TITLE
Fix typo in SentryOptions.DefaultTags description

### DIFF
--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -34,7 +34,7 @@ public static class SentrySinkExtensions
     /// <param name="diagnosticLevel">The diagnostics level to be used. <seealso cref="SentryOptions.DiagnosticLevel"/></param>
     /// <param name="reportAssembliesMode">What mode to use for reporting referenced assemblies in each event sent to sentry. Defaults to <see cref="Sentry.ReportAssembliesMode.Version"/></param>
     /// <param name="deduplicateMode">What modes to use for event automatic de-duplication. <seealso cref="SentryOptions.DeduplicateMode"/></param>
-    /// <param name="defaultTags">Defaults tags to add to all events. <seealso cref="SentryOptions.DefaultTags"/></param>
+    /// <param name="defaultTags">Default tags to add to all events. <seealso cref="SentryOptions.DefaultTags"/></param>
     /// <returns><see cref="LoggerConfiguration"/></returns>
     /// <example>This sample shows how each item may be set from within a configuration file:
     /// <code>

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -825,7 +825,7 @@ public class SentryOptions
     public TimeSpan InitCacheFlushTimeout { get; set; } = TimeSpan.FromSeconds(1);
 
     /// <summary>
-    /// Defaults tags to add to all events. (These are indexed by Sentry).
+    /// Default tags to add to all events. (These are indexed by Sentry).
     /// </summary>
     /// <remarks>
     /// If the key already exists in the event, it will not be overwritten by a default tag.


### PR DESCRIPTION
Found the same typo in `SentrySinkExtensions`, so fixed that as well.