### PR TITLE
Add SentrySdk.SetTag #4228

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Reduced memory pressure when sampling less than 100% of traces/transactions ([#4212](https://github.com/getsentry/sentry-dotnet/pull/4212))
+- Add SentrySdk.SetTag ([#4232](https://github.com/getsentry/sentry-dotnet/pull/4232))
 
 ### Fixes
 

--- a/src/Sentry/Extensibility/DisabledHub.cs
+++ b/src/Sentry/Extensibility/DisabledHub.cs
@@ -38,6 +38,20 @@ public class DisabledHub : IHub, IDisposable
     /// <summary>
     /// No-Op.
     /// </summary>
+    public void SetTag(string key, string value)
+    {
+    }
+
+    /// <summary>
+    /// No-Op.
+    /// </summary>
+    public void UnsetTag(string key)
+    {
+    }
+
+    /// <summary>
+    /// No-Op.
+    /// </summary>
     public IDisposable PushScope() => this;
 
     /// <summary>

--- a/src/Sentry/Extensibility/HubAdapter.cs
+++ b/src/Sentry/Extensibility/HubAdapter.cs
@@ -50,6 +50,20 @@ public sealed class HubAdapter : IHub
     /// Forwards the call to <see cref="SentrySdk"/>.
     /// </summary>
     [DebuggerStepThrough]
+    public void SetTag(string key, string value)
+        => SentrySdk.SetTag(key, value);
+
+    /// <summary>
+    /// Forwards the call to <see cref="SentrySdk"/>.
+    /// </summary>
+    [DebuggerStepThrough]
+    public void UnsetTag(string key)
+        => SentrySdk.UnsetTag(key);
+
+    /// <summary>
+    /// Forwards the call to <see cref="SentrySdk"/>.
+    /// </summary>
+    [DebuggerStepThrough]
     public IDisposable PushScope()
         => SentrySdk.PushScope();
 

--- a/src/Sentry/ISentryScopeManager.cs
+++ b/src/Sentry/ISentryScopeManager.cs
@@ -23,6 +23,16 @@ public interface ISentryScopeManager
     public Task ConfigureScopeAsync(Func<Scope, Task> configureScope);
 
     /// <summary>
+    /// Sets a tag on the current scope.
+    /// </summary>
+    public void SetTag(string key, string value);
+
+    /// <summary>
+    /// Removes a tag from the current scope.
+    /// </summary>
+    public void UnsetTag(string key);
+
+    /// <summary>
     /// Binds the client to the current scope.
     /// </summary>
     /// <param name="client">The client.</param>

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -111,6 +111,10 @@ internal class Hub : IHub, IDisposable
         }
     }
 
+    public void SetTag(string key, string value) => ScopeManager.SetTag(key, value);
+
+    public void UnsetTag(string key) => ScopeManager.UnsetTag(key);
+
     public IDisposable PushScope() => ScopeManager.PushScope();
 
     public IDisposable PushScope<TState>(TState state) => ScopeManager.PushScope(state);

--- a/src/Sentry/Internal/SentryScopeManager.cs
+++ b/src/Sentry/Internal/SentryScopeManager.cs
@@ -44,6 +44,18 @@ internal sealed class SentryScopeManager : IInternalScopeManager
         return configureScope?.Invoke(scope) ?? Task.CompletedTask;
     }
 
+    public void SetTag(string key, string value)
+    {
+        var (scope, _) = GetCurrent();
+        scope.SetTag(key, value);
+    }
+
+    public void UnsetTag(string key)
+    {
+        var (scope, _) = GetCurrent();
+        scope.UnsetTag(key);
+    }
+
     public IDisposable PushScope() => PushScope<object>(null);
 
     public IDisposable PushScope<TState>(TState? state)

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -389,6 +389,20 @@ public static partial class SentrySdk
     public static Task ConfigureScopeAsync(Func<Scope, Task> configureScope)
         => CurrentHub.ConfigureScopeAsync(configureScope);
 
+    /// <summary>
+    /// Sets a tag on the current scope.
+    /// </summary>
+    [DebuggerStepThrough]
+    public static void SetTag(string key, string value)
+        => CurrentHub.SetTag(key, value);
+
+    /// <summary>
+    /// Removes a tag from the current scope.
+    /// </summary>
+    [DebuggerStepThrough]
+    public static void UnsetTag(string key)
+        => CurrentHub.UnsetTag(key);
+
     /// <inheritdoc cref="ISentryClient.CaptureEnvelope"/>
     [DebuggerStepThrough]
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -259,6 +259,8 @@ namespace Sentry
         System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope);
         System.IDisposable PushScope();
         System.IDisposable PushScope<TState>(TState state);
