### PR TITLE
ref: Support `Unity` as a platfom

### DIFF
--- a/src/Sentry/Platforms/Unity/Sentry.Unity.props
+++ b/src/Sentry/Platforms/Unity/Sentry.Unity.props
@@ -1,0 +1,15 @@
+<Project>
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <!-- To be able to make the internals visible, since we're not signing the assembly for Unity -->
+    <SignAssembly>false</SignAssembly>
+    <DefineConstants>$(DefineConstants);SENTRY_UNITY</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Sentry.Unity" />
+    <InternalsVisibleTo Include="Sentry.Unity.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Sentry/Platforms/Unity/SentrySdk.Unity.cs
+++ b/src/Sentry/Platforms/Unity/SentrySdk.Unity.cs
@@ -1,0 +1,21 @@
+#if SENTRY_UNITY
+
+namespace Sentry;
+
+/// <summary>
+/// Internal Sentry SDK entrypoint.
+/// </summary>
+/// <remarks>
+/// This class is now internal. Use <c>Sentry.Unity.SentrySdk</c> instead.
+/// <para>
+/// To migrate your code:
+/// <list type="number">
+/// <item>Change <c>using Sentry;</c> to <c>using Sentry.Unity;</c></item>
+/// <item>Keep using the <c>SentrySdk</c> API itself - no changes needed to method calls</item>
+/// <item>Add <c>using Sentry;</c> if you need access to types like <c>SentryId</c>, <c>SentryLevel</c>, etc.</item>
+/// </list>
+/// </para>
+/// </remarks>
+internal static partial class SentrySdk;
+
+#endif

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -18,11 +18,13 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <!-- To be able to make the internals visible, since we're not signing the assembly for Unity -->
     <SignAssembly>false</SignAssembly>
+    <DefineConstants>$(DefineConstants);SENTRY_UNITY</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(SolutionName)' == 'Sentry.Unity'">
     <InternalsVisibleTo Include="Sentry.Unity" />
     <InternalsVisibleTo Include="Sentry.Unity.Tests" />
+    <Compile Remove="path/to/file"></Compile>
   </ItemGroup>
 
   <!-- Platform-specific props included here -->

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -7,30 +7,19 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(SolutionName)' != 'Sentry.Unity'">
+  <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_ANDROID)' == ''">$(TargetFrameworks);net9.0-android35.0;net8.0-android34.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net9.0-ios18.0;net8.0-ios17.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_MACCATALYST)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net9.0-maccatalyst18.0;net8.0-maccatalyst17.0</TargetFrameworks>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(SolutionName)' == 'Sentry.Unity'">
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <!-- To be able to make the internals visible, since we're not signing the assembly for Unity -->
-    <SignAssembly>false</SignAssembly>
-    <DefineConstants>$(DefineConstants);SENTRY_UNITY</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(SolutionName)' == 'Sentry.Unity'">
-    <InternalsVisibleTo Include="Sentry.Unity" />
-    <InternalsVisibleTo Include="Sentry.Unity.Tests" />
-  </ItemGroup>
-
+  
   <!-- Platform-specific props included here -->
   <Import Project="Platforms\Android\Sentry.Android.props" Condition="'$(TargetPlatformIdentifier)' == 'android'" />
   <Import Project="Platforms\Cocoa\Sentry.Cocoa.props" Condition="'$(TargetPlatformIdentifier)' == 'ios' Or '$(TargetPlatformIdentifier)' == 'maccatalyst'" />
   <Import Project="Platforms\Native\Sentry.Native.targets"
         Condition="'$(TargetPlatformIdentifier)' != 'android' and '$(TargetPlatformIdentifier)' != 'ios' and '$(TargetPlatformIdentifier)' != 'maccatalyst'"/>
+  <Import Project="Platforms\Unity\Sentry.Unity.props" Condition="'$(SolutionName)' == 'Sentry.Unity'"/>
 
   <PropertyGroup Condition="'$(EnableAot)' == 'true'">
     <IsAotCompatible>true</IsAotCompatible>

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -24,7 +24,6 @@
   <ItemGroup Condition="'$(SolutionName)' == 'Sentry.Unity'">
     <InternalsVisibleTo Include="Sentry.Unity" />
     <InternalsVisibleTo Include="Sentry.Unity.Tests" />
