### PR TITLE
fix: EventProcessors not running for native crashes on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added StartSpan and GetTransaction methods to the SentrySdk ([#4303](https://github.com/getsentry/sentry-dotnet/pull/4303))
 
+### Fixes
+
+- Custom ISentryEventProcessors are now run for native iOS events ([#4318](https://github.com/getsentry/sentry-dotnet/pull/4318))
+
 ### Dependencies
 
 - Bump Native SDK from v0.9.0 to v0.9.1 ([#4309](https://github.com/getsentry/sentry-dotnet/pull/4309))

--- a/src/Sentry/Internal/SentryEventHelper.cs
+++ b/src/Sentry/Internal/SentryEventHelper.cs
@@ -2,9 +2,9 @@ using Sentry.Extensibility;
 
 namespace Sentry.Internal;
 
-internal class SentryEventHelper(SentryOptions options)
+internal static class SentryEventHelper
 {
-    public SentryEvent? ProcessEvent(SentryEvent? evt, IEnumerable<ISentryEventProcessor> processors, SentryHint? hint)
+    public static SentryEvent? ProcessEvent(SentryEvent? evt, IEnumerable<ISentryEventProcessor> processors, SentryHint? hint, SentryOptions options)
     {
         if (evt == null)
         {
@@ -12,7 +12,7 @@ internal class SentryEventHelper(SentryOptions options)
         }
 
         var processedEvent = evt;
-        var effectiveHint = hint ?? new SentryHint();
+        var effectiveHint = hint ?? new SentryHint(options);
 
         foreach (var processor in processors)
         {
@@ -30,7 +30,7 @@ internal class SentryEventHelper(SentryOptions options)
 #if NET6_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026: RequiresUnreferencedCode", Justification = AotHelper.AvoidAtRuntime)]
 #endif
-    public SentryEvent? DoBeforeSend(SentryEvent? @event, SentryHint hint)
+    public static SentryEvent? DoBeforeSend(SentryEvent? @event, SentryHint hint, SentryOptions options)
     {
         if (@event is null || options.BeforeSendInternal is null)
         {

--- a/src/Sentry/Internal/SentryEventHelper.cs
+++ b/src/Sentry/Internal/SentryEventHelper.cs
@@ -1,0 +1,76 @@
+using Sentry.Extensibility;
+
+namespace Sentry.Internal;
+
+internal class SentryEventHelper(SentryOptions options)
+{
+    public SentryEvent? ProcessEvent(SentryEvent? evt, IEnumerable<ISentryEventProcessor> processors, SentryHint? hint)
+    {
+        if (evt == null)
+        {
+            return evt;
+        }
+
+        var processedEvent = evt;
+        var effectiveHint = hint ?? new SentryHint();
+
+        foreach (var processor in processors)
+        {
+            processedEvent = processor.DoProcessEvent(processedEvent, effectiveHint);
+            if (processedEvent == null)
+            {
+                options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.EventProcessor, DataCategory.Error);
+                options.LogInfo("Event dropped by processor {0}", processor.GetType().Name);
+                break;
+            }
+        }
+        return processedEvent;
+    }
+
+#if NET6_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026: RequiresUnreferencedCode", Justification = AotHelper.AvoidAtRuntime)]
+#endif
+    public SentryEvent? DoBeforeSend(SentryEvent? @event, SentryHint hint)
+    {
+        if (@event is null || options.BeforeSendInternal is null)
+        {
+            return @event;
+        }
+
+        options.LogDebug("Calling the BeforeSend callback");
+        try
+        {
+            @event = options.BeforeSendInternal?.Invoke(@event, hint);
+            if (@event == null) // Rejected event
+            {
+                options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Error);
+                options.LogInfo("Event dropped by BeforeSend callback.");
+            }
+        }
+        catch (Exception e)
+        {
+            if (!AotHelper.IsTrimmed)
+            {
+                // Attempt to demystify exceptions before adding them as breadcrumbs.
+                e.Demystify();
+            }
+
+            options.LogError(e, "The BeforeSend callback threw an exception. It will be added as breadcrumb and continue.");
+            var data = new Dictionary<string, string>
+            {
+                {"message", e.Message}
+            };
+            if (e.StackTrace is not null)
+            {
+                data.Add("stackTrace", e.StackTrace);
+            }
+            @event?.AddBreadcrumb(
+                "BeforeSend callback failed.",
+                category: "SentryClient",
+                data: data,
+                level: BreadcrumbLevel.Error);
+        }
+
+        return @event;
+    }
+}

--- a/src/Sentry/Platforms/Cocoa/SentrySdk.cs
+++ b/src/Sentry/Platforms/Cocoa/SentrySdk.cs
@@ -267,8 +267,6 @@ public static partial class SentrySdk
             // we only support a subset of mutated data to be passed back to the native SDK at this time
             processedEvent.CopyToCocoaSentryEvent(evt);
 
-            // Note: A nullable result is allowed, but delegate is generated incorrectly
-            // See https://github.com/xamarin/xamarin-macios/issues/15299#issuecomment-1201863294
             return evt;
         }
         catch (Exception ex)

--- a/test/Sentry.Tests/SentryClientTests.CaptureEvent_BeforeEventThrows_ErrorToEventBreadcrumb.verified.txt
+++ b/test/Sentry.Tests/SentryClientTests.CaptureEvent_BeforeEventThrows_ErrorToEventBreadcrumb.verified.txt
@@ -6,7 +6,7 @@
       message: Exception message!,
       stackTrace:
 at Task Sentry.Tests.SentryClientTests.CaptureEvent_BeforeEventThrows_ErrorToEventBreadcrumb()
-at SentryEvent Sentry.SentryClient.BeforeSend(...)
+at SentryEvent Sentry.Internal.SentryEventHelper.DoBeforeSend(...)
     },
     Category: SentryClient,
     Level: error


### PR DESCRIPTION
Resolves #3621:
- https://github.com/getsentry/sentry-dotnet/issues/3621