### PR TITLE
fix: system frames marked as inApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+- Fix InApp Exclude for frames without Module by checking against frame's Package ([#4236](https://github.com/getsentry/sentry-dotnet/pull/4236))
+
 ## 5.9.0
 
 ### Features

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -1292,48 +1292,7 @@ public class SentryOptions
         Native = new NativeOptions(this);
 #endif
 
-        InAppExclude = new() {
-                "System",
-                "Mono",
-                "Sentry",
-                "Microsoft",
-                "MS", // MS.Win32, MS.Internal, etc: Desktop apps
-                "ABI.Microsoft", // MAUI
-                "WinRT", // WinRT, UWP, WinUI
-                "UIKit", // iOS / MacCatalyst
-                "Newtonsoft.Json",
-                "FSharp",
-                "Serilog",
-                "Giraffe",
-                "NLog",
-                "Npgsql",
-                "RabbitMQ",
-                "Hangfire",
-                "IdentityServer4",
-                "AWSSDK",
-                "Polly",
-                "Swashbuckle",
-                "FluentValidation",
-                "Autofac",
-                "Stackexchange.Redis",
-                "Dapper",
-                "RestSharp",
-                "SkiaSharp",
-                "IdentityModel",
-                "SqlitePclRaw",
-                "Xamarin",
-                "Android", // Ex: Android.Runtime.JNINativeWrapper...
-                "Google",
-                "MongoDB",
-                "Remotion.Linq",
-                "AutoMapper",
-                "Nest",
-                "Owin",
-                "MediatR",
-                "ICSharpCode",
-                "Grpc",
-                "ServiceStack"
-        };
+        InAppExclude = GetDefaultInAppExclude();
 
 #if DEBUG
         InAppInclude = new()
@@ -1827,4 +1786,49 @@ public class SentryOptions
         // In the future, this will most likely contain process ID
         return TryGetDsnSpecificCacheDirectoryPath();
     }
+
+    internal static List<StringOrRegex> GetDefaultInAppExclude() =>
+    [
+        "System",
+        "Mono",
+        "Sentry",
+        "Microsoft",
+        "MS", // MS.Win32, MS.Internal, etc: Desktop apps
+        "ABI.Microsoft", // MAUI
+        "WinRT", // WinRT, UWP, WinUI
+        "UIKit", // iOS / MacCatalyst
+        "Newtonsoft.Json",
+        "FSharp",
+        "Serilog",
+        "Giraffe",
+        "NLog",
+        "Npgsql",
+        "RabbitMQ",
+        "Hangfire",
+        "IdentityServer4",
+        "AWSSDK",
+        "Polly",
+        "Swashbuckle",
+        "FluentValidation",
+        "Autofac",
+        "Stackexchange.Redis",
+        "Dapper",
+        "RestSharp",
+        "SkiaSharp",
+        "IdentityModel",
+        "SqlitePclRaw",
+        "Xamarin",
+        "Android", // Ex: Android.Runtime.JNINativeWrapper...
+        "Google",
+        "MongoDB",
+        "Remotion.Linq",
+        "AutoMapper",
+        "Nest",
+        "Owin",
+        "MediatR",
+        "ICSharpCode",
+        "Grpc",
+        "ServiceStack",
+        "Java.Interop",
+    ];
 }

--- a/src/Sentry/SentryStackFrame.cs
+++ b/src/Sentry/SentryStackFrame.cs
@@ -201,6 +201,10 @@ public sealed class SentryStackFrame : ISentryJsonSerializable
         {
             ConfigureAppFrame(options, Module, LazyModuleMatcher.Value);
         }
+        else if (!string.IsNullOrEmpty(Package))
+        {
+            ConfigureAppFrame(options, Package, LazyModuleMatcher.Value);
+        }
         else if (!string.IsNullOrEmpty(Function))
         {
             ConfigureAppFrame(options, Function, LazyFunctionMatcher.Value);

--- a/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
+++ b/test/Sentry.Tests/Protocol/Exceptions/SentryStackFrameTests.cs
@@ -223,6 +223,58 @@ public class SentryStackFrameTests
     }
 
     [Fact]