+        void SetTag(string key, string value);
+        void UnsetTag(string key);
     }
     public interface ISentryScopeStateProcessor
     {
@@ -863,12 +865,14 @@ namespace Sentry
         public static System.IDisposable PushScope() { }
         public static System.IDisposable PushScope<TState>(TState state) { }
         public static void ResumeSession() { }
+        public static void SetTag(string key, string value) { }
         public static void StartSession() { }
         public static Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context) { }
         public static Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
         public static Sentry.ITransactionTracer StartTransaction(string name, string operation) { }
         public static Sentry.ITransactionTracer StartTransaction(string name, string operation, Sentry.SentryTraceHeader traceHeader) { }
         public static Sentry.ITransactionTracer StartTransaction(string name, string operation, string? description) { }
+        public static void UnsetTag(string key) { }
     }
     public class SentrySession : Sentry.ISentrySession
     {
@@ -1367,8 +1371,10 @@ namespace Sentry.Extensibility
         public System.IDisposable PushScope() { }
         public System.IDisposable PushScope<TState>(TState state) { }
         public void ResumeSession() { }
+        public void SetTag(string key, string value) { }
         public void StartSession() { }
         public Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
+        public void UnsetTag(string key) { }
     }
     public class FormRequestPayloadExtractor : Sentry.Extensibility.BaseRequestPayloadExtractor
     {
@@ -1413,8 +1419,10 @@ namespace Sentry.Extensibility
         public System.IDisposable PushScope() { }
         public System.IDisposable PushScope<TState>(TState state) { }
         public void ResumeSession() { }
+        public void SetTag(string key, string value) { }
         public void StartSession() { }
         public Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
+        public void UnsetTag(string key) { }
     }
     public interface IBackgroundWorker
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -259,6 +259,8 @@ namespace Sentry
         System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope);
         System.IDisposable PushScope();
         System.IDisposable PushScope<TState>(TState state);
+        void SetTag(string key, string value);
+        void UnsetTag(string key);
     }
     public interface ISentryScopeStateProcessor
     {
@@ -863,12 +865,14 @@ namespace Sentry
         public static System.IDisposable PushScope() { }
         public static System.IDisposable PushScope<TState>(TState state) { }
         public static void ResumeSession() { }
+        public static void SetTag(string key, string value) { }
         public static void StartSession() { }
         public static Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context) { }
         public static Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
         public static Sentry.ITransactionTracer StartTransaction(string name, string operation) { }
         public static Sentry.ITransactionTracer StartTransaction(string name, string operation, Sentry.SentryTraceHeader traceHeader) { }
         public static Sentry.ITransactionTracer StartTransaction(string name, string operation, string? description) { }
+        public static void UnsetTag(string key) { }
     }
     public class SentrySession : Sentry.ISentrySession
     {
@@ -1367,8 +1371,10 @@ namespace Sentry.Extensibility
         public System.IDisposable PushScope() { }
         public System.IDisposable PushScope<TState>(TState state) { }
         public void ResumeSession() { }
+        public void SetTag(string key, string value) { }
         public void StartSession() { }
         public Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
+        public void UnsetTag(string key) { }
     }
     public class FormRequestPayloadExtractor : Sentry.Extensibility.BaseRequestPayloadExtractor
     {
@@ -1413,8 +1419,10 @@ namespace Sentry.Extensibility
         public System.IDisposable PushScope() { }
         public System.IDisposable PushScope<TState>(TState state) { }
         public void ResumeSession() { }
+        public void SetTag(string key, string value) { }
         public void StartSession() { }
         public Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
+        public void UnsetTag(string key) { }
     }
     public interface IBackgroundWorker
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -247,6 +247,8 @@ namespace Sentry
         System.Threading.Tasks.Task ConfigureScopeAsync(System.Func<Sentry.Scope, System.Threading.Tasks.Task> configureScope);
         System.IDisposable PushScope();
         System.IDisposable PushScope<TState>(TState state);
