### PR TITLE
test: fix local integration tests on case-sensitive file systems

### DIFF
--- a/integration-test/common.ps1
+++ b/integration-test/common.ps1
@@ -85,7 +85,7 @@ BeforeAll {
         }
 
         # We need to remove the package from cache or it won't re resolved properly
-        Remove-Item -Path ~/.nuget/packages/$name/$packageVersion -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path ~/.nuget/packages/$($name.ToLower())/$packageVersion -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     Remove-Item -Path "$PSScriptRoot/packages" -Recurse -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
The integration test tries to remove `~/.nuget/packages/Sentry/x.y.z` (capitalized package name) but the package is stored in `~/.nuget/packages/sentry/x.y.z` (lowercase package id). The failure is silently ignored because it might not exist on a clean system. However, when it does, running integration tests locally on a case-sensitive file system won't resolve the local package in `integration-test/packages` but uses the wrong package from `~/.nuget/packages`.

#skip-changelog