### PR TITLE
Bump DeviceRunners from preview.1 to preview.5

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -35,7 +35,7 @@ runs:
     - name: Pin the Xcode Version
       if: runner.os == 'macOS'
       shell: bash
-      run: sudo xcode-select --switch /Applications/Xcode_16.2.app
+      run: sudo xcode-select --switch /Applications/Xcode_16.4.app
 
     # Java 17 is needed for Android SDK setup step
     - name: Install Java 17

--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tfm: [net8.0, net9.0]
+        tfm: [net9.0]
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
@@ -39,14 +39,6 @@ jobs:
       - name: Build Android Test App
         run: pwsh ./scripts/device-test.ps1 android -Build -Tfm ${{ matrix.tfm }}
 
-      - name: Upload Android Test App (net8.0)
-        if: matrix.tfm == 'net8.0'
-        uses: actions/upload-artifact@v4
-        with:
-          name: device-test-android-net8.0
-          if-no-files-found: error
-          path: test/Sentry.Maui.Device.TestApp/bin/Release/net8.0-android/android-x64/io.sentry.dotnet.maui.device.testapp-Signed.apk
-
       - name: Upload Android Test App (net9.0)
         if: matrix.tfm == 'net9.0'
         uses: actions/upload-artifact@v4
@@ -65,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tfm: [net8.0, net9.0]
+        tfm: [net9.0]
         # We run against both an older and a newer API
         api-level: [27, 33]
     env:

--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -59,9 +59,6 @@ try
             '--launch-timeout', '00:10:00',
             '--set-env', 'CI=$envValue'
         )
-        if ($CI) {
-            $arguments += '--reset-simulator'
-        }
     }
 
     if ($Build)

--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -59,6 +59,9 @@ try
             '--launch-timeout', '00:10:00',
             '--set-env', 'CI=$envValue'
         )
+        if ($CI) {
+            $arguments += '--reset-simulator'
+        }
     }
 
     if ($Build)

--- a/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
+++ b/test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworks);net8.0-android;net9.0-android</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net8.0-ios;net9.0-ios</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net9.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net9.0-ios</TargetFrameworks>
     <DefineConstants Condition="'$(EnableMauiDeviceTestVisualRunner)' == 'true'">$(DefineConstants);VISUAL_RUNNER</DefineConstants>
   </PropertyGroup>
 
@@ -85,17 +85,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DeviceRunners.XHarness.Maui" Version="0.1.0-preview.1"/>
-    <PackageReference Include="DeviceRunners.XHarness.Xunit" Version="0.1.0-preview.1"/>
-
-    <!-- Prevent downgrade of these packages for DeviceRunners.XHarness.Xunit 0.1.0-preview.1   -->
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0"/>
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0"/>
+    <PackageReference Include="DeviceRunners.XHarness.Maui" Version="0.1.0-preview.5"/>
+    <PackageReference Include="DeviceRunners.XHarness.Xunit" Version="0.1.0-preview.5"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(EnableMauiDeviceTestVisualRunner)' == 'true'">
-    <PackageReference Include="DeviceRunners.VisualRunners.Maui" Version="0.1.0-preview.1"/>
-    <PackageReference Include="DeviceRunners.VisualRunners.Xunit" Version="0.1.0-preview.1"/>
+    <PackageReference Include="DeviceRunners.VisualRunners.Maui" Version="0.1.0-preview.5"/>
+    <PackageReference Include="DeviceRunners.VisualRunners.Xunit" Version="0.1.0-preview.5"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Also dropped the net8.0 targets for device tests, since preview.5 does not support net8.0 (and this is EOL now).

Was originally meant to fix #4337:
- https://github.com/getsentry/sentry-dotnet/issues/4337

That was resolved separately by pinning the version of xharness:
- https://github.com/getsentry/sentry-dotnet/pull/4339

@Flash0ver we could still go ahead and bump the DeviceRunners version as there are a number of other fixes/improvements here. We'll need to do this eventually when we want to support .NET 10 anyway.

#skip-changelog