### PR TITLE
Bump to Google API levels 34 and 36 for device tests

### DIFF
--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -58,8 +58,9 @@ jobs:
       fail-fast: false
       matrix:
         tfm: [net9.0]
-        # We run against both an older and a newer API
-        api-level: [27, 33]
+        # Must be 34+ for new apps and app updates as of August 31, 2024.
+        # See https://apilevels.com/
+        api-level: [34, 36]
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1


### PR DESCRIPTION
Extracted from https://github.com/getsentry/sentry-dotnet/pull/4294

#skip-changelog