### PR TITLE
fix: Unsampled spans no longer propagate empty trace headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Unsampled spans no longer propagate empty trace headers ([#4302](https://github.com/getsentry/sentry-dotnet/pull/4302))
+
 ## 5.11.1
 
 ### Fixes

--- a/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Sentry.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -56,7 +56,14 @@ internal static class HttpContextExtensions
 
         try
         {
-            return SentryTraceHeader.Parse(value!);
+            var traceHeader = SentryTraceHeader.Parse(value!);
+            if (traceHeader?.TraceId != SentryId.Empty)
+            {
+                return traceHeader;
+            }
+
+            options?.LogWarning("Sentry trace header '{0}' has an empty trace ID.", value);
+            return null;
         }
         catch (Exception ex)
         {

--- a/src/Sentry/Internal/UnsampledSpan.cs
+++ b/src/Sentry/Internal/UnsampledSpan.cs
@@ -6,4 +6,5 @@ internal sealed class UnsampledSpan(UnsampledTransaction transaction, SpanId? sp
     public override SpanId SpanId { get; } = spanId ?? SpanId.Empty;
     internal UnsampledTransaction Transaction => transaction;
     public override ISpan StartChild(string operation) => transaction.StartChild(operation);
+    public override SentryTraceHeader GetTraceHeader() => transaction.GetTraceHeader();
 }

--- a/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
@@ -78,5 +78,20 @@ public class HttpContextExtensionsTests
         // Assert
         Assert.Equal(expectedName, filteredRoute);
     }
+
+    [Fact]
+    public void TryGetSentryTraceHeader_WithEmptyTraceId_ReturnsNull()
+    {
+        // Arrange
+        var httpContext = Fixture.GetSut();
+        var options = new SentryOptions();
+        httpContext.Request.Headers.Append(SentryTraceHeader.HttpHeaderName, "00000000000000000000000000000000-1000000000000000-1");
+
+        // Act
+        var header = httpContext.TryGetSentryTraceHeader(options);
+
+        // Assert
+        Assert.Null(header);
+    }
 }
 #endif

--- a/test/Sentry.Tests/Internals/UnsampledSpanTests.cs
+++ b/test/Sentry.Tests/Internals/UnsampledSpanTests.cs
@@ -1,0 +1,24 @@
+namespace Sentry.Tests.Internals;
+
+public class UnsampledSpanTests
+{
+    [Fact]
+    public void GetTraceHeader_CreatesHeaderFromUnsampledTransaction()
+    {
+        // Arrange
+        var hub = Substitute.For<IHub>();
+        ITransactionContext context = new TransactionContext("TestTransaction", "TestOperation",
+            new SentryTraceHeader(SentryId.Create(), SpanId.Create(), false)
+        );
+        var transaction = new UnsampledTransaction(hub, context);
+        var unsampledSpan = transaction.StartChild("Foo");
+
+        // Act
+        var traceHeader = unsampledSpan.GetTraceHeader();
+
+        // Assert
+        traceHeader.TraceId.Should().Be(context.TraceId);
+        traceHeader.SpanId.Should().Be(context.SpanId);
+        traceHeader.IsSampled.Should().Be(context.IsSampled);
+    }
+}


### PR DESCRIPTION
Resolves #4301:
- https://github.com/getsentry/sentry-dotnet/issues/4301

This PR corrects two issues from separate comments:
- One in the HttpContextExtensions (see [comment](https://github.com/getsentry/sentry-dotnet/issues/4301#issuecomment-2998754057))
- One in the UnsampledSpan class (see [comment](https://github.com/getsentry/sentry-dotnet/issues/4301#issuecomment-2999721030))