### PR TITLE
fix: Native AOT for `linux-musl-arm64`

### DIFF
--- a/.github/alpine/setup-node.sh
+++ b/.github/alpine/setup-node.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+[ -n "$1" ] || { echo "Usage: $0 <path>"; exit 1; }
+
+# A workaround for "JavaScript Actions in Alpine containers are only supported on x64 Linux runners."
+# https://github.com/actions/runner/blob/8a9b96806d12343f7d123c669e29c629138023dd/src/Runner.Worker/Handlers/StepHost.cs#L283-L290
+if [ "$(uname -m)" != "x86_64" ]; then
+    mkdir -p $1
+    ln -s /usr/bin/node $1
+    ln -s /usr/bin/npm $1
+    sed -i 's/ID=alpine/ID=unknown/' /usr/lib/os-release
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,12 @@ jobs:
             rid: linux-musl-x64
             container:
               image: ghcr.io/getsentry/sentry-dotnet-alpine:3.21
+          - os: ubuntu-24.04-arm
+            rid: linux-musl-arm64
+            container:
+              image: ghcr.io/jpnurmi/sentry-dotnet-alpine:3.21 # TODO: getsentry
+              volumes:
+                - /tmp/node20:/__e/node20
           - os: macos-15 # Pin macos to get the version of Xcode that we need: https://github.com/actions/runner-images/issues/10703
             rid: macos # universal (osx-arm64 + osx-x64)
           - os: windows-latest
@@ -35,6 +41,16 @@ jobs:
             rid: win-arm64
 
     steps:
+      ### TODO: clean up
+      - name: Prepare Node.js for non-x64 Alpine Linux
+        if: ${{ contains(matrix.container.image, 'alpine') && runner.arch != 'X64' }}
+        shell: bash
+        run: |
+          sudo mkdir -p /__e/node20/bin
+          sudo ln -sf /usr/bin/node /__e/node20/bin/node
+          sudo ln -sf /usr/bin/npm /__e/node20/bin/npm
+          sudo sed -i 's/ID=alpine/ID=unknown/' /usr/lib/os-release
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -83,6 +99,14 @@ jobs:
               image: ghcr.io/getsentry/sentry-dotnet-alpine:3.21
               volumes:
                 - /var/run/docker.sock:/var/run/docker.sock
+          - os: ubuntu-24.04-arm
+            rid: linux-musl-arm64
+            slnf: Sentry-CI-Build-Linux-musl.slnf
+            container:
+              image: ghcr.io/jpnurmi/sentry-dotnet-alpine:3.21 # TODO: getsentry
+              volumes:
+                - /tmp/node20:/__e/node20
+                - /var/run/docker.sock:/var/run/docker.sock
           - os: macos-15 # Pin macos to get the version of Xcode that we need: https://github.com/actions/runner-images/issues/10703
             rid: macos # universal (osx-arm64 + osx-x64)
             slnf: Sentry-CI-Build-macOS.slnf
@@ -94,6 +118,16 @@ jobs:
             slnf: Sentry-CI-Build-Windows-arm64.slnf
 
     steps:
+      ### TODO: clean up
+      - name: Prepare Node.js for non-x64 Alpine Linux
+        if: ${{ contains(matrix.container.image, 'alpine') && runner.arch != 'X64' }}
+        shell: bash
+        run: |
+          sudo mkdir -p /__e/node20/bin
+          sudo ln -sf /usr/bin/node /__e/node20/bin/node
+          sudo ln -sf /usr/bin/npm /__e/node20/bin/npm
+          sudo sed -i 's/ID=alpine/ID=unknown/' /usr/lib/os-release
+
       - name: Cancel Previous Runs
         if: github.ref_name != 'main' && !startsWith(github.ref_name, 'release/')
         uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # Tag: 0.12.1
@@ -138,6 +172,14 @@ jobs:
         with:
           path: src/Sentry/Platforms/Native/sentry-native
           key: sentry-native-linux-musl-x64-${{ hashFiles('scripts/build-sentry-native.ps1') }}-${{ hashFiles('.git/modules/modules/sentry-native/HEAD') }}
+          fail-on-cache-miss: true
+
+      - name: Download sentry-native (linux-musl-arm64)
+        if: ${{ (env.CI_PUBLISHING_BUILD == 'true') || (matrix.rid == 'linux-musl-arm64') }}
+        uses: actions/cache/restore@v4
+        with:
+          path: src/Sentry/Platforms/Native/sentry-native
+          key: sentry-native-linux-musl-arm64-${{ hashFiles('scripts/build-sentry-native.ps1') }}-${{ hashFiles('.git/modules/modules/sentry-native/HEAD') }}
           fail-on-cache-miss: true
 
       - name: Download sentry-native (macos)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           - os: ubuntu-24.04-arm
             rid: linux-musl-arm64
             container:
