### PR TITLE
ci(build): allow workflow_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
+  workflow_dispatch:
 
 jobs:
   build-sentry-native:


### PR DESCRIPTION
`workflow_dispatch` must be enabled in the default branch to be able to re-run #4363 from the GitHub Web UI:

<img width="1804" height="764" alt="image" src="https://github.com/user-attachments/assets/9153814c-87a8-48e4-8bcd-8f86c1bb4636" />

#skip-changelog