### PR TITLE
Remove call to BuildServiceProvider when initialising Sentry.Maui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support musl on Linux ([#4188](https://github.com/getsentry/sentry-dotnet/pull/4188))
 - Support for Windows ARM64 with Native AOT ([#4187](https://github.com/getsentry/sentry-dotnet/pull/4187))
+- Addressed potential performance issue with Sentry.Maui ([#4219](https://github.com/getsentry/sentry-dotnet/pull/4219))
 
 ## 5.8.0
 

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -57,9 +57,8 @@ public static class SentryMauiAppBuilderExtensions
         services.AddSingleton<Disposer>();
 
         // Resolve the configured options and register any element event binders from these
-        IServiceProvider serviceProvider = services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptions<SentryMauiOptions>>().Value;
-        services.TryAddSingleton<SentryOptions>(options); // Ensure this doesn't get resolved again in AddSentry
+        var options = new SentryMauiOptions();
+        configureOptions?.Invoke(options);
         foreach (var eventBinder in options.DefaultEventBinders)
         {
             eventBinder.Register(services);


### PR DESCRIPTION
Resolves #4216:
- https://github.com/getsentry/sentry-dotnet/issues/4216