-              image: ghcr.io/jpnurmi/sentry-dotnet-alpine:3.21 # TODO: getsentry
+              image: ghcr.io/getsentry/sentry-dotnet-alpine:3.21
               volumes:
                 - /tmp/node20:/__e/node20
           - os: macos-15 # Pin macos to get the version of Xcode that we need: https://github.com/actions/runner-images/issues/10703
@@ -103,7 +103,7 @@ jobs:
             rid: linux-musl-arm64
             slnf: Sentry-CI-Build-Linux-musl.slnf
             container:
-              image: ghcr.io/jpnurmi/sentry-dotnet-alpine:3.21 # TODO: getsentry
+              image: ghcr.io/getsentry/sentry-dotnet-alpine:3.21
               volumes:
                 - /tmp/node20:/__e/node20
                 - /var/run/docker.sock:/var/run/docker.sock

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,15 +41,10 @@ jobs:
             rid: win-arm64
 
     steps:
-      ### TODO: clean up
-      - name: Prepare Node.js for non-x64 Alpine Linux
-        if: ${{ contains(matrix.container.image, 'alpine') && runner.arch != 'X64' }}
-        shell: bash
+      - name: Initialize Alpine Linux
+        if: ${{ contains(matrix.container.image, 'alpine') }}
         run: |
-          sudo mkdir -p /__e/node20/bin
-          sudo ln -sf /usr/bin/node /__e/node20/bin/node
-          sudo ln -sf /usr/bin/npm /__e/node20/bin/npm
-          sudo sed -i 's/ID=alpine/ID=unknown/' /usr/lib/os-release
+          curl -sSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/.github/alpine/setup-node.sh | sudo bash /dev/stdin /__e/node20/bin/
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -118,15 +113,10 @@ jobs:
             slnf: Sentry-CI-Build-Windows-arm64.slnf
 
     steps:
-      ### TODO: clean up
-      - name: Prepare Node.js for non-x64 Alpine Linux
-        if: ${{ contains(matrix.container.image, 'alpine') && runner.arch != 'X64' }}
-        shell: bash
+      - name: Initialize Alpine Linux
+        if: ${{ contains(matrix.container.image, 'alpine') }}
         run: |
