### PR TITLE
feat: replace libcurl with .NET HttpClient for sentry-native

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,12 +53,6 @@ jobs:
         if: ${{ !matrix.container }}
         uses: ./.github/actions/freediskspace
 
-      - name: Install build dependencies
-        if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'Linux' && !matrix.container
-        run: |
-          sudo apt update
-          sudo apt install libcurl4-openssl-dev
-
       - run: scripts/build-sentry-native.ps1
         if: steps.cache.outputs.cache-hit != 'true'
         shell: pwsh
@@ -238,12 +232,6 @@ jobs:
         with:
           name: ${{ github.sha }}
           path: src
-
-      - name: Install build dependencies
-        if: runner.os == 'Linux' && !matrix.container
-        run: |
-          sudo apt update
-          sudo apt install libcurl4-openssl-dev
 
       - name: Setup Environment
         uses: ./.github/actions/environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Rename MemoryInfo.AllocatedBytes to MemoryInfo.TotalAllocatedBytes ([#4243](https://github.com/getsentry/sentry-dotnet/pull/4243))
+- Replace libcurl with .NET HttpClient for sentry-native ([#4222](https://github.com/getsentry/sentry-dotnet/pull/4222))
 
 ## 5.9.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,15 +32,13 @@ For big feature it's advised to raise an issue to discuss it first.
 
 * [`pwsh`](https://github.com/PowerShell/PowerShell#get-powershell) Core version 6 or later on PATH.
 
-* `CMake` on PATH. On Windows you can install the [C++ CMake tools for Windows](https://learn.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-170#installation). On macOS you can use your favourite package manager (e.g. `brew install cmake`).
+* `CMake` on PATH. On Windows you can install the [C++ CMake tools for Windows](https://learn.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-170#installation). On macOS and Linux you can use your favourite package manager (e.g. `brew install cmake` or `apt install cmake`).
 
 * On Windows:
   - [.NET Framework](https://dotnet.microsoft.com/download/dotnet-framework) 4.6.2 or higher.
   - `Sentry.DiagnosticSource.IntegrationTests.csproj` uses [SQL LocalDb](https://docs.microsoft.com/sql/database-engine/configure-windows/sql-server-express-localdb) - [download SQL LocalDB 2019](https://download.microsoft.com/download/7/c/1/7c14e92e-bdcb-4f89-b7cf-93543e7112d1/SqlLocalDB.msi). To avoid running these tests, unload `Sentry.DiagnosticSource.IntegrationTests.csproj` from the solution.
 * On macOS/Linux
   - [Mono 6 or higher](https://www.mono-project.com/download/stable) to run the unit tests on the `net4x` targets.
-* On Linux
-  - **curl** and **zlib** libraries (e.g. on Ubuntu: libcurl4-openssl-dev, libz-dev) to build the [sentry-native](https://github.com/getsentry/sentry-native/) module.
 
 ## .NET MAUI Requirements
 

--- a/scripts/build-sentry-native.ps1
+++ b/scripts/build-sentry-native.ps1
@@ -69,6 +69,7 @@ try
         -D SENTRY_SDK_NAME=sentry.native.dotnet `
         -D SENTRY_BUILD_SHARED_LIBS=0 `
         -D SENTRY_BACKEND=inproc `
+        -D SENTRY_TRANSPORT=none `
         $additionalArgs
 
     cmake `

--- a/src/Sentry/Http/HttpTransportBase.cs
+++ b/src/Sentry/Http/HttpTransportBase.cs
@@ -187,20 +187,8 @@ public abstract class HttpTransportBase
             throw new InvalidOperationException("The DSN is expected to be set at this point.");
         }
 
-        var dsn = Dsn.Parse(_options.Dsn);
-        var authHeader =
-            $"Sentry sentry_version={_options.SentryVersion}," +
-            $"sentry_client={SdkVersion.Instance.Name}/{SdkVersion.Instance.Version}," +
-            $"sentry_key={dsn.PublicKey}" +
-            (dsn.SecretKey is { } secretKey ? $",sentry_secret={secretKey}" : null);
-
-        return new HttpRequestMessage
-        {
-            RequestUri = dsn.GetEnvelopeEndpointUri(),
-            Method = HttpMethod.Post,
-            Headers = { { "X-Sentry-Auth", authHeader } },
-            Content = new EnvelopeHttpContent(envelope, _options.DiagnosticLogger, _clock)
-        };
+        var content = new EnvelopeHttpContent(envelope, _options.DiagnosticLogger, _clock);
+        return _options.CreateHttpRequest(content);
     }
 
     /// <summary>

--- a/src/Sentry/Platforms/Native/CFunctions.cs
+++ b/src/Sentry/Platforms/Native/CFunctions.cs
@@ -396,9 +396,9 @@ internal static class C
     [UnmanagedCallersOnly]
     private static void nativeTransport(IntPtr envelope, IntPtr state)
     {
+        var options = GCHandle.FromIntPtr(state).Target as SentryOptions;
         try
         {
-            var options = GCHandle.FromIntPtr(state).Target as SentryOptions;
             if (options is not null)
             {
                 var data = sentry_envelope_serialize(envelope, out var size);
@@ -409,9 +409,10 @@ internal static class C
                 client.SendAsync(request).GetAwaiter().GetResult();
             }
         }
-        catch
+        catch (Exception e)
         {
             // never allow an exception back to native code - it would crash the app
+            options?.DiagnosticLogger?.LogError(e, "Exception in native transport callback. The native envelope will not be sent.");
         }
         finally
         {

--- a/src/Sentry/Platforms/Native/CFunctions.cs
+++ b/src/Sentry/Platforms/Native/CFunctions.cs
@@ -391,7 +391,7 @@ internal static class C
     private static extern void sentry_envelope_free(IntPtr envelope);
 
     [DllImport("sentry-native")]
-    private static extern void sentry_free(IntPtr ptr);
+    internal static extern void sentry_free(IntPtr ptr);
 
     [UnmanagedCallersOnly]
     private static void nativeTransport(IntPtr envelope, IntPtr state)
@@ -402,8 +402,7 @@ internal static class C
             if (options is not null)
             {
                 var data = sentry_envelope_serialize(envelope, out var size);
-                var content = new StringContent(Marshal.PtrToStringAnsi(data, (int)size));
-                sentry_free(data);
+                using var content = new UnmanagedHttpContent(data, (int)size, options.DiagnosticLogger);
 
                 using var client = options.GetHttpClient();
                 using var request = options.CreateHttpRequest(content);

--- a/src/Sentry/Platforms/Native/UnmanagedHttpContent.cs
+++ b/src/Sentry/Platforms/Native/UnmanagedHttpContent.cs
@@ -4,7 +4,7 @@ namespace Sentry.Native;
 
 internal sealed class UnmanagedHttpContent : SerializableHttpContent
 {
-    private readonly IntPtr _content;
+    private IntPtr _content;
     private readonly int _length = 0;
     private readonly IDiagnosticLogger? _logger;
 
@@ -52,6 +52,7 @@ internal sealed class UnmanagedHttpContent : SerializableHttpContent
     protected override void Dispose(bool disposing)
     {
         C.sentry_free(_content);
+        _content = IntPtr.Zero;
         base.Dispose(disposing);
     }
 

--- a/src/Sentry/Platforms/Native/UnmanagedHttpContent.cs
+++ b/src/Sentry/Platforms/Native/UnmanagedHttpContent.cs
@@ -22,7 +22,7 @@ internal sealed class UnmanagedHttpContent : SerializableHttpContent
 
     protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
     {
-        ObjectDisposedException.ThrowIf(_content == IntPtr.Zero, this);
+        ThrowIfObjectDisposed();
         try
         {
             using var unmanagedStream = CreateStream();
@@ -37,7 +37,7 @@ internal sealed class UnmanagedHttpContent : SerializableHttpContent
 
     protected override void SerializeToStream(Stream stream, TransportContext? context, CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_content == IntPtr.Zero, this);
+        ThrowIfObjectDisposed();
         try
         {
             using var unmanagedStream = CreateStream();
@@ -66,5 +66,13 @@ internal sealed class UnmanagedHttpContent : SerializableHttpContent
     private unsafe UnmanagedMemoryStream CreateStream()
     {
         return new UnmanagedMemoryStream((byte*)_content.ToPointer(), _length);
+    }
+
+    private void ThrowIfObjectDisposed()
+    {
+        if (_content == IntPtr.Zero)
+        {
+            throw new ObjectDisposedException(GetType().FullName);
+        }
     }
 }

--- a/src/Sentry/Platforms/Native/UnmanagedHttpContent.cs
+++ b/src/Sentry/Platforms/Native/UnmanagedHttpContent.cs
@@ -22,6 +22,7 @@ internal sealed class UnmanagedHttpContent : SerializableHttpContent
 
     protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
     {
+        ObjectDisposedException.ThrowIf(_content == IntPtr.Zero, this);
         try
         {
             using var unmanagedStream = CreateStream();
@@ -36,6 +37,7 @@ internal sealed class UnmanagedHttpContent : SerializableHttpContent
 
     protected override void SerializeToStream(Stream stream, TransportContext? context, CancellationToken cancellationToken)
     {
+        ObjectDisposedException.ThrowIf(_content == IntPtr.Zero, this);
         try
         {
             using var unmanagedStream = CreateStream();

--- a/src/Sentry/Platforms/Native/UnmanagedHttpContent.cs
+++ b/src/Sentry/Platforms/Native/UnmanagedHttpContent.cs
@@ -15,6 +15,11 @@ internal sealed class UnmanagedHttpContent : SerializableHttpContent
         _logger = logger;
     }
 
+    ~UnmanagedHttpContent()
+    {
+        Dispose(false);
+    }
+
     protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
     {
         try
@@ -51,8 +56,8 @@ internal sealed class UnmanagedHttpContent : SerializableHttpContent
 
     protected override void Dispose(bool disposing)
     {
-        C.sentry_free(_content);
-        _content = IntPtr.Zero;
+        IntPtr content = Interlocked.Exchange(ref _content, IntPtr.Zero);
+        C.sentry_free(content);
         base.Dispose(disposing);
     }
 

--- a/src/Sentry/Platforms/Native/UnmanagedHttpContent.cs
+++ b/src/Sentry/Platforms/Native/UnmanagedHttpContent.cs
@@ -52,7 +52,7 @@ internal sealed class UnmanagedHttpContent : SerializableHttpContent
     protected override bool TryComputeLength(out long length)
     {
         length = _length;
-        return false;
+        return true;
     }
 
     protected override void Dispose(bool disposing)

--- a/src/Sentry/Platforms/Native/UnmanagedHttpContent.cs
+++ b/src/Sentry/Platforms/Native/UnmanagedHttpContent.cs
@@ -2,7 +2,7 @@ using Sentry.Extensibility;
 
 namespace Sentry.Native;
 
-internal class UnmanagedHttpContent : SerializableHttpContent
+internal sealed class UnmanagedHttpContent : SerializableHttpContent
 {
     private readonly IntPtr _content;
     private readonly int _length = 0;

--- a/src/Sentry/Platforms/Native/UnmanagedHttpContent.cs
+++ b/src/Sentry/Platforms/Native/UnmanagedHttpContent.cs
@@ -1,0 +1,63 @@
+using Sentry.Extensibility;
+
+namespace Sentry.Native;
+
+internal class UnmanagedHttpContent : SerializableHttpContent
+{
+    private readonly IntPtr _content;
+    private readonly int _length = 0;
+    private readonly IDiagnosticLogger? _logger;
+
+    public UnmanagedHttpContent(IntPtr content, int length, IDiagnosticLogger? logger)
+    {
+        _content = content;
+        _length = length;
+        _logger = logger;
+    }
+
+    protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+    {
+        try
+        {
+            unsafe
+            {
+                using var unmanagedStream = new UnmanagedMemoryStream((byte*)_content.ToPointer(), _length);
+                return unmanagedStream.CopyToAsync(stream);
+            }
+        }
+        catch (Exception e)
+        {
+            _logger?.LogError(e, "Failed to serialize unmanaged content into the network stream");
+            throw;
+        }
+    }
+
+    protected override void SerializeToStream(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+    {
+        try
+        {
+            unsafe
+            {
+                using var unmanagedStream = new UnmanagedMemoryStream((byte*)_content.ToPointer(), _length);
+                unmanagedStream.CopyTo(stream);
+            }
+        }
+        catch (Exception e)
+        {
+            _logger?.LogError(e, "Failed to serialize unmanaged content into the network stream");
+            throw;
+        }
+    }
+
+    protected override bool TryComputeLength(out long length)
+    {
+        length = _length;
+        return false;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        C.sentry_free(_content);
+        base.Dispose(disposing);
+    }
+}

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -36,8 +36,6 @@
   <ItemGroup Condition="'$(FrameworkSupportsNative)' == 'true' and ('$(RuntimeIdentifier)' == 'linux-x64' or '$(RuntimeIdentifier)' == 'linux-arm64')">
     <DirectPInvoke Include="sentry-native" />
     <NativeLibrary Include="$(MSBuildThisFileDirectory)..\sentry-native\$(RuntimeIdentifier)\libsentry-native.a" />
-    <!-- See: https://github.com/dotnet/runtime/issues/97414 -->
-    <NativeSystemLibrary Include="curl" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(FrameworkSupportsNative)' == 'true' and '$(RuntimeIdentifier)' == 'linux-musl-x64'">
@@ -46,13 +44,10 @@
     <LinkerArg Include="-Wl,-Bstatic -Wl,--whole-archive -lunwind -Wl,--no-whole-archive -Wl,-Bdynamic" />
     <NativeSystemLibrary Include="lzma" />
     <NativeLibrary Include="$(MSBuildThisFileDirectory)..\sentry-native\linux-musl-x64\libsentry-native.a" />
-    <!-- See: https://github.com/dotnet/runtime/issues/97414 -->
-    <NativeSystemLibrary Include="curl" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(FrameworkSupportsNative)' == 'true' and ('$(RuntimeIdentifier)' == 'osx-x64' or '$(RuntimeIdentifier)' == 'osx-arm64')">
     <DirectPInvoke Include="sentry-native" />
     <NativeLibrary Include="$(MSBuildThisFileDirectory)..\sentry-native\osx\libsentry-native.a" />
-    <NativeSystemLibrary Include="curl" />
   </ItemGroup>
 </Project>

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -245,6 +245,23 @@ public class SentryOptions
         return factory.Create(this);
     }
 
+    internal HttpRequestMessage CreateHttpRequest(HttpContent content)
+    {
+        var authHeader =
+            $"Sentry sentry_version={SentryVersion}," +
+            $"sentry_client={SdkVersion.Instance.Name}/{SdkVersion.Instance.Version}," +
+            $"sentry_key={ParsedDsn.PublicKey}" +
+            (ParsedDsn.SecretKey is { } secretKey ? $",sentry_secret={secretKey}" : null);
+
+        return new HttpRequestMessage
+        {
+            RequestUri = ParsedDsn.GetEnvelopeEndpointUri(),
+            Method = HttpMethod.Post,
+            Headers = { { "X-Sentry-Auth", authHeader } },
+            Content = content
+        };
+    }
+
     /// <summary>
     /// Scope state processor.
     /// </summary>


### PR DESCRIPTION
Install a custom function transport for sentry-native, and send native envelopes with the .NET HttpClient instead of relying on the default libcurl-based HTTP transport in sentry-native. This way, sentry-native can be built with `-DSENTRY_TRANSPORT=none` to eliminate the libcurl dependency, which is problematic for minimal/chiseled .NET Native AOT containers.

The behavior remains virtually identical compared to the current native transport with libcurl. The Native AOT integration test that [captures a native envelope on restart](https://github.com/getsentry/sentry-dotnet/blob/9beef00b325bd79c2cf43829f069142461aec113/integration-test/runtime.Tests.ps1#L163-L176) passes without any changes. The only difference is that native envelopes are sent with .NET HttpClient instead of libcurl. There's no native -> .NET envelope conversion nor hooks being called.

Close: #4116