### PR TITLE
fix(mobile): avoid double session reporting release health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- Avoid double reporting sessions on iOS and Android apps ([#4341](https://github.com/getsentry/sentry-dotnet/pull/4341))
 - Sentry now decompresses Request bodies in ASP.NET Core when RequestDecompression middleware is enabled ([#4315](https://github.com/getsentry/sentry-dotnet/pull/4315))
 - Custom ISentryEventProcessors are now run for native iOS events ([#4318](https://github.com/getsentry/sentry-dotnet/pull/4318))
 - Crontab validation when capturing checkins ([#4314](https://github.com/getsentry/sentry-dotnet/pull/4314))

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -47,7 +47,8 @@ public static partial class SentrySdk
             o.DiagnosticLevel = options.DiagnosticLevel.ToJavaSentryLevel();
             o.Dist = options.Distribution;
             o.Dsn = options.Dsn;
-            o.EnableAutoSessionTracking = options.AutoSessionTracking;
+            // Hardcode to false because .NET SDK manages sessions itself
+            o.EnableAutoSessionTracking = false;
             o.Environment = options.Environment;
             o.FlushTimeoutMillis = (long)options.InitCacheFlushTimeout.TotalMilliseconds;
             o.MaxAttachmentSize = options.MaxAttachmentSize;

--- a/src/Sentry/Platforms/Cocoa/SentrySdk.cs
+++ b/src/Sentry/Platforms/Cocoa/SentrySdk.cs
@@ -24,7 +24,8 @@ public static partial class SentrySdk
         nativeOptions.Debug = options.Debug;
         nativeOptions.DiagnosticLevel = options.DiagnosticLevel.ToCocoaSentryLevel();
         nativeOptions.Dsn = options.Dsn;
-        nativeOptions.EnableAutoSessionTracking = options.AutoSessionTracking;
+        // Hardcode to false because .NET SDK manages sessions itself
+        nativeOptions.EnableAutoSessionTracking = false;
         nativeOptions.EnableCaptureFailedRequests = options.CaptureFailedRequests;
         nativeOptions.FailedRequestStatusCodes = GetFailedRequestStatusCodes(options.FailedRequestStatusCodes);
         nativeOptions.MaxAttachmentSize = (nuint)options.MaxAttachmentSize;


### PR DESCRIPTION
Hardcode `AutoSessionTracking` to `false` for native iOS and Android SDKs to prevent double session counting (fixes #4334).

---

[Slack Thread](https://sentry.slack.com/archives/D09151U0YN9/p1752323890319389?thread_ts=1752323890.319389&cid=D09151U0YN9)