-          sudo mkdir -p /__e/node20/bin
-          sudo ln -sf /usr/bin/node /__e/node20/bin/node
-          sudo ln -sf /usr/bin/npm /__e/node20/bin/npm
-          sudo sed -i 's/ID=alpine/ID=unknown/' /usr/lib/os-release
+          curl -sSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/.github/alpine/setup-node.sh | sudo bash /dev/stdin /__e/node20/bin/
 
       - name: Cancel Previous Runs
         if: github.ref_name != 'main' && !startsWith(github.ref_name, 'release/')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Native AOT: don't load SentryNative on unsupported platforms ([#4347](https://github.com/getsentry/sentry-dotnet/pull/4347))
 - Fixed issue introduced in release 5.12.0 that might prevent other middleware or user code from reading request bodies ([#4373](https://github.com/getsentry/sentry-dotnet/pull/4373))
+- Native AOT support for `linux-musl-arm64` ([#4365](https://github.com/getsentry/sentry-dotnet/pull/4365))
 
 ### Dependencies
 

--- a/integration-test/runtime.Tests.ps1
+++ b/integration-test/runtime.Tests.ps1
@@ -42,37 +42,9 @@ internal class FakeTransport : ITransport
 
         function getConsoleAppPath()
         {
-            if ($IsMacOS)
-            {
-                $arch = $(uname -m) -eq 'arm64' ? 'arm64' : 'x64'
-                return "./console-app/bin/Release/$framework/osx-$arch/publish/console-app"
-            }
-            elseif ($IsWindows)
-            {
-                if ("Arm64".Equals([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()))
-                {
-                    return "./console-app/bin/Release/$framework/win-arm64/publish/console-app.exe"
-                }
-                else
-                {
-                    return "./console-app/bin/Release/$framework/win-x64/publish/console-app.exe"
-                }
-            }
-            else
-            {
-                if ("Arm64".Equals([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()))
-                {
-                    return "./console-app/bin/Release/$framework/linux-arm64/publish/console-app"
-                }
-                elseif ((ldd --version 2>&1) -match 'musl')
-                {
-                    return "./console-app/bin/Release/$framework/linux-musl-x64/publish/console-app"
-                }
-                else
-                {
-                    return "./console-app/bin/Release/$framework/linux-x64/publish/console-app"
-                }
-            }
+            $rid = [System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier
+            $suffix = if ($IsWindows) { '.exe' } else { '' }
+            return "./console-app/bin/Release/$framework/$rid/publish/console-app$suffix"
         }
 
         function publishConsoleApp([bool]$SentryNative = $true)

--- a/scripts/build-sentry-native.ps1
+++ b/scripts/build-sentry-native.ps1
@@ -25,30 +25,11 @@ try
         $actualBuildDir = "$buildDir/RelWithDebInfo"
         $libPrefix = ''
         $libExtension = '.lib'
-
-        if ("Arm64".Equals([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()))
-        {
-            $outDir += '/win-arm64'
-        }
-        else
-        {
-            $outDir += '/win-x64'
-        }
+        $outDir += '/' + [System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier
     }
     elseif ($IsLinux)
     {
-        if ("Arm64".Equals([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()))
-        {
-            $outDir += '/linux-arm64'
-        }
-        elseif ((ldd --version 2>&1) -match 'musl')
-        {
-            $outDir += '/linux-musl-x64'
-        }
-        else
-        {
-            $outDir += '/linux-x64'
-        }
+        $outDir += '/' + [System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier
     }
     else
     {

--- a/scripts/build-sentry-native.ps1
+++ b/scripts/build-sentry-native.ps1
@@ -25,11 +25,36 @@ try
         $actualBuildDir = "$buildDir/RelWithDebInfo"
         $libPrefix = ''
         $libExtension = '.lib'
-        $outDir += '/' + [System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier
+
+        if ("Arm64".Equals([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()))
+        {
+            $outDir += '/win-arm64'
+        }
+        else
+        {
+            $outDir += '/win-x64'
+        }
     }
     elseif ($IsLinux)
     {
-        $outDir += '/' + [System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier
+        $musl = (ldd --version 2>&1) -match 'musl'
+        $arm64 = ("Arm64".Equals([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()))
+        if ($musl -and $arm64)
+        {
+            $outDir += '/linux-musl-arm64'
+        }
+        elseif ($arm64)
+        {
+            $outDir += '/linux-arm64'
+        }
+        elseif ($musl)
+        {
+            $outDir += '/linux-musl-x64'
+        }
+        else
+        {
+            $outDir += '/linux-x64'
+        }
     }
     else
     {

--- a/scripts/build-sentry-native.ps1
+++ b/scripts/build-sentry-native.ps1
@@ -38,7 +38,7 @@ try
     elseif ($IsLinux)
     {
         $musl = (ldd --version 2>&1) -match 'musl'
-        $arm64 = ("Arm64".Equals([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()))
+        $arm64 = "Arm64".Equals([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString())
         if ($musl -and $arm64)
         {
             $outDir += '/linux-musl-arm64'

--- a/src/Sentry/Platforms/Native/CFunctions.cs
+++ b/src/Sentry/Platforms/Native/CFunctions.cs
@@ -81,9 +81,6 @@ internal static class C
 
     public static bool Init(SentryOptions options)
     {
-        _isWindows = System.OperatingSystem.IsWindows();
-        _isArm64 = RuntimeInformation.OSArchitecture == Architecture.Arm64;
-
         var cOptions = sentry_options_new();
 
         // Note: DSN is not null because options.IsValid() must have returned true for this to be called.
@@ -443,8 +440,9 @@ internal static class C
 
     // The logger we should forward native messages to. This is referenced by nativeLog() which in turn for.
     private static IDiagnosticLogger? _logger;
-    private static bool _isWindows = false;
-    private static bool _isArm64 = false;
+    private static bool _isWindows = System.OperatingSystem.IsWindows();
+    private static bool _isLinux = System.OperatingSystem.IsLinux();
+    private static bool _isArm64 = RuntimeInformation.OSArchitecture == Architecture.Arm64;
 
     // This method is called from the C library and forwards incoming messages to the currently set _logger.
     // [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]  //  error CS3016: Arrays as attribute arguments is not CLS-complian
@@ -499,7 +497,7 @@ internal static class C
                 });
             }
             // For Linux/macOS, we must make a copy of the VaList to be able to pass it back...
-            else if (_isArm64)
+            else if (_isLinux && _isArm64)
             {
                 message = FormatWithVaList<VaListArm64>(format, args);
             }

--- a/src/Sentry/Platforms/Native/CFunctions.cs
+++ b/src/Sentry/Platforms/Native/CFunctions.cs
@@ -441,7 +441,6 @@ internal static class C
     // The logger we should forward native messages to. This is referenced by nativeLog() which in turn for.
     private static IDiagnosticLogger? _logger;
     private static bool _isWindows = System.OperatingSystem.IsWindows();
-    private static bool _isLinux = System.OperatingSystem.IsLinux();
     private static bool _isArm64 = RuntimeInformation.OSArchitecture == Architecture.Arm64;
 
     // This method is called from the C library and forwards incoming messages to the currently set _logger.
@@ -497,7 +496,7 @@ internal static class C
                 });
             }
             // For Linux/macOS, we must make a copy of the VaList to be able to pass it back...
-            else if (_isLinux && _isArm64)
+            else if (_isArm64)
             {
                 message = FormatWithVaList<VaListArm64>(format, args);
             }

--- a/src/Sentry/Platforms/Native/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/Sentry.Native.targets
@@ -17,6 +17,8 @@
     <SentryNativeOutputDirectory-linux-musl-x64>$(SentryNativeOutputDirectory)$(NativeLibRelativePath-linux-musl-x64)\</SentryNativeOutputDirectory-linux-musl-x64>
     <NativeLibRelativePath-linux-arm64>linux-arm64</NativeLibRelativePath-linux-arm64>
     <SentryNativeOutputDirectory-linux-arm64>$(SentryNativeOutputDirectory)$(NativeLibRelativePath-linux-arm64)\</SentryNativeOutputDirectory-linux-arm64>
+    <NativeLibRelativePath-linux-musl-arm64>linux-musl-arm64</NativeLibRelativePath-linux-musl-arm64>
+    <SentryNativeOutputDirectory-linux-musl-arm64>$(SentryNativeOutputDirectory)$(NativeLibRelativePath-linux-musl-arm64)\</SentryNativeOutputDirectory-linux-musl-arm64>
     <NativeLibRelativePath-osx>osx</NativeLibRelativePath-osx>
     <SentryNativeOutputDirectory-osx>$(SentryNativeOutputDirectory)$(NativeLibRelativePath-osx)\</SentryNativeOutputDirectory-osx>
     <SentryNativeBuildOutputs Condition="'$(RuntimeIdentifier)' == 'win-x64'">$(SentryNativeOutputDirectory-win-x64)lib$(SentryNativeLibraryName).lib</SentryNativeBuildOutputs>
@@ -24,6 +26,7 @@
     <SentryNativeBuildOutputs Condition="'$(RuntimeIdentifier)' == 'linux-x64'">$(SentryNativeOutputDirectory-linux-x64)lib$(SentryNativeLibraryName).a</SentryNativeBuildOutputs>
     <SentryNativeBuildOutputs Condition="'$(RuntimeIdentifier)' == 'linux-musl-x64'">$(SentryNativeOutputDirectory-linux-musl-x64)lib$(SentryNativeLibraryName).a</SentryNativeBuildOutputs>
     <SentryNativeBuildOutputs Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">$(SentryNativeOutputDirectory-linux-arm64)lib$(SentryNativeLibraryName).a</SentryNativeBuildOutputs>
+    <SentryNativeBuildOutputs Condition="'$(RuntimeIdentifier)' == 'linux-musl-arm64'">$(SentryNativeOutputDirectory-linux-musl-arm64)lib$(SentryNativeLibraryName).a</SentryNativeBuildOutputs>
     <SentryNativeBuildOutputs Condition="$([MSBuild]::IsOsPlatform('OSX'))">$(SentryNativeOutputDirectory-osx)lib$(SentryNativeLibraryName).a</SentryNativeBuildOutputs>
   </PropertyGroup>
 
@@ -66,6 +69,13 @@
     <None Include="$(SentryNativeOutputDirectory-linux-arm64)lib$(SentryNativeLibraryName).a">
       <Pack>true</Pack>
       <PackagePath>\sentry-native\$(NativeLibRelativePath-linux-arm64)</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(CI_PUBLISHING_BUILD)' == 'true' or '$(NETCoreSdkRuntimeIdentifier)' == 'linux-musl-arm64'">
+    <None Include="$(SentryNativeOutputDirectory-linux-musl-arm64)lib$(SentryNativeLibraryName).a">
+      <Pack>true</Pack>
+      <PackagePath>\sentry-native\$(NativeLibRelativePath-linux-musl-arm64)</PackagePath>
     </None>
   </ItemGroup>
 

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -52,11 +52,11 @@
     <NativeLibrary Include="$(MSBuildThisFileDirectory)..\sentry-native\$(RuntimeIdentifier)\libsentry-native.a" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(FrameworkSupportsNative)' == 'true' and '$(RuntimeIdentifier)' == 'linux-musl-x64'">
+  <ItemGroup Condition="'$(FrameworkSupportsNative)' == 'true' and ('$(RuntimeIdentifier)' == 'linux-musl-x64' or '$(RuntimeIdentifier)' == 'linux-musl-arm64')">
     <DirectPInvoke Include="sentry-native" />
     <!-- When musl is detected, static sentry-native links to static libunwind, which depends on liblzma -->
     <LinkerArg Include="-Wl,-Bstatic -Wl,--whole-archive -lunwind -Wl,--no-whole-archive -llzma -Wl,-Bdynamic" />
-    <NativeLibrary Include="$(MSBuildThisFileDirectory)..\sentry-native\linux-musl-x64\libsentry-native.a" />
+    <NativeLibrary Include="$(MSBuildThisFileDirectory)..\sentry-native\$(RuntimeIdentifier)\libsentry-native.a" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(FrameworkSupportsNative)' == 'true' and ('$(RuntimeIdentifier)' == 'osx-x64' or '$(RuntimeIdentifier)' == 'osx-arm64')">

--- a/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/buildTransitive/Sentry.Native.targets
@@ -19,7 +19,7 @@
     <!-- Windows -->
     <FrameworkSupportsNative Condition="'$(RuntimeIdentifier)' == 'win-x64' or '$(RuntimeIdentifier)' == 'win-arm64'">true</FrameworkSupportsNative>
     <!-- Linux -->
-    <FrameworkSupportsNative Condition="'$(RuntimeIdentifier)' == 'linux-x64' or '$(RuntimeIdentifier)' == 'linux-arm64' or '$(RuntimeIdentifier)' == 'linux-musl-x64'">true</FrameworkSupportsNative>
+    <FrameworkSupportsNative Condition="'$(RuntimeIdentifier)' == 'linux-x64' or '$(RuntimeIdentifier)' == 'linux-arm64' or '$(RuntimeIdentifier)' == 'linux-musl-x64' or '$(RuntimeIdentifier)' == 'linux-musl-arm64'">true</FrameworkSupportsNative>
     <!-- macOS -->
     <FrameworkSupportsNative Condition="'$(RuntimeIdentifier)' == 'osx-x64' or '$(RuntimeIdentifier)' == 'osx-arm64'">true</FrameworkSupportsNative>
     <!-- net8.0 or greater -->


### PR DESCRIPTION
Publishing a minimal Alpine .NET AOT container on a Mac with Apple silicon requires `linux-musl-arm64` as brought up in:
- https://github.com/getsentry/sentry-dotnet/issues/4296#issuecomment-3066775157

<details><summary>Problem: GitHub Actions hosted Node.js not available for MUSL ARM64</summary>

Node.js is required for JS actions, such as `actions/checkout`. For various reasons, GitHub Actions forces all containers to run a pre-compiled Node.js from the host, bind-mounted to the container in the `/__e` (aka. "externals") directory. The problem is that there's no suitable pre-compiled version for Linux MUSL ARM64.

A workaround is possible but it gets quite hacky. First of all, we need to bind-mount either `/__e/node20` or `/__e/node20/bin` to "escape" the built-in `/__e` bind-mount. Secondly, we need to make sure `/__e/node20/bin/node` points to a working node executable. In our case, we link it to the system installation i.e. `/usr/bin/node`. Finally, we need to alter `/etc/os-release` and pretend not to be Alpine (change `ID=alpine` to anything else) to avoid the following hard-coded Alpine container compatibility check:

> Error: JavaScript Actions in Alpine containers are only supported on x64 Linux runners. Detected ...

```csharp
// Check for Alpine container compatibility
if (!Constants.Runner.PlatformArchitecture.Equals(Constants.Architecture.X64))
{
    var os = Constants.Runner.Platform.ToString();
    var arch = Constants.Runner.PlatformArchitecture.ToString();
    var msg = $"JavaScript Actions in Alpine containers are only supported on x64 Linux runners. Detected {os} {arch}";
    throw new NotSupportedException(msg);
}
```
https://github.com/actions/runner/blob/main/src/Runner.Worker/Handlers/StepHost.cs

See also:
- https://github.com/actions/runner/issues/801
</details>