+    public void ConfigureAppFrame_WithDefaultOptions_NotBuiltInIgnoredMarkedAsInApp()
+    {
+        var options = new SentryOptions();
+        var sut = new SentryStackFrame
+        {
+            Function = "async void MainActivity.OnCreate(Bundle savedInstanceState)+(?) =\\u003E { }",
+            Package = "SymbolCollector.Android, Version=1.23.0.0, Culture=neutral, PublicKeyToken=null"
+        };
+
+        // Act
+        sut.ConfigureAppFrame(options);
+
+        // Assert
+        Assert.True(sut.InApp);
+    }
+
+    [Fact]
+    public void ConfigureAppFrame_WithDefaultOptions_JavaPackageNotInApp()
+    {
+        var options = new SentryOptions();
+        var sut = new SentryStackFrame
+        {
+            Function = "void StaticMethods.CallStaticVoidMethod(JniObjectReference, JniMethodInfo, JniArgumentValue*)",
+            Package = "Java.Interop, Version=9.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065"
+        };
+
+        // Act
+        sut.ConfigureAppFrame(options);
+
+        // Assert
+        Assert.False(sut.InApp);
+    }
+
+    [Fact]
+    public void ConfigureAppFrame_WithDefaultOptions_SystemPackageNotInApp()
+    {
+        var options = new SentryOptions();
+        var sut = new SentryStackFrame
+        {
+            Function = "void Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, string path, bool isDirError)",
+            Package = "System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+            FileName = "Interop.IOErrors.cs",
+        };
+
+        // Act
+        sut.ConfigureAppFrame(options);
+
+        // Assert
+        Assert.False(sut.InApp);
+    }
+
+    [Fact]
     public void ConfigureAppFrame_InAppAlreadySet_InAppIgnored()
     {
         // Arrange

--- a/test/Sentry.Tests/SentryOptionsTests.cs
+++ b/test/Sentry.Tests/SentryOptionsTests.cs
@@ -345,16 +345,6 @@ public partial class SentryOptionsTests
     }
 
     [Fact]
-    public void InAppExcludes_IgnoresJavaFrames()
-    {
-        var sut = new SentryOptions();
-        const string expected = "test";
-        sut.AddInAppExclude(expected);
-        Assert.All(SentryOptions.GetDefaultInAppExclude(),
-            item => Assert.Contains(item, sut.InAppExclude!));
-    }
-
-    [Fact]
     public void AddInAppExcludeRegex_StoredInOptions()
     {
         var sut = new SentryOptions();

--- a/test/Sentry.Tests/SentryOptionsTests.cs
+++ b/test/Sentry.Tests/SentryOptionsTests.cs
@@ -335,6 +335,26 @@ public partial class SentryOptionsTests
     }
 
     [Fact]
+    public void AddInAppExclude_DoesNotOverrideDefaults()
+    {
+        var sut = new SentryOptions();
+        const string expected = "test";
+        sut.AddInAppExclude(expected);
+        Assert.All(SentryOptions.GetDefaultInAppExclude(),
+            item => Assert.Contains(item, sut.InAppExclude!));
+    }
+
+    [Fact]
+    public void InAppExcludes_IgnoresJavaFrames()
+    {
+        var sut = new SentryOptions();
+        const string expected = "test";
+        sut.AddInAppExclude(expected);
+        Assert.All(SentryOptions.GetDefaultInAppExclude(),
+            item => Assert.Contains(item, sut.InAppExclude!));
+    }
+
+    [Fact]
     public void AddInAppExcludeRegex_StoredInOptions()
     {
         var sut = new SentryOptions();


### PR DESCRIPTION
While dogfooding Symbol Collector I came across a few issues. This patch attempts to fix one of them where clearly system frames were marked as InApp.

It seems that our logic in the SDK is not taking `Package` into account at all but we set it here:

https://github.com/getsentry/sentry-dotnet/blob/0e11682db1da08cf4052525e528328197bc26354/src/Sentry/Internal/DebugStackTrace.cs#L310-L311

And it seems in some conditions, `Module` isn't set at all. For example on my test events:

From a .NET 9 CLI tool:
```json
{
  "function": "void Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, string path, bool isDirError)",
  "package": "System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
  "filename": "Interop.IOErrors.cs",
  "abs_path": "/_/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs",
  "lineno": 16,
  "pre_context": [
    "    private static void ThrowExceptionForIoErrno(ErrorInfo errorInfo, string? path, bool isDirError)",
    "    {",
    "        Debug.Assert(errorInfo.Error != Error.SUCCESS);",
    "        Debug.Assert(errorInfo.Error != Error.EINTR, \"EINTR errors should be handled by the native shim and never bubble up to managed code\");",
    ""
  ],
  "context_line": "        throw Interop.GetExceptionForIoErrno(errorInfo, path, isDirError);",
  "post_context": [
    "    }",
    "",
    "    internal static void CheckIo(Error error, string? path = null, bool isDirError = false)",
    "    {",
    "        if (error != Interop.Error.SUCCESS)"
  ],
  "in_app": true,
  "data": {
    "client_in_app": true,
    "symbolicator_status": "symbolicated"
  },
  "instruction_addr": "0x0",
  "addr_mode": "rel:0",
  "function_id": "0x2",
  "source_link": "https://raw.githubusercontent.com/dotnet/runtime/f57e6dc747158ab7ade4e62a75a6750d16b771e8/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs"
}
```

Note `"in_app": true` when clearly this is not inApp (Package is `System.`)

And .NET 9 Android, but in this case seems like we didn't mark `Java.` as InApp

```json
{
  "function": "void JniStaticMethods.InvokeVoidMethod(string, JniArgumentValue*)",
  "package": "Java.Interop, Version=9.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065",
  "in_app": true,
  "data": {
    "client_in_app": true,
    "symbolicator_status": "missing_symbol"
  },
  "instruction_addr": "0x14"
},
```

At first I thought we were overriding the default list, hence the test and refactoring. Let me know if you rather I undo that.