### PR TITLE
fix: respect `SentryNative=false` at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Support musl on Linux ([#4188](https://github.com/getsentry/sentry-dotnet/pull/4188))
 - Support for Windows ARM64 with Native AOT ([#4187](https://github.com/getsentry/sentry-dotnet/pull/4187))
 - Addressed potential performance issue with Sentry.Maui ([#4219](https://github.com/getsentry/sentry-dotnet/pull/4219))
+- Respect `SentryNative=false` at runtime ([#4220](https://github.com/getsentry/sentry-dotnet/pull/4220))
 
 ## 5.8.0
 

--- a/src/Sentry/Internal/DebugStackTrace.cs
+++ b/src/Sentry/Internal/DebugStackTrace.cs
@@ -260,6 +260,10 @@ internal class DebugStackTrace : SentryStackTrace
 #elif __IOS__ || MACCATALYST
         _nativeDebugImages ??= Sentry.Cocoa.C.LoadDebugImages(_options.DiagnosticLogger);
 #else
+        if (!SentryNative.IsAvailable)
+        {
+            _nativeDebugImages ??= new();
+        }
         _nativeDebugImages ??= Sentry.Native.C.LoadDebugImages(_options.DiagnosticLogger);
 #endif
 

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -13,8 +13,8 @@
     <!-- SentryNative.IsEnabled should result in compile-time constant for trimmed applications -->
     <!-- Effectively disabling native library -->
     <RuntimeHostConfigurationOption Include="Sentry.Native.IsEnabled"
-                                    Condition="'$(SentryNative)' != 'false' and '$(SentryNative)' != 'disable'"
-                                    Value="true"
+                                    Condition="'$(SentryNative)' == 'false' or '$(SentryNative)' == 'disable'"
+                                    Value="false"
                                     Trim="true" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR fixes the problem that `<SentryNative>false</SentryNative>` results in `Sentry.Native.IsEnabled=true` at runtime, as it came up in:
- https://github.com/getsentry/sentry-dotnet/issues/4116#issuecomment-2887052166