### PR TITLE
experiment: gcdump reading

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <!--Generate xml docs for all projects under 'src'-->
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+<!--    <GenerateDocumentationFile>true</GenerateDocumentationFile>-->
 
     <Authors>Sentry Team and Contributors</Authors>
     <Company>Sentry.io</Company>

--- a/src/Sentry.Profiling/Downsampler.cs
+++ b/src/Sentry.Profiling/Downsampler.cs
@@ -1,30 +1,30 @@
-/// <summary>
-/// Reduce sampling rate from 1 Hz that is the default for the provider to the configured SamplingRateMs.
-/// </summary>
-internal class Downsampler
-{
-    private static double _samplingRateMs = (double)1_000 / 101; // 101 Hz
-
-    // Maps from ThreadIndex to the last sample timestamp for that thread.
-    private GrowableArray<double> _prevThreadSamples = new(10);
-
-    public void NewThreadAdded(int threadIndex)
-    {
-        if (threadIndex >= _prevThreadSamples.Count)
-        {
-            _prevThreadSamples.Count = threadIndex + 1;
-            _prevThreadSamples[threadIndex] = double.MinValue;
-        }
-    }
-
-    public bool ShouldSample(int threadIndex, double timestampMs)
-    {
-        Debug.Assert(threadIndex < _prevThreadSamples.Count, "ThreadIndex too large - you must call NewThreadAdded() if a new thread is added.");
-        if (_prevThreadSamples[threadIndex] + _samplingRateMs <= timestampMs)
-        {
-            _prevThreadSamples[threadIndex] = timestampMs;
-            return true;
-        }
-        return false;
-    }
-}
+// /// <summary>
+// /// Reduce sampling rate from 1 Hz that is the default for the provider to the configured SamplingRateMs.
+// /// </summary>
+// internal class Downsampler
+// {
+//     private static double _samplingRateMs = (double)1_000 / 101; // 101 Hz
+//
+//     // Maps from ThreadIndex to the last sample timestamp for that thread.
+//     private GrowableArray<double> _prevThreadSamples = new(10);
+//
+//     public void NewThreadAdded(int threadIndex)
+//     {
+//         if (threadIndex >= _prevThreadSamples.Count)
+//         {
+//             _prevThreadSamples.Count = threadIndex + 1;
+//             _prevThreadSamples[threadIndex] = double.MinValue;
+//         }
+//     }
+//
+//     public bool ShouldSample(int threadIndex, double timestampMs)
+//     {
+//         Debug.Assert(threadIndex < _prevThreadSamples.Count, "ThreadIndex too large - you must call NewThreadAdded() if a new thread is added.");
+//         if (_prevThreadSamples[threadIndex] + _samplingRateMs <= timestampMs)
+//         {
+//             _prevThreadSamples[threadIndex] = timestampMs;
+//             return true;
+//         }
+//         return false;
+//     }
+// }

--- a/src/Sentry.Profiling/SampleProfileBuilder.cs
+++ b/src/Sentry.Profiling/SampleProfileBuilder.cs
@@ -30,7 +30,7 @@ internal class SampleProfileBuilder
     private readonly Dictionary<int, int> _threadIndexes = new();
 
     // TODO make downsampling conditional once this is available: https://github.com/dotnet/runtime/issues/82939
-    private readonly Downsampler _downsampler = new();
+    // private readonly Downsampler _downsampler = new();
 
     public SampleProfileBuilder(SentryOptions options, TraceLog traceLog)
     {
@@ -61,10 +61,10 @@ internal class SampleProfileBuilder
             return;
         }
 
-        if (!_downsampler.ShouldSample(threadIndex, timestampMs))
-        {
-            return;
-        }
+        // if (!_downsampler.ShouldSample(threadIndex, timestampMs))
+        // {
+        //     return;
+        // }
 
         var stackIndex = AddStackTrace(callStackIndex);
         if (stackIndex < 0)
@@ -204,7 +204,7 @@ internal class SampleProfileBuilder
             });
             value = Profile.Threads.Count - 1;
             _threadIndexes[key] = value;