-    <Compile Remove="path/to/file"></Compile>
   </ItemGroup>
 
   <!-- Platform-specific props included here -->

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -6,11 +6,11 @@ using Sentry.Protocol.Envelopes;
 
 namespace Sentry;
 
-
 #if SENTRY_UNITY
 /// <summary>
-/// please, don't
+/// Internal Sentry SDK entrypoint.
 /// </summary>
+/// <remarks>Use `Sentry.Unity.SentrySdk` instead.</remarks>
 internal
 #else
 /// <summary>

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -10,7 +10,17 @@ namespace Sentry;
 /// <summary>
 /// Internal Sentry SDK entrypoint.
 /// </summary>
-/// <remarks>Use `Sentry.Unity.SentrySdk` instead.</remarks>
+/// <remarks>
+/// This class is now internal. Use <c>Sentry.Unity.SentrySdk</c> instead.
+/// <para>
+/// To migrate your code:
+/// <list type="number">
+/// <item>Change <c>using Sentry;</c> to <c>using Sentry.Unity;</c></item>
+/// <item>Keep using the <c>SentrySdk</c> API itself - no changes needed to method calls</item>
+/// <item>Add <c>using Sentry;</c> if you need access to types like <c>SentryId</c>, <c>SentryLevel</c>, etc.</item>
+/// </list>
+/// </para>
+/// </remarks>
 internal
 #else
 /// <summary>

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -6,6 +6,13 @@ using Sentry.Protocol.Envelopes;
 
 namespace Sentry;
 
+
+#if SENTRY_UNITY
+/// <summary>
+/// please, don't
+/// </summary>
+internal
+#else
 /// <summary>
 /// Sentry SDK entrypoint.
 /// </summary>
@@ -14,7 +21,9 @@ namespace Sentry;
 /// It allows safe static access to a client and scope management.
 /// When the SDK is uninitialized, calls to this class result in no-op so no callbacks are invoked.
 /// </remarks>
-public static partial class SentrySdk
+public
+#endif
+    static partial class SentrySdk
 {
     internal static IHub CurrentHub = DisabledHub.Instance;
 

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -6,23 +6,7 @@ using Sentry.Protocol.Envelopes;
 
 namespace Sentry;
 
-#if SENTRY_UNITY
-/// <summary>
-/// Internal Sentry SDK entrypoint.
-/// </summary>
-/// <remarks>
-/// This class is now internal. Use <c>Sentry.Unity.SentrySdk</c> instead.
-/// <para>
-/// To migrate your code:
-/// <list type="number">
-/// <item>Change <c>using Sentry;</c> to <c>using Sentry.Unity;</c></item>
-/// <item>Keep using the <c>SentrySdk</c> API itself - no changes needed to method calls</item>
-/// <item>Add <c>using Sentry;</c> if you need access to types like <c>SentryId</c>, <c>SentryLevel</c>, etc.</item>
-/// </list>
-/// </para>
-/// </remarks>
-internal
-#else
+#if !SENTRY_UNITY
 /// <summary>
 /// Sentry SDK entrypoint.
 /// </summary>
@@ -33,7 +17,7 @@ internal
 /// </remarks>
 public
 #endif
-    static partial class SentrySdk
+static partial class SentrySdk
 {
     internal static IHub CurrentHub = DisabledHub.Instance;
 


### PR DESCRIPTION
This comes from https://github.com/getsentry/sentry-unity/pull/2227

The goal is to provide the Unity SDK a way to "internalize" the .NET SDK. This works because the Unity SDK builds the .NET SDK from source. The relevant changes happen in `SentrySdk.cs`.

We noticed the similarity between `Unity` and the platforms `Android`, `iOS`, and `Native`. All the Unity specific junk from the `Sentry.csproj` now goes into its own `.props`.

To lend the argument "Unity is its own platform" some credibility we dug out [some ms docs](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-1-0#net-standard-versions).

#skip-changelog