### PR TITLE
Improve the caching transport tests

### DIFF
--- a/test/Sentry.Testing/FakeReliableNetworkStatusListener.cs
+++ b/test/Sentry.Testing/FakeReliableNetworkStatusListener.cs
@@ -1,0 +1,20 @@
+namespace Sentry.Testing;
+
+/// <summary>
+/// To be used when we don't want the real network status to affect the reliability of our tests
+/// </summary>
+public class FakeReliableNetworkStatusListener : INetworkStatusListener
+{
+    public static readonly FakeReliableNetworkStatusListener Instance = new();
+
+    private FakeReliableNetworkStatusListener()
+    {
+    }
+
+    public bool Online => true;
+
+    public Task WaitForNetworkOnlineAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -630,22 +630,3 @@ public class CachingTransportTests : IDisposable
         Assert.DoesNotContain("sent_at", contents);
     }
 }
-
-/// <summary>
-/// We don't want the real network status to affect the reliability of our tests
-/// </summary>
-file class FakeReliableNetworkStatusListener : INetworkStatusListener
-{
-    public static readonly FakeReliableNetworkStatusListener Instance = new();
-
-    private FakeReliableNetworkStatusListener()
-    {
-    }
-
-    public bool Online => true;
-
-    public Task WaitForNetworkOnlineAsync(CancellationToken cancellationToken)
-    {
-        return Task.CompletedTask;
-    }
-}

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -192,6 +192,7 @@ public class CachingTransportTests : IDisposable
     public async Task MaintainsLimit()
     {
         // Arrange
+        _options.MaxCacheItems = 2;
         var innerTransport = Substitute.For<ITransport>();
         await using var transport = CachingTransport.Create(innerTransport, _options, startWorker: false);
 


### PR DESCRIPTION
The caching transport tests can fail when running the device tests if the simulator looses network connectivity. This PR changes the test to use a `FakeReliableNetworkStatusListener ` implementation of `INetworkStatusListener` that ignores the real network status and just pretends that everything is OK, so that test reliability isn't impacted by network connectivity.

Extracted from https://github.com/getsentry/sentry-dotnet/pull/4294

#skip-changelog