-            _downsampler.NewThreadAdded(_threadIndexes[key]);
+            // _downsampler.NewThreadAdded(_threadIndexes[key]);
         }
 
         return value;

--- a/src/Sentry.Profiling/Sentry.Profiling.csproj
+++ b/src/Sentry.Profiling/Sentry.Profiling.csproj
@@ -31,9 +31,9 @@
     <None Include="$(MSBuildThisFileDirectory)buildTransitive\Sentry.Profiling.targets" Pack="true" PackagePath="build\Sentry.Profiling.targets" />
   </ItemGroup>
   <ItemGroup>
-    <ProfilingDependency Include="..\..\modules\perfview\src\FastSerialization\bin\$(Configuration)\netstandard2.0\Microsoft.Diagnostics.FastSerialization.dll" />
+<!--    <ProfilingDependency Include="..\..\modules\perfview\src\FastSerialization\bin\$(Configuration)\netstandard2.0\Microsoft.Diagnostics.FastSerialization.dll" />-->
     <ProfilingDependency Include="..\..\modules\perfview\src\TraceEvent\bin\$(Configuration)\netstandard2.0\Microsoft.Diagnostics.Tracing.TraceEvent.dll" />
-    <ProfilingDependency Include="..\..\modules\perfview\src\FastSerialization\bin\$(Configuration)\netstandard2.0\Microsoft.Diagnostics.FastSerialization.pdb" />
+<!--    <ProfilingDependency Include="..\..\modules\perfview\src\FastSerialization\bin\$(Configuration)\netstandard2.0\Microsoft.Diagnostics.FastSerialization.pdb" />-->
     <ProfilingDependency Include="..\..\modules\perfview\src\TraceEvent\bin\$(Configuration)\netstandard2.0\Microsoft.Diagnostics.Tracing.TraceEvent.pdb" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Sentry/ISpanData.cs
+++ b/src/Sentry/ISpanData.cs
@@ -63,10 +63,6 @@ public static class SpanDataExtensions
         spanData.SetMeasurement(name, new Measurement(value, unit));
 
     /// <inheritdoc cref="SetMeasurement(Sentry.ISpanData,string,int,Sentry.MeasurementUnit)" />
-#if !__MOBILE__
-    // ulong parameter is not CLS compliant
-    [CLSCompliant(false)]
-#endif
     public static void SetMeasurement(this ISpanData spanData, string name, ulong value,
         MeasurementUnit unit = default) =>
         spanData.SetMeasurement(name, new Measurement(value, unit));

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <Description>Official SDK for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.</Description>
     <NoWarn Condition="'$(TargetFramework)' == 'netstandard2.0'">$(NoWarn);RS0017</NoWarn>
-    <CLSCompliant Condition="'$(TargetPlatformIdentifier)' == ''">true</CLSCompliant>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -50,7 +49,42 @@
     </Compile>
     <Compile Remove="..\..\modules\Ben.Demystifier\**\obj\**" />
   </ItemGroup>
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('netstandard')) and !$(TargetFramework.StartsWith('net4'))">
+    <Compile Include="..\..\modules\perfview\src\HeapDump\**\*.cs"
+             Link="perfview\HeapDump\%(RecursiveDir)\%(Filename)%(Extension)"
+             Nullable="disable" />
+    <Compile Include="..\..\modules\perfview\src\MemoryGraph\**\*.cs"
+             Link="perfview\MemoryGraph\%(RecursiveDir)\%(Filename)%(Extension)"
+             Nullable="disable" />
+    <Compile Include="..\..\modules\perfview\src\Utilities\XmlUtilities.cs"
+             Link="perfview\Utilities\%(RecursiveDir)\%(Filename)%(Extension)"
+             Nullable="disable" />
+    <Compile Include="..\..\modules\perfview\src\Utilities\EnvironmentUtilities.cs"
+             Link="perfview\Utilities\%(RecursiveDir)\%(Filename)%(Extension)"
+             Nullable="disable" />
+    <Compile Include="..\..\modules\perfview\src\Utilities\StringUtilities.cs"
+             Link="perfview\Utilities\%(RecursiveDir)\%(Filename)%(Extension)"
+             Nullable="disable" />
+    <!-- Will probably conflict with Sentry.Profiling -->
+    <Compile Include="..\..\modules\perfview\src\FastSerialization\**\*.cs"
+             Link="perfview\FastSerialization\%(RecursiveDir)\%(Filename)%(Extension)"
+             Nullable="disable" />
+    <Compile Include="..\..\modules\perfview\src\HeapDumpCommon\DotNetHeapInfo.cs"
+             Link="perfview\HeapDumpCommon\%(RecursiveDir)\%(Filename)%(Extension)"
+             Nullable="disable" />
 
