### PR TITLE
fix: Don't load SentryNative on unsupported platforms

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -24,6 +24,14 @@ runs:
       shell: bash
       run: sudo chmod 666 /var/run/docker.sock
 
+    - name: Install Linux ARM 32-bit dependencies
+      if: ${{ matrix.rid == 'linux-arm' }}
+      shell: bash
+      run: |
+        sudo dpkg --add-architecture armhf
+        sudo apt-get update
+        sudo apt-get install -y gcc-arm-linux-gnueabihf libc6:armhf
+
     # zstd is needed for cross OS actions/cache but missing from windows-11-arm
     # https://github.com/actions/partner-runner-images/issues/99
     - name: Install zstd on Windows ARM64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,6 +281,47 @@ jobs:
             msbuild.binlog
           if-no-files-found: ignore
 
+  # Unsupported Native AOT runtimes should have SentryNative auto-disabled
+  # to avoid native library loading errors on startup.
+  unsupported-aot:
+    needs: build
+    name: Unsupported AOT (${{ matrix.rid }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04-arm
+            rid: linux-arm
+          - os: windows-latest
+            rid: win-x86
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Environment
+        uses: ./.github/actions/environment
+
+      - name: Build Native Dependencies
+        uses: ./.github/actions/buildnative
+
+      - name: Fetch NuGet Packages
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ github.sha }}
+          path: src
+
+      - name: Test AOT
+        uses: getsentry/github-workflows/sentry-cli/integration-test/@v2
+        env:
+          RuntimeIdentifier: ${{ matrix.rid }}
+        with:
+          path: integration-test/aot.Tests.ps1
+
   trim-analysis:
     needs: build-sentry-native
     name: Trim analysis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Native AOT: don't load SentryNative on unsupported platforms ([#4347](https://github.com/getsentry/sentry-dotnet/pull/4347))
