### PR TITLE
App Hang Tracking for iOS is now disabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### API changes
+
+- App Hang Tracking for iOS is now disabled by default. You'll need to enable this manually if you want to use it in your applications. ([#4320](https://github.com/getsentry/sentry-dotnet/pull/4320))
+
 ### Features
 
 - Added StartSpan and GetTransaction methods to the SentrySdk ([#4303](https://github.com/getsentry/sentry-dotnet/pull/4303))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### API changes
 
-- App Hang Tracking for iOS is now disabled by default. You'll need to enable this manually if you want to use it in your applications. ([#4320](https://github.com/getsentry/sentry-dotnet/pull/4320))
+- App Hang Tracking for iOS is now disabled by default, until this functionality is more stable. If you want to use it in your applications then you'll need to enable this manually. ([#4320](https://github.com/getsentry/sentry-dotnet/pull/4320))
 
 ### Features
 

--- a/src/Sentry/Platforms/Cocoa/SentryOptions.cs
+++ b/src/Sentry/Platforms/Cocoa/SentryOptions.cs
@@ -61,12 +61,12 @@ public partial class SentryOptions
         /// <summary>
         /// When enabled, the SDK tracks when the application stops responding for a specific amount of
         /// time defined by the <see cref="AppHangTimeoutInterval"/> option.
-        /// The default value is <c>true</c> (enabled).
+        /// The default value is <c>false</c> (disabled).
         /// </summary>
         /// <remarks>
         /// See https://docs.sentry.io/platforms/apple/configuration/app-hangs/
         /// </remarks>
-        public bool EnableAppHangTracking { get; set; } = true;
+        public bool EnableAppHangTracking { get; set; } = false;
 
         /// <summary>
         /// IMPORTANT: This feature is experimental and may have bugs.


### PR DESCRIPTION
Resolves #4150:
- https://github.com/getsentry/sentry-dotnet/issues/4150#issuecomment-3025873457