### PR TITLE
fix: Sentry capturing compressed bodies when RequestDecompression middleware is enabled

### DIFF
--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -10,7 +10,7 @@
 
   <Target Name="GenerateSharedDsnConstant"
           BeforeTargets="BeforeCompile"
-          Condition=" '$(SENTRY_DSN)' != '' and '$(PlatformIsMobile)' == 'true'">
+          Condition="'$(SENTRY_DSN)' != ''">
 
     <Message Text="Generating shared EnvironmentVariables.g.cs with embedded DSN..." Importance="High" />
 
@@ -25,7 +25,7 @@ namespace Sentry.Samples%3B
 internal static class EnvironmentVariables
 {
     /// &lt;summary&gt;
-    /// To make things easier for the SDK maintainers we have a custom build target that writes the
+    /// To make things easier for the SDK maintainers, we have a custom build target that writes the
     /// SENTRY_DSN environment variable into an EnvironmentVariables class that is available for mobile
     /// targets. This allows us to share one DSN defined in the ENV across desktop and mobile samples.
     /// Generally, you won't want to do this in your own mobile projects though - you should set the DSN

--- a/src/Sentry.AspNetCore/SentryStartupFilter.cs
+++ b/src/Sentry.AspNetCore/SentryStartupFilter.cs
@@ -1,5 +1,9 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.RequestDecompression;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Sentry.Extensibility;
 
 namespace Sentry.AspNetCore;
 
@@ -11,10 +15,20 @@ public class SentryStartupFilter : IStartupFilter
     /// <summary>
     /// Adds Sentry to the pipeline.
     /// </summary>
-    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) => e =>
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) => app =>
     {
-        e.UseSentry();
+        app.UseSentry();
 
-        next(e);
+        // If we are capturing request bodies and the user has configured request body decompression, we need to
+        // ensure that the RequestDecompression middleware gets called before Sentry's middleware. The last middleware
+        // added is the first one to be executed.
+        var options = app.ApplicationServices.GetService<IOptions<SentryAspNetCoreOptions>>();
+        if (options?.Value is { } o&& o.MaxRequestBodySize != RequestSize.None
+            && app.ApplicationServices.GetService<IRequestDecompressionProvider>() is not null)
+        {
+            app.UseRequestDecompression();
+        }
+
+        next(app);
     };
 }

--- a/src/Sentry/Extensibility/BaseRequestPayloadExtractor.cs
+++ b/src/Sentry/Extensibility/BaseRequestPayloadExtractor.cs
@@ -18,24 +18,29 @@ public abstract class BaseRequestPayloadExtractor : IRequestPayloadExtractor
             return null;
         }
 
-        if (request.Body == null
-            || !request.Body.CanSeek
-            || !request.Body.CanRead
-            || !IsSupported(request))
+        if (request.Body is not { CanRead: true } || !IsSupported(request))
         {
             return null;
         }
 
-        var originalPosition = request.Body.Position;
+        // When RequestDecompression is enabled, the RequestDecompressionMiddleware will store a SizeLimitedStream
+        // in the request body after decompression. Seek operations throw an exception, but we can still read the stream
+        var originalPosition = request.Body.CanSeek ? request.Body.Position : 0;
         try
         {
-            request.Body.Position = 0;
+            if (request.Body.CanSeek)
+            {
+                request.Body.Position = 0;
+            }
 
             return DoExtractPayLoad(request);
         }
         finally
         {
-            request.Body.Position = originalPosition;
+            if (request.Body.CanSeek)
+            {
+                request.Body.Position = originalPosition;
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #4312:
- https://github.com/getsentry/sentry-dotnet/issues/4312

## Summary

Due to the [SentryStartupFilter](https://github.com/getsentry/sentry-dotnet/blob/263961124a49c5fa8290c8721294e7fd472e7027/src/Sentry.AspNetCore/SentryStartupFilter.cs#L9-L20), Sentry's middleware is the first middleware in the chain, so was being called before the `RequestDecompressionMiddleware`. Because of this, the `HttpContext.Request.Body` that Sentry was storing on the Scope (and therefore events) was not being uncompressed as you would expect when enabling this middleware.

## Solution

This PR alters the `SentryStartupFilter` so that it checks whether `IRequestDecompressionProvider` has been registered in the services collection (see [RequestDecompressionServiceExtensions](https://github.com/dotnet/aspnetcore/blob/9e69f19a5c7efa19577627a62c029ff387810d50/src/Middleware/RequestDecompression/src/RequestDecompressionServiceExtensions.cs#L19-L25)). If it is then the `RequestDecompressionMiddleware` is registered before Sentry's middleware. 

### Potential issues

Errors decompressing the request body in the `RequestDecompressionMiddleware` itself will not be captured by Sentry.

### TODO

- [ ] We could a wrapper around the app builder to prevent re-registrations of the `RequestDecompressionMiddleware` once we've already registered it (similar to [what we do for tracing](https://github.com/getsentry/sentry-dotnet/blob/bd62cf0421cc7a5d7b7804f8461fae00d47d43b8/src/Sentry.AspNetCore/SentryTracingStartupFilter.cs#L8-L15)).
- [ ] We could also add an option like `AutoRegisterRequestDecompressionMiddleware` to `SentryAspNetCoreOptions` to make it possible to disable this logic.