### PR TITLE
Add MAUI AutomationId to generic element info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Rename MemoryInfo.AllocatedBytes to MemoryInfo.TotalAllocatedBytes ([#4243](https://github.com/getsentry/sentry-dotnet/pull/4243))
 - Replace libcurl with .NET HttpClient for sentry-native ([#4222](https://github.com/getsentry/sentry-dotnet/pull/4222))
+- Add .NET MAUI `AutomationId` element information to breadcrumbs ([#4248](https://github.com/getsentry/sentry-dotnet/pull/4248)) 
 
 ### Fixes
 

--- a/src/Sentry.Maui/Internal/Extensions.cs
+++ b/src/Sentry.Maui/Internal/Extensions.cs
@@ -53,21 +53,26 @@ internal static class Extensions
         // The element ID seems to be mostly useless noise
         //data.Add(prefix + nameof(element.Id), element.Id.ToString());
 
-        if (element.StyleId != null)
+        if (element.AutomationId is { } automationId)
+        {
+            data.Add(prefix + nameof(Element.AutomationId), automationId);
+        }
+
+        if (element.StyleId is { } styleId)
         {
             // The StyleId correlates to the element's name if one is set in XAML
             // TODO: Is there a better way to get this?
-            data.Add(prefix + "Name", element.StyleId);
+            data.Add(prefix + "Name", styleId);
         }
 
-        if (options.IncludeTitleInBreadcrumbs && element is ITitledElement { Title: { } } titledElement)
+        if (options.IncludeTitleInBreadcrumbs && element is ITitledElement { Title: { } title })
         {
-            data.Add(prefix + nameof(titledElement.Title), titledElement.Title);
+            data.Add(prefix + nameof(ITitledElement.Title), title);
         }
 
-        if (options.IncludeTextInBreadcrumbs && element is IText { Text: { } } textElement)
+        if (options.IncludeTextInBreadcrumbs && element is IText { Text: { } text })
         {
-            data.Add(prefix + nameof(textElement.Text), textElement.Text);
+            data.Add(prefix + nameof(IText.Text), text);
         }
     }
 

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.Element.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.Element.cs
@@ -42,6 +42,7 @@ public partial class MauiEventsBinderTests
         _fixture.Binder.HandleElementEvents(parent);
 
         var child = new MockElement("child");
+        child.AutomationId = "child-automation-id";
 
         parent.RaiseEvent(eventName, new ElementEventArgs(child));
         Assert.Single(_fixture.Scope.Breadcrumbs); // Sanity check

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.Element.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.Element.cs
@@ -15,6 +15,7 @@ public partial class MauiEventsBinderTests
         _fixture.Binder.HandleElementEvents(parent);
 
         var child = new MockElement("child");
+        child.AutomationId = "child-automation-id";
 
         // Act
         parent.RaiseEvent(eventName, new ElementEventArgs(child));
@@ -28,6 +29,7 @@ public partial class MauiEventsBinderTests
         crumb.Data.Should().Contain($"{nameof(MockElement)}.Name", "parent");
         crumb.Data.Should().Contain("Element", nameof(MockElement));
         crumb.Data.Should().Contain("Element.Name", "child");
+        crumb.Data.Should().Contain("Element.AutomationId", "child-automation-id");
     }
 
     [Theory]


### PR DESCRIPTION
- Add `AutomationId` to elements info: if the developer choose to set one it means it's an important info to discriminate a given element
- Avoid reading the same bindable properties twice (minor perf improvement)