### PR TITLE
chore: Fix reference to Sentry.SourceGenerators

### DIFF
--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -201,9 +201,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\Sentry.SourceGenerators\bin\Release\netstandard2.0\Sentry.SourceGenerators.dll"
-          Pack="true"
-          PackagePath="analyzers/dotnet/cs"
-          Visible="false" />
+    <ProjectReference Include="..\Sentry.SourceGenerators\Sentry.SourceGenerators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -206,8 +206,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Sentry.SourceGenerators\Sentry.SourceGenerators.csproj" OutputItemType="" ReferenceOutputAssembly="false" PrivateAssets="all" SetTargetFramework="TargetFramework=netstandard2.0" SentryAnalyzersPack="true" />
   </ItemGroup>
-  <!-- See https://github.com/ViktorHofer/PackAsAnalyzer -->
-  <Target Name="_SentryPackAnalyzers" BeforeTargets="GenerateNuspec;_GetPackageFiles">
+  <!-- See https://learn.microsoft.com/dotnet/core/project-sdk/overview -->
+  <!-- See also https://github.com/ViktorHofer/PackAsAnalyzer -->
+  <Target Name="_SentryPackAnalyzers" BeforeTargets="_GetPackageFiles">
     <MSBuild Projects="@(ProjectReference->WithMetadataValue('SentryAnalyzersPack', 'true'))" Targets="GetTargetPath">
       <Output TaskParameter="TargetOutputs" ItemName="_SentryAnalyzersPackagePath" />
     </MSBuild>

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -202,16 +202,17 @@
     <None Include="buildTransitive\Sentry.SourceGenerators.targets" Pack="true" PackagePath="build\Sentry.SourceGenerators.targets" />
   </ItemGroup>
 
-  <!-- Build and Pack (without reference to) Sentry Generator. -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackSentryGenerator</TargetsForTfmSpecificContentInPackage>
-  </PropertyGroup>
+  <!-- Build and Pack (without dependency to) Sentry Generator (as Analyzer). -->
   <ItemGroup>
-    <ProjectReference Include="..\Sentry.SourceGenerators\Sentry.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" PrivateAssets="all" SetTargetFramework="TargetFramework=netstandard2.0" />
+    <ProjectReference Include="..\Sentry.SourceGenerators\Sentry.SourceGenerators.csproj" OutputItemType="" ReferenceOutputAssembly="false" PrivateAssets="all" SetTargetFramework="TargetFramework=netstandard2.0" SentryAnalyzersPack="true" />
   </ItemGroup>
-  <Target Name="PackSentryGenerator">
+  <!-- See https://github.com/ViktorHofer/PackAsAnalyzer -->
+  <Target Name="_SentryPackAnalyzers" BeforeTargets="GenerateNuspec;_GetPackageFiles">
+    <MSBuild Projects="@(ProjectReference->WithMetadataValue('SentryAnalyzersPack', 'true'))" Targets="GetTargetPath">
+      <Output TaskParameter="TargetOutputs" ItemName="_SentryAnalyzersPackagePath" />
+    </MSBuild>
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)\Sentry.SourceGenerators.dll" PackagePath="analyzers/dotnet/cs" BuildAction="None" />
+      <None Include="@(_SentryAnalyzersPackagePath)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
   </Target>
 

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -200,9 +200,17 @@
     <None Include="buildTransitive\Sentry.SourceGenerators.targets" Pack="true" PackagePath="build\Sentry.SourceGenerators.targets" />
   </ItemGroup>
 
+  <!-- Build and Pack (without reference to) Sentry Generator. -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackSentryGenerator</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Sentry.SourceGenerators\Sentry.SourceGenerators.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Sentry.SourceGenerators\Sentry.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" PrivateAssets="all" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
+  <Target Name="PackSentryGenerator">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(OutputPath)\Sentry.SourceGenerators.dll" PackagePath="analyzers/dotnet/cs" BuildAction="None" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
The current reference is very brittle:
- It assumes the Sentry.SourceGenerators project has already been built
- It assumes a release build
- It will break if the TFM ever changes or in a multi-targeting scenario

This breaks integration tests when these are run locally (since not all of the above assumptions hold up when running these locally).

#skip-changelog