+    <Compile Remove="..\..\modules\perfview\src\HeapDump\**\GCHeapDumper.cs" />
+    <Compile Remove="..\..\modules\perfview\src\HeapDump\**\Program.cs" />
+    <Compile Remove="..\..\modules\perfview\src\HeapDump\Properties\*.cs" />
+    <Compile Remove="..\..\modules\perfview\src\HeapDump\Utilities\*.cs" />
+    <Compile Remove="..\..\modules\perfview\**\obj\**" />
+  </ItemGroup>
+<!--  <Compile Include="..\MemoryGraph\graph.cs">-->
+<!--    <Link>MemoryGraph\graph.cs</Link>-->
+<!--  </Compile>-->
+<!--  <Compile Include="..\MemoryGraph\MemoryGraph.cs">-->
+<!--    <Link>MemoryGraph\MemoryGraph.cs</Link>-->
+<!--  </Compile>-->
   <!-- Ben.Demystifier also needs System.Reflection.Metadata 5.0.0 or higher on all platforms. -->
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) or $(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -1199,9 +1199,6 @@ public class SentryOptions
     /// <remarks>
     /// This is for Sentry use only, and can change without a major version bump.
     /// </remarks>
-#if !__MOBILE__
-    [CLSCompliant(false)]
-#endif
     [EditorBrowsable(EditorBrowsableState.Never)]
     public Func<string, PEReader?>? AssemblyReader { get; set; }
 

--- a/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs
+++ b/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs
@@ -445,13 +445,13 @@ public class SamplingTransactionProfilerTests
     [SkippableFact]
     public void Downsampler_ShouldSample_Works()
     {
-        var sut = new Downsampler();
-        sut.NewThreadAdded(0);
-        Assert.True(sut.ShouldSample(0, 5));
-        Assert.False(sut.ShouldSample(0, 3));
-        Assert.False(sut.ShouldSample(0, 6));
-        Assert.True(sut.ShouldSample(0, 15));
-        Assert.False(sut.ShouldSample(0, 6));
-        Assert.False(sut.ShouldSample(0, 16));
+        // var sut = new Downsampler();
+        // sut.NewThreadAdded(0);
+        // Assert.True(sut.ShouldSample(0, 5));
+        // Assert.False(sut.ShouldSample(0, 3));
+        // Assert.False(sut.ShouldSample(0, 6));
+        // Assert.True(sut.ShouldSample(0, 15));
+        // Assert.False(sut.ShouldSample(0, 6));
+        // Assert.False(sut.ShouldSample(0, 16));
     }
 }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -1,5 +1,4 @@
