### PR TITLE
meta: replace default blank issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/maintainer-blank.yml
+++ b/.github/ISSUE_TEMPLATE/maintainer-blank.yml
@@ -1,0 +1,17 @@
+name: Blank Issue
+description: Blank Issue. Reserved for maintainers.
+labels: [".NET"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please describe the issue.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |-
+        ## Thanks 🙏
+        Check our [triage docs](https://open.sentry.io/triage/) for what to expect next.


### PR DESCRIPTION
@stephanie-anderson noted that our blank issue template does not add the `.NET` label, which we should add to all new issues (i.a. for use in _Linear_).

This PR
- disables the default bank issue
- adds an explicit blank issue
  - template copied from `sentry-java`
    - see https://github.com/getsentry/sentry-java/blob/main/.github/ISSUE_TEMPLATE/maintainer-blank.yml

#skip-changelog