### PR TITLE
ci: pin xharness

### DIFF
--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -76,7 +76,7 @@ try
         if (!(Get-Command xharness -ErrorAction SilentlyContinue))
         {
             Push-Location ($CI ? $env:RUNNER_TEMP : $IsWindows ? $env:TMP : $IsMacos ? $env:TMPDIR : '/temp')
-            dotnet tool install Microsoft.DotNet.XHarness.CLI --global --version '10.0.0-prerelease*' `
+            dotnet tool install Microsoft.DotNet.XHarness.CLI --global --version '10.0.0-prerelease.25330.2' `
                 --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
             Pop-Location
         }


### PR DESCRIPTION
iOS builds started failing without any code changes, just by xharness being updated.

See https://github.com/getsentry/sentry-dotnet/actions/runs/16180208260/job/45674883905 where the first attempt was successful and the second one on the same branch failed after two days.

The only difference is the xharness version:

## Successful attempt

```
[10.0.0-prerelease.25330.2+feac80219b22c403d32df9b6bd61cbf78e1b9986] XHarness command issued: apple test --app test/Sentry.Maui.Device.TestApp/bin/Release/net9.0-ios/iossimulator-x64/Sentry.Maui.Device.TestApp.app --target ios-simulator-64 --launch-timeout 00:10:00 --set-env CI=$envValue --output-directory=test_output
info: Preparing run for ios-simulator-64
info: Looking for available ios-simulator-64 simulators..
info: Found simulator device 'iPhone Xs (iOS 18.5) - created by XHarness'
info: Getting app bundle information from '/Users/runner/work/sentry-dotnet/sentry-dotnet/test/Sentry.Maui.Device.TestApp/bin/Release/net9.0-ios/iossimulator-x64/Sentry.Maui.Device.TestApp.app'..
info: Uninstalling any previous instance of 'io.sentry.dotnet.maui.device.testapp' from 'iPhone Xs (iOS 18.5) - created by XHarness'
info: Application 'io.sentry.dotnet.maui.device.testapp' was uninstalled successfully
info: Installing application 'Sentry.Maui.Device.TestApp' on 'iPhone Xs (iOS 18.5) - created by XHarness'
info: Application 'Sentry.Maui.Device.TestApp' was installed successfully on 'iPhone Xs (iOS 18.5) - created by XHarness'
info: Starting test run for io.sentry.dotnet.maui.device.testapp..
info: Application finished the test run successfully
info: Tests run: 1983 Passed: 1952 Inconclusive: 0 Failed: 0 Ignored: 31
info: Uninstalling the application 'io.sentry.dotnet.maui.device.testapp' from 'iPhone Xs (iOS 18.5) - created by XHarness'
info: Application 'io.sentry.dotnet.maui.device.testapp' was uninstalled successfully
XHarness exit code: 0
```

## Failed attempt
```
[10.0.0-prerelease.25360.1+faf00a180a0b711eb0ce107ad7a30fbebe665d3f] XHarness command issued: apple test --app test/Sentry.Maui.Device.TestApp/bin/Release/net9.0-ios/iossimulator-x64/Sentry.Maui.Device.TestApp.app --target ios-simulator-64 --launch-timeout 00:10:00 --set-env CI=$envValue --output-directory=test_output
info: Preparing run for ios-simulator-64
info: Looking for available ios-simulator-64 simulators..
info: Found simulator device 'iPhone Xs (iOS 18.5) - created by XHarness'
info: Getting app bundle information from '/Users/runner/work/sentry-dotnet/sentry-dotnet/test/Sentry.Maui.Device.TestApp/bin/Release/net9.0-ios/iossimulator-x64/Sentry.Maui.Device.TestApp.app'..
info: Uninstalling any previous instance of 'io.sentry.dotnet.maui.device.testapp' from 'iPhone Xs (iOS 18.5) - created by XHarness'
info: Installing application 'Sentry.Maui.Device.TestApp' on 'iPhone Xs (iOS 18.5) - created by XHarness'
fail: Failed to install the application
info: Cleaning up the failed installation from 'iPhone Xs (iOS 18.5) - created by XHarness'
info: Uninstalling the application 'io.sentry.dotnet.maui.device.testapp' from 'iPhone Xs (iOS 18.5) - created by XHarness'
fail: Failed to uninstall the app bundle! Check logs for more details!
XHarness exit code: 78 (PACKAGE_INSTALLATION_FAILURE)
device-test.ps1: The property 'FullName' cannot be found on this object. Verify that the property exists.
Error: Process completed with exit code 1.
```