-﻿[assembly: System.CLSCompliant(true)]
-namespace Sentry
+﻿namespace Sentry
 {
     public enum AttachmentType
     {
@@ -663,7 +662,6 @@ namespace Sentry
     public class SentryOptions
     {
         public SentryOptions() { }
-        [System.CLSCompliant(false)]
         public System.Func<string, System.Reflection.PortableExecutable.PEReader?>? AssemblyReader { get; set; }
         public bool AttachStacktrace { get; set; }
         public bool AutoSessionTracking { get; set; }
@@ -1060,7 +1058,6 @@ namespace Sentry
         public static void SetMeasurement(this Sentry.ISpanData spanData, string name, double value, Sentry.MeasurementUnit unit = default) { }
         public static void SetMeasurement(this Sentry.ISpanData spanData, string name, int value, Sentry.MeasurementUnit unit = default) { }
         public static void SetMeasurement(this Sentry.ISpanData spanData, string name, long value, Sentry.MeasurementUnit unit = default) { }
-        [System.CLSCompliant(false)]
         public static void SetMeasurement(this Sentry.ISpanData spanData, string name, ulong value, Sentry.MeasurementUnit unit = default) { }
     }
     public static class SpanExtensions

--- a/test/Sentry.Tests/MemDumpTests.cs
+++ b/test/Sentry.Tests/MemDumpTests.cs
@@ -1,0 +1,59 @@
+#if NET8_0_OR_GREATER
+using Graphs;
+using Microsoft.Diagnostics.Utilities;
+
+namespace Sentry.Tests;
+
+public class MemDumpTests
+{
+    // private readonly ITestOutputHelper _testOutputHelper;
+    // private readonly IDiagnosticLogger _testOutputLogger;
+
+    // public MemDumpTests(ITestOutputHelper output, ITestOutputHelper testOutputHelper)
+    // {
+    //     _testOutputHelper = testOutputHelper;
+    //     _testOutputLogger = new TestOutputDiagnosticLogger(output);
+    // }
+
+    [Fact]
+    public void MemDump_Tests()
+    {
+        var path = "/Users/bruno/git/ConsoleApp1/ConsoleApp1/ConsoleApp1/20250526_133030_1.gcdump";
+        var dump = new GCHeapDump(path);
+        var graph = dump.MemoryGraph;
+        Console.WriteLine(dump.CreationTool);
+        Console.WriteLine(dump.CollectionLog);
+        var ret = new Graph.SizeAndCount[(int)graph.NodeTypeIndexLimit];
+        for (int i = 0; i < ret.Length; i++)
+        {
+            ret[i] = new Graph.SizeAndCount((NodeTypeIndex)i);
+        }
+
+        var nodeStorage = graph.AllocNodeStorage();
+        for (NodeIndex idx = 0; idx < graph.NodeIndexLimit; idx++)
+        {
+            var node = graph.GetNode(idx, nodeStorage);
+            var sizeAndCount = ret[(int)node.TypeIndex];
+            sizeAndCount.Count++;
+            sizeAndCount.Size += node.Size;
+        }
+
+        Array.Sort(ret, (Graph.SizeAndCount x, Graph.SizeAndCount y) => y.Size.CompareTo(x.Size));
+        Console.WriteLine("<HistogramByType Size=\"{0}\" Count=\"{1}\">", dump.MemoryGraph.TotalSize, (int)dump.MemoryGraph.NodeIndexLimit);
+        var typeStorage = new NodeType(graph);
+        var sizeAndCounts = graph.GetHistogramByType();
+        long minSize = 0;
+        foreach (var sizeAndCount in sizeAndCounts)
+        {
+            if (sizeAndCount.Size <= minSize)
+            {
+                break;
+            }
+
+            var line = string.Format("Name=\"{0}\" Size=\"{1}\" Count=\"{2}\"",
+                graph.GetType(sizeAndCount.TypeIdx, typeStorage).Name, sizeAndCount.Size, sizeAndCount.Count);
+            Console.WriteLine(line);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
What if we read the gcdump, then augment the low memory event with the top offending types

Not sure how much memory would take to do this in-memory in a process that just triggered a memory dump for being out of memory
It probably needs to be done on a separate process. Or only on restart?

Or on the server, at ingestion time. Considering the mess it would be to get this into the SDK (I had to hack a lot to get it to run) it might be better doing this as a stand alone library, and load it during ingestion time in Sentry when processing `gcdump` files.

![image](https://github.com/user-attachments/assets/c92d4c42-4d19-4019-a1ab-39b8bab8f9ff)