+        void SetTag(string key, string value);
+        void UnsetTag(string key);
     }
     public interface ISentryScopeStateProcessor
     {
@@ -844,12 +846,14 @@ namespace Sentry
         public static System.IDisposable PushScope() { }
         public static System.IDisposable PushScope<TState>(TState state) { }
         public static void ResumeSession() { }
+        public static void SetTag(string key, string value) { }
         public static void StartSession() { }
         public static Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context) { }
         public static Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
         public static Sentry.ITransactionTracer StartTransaction(string name, string operation) { }
         public static Sentry.ITransactionTracer StartTransaction(string name, string operation, Sentry.SentryTraceHeader traceHeader) { }
         public static Sentry.ITransactionTracer StartTransaction(string name, string operation, string? description) { }
+        public static void UnsetTag(string key) { }
     }
     public class SentrySession : Sentry.ISentrySession
     {
@@ -1348,8 +1352,10 @@ namespace Sentry.Extensibility
         public System.IDisposable PushScope() { }
         public System.IDisposable PushScope<TState>(TState state) { }
         public void ResumeSession() { }
+        public void SetTag(string key, string value) { }
         public void StartSession() { }
         public Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
+        public void UnsetTag(string key) { }
     }
     public class FormRequestPayloadExtractor : Sentry.Extensibility.BaseRequestPayloadExtractor
     {
@@ -1394,8 +1400,10 @@ namespace Sentry.Extensibility
         public System.IDisposable PushScope() { }
         public System.IDisposable PushScope<TState>(TState state) { }
         public void ResumeSession() { }
+        public void SetTag(string key, string value) { }
         public void StartSession() { }
         public Sentry.ITransactionTracer StartTransaction(Sentry.ITransactionContext context, System.Collections.Generic.IReadOnlyDictionary<string, object?> customSamplingContext) { }
+        public void UnsetTag(string key) { }
     }
     public interface IBackgroundWorker
     {

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -468,6 +468,57 @@ public class SentrySdkTests : IDisposable
     }
 
     [Fact]
+    public void SetTag_SetsTagOnCurrentScope()
+    {
+        using var _ = SentrySdk.Init(o =>
+        {
+            o.Dsn = ValidDsn;
+            o.AutoSessionTracking = false;
+            o.BackgroundWorker = Substitute.For<IBackgroundWorker>();
+            o.InitNativeSdks = false;
+        });
+
+        const string key = "key";
+        const string value = "value";
+
+        SentrySdk.SetTag(key, value);
+
+        string actual = null;
+        SentrySdk.ConfigureScope(s => actual = s.Tags[key]);
+
+        Assert.Equal(value, actual);
+    }
+
+    [Fact]
+    public void SetTag_NotInit_NoOp() => SentrySdk.SetTag("key", "value");
+
+    [Fact]
+    public void UnsetTag_UnsetsTagOnCurrentScope()
+    {
+        using var _ = SentrySdk.Init(o =>
+        {
+            o.Dsn = ValidDsn;
+            o.AutoSessionTracking = false;
+            o.BackgroundWorker = Substitute.For<IBackgroundWorker>();
+            o.InitNativeSdks = false;
+        });
+
+        const string key = "key";
+        const string value = "value";
+
+        SentrySdk.SetTag(key, value);
+        SentrySdk.UnsetTag(key);
+
+        bool? containsKey = null;
+        SentrySdk.ConfigureScope(s => containsKey = s.Tags.ContainsKey(key));
+
+        Assert.True(containsKey is false);
+    }
+
+    [Fact]
+    public void UnsetTag_NotInit_NoOp() => SentrySdk.UnsetTag("key");
+
+    [Fact]
     public void CaptureEvent_WithConfiguredScope_ScopeAppliesToEvent()
     {
         const string expected = "test";


### PR DESCRIPTION
I also added `SentrySdk.UnsetTag`, because it feels closely related with `SetTag`.

Some questions I had while implementing this:
- `Hub.ConfigureScope` wraps the call to `ScopeManager.ConfigureScope` in a try/catch, would that be appropriate for these methods too? E.g. `PushScope` doesn't use a try/catch.
  https://github.com/getsentry/sentry-dotnet/blob/aebd6a2e711c31087ca77652c31c6a624e22075b/src/Sentry/Internal/Hub.cs#L90-L100
- There is an extension method on `IHasTags` which can set multiple tags at once. Does it make sense to add it to `SentrySdk` too?
  https://github.com/getsentry/sentry-dotnet/blob/aebd6a2e711c31087ca77652c31c6a624e22075b/src/Sentry/IHasTags.cs#L33