+
 ### Dependencies
 
 - Bump CLI from v2.47.0 to v2.47.1 ([#4348](https://github.com/getsentry/sentry-dotnet/pull/4348))

--- a/integration-test/aot.Tests.ps1
+++ b/integration-test/aot.Tests.ps1
@@ -50,11 +50,22 @@ Console.WriteLine("Hello, Sentry!");
     }
 
     It 'Aot' {
-        dotnet publish -c Release | Write-Host
+        $rid = $env:RuntimeIdentifier
+        if ($env:RuntimeIdentifier)
+        {
+            dotnet publish -c Release -r $rid | Write-Host
+        }
+        else
+        {
+            dotnet publish -c Release | Write-Host
+        }
         $LASTEXITCODE | Should -Be 0
 
         $tfm = (Get-ChildItem -Path "bin/Release" -Directory | Select-Object -First 1).Name
-        $rid = (Get-ChildItem -Path "bin/Release/$tfm" -Directory | Select-Object -First 1).Name
+        if (-not $rid)
+        {
+            $rid = (Get-ChildItem -Path "bin/Release/$tfm" -Directory | Select-Object -First 1).Name
+        }
         & "bin/Release/$tfm/$rid/publish/hello-sentry" | Write-Host
         $LASTEXITCODE | Should -Be 0
     }

--- a/integration-test/aot.Tests.ps1
+++ b/integration-test/aot.Tests.ps1
@@ -51,7 +51,7 @@ Console.WriteLine("Hello, Sentry!");
 
     It 'Aot' {
         $rid = $env:RuntimeIdentifier
-        if ($env:RuntimeIdentifier)
+        if ($rid)
         {
             dotnet publish -c Release -r $rid | Write-Host
         }

--- a/src/Sentry/Platforms/Native/SentryNative.cs
+++ b/src/Sentry/Platforms/Native/SentryNative.cs
@@ -17,7 +17,7 @@ internal static class SentryNative
     // This way, `SentryNative.IsEnabled` should be treated as a compile-time constant for trimmed apps.
     [FeatureSwitchDefinition(SentryNativeIsEnabledSwitchName)]
 #endif
-    private static bool IsEnabled => !AppContext.TryGetSwitch(SentryNativeIsEnabledSwitchName, out var isEnabled) || isEnabled;
+    private static bool IsEnabled => AppContext.TryGetSwitch(SentryNativeIsEnabledSwitchName, out var isEnabled) && isEnabled;
 
     internal static bool IsAvailable => IsEnabled && IsAvailableCore;
 

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -8,16 +8,6 @@
   Note:Target framework conditions should be kept synchronized with src/Sentry/buildTransitive/Sentry.Native.targets -->
 <Project>
 
-  <ItemGroup>
-    <!-- When user sets <SentryNative>false</SentryNative> or <SentryNative>disable</SentryNative> in their project -->
-    <!-- SentryNative.IsEnabled should result in compile-time constant for trimmed applications -->
-    <!-- Effectively disabling native library -->
-    <RuntimeHostConfigurationOption Include="Sentry.Native.IsEnabled"
-                                    Condition="'$(FrameworkSupportsNative)' == 'true'"
-                                    Value="true"
-                                    Trim="true" />
-  </ItemGroup>
-
   <!-- Helpful properties copied from Sentry.props -->
   <PropertyGroup Condition="'$(TargetFramework)' != ''">
     <_SentryTargetFrameworkVersion>$([MSBuild]::GetTargetFrameworkVersion($(TargetFramework)))</_SentryTargetFrameworkVersion>
@@ -38,6 +28,16 @@
     <FrameworkSupportsNative Condition="'$(SentryNative)' == 'true' or '$(SentryNative)' == 'enable'">true</FrameworkSupportsNative>
     <FrameworkSupportsNative Condition="'$(SentryNative)' == 'false' or '$(SentryNative)' == 'disable'">false</FrameworkSupportsNative>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- When user sets <SentryNative>false</SentryNative> or <SentryNative>disable</SentryNative> in their project -->
+    <!-- SentryNative.IsEnabled should result in compile-time constant for trimmed applications -->
+    <!-- Effectively disabling native library -->
+    <RuntimeHostConfigurationOption Include="Sentry.Native.IsEnabled"
+                                    Condition="'$(FrameworkSupportsNative)' == 'true'"
+                                    Value="true"
+                                    Trim="true" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(FrameworkSupportsNative)' == 'true' and ('$(RuntimeIdentifier)' == 'win-x64' or '$(RuntimeIdentifier)' == 'win-arm64')">
     <DirectPInvoke Include="sentry-native" />

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -13,7 +13,8 @@
     <!-- SentryNative.IsEnabled should result in compile-time constant for trimmed applications -->
     <!-- Effectively disabling native library -->
     <RuntimeHostConfigurationOption Include="Sentry.Native.IsEnabled"
-                                    Value="$(_SentryNativeEnabled)"
+                                    Condition="'$(FrameworkSupportsNative)' == 'true'"
+                                    Value="true"
                                     Trim="true" />
   </ItemGroup>
 
@@ -25,31 +26,17 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Windows -->
+    <FrameworkSupportsNative Condition="'$(RuntimeIdentifier)' == 'win-x64' or '$(RuntimeIdentifier)' == 'win-arm64'">true</FrameworkSupportsNative>
+    <!-- Linux -->
+    <FrameworkSupportsNative Condition="'$(RuntimeIdentifier)' == 'linux-x64' or '$(RuntimeIdentifier)' == 'linux-arm64' or '$(RuntimeIdentifier)' == 'linux-musl-x64'">true</FrameworkSupportsNative>
+    <!-- macOS -->
+    <FrameworkSupportsNative Condition="'$(RuntimeIdentifier)' == 'osx-x64' or '$(RuntimeIdentifier)' == 'osx-arm64'">true</FrameworkSupportsNative>
     <!-- net8.0 or greater -->
-    <FrameworkSupportsNative Condition="'$(_SentryIsNet8OrGreater)' == 'true' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe')">true</FrameworkSupportsNative>
+    <FrameworkSupportsNative Condition="'$(_SentryIsNet8OrGreater)' != 'true' or !('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe')">false</FrameworkSupportsNative>
     <!-- Make it opt-out -->
     <FrameworkSupportsNative Condition="'$(SentryNative)' == 'false' or '$(SentryNative)' == 'disable'">false</FrameworkSupportsNative>
   </PropertyGroup>
-
-  <!-- Whitelist supported runtimes -->
-  <Choose>
-    <When Condition="'$(FrameworkSupportsNative)' == 'true'">
-      <PropertyGroup>
-        <_SentryNativeEnabled>false</_SentryNativeEnabled>
-        <!-- Windows -->
-        <_SentryNativeEnabled Condition="'$(RuntimeIdentifier)' == 'win-x64' or '$(RuntimeIdentifier)' == 'win-arm64'">true</_SentryNativeEnabled>
-        <!-- Linux -->
-        <_SentryNativeEnabled Condition="'$(RuntimeIdentifier)' == 'linux-x64' or '$(RuntimeIdentifier)' == 'linux-arm64' or '$(RuntimeIdentifier)' == 'linux-musl-x64'">true</_SentryNativeEnabled>
-        <!-- macOS -->
-        <_SentryNativeEnabled Condition="'$(RuntimeIdentifier)' == 'osx-x64' or '$(RuntimeIdentifier)' == 'osx-arm64'">true</_SentryNativeEnabled>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <_SentryNativeEnabled>false</_SentryNativeEnabled>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
 
   <ItemGroup Condition="'$(FrameworkSupportsNative)' == 'true' and ('$(RuntimeIdentifier)' == 'win-x64' or '$(RuntimeIdentifier)' == 'win-arm64')">
     <DirectPInvoke Include="sentry-native" />

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -13,8 +13,7 @@
     <!-- SentryNative.IsEnabled should result in compile-time constant for trimmed applications -->
     <!-- Effectively disabling native library -->
     <RuntimeHostConfigurationOption Include="Sentry.Native.IsEnabled"
-                                    Condition="'$(SentryNative)' == 'false' or '$(SentryNative)' == 'disable'"
-                                    Value="false"
+                                    Value="$(_SentryNativeEnabled)"
                                     Trim="true" />
   </ItemGroup>
 
@@ -31,6 +30,26 @@
     <!-- Make it opt-out -->
     <FrameworkSupportsNative Condition="'$(SentryNative)' == 'false' or '$(SentryNative)' == 'disable'">false</FrameworkSupportsNative>
   </PropertyGroup>
+
+  <!-- Whitelist supported runtimes -->
+  <Choose>
+    <When Condition="'$(FrameworkSupportsNative)' == 'true'">
+      <PropertyGroup>
+        <_SentryNativeEnabled>false</_SentryNativeEnabled>
+        <!-- Windows -->
+        <_SentryNativeEnabled Condition="'$(RuntimeIdentifier)' == 'win-x64' or '$(RuntimeIdentifier)' == 'win-arm64'">true</_SentryNativeEnabled>
+        <!-- Linux -->
+        <_SentryNativeEnabled Condition="'$(RuntimeIdentifier)' == 'linux-x64' or '$(RuntimeIdentifier)' == 'linux-arm64' or '$(RuntimeIdentifier)' == 'linux-musl-x64'">true</_SentryNativeEnabled>
+        <!-- macOS -->
+        <_SentryNativeEnabled Condition="'$(RuntimeIdentifier)' == 'osx-x64' or '$(RuntimeIdentifier)' == 'osx-arm64'">true</_SentryNativeEnabled>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <_SentryNativeEnabled>false</_SentryNativeEnabled>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
   <ItemGroup Condition="'$(FrameworkSupportsNative)' == 'true' and ('$(RuntimeIdentifier)' == 'win-x64' or '$(RuntimeIdentifier)' == 'win-arm64')">
     <DirectPInvoke Include="sentry-native" />

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -34,7 +34,8 @@
     <FrameworkSupportsNative Condition="'$(RuntimeIdentifier)' == 'osx-x64' or '$(RuntimeIdentifier)' == 'osx-arm64'">true</FrameworkSupportsNative>
     <!-- net8.0 or greater -->
     <FrameworkSupportsNative Condition="'$(_SentryIsNet8OrGreater)' != 'true' or !('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe')">false</FrameworkSupportsNative>
-    <!-- Make it opt-out -->
+    <!-- Make it opt-in/out -->
+    <FrameworkSupportsNative Condition="'$(SentryNative)' == 'true' or '$(SentryNative)' == 'enable'">true</FrameworkSupportsNative>
     <FrameworkSupportsNative Condition="'$(SentryNative)' == 'false' or '$(SentryNative)' == 'disable'">false</FrameworkSupportsNative>
   </PropertyGroup>
 


### PR DESCRIPTION
TLDR; default `Sentry.Native.IsEnabled` to false for unsupported Native AOT platforms.

The existing `integration-test/aot.Tests.ps1` works great for testing unsupported platforms with a minor tweak to allow specifying the desired target `RuntimeIdentifier` in the environment. It only tests `dotnet publish` for a minimal Sentry console app, and that the compiled binary executes ok (without capturing any native exceptions). The original purpose was to test that `libsentry-native.a` doesn't have problematic dependencies (`libcurl.so`), but the same integration test works just as well for testing that sentry-dotnet doesn't try to load a non-existent `libsentry-native.so`.

Without the newly introduced changes that make `Sentry.Native.IsEnabled` default to false for unsupported Native AOT platforms, the test would produce such failures:

### `win-x86` (Windows 32-bit)
```
  Debug: This looks like a Native AOT application build.
Unhandled exception. System.DllNotFoundException: Unable to load DLL 'sentry-native' or one of its dependencies: The specified module could not be found.
   at System.Runtime.InteropServices.NativeLibrary.LoadLibErrorTracker.Throw(String) + 0x42
   at Internal.Runtime.CompilerHelpers.InteropHelpers.FixupModuleCell(InteropHelpers.ModuleFixupCell*) + 0xdf
   at Internal.Runtime.CompilerHelpers.InteropHelpers.ResolvePInvokeSlow(InteropHelpers.MethodFixupCell*) + 0x29
   at Internal.Runtime.CompilerHelpers.InteropHelpers.ResolvePInvoke(InteropHelpers.MethodFixupCell*) + 0xb
   at Sentry.Native.C.sentry_options_new() + 0x13
   at Sentry.Native.C.Init(SentryOptions) + 0x17
   at Sentry.SentrySdk.InitNativeSdk(SentryOptions) + 0x1e
   at Sentry.SentrySdk.InitHub(SentryOptions) + 0x179
   at Sentry.SentrySdk.Init(Action`1) + 0x2d
   at Program.<Main>$(String[] args) + 0x3e
```

### `linux-arm` (Linux ARM 32-bit)
```
  Debug: This looks like a Native AOT application build.
Unhandled exception. System.DllNotFoundException: Unable to load shared library 'sentry-native' or one of its dependencies. In order to help diagnose loading problems, consider using a tool like strace. If you're using glibc, consider setting the LD_DEBUG environment variable:
sentry-native.so: cannot open shared object file: No such file or directory
libsentry-native.so: cannot open shared object file: No such file or directory
sentry-native: cannot open shared object file: No such file or directory
libsentry-native: cannot open shared object file: No such file or directory

   at System.Runtime.InteropServices.NativeLibrary.LoadLibErrorTracker.Throw(String) + 0x5b
   at Internal.Runtime.CompilerHelpers.InteropHelpers.FixupModuleCell(InteropHelpers.ModuleFixupCell*) + 0x16f
   at Internal.Runtime.CompilerHelpers.InteropHelpers.ResolvePInvokeSlow(InteropHelpers.MethodFixupCell*) + 0x3d
   at Sentry.Native.C.sentry_options_new() + 0x1f
   at Sentry.Native.C.Init(SentryOptions) + 0x29
   at Sentry.SentrySdk.InitNativeSdk(SentryOptions) + 0x31
   at Sentry.SentrySdk.InitHub(SentryOptions) + 0x1e9
   at Sentry.SentrySdk.Init(Action`1) + 0x49
   at Program.<Main>$(String[] args) + 0x69
qemu: uncaught target signal 6 (Aborted) - core dumped
```

Note: These two platforms were chosen because both are straightforward to set up for testing. If either platform becomes supported in the future, the respective matrix item can be removed.

Resolves: #4343