### PR TITLE
fix: InvalidOperationException sending attachments on Android with LLVM enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - The HTTP instrumentation uses the span created for the outgoing request in the sentry-trace header, fixing the parent-child relationship between client and server ([#4264](https://github.com/getsentry/sentry-dotnet/pull/4264))
+- InvalidOperationException sending attachments on Android with LLVM enabled ([#4276](https://github.com/getsentry/sentry-dotnet/pull/4276))
 
 ### Dependencies
 

--- a/src/Sentry/Internal/PartialStream.cs
+++ b/src/Sentry/Internal/PartialStream.cs
@@ -60,7 +60,8 @@ internal class PartialStream : Stream
             _innerStream.Position = innerPosition;
         }
 
-        var read = await _innerStream.ReadAsync(buffer, offset, actualCount, cancellationToken)
+        // See https://github.com/getsentry/sentry-dotnet/issues/3101
+        var read = await _innerStream.ReadAsync(buffer.AsMemory(offset, actualCount), cancellationToken)
             .ConfigureAwait(false);
 
         if (_length != null)


### PR DESCRIPTION
Resolves #3101:
- https://github.com/getsentry/sentry-dotnet/issues/3101

Also see:
- CA2022: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2022
- CA1835: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1835