### PR TITLE
fix: remove blocking detection for background worker

### DIFF
--- a/src/Sentry.Profiling/SamplingTransactionProfilerFactory.cs
+++ b/src/Sentry.Profiling/SamplingTransactionProfilerFactory.cs
@@ -1,6 +1,6 @@
+using Sentry.Ben.BlockingDetector;
 using Sentry.Extensibility;
 using Sentry.Internal;
-using Sentry.Ben.BlockingDetector;
 
 namespace Sentry.Profiling;
 

--- a/src/Sentry/Internal/BackgroundWorker.cs
+++ b/src/Sentry/Internal/BackgroundWorker.cs
@@ -1,8 +1,8 @@
+using Sentry.Ben.BlockingDetector;
 using Sentry.Extensibility;
 using Sentry.Internal.Extensions;
 using Sentry.Internal.Http;
 using Sentry.Protocol.Envelopes;
-using Sentry.Ben.BlockingDetector;
 
 namespace Sentry.Internal;
 

--- a/src/Sentry/Internal/GarbageCollectionMonitor.cs
+++ b/src/Sentry/Internal/GarbageCollectionMonitor.cs
@@ -1,5 +1,5 @@
-using Sentry.Extensibility;
 using Sentry.Ben.BlockingDetector;
+using Sentry.Extensibility;
 
 namespace Sentry.Internal;
 

--- a/src/Sentry/Internal/Http/CachingTransport.cs
+++ b/src/Sentry/Internal/Http/CachingTransport.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
+using Sentry.Ben.BlockingDetector;
 using Sentry.Extensibility;
 using Sentry.Internal.Extensions;
 using Sentry.Protocol.Envelopes;
-using Sentry.Ben.BlockingDetector;
 
 namespace Sentry.Internal.Http;
 

--- a/src/Sentry/Internal/ProcessInfo.cs
+++ b/src/Sentry/Internal/ProcessInfo.cs
@@ -1,5 +1,5 @@
-using Sentry.Extensibility;
 using Sentry.Ben.BlockingDetector;
+using Sentry.Extensibility;
 
 namespace Sentry.Internal;
 

--- a/test/Sentry.Tests/Internals/BackgroundWorkerTests.cs
+++ b/test/Sentry.Tests/Internals/BackgroundWorkerTests.cs
@@ -1,6 +1,6 @@
 using System.IO.Abstractions.TestingHelpers;
-using Sentry.Internal.Http;
 using Sentry.Ben.BlockingDetector;
+using Sentry.Internal.Http;
 using BackgroundWorker = Sentry.Internal.BackgroundWorker;
 
 namespace Sentry.Tests.Internals;
@@ -530,19 +530,19 @@ public class BackgroundWorkerTests
         var listenerState = Substitute.For<ITaskBlockingListenerState>();
         var monitor = Substitute.For<IBlockingMonitor>();
         var context = new DetectBlockingSynchronizationContext(monitor);
-        
+
         // Mock the current sync context to our test context
         SynchronizationContext.SetSynchronizationContext(context);
-        
+
         // Mock the TaskBlockingListener to return our test state
         var originalDefaultState = TaskBlockingListener.DefaultState;
         TaskBlockingListener.DefaultState = listenerState;
-        
+
         try
         {
             // Act
             using var sut = _fixture.GetSut();
-            
+
             // Assert
             // Verify that suppression was called when creating the task
             listenerState.Received(1).Suppress();


### PR DESCRIPTION
Example: https://demo.sentry.io/issues/6554714607/?project=4508968088698880&query=is%3Aunresolved&referrer=issue-stream&stream_index=5

![image](https://github.com/user-attachments/assets/4a6366a3-260c-4a6b-9a32-316a24b65e6a)


Fixed:
* https://github.com/getsentry/sentry-dotnet/issues/4262