### PR TITLE
Rename MemoryInfo.AllocatedBytes to MemoryInfo.TotalAllocatedBytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Rename MemoryInfo.AllocatedBytes to MemoryInfo.TotalAllocatedBytes ([#4243](https://github.com/getsentry/sentry-dotnet/pull/4243))
+
 ## 5.9.0
 
 ### Features

--- a/src/Sentry/Internal/MainSentryEventProcessor.cs
+++ b/src/Sentry/Internal/MainSentryEventProcessor.cs
@@ -163,10 +163,10 @@ internal class MainSentryEventProcessor : ISentryEventProcessor
     {
 #if NETCOREAPP3_0_OR_GREATER
         var memory = GC.GetGCMemoryInfo();
-        var allocatedBytes = GC.GetTotalAllocatedBytes();
+        var totalAllocatedBytes = GC.GetTotalAllocatedBytes();
 #if NET5_0_OR_GREATER
         contexts[MemoryInfoKey] = new MemoryInfo(
-            allocatedBytes,
+            totalAllocatedBytes,
             memory.FragmentedBytes,
             memory.HeapSizeBytes,
             memory.HighMemoryLoadThresholdBytes,
@@ -183,7 +183,7 @@ internal class MainSentryEventProcessor : ISentryEventProcessor
             memory.PauseDurations.ToArray());
 #else
             contexts[MemoryInfoKey] = new MemoryInfo(
-            allocatedBytes,
+            totalAllocatedBytes,
             memory.FragmentedBytes,
             memory.HeapSizeBytes,
             memory.HighMemoryLoadThresholdBytes,

--- a/src/Sentry/Internal/MemoryInfo.cs
+++ b/src/Sentry/Internal/MemoryInfo.cs
@@ -7,7 +7,7 @@ namespace Sentry.Internal;
 
 internal sealed class MemoryInfo : ISentryJsonSerializable
 {
-    public long AllocatedBytes { get; }
+    public long TotalAllocatedBytes { get; }
     public long FragmentedBytes { get; }
     public long HeapSizeBytes { get; }
     public long HighMemoryLoadThresholdBytes { get; }
@@ -26,7 +26,7 @@ internal sealed class MemoryInfo : ISentryJsonSerializable
     public bool Concurrent { get; }
 
     public MemoryInfo(
-        long allocatedBytes,
+        long totalAllocatedBytes,
         long fragmentedBytes,
         long heapSizeBytes,
         long highMemoryLoadThresholdBytes,
@@ -42,7 +42,7 @@ internal sealed class MemoryInfo : ISentryJsonSerializable
         bool concurrent,
         TimeSpan[] pauseDurations)
     {
-        AllocatedBytes = allocatedBytes;
+        TotalAllocatedBytes = totalAllocatedBytes;
         FragmentedBytes = fragmentedBytes;
         HeapSizeBytes = heapSizeBytes;
         HighMemoryLoadThresholdBytes = highMemoryLoadThresholdBytes;
@@ -60,14 +60,14 @@ internal sealed class MemoryInfo : ISentryJsonSerializable
     }
 #else
     public MemoryInfo(
-        long allocatedBytes,
+        long totalAllocatedBytes,
         long fragmentedBytes,
         long heapSizeBytes,
         long highMemoryLoadThresholdBytes,
         long totalAvailableMemoryBytes,
         long memoryLoadBytes)
     {
-        AllocatedBytes = allocatedBytes;
+        TotalAllocatedBytes = totalAllocatedBytes;
         FragmentedBytes = fragmentedBytes;
         HeapSizeBytes = heapSizeBytes;
         HighMemoryLoadThresholdBytes = highMemoryLoadThresholdBytes;
@@ -80,7 +80,7 @@ internal sealed class MemoryInfo : ISentryJsonSerializable
         //WriteNumberIfNotZero since on OS that dont implement all props, those props are stubbed out to zero
         writer.WriteStartObject();
 
-        writer.WriteNumberIfNotZero("allocated_bytes", AllocatedBytes);
+        writer.WriteNumberIfNotZero("total_allocated_bytes", TotalAllocatedBytes);
         writer.WriteNumberIfNotZero("fragmented_bytes", FragmentedBytes);
         writer.WriteNumberIfNotZero("heap_size_bytes", HeapSizeBytes);
         writer.WriteNumberIfNotZero("high_memory_load_threshold_bytes", HighMemoryLoadThresholdBytes);

--- a/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainSentryEventProcessorTests.cs
@@ -62,7 +62,6 @@ public class MainSentryEventProcessorTests
 
         _ = sut.Process(evt);
         var memory = (MemoryInfo)evt.Contexts[MainSentryEventProcessor.MemoryInfoKey];
-        Assert.NotEqual(0, memory.TotalAvailableMemoryBytes);
         Assert.NotEqual(0, memory.HighMemoryLoadThresholdBytes);
         Assert.NotEqual(0, memory.TotalAvailableMemoryBytes);
     }

--- a/test/Sentry.Tests/Internals/MemoryInfoTests.WriteTo.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/Internals/MemoryInfoTests.WriteTo.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  allocated_bytes: 1,
+  total_allocated_bytes: 1,
   fragmented_bytes: 2,
   heap_size_bytes: 3,
   high_memory_load_threshold_bytes: 4,

--- a/test/Sentry.Tests/Internals/MemoryInfoTests.WriteTo.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/Internals/MemoryInfoTests.WriteTo.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  allocated_bytes: 1,
+  total_allocated_bytes: 1,
   fragmented_bytes: 2,
   heap_size_bytes: 3,
   high_memory_load_threshold_bytes: 4,


### PR DESCRIPTION
Fixes #4242.