### PR TITLE
meta: fix default labels of issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: 🐞 Bug Report
 description: Tell us about something that's not working the way we (probably) intend.
-labels: ["Platform: .NET", "bug"]
+labels: [".NET", "Bug"]
 body:
   - type: dropdown
     id: nuget

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,6 @@
 name: 💡 Feature Request
 description: Tell us about a problem our SDK could solve but doesn't.
-labels: [".NET", "Improvement"]
+labels: [".NET", "Feature"]
 body:
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,6 @@
 name: 💡 Feature Request
 description: Tell us about a problem our SDK could solve but doesn't.
-labels: ["Platform: .NET", "enhancement"]
+labels: [".NET", "Improvement"]
 body:
   - type: textarea
     id: problem


### PR DESCRIPTION
@stephanie-anderson indicated that the default labels of our issue templates are incorrect

- Platform: use just `.NET` rather than `Platform: .NET`
- Type: "type" labels are _PascalCase_ rather than _camelCase_

#skip-changelog