### PR TITLE
fix: http integration uses correct parent span id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- The HTTP instrumentation uses the span created for the outgoing request in the sentry-trace header, fixing the parent-child relationship between client and server ([#4264](https://github.com/getsentry/sentry-dotnet/pull/4264))
+
 ### Dependencies
 
 - Bump Native SDK from v0.8.5 to v0.9.0 ([#4260](https://github.com/getsentry/sentry-dotnet/pull/4260))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 5.11.0-alpha.1
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.11.0-alpha.1
+## Unreleased
 
 ### Fixes
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>5.10.0</VersionPrefix>
+    <VersionPrefix>5.11.0-alpha.1</VersionPrefix>
     <LangVersion>13</LangVersion>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/test/Sentry.Tests/SentryHttpMessageHandlerTests.cs
+++ b/test/Sentry.Tests/SentryHttpMessageHandlerTests.cs
@@ -34,6 +34,40 @@ public class SentryHttpMessageHandlerTests
     }
 
     [Fact]
+    public async Task SendAsync_SentryTraceHeaderNotSet_SetsHeader_ToCorrectParent()
+    {
+        // Arrange
+        var hub = Substitute.For<IHub>();
+
+        const string rootTraceHeader = "75302ac48a024bde9a3b3734a82e36c8-1000000000000000-1";
+        hub.GetTraceHeader().ReturnsForAnyArgs(
+            SentryTraceHeader.Parse(rootTraceHeader));
+        var parentSpan = Substitute.For<ISpan>();
+        parentSpan.GetTraceHeader().ReturnsForAnyArgs(
+            SentryTraceHeader.Parse(rootTraceHeader));
+        hub.GetSpan().ReturnsForAnyArgs(parentSpan);
+        const string httpSpanTraceHeader = "75302ac48a024bde9a3b3734a82e36c8-2000000000000000-1";
+        var httpSpan = Substitute.For<ISpan>();
+        httpSpan.GetTraceHeader().ReturnsForAnyArgs(
+            SentryTraceHeader.Parse(httpSpanTraceHeader));
+        parentSpan.StartChild(Arg.Any<string>()).ReturnsForAnyArgs(httpSpan);
+
+        using var innerHandler = new RecordingHttpMessageHandler(new FakeHttpMessageHandler());
+        using var sentryHandler = new SentryHttpMessageHandler(innerHandler, hub);
+        using var client = new HttpClient(sentryHandler);
+
+        // Act
+        await client.GetAsync("https://localhost/");
+
+        using var request = innerHandler.GetRequests().Single();
+
+        // Assert
+        request.Headers.Should().Contain(h =>
+            h.Key == "sentry-trace" &&
+            string.Concat(h.Value) == httpSpanTraceHeader);
+    }
+
+    [Fact]
     public async Task SendAsync_SentryTraceHeaderNotSet_SetsHeader_WhenUrlMatchesPropagationOptions()
     {
         // Arrange


### PR DESCRIPTION
We create a span for the HTTP operation, but we don't pass that span id as the parent to the outgoing request. 
Resulting in the incorrect parent-child relationship

Changing the implementation didn't break a single test though, which is quite concerning.

I added a test that failed, and with my changed passed. 
Verifying that we indeed use the correct span as parent int he outgoing HTTP request


Before:
![image](https://github.com/user-attachments/assets/0345d42e-d724-4ce1-a86a-6974e4c831da)


After:
tested as 5.10.0-alpha.1 on symbol collector
![image](https://github.com/user-attachments/assets/a6f510f7-5ca5-4a47-ac44-48491ec706c6)
