### PR TITLE
fix: Clean repo builds no longer fail when building native

### DIFF
--- a/src/Sentry/Platforms/Native/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/Sentry.Native.targets
@@ -1,10 +1,10 @@
 <Project>
 
   <PropertyGroup>
-    <SentryNativeSourceDirectory>..\..\modules\sentry-native\</SentryNativeSourceDirectory>
+    <SentryNativeSourceDirectory>$(MSBuildStartupDirectory)\modules\sentry-native\</SentryNativeSourceDirectory>
     <SentryNativeLibraryName>sentry-native</SentryNativeLibraryName>
-    <SentryNativeBuildScript>../../scripts/build-sentry-native.ps1</SentryNativeBuildScript>
-    <SentryNativeBuildInputs>../../.git/modules/modules/sentry-native/HEAD;$(MSBuildThisFileDirectory)Sentry.Native.targets;$(SentryNativeBuildScript)</SentryNativeBuildInputs>
+    <SentryNativeBuildScript>$(MSBuildStartupDirectory)/scripts/build-sentry-native.ps1</SentryNativeBuildScript>
+    <SentryNativeBuildInputs>$(MSBuildStartupDirectory)/.git/modules/modules/sentry-native/HEAD;$(MSBuildThisFileDirectory)Sentry.Native.targets;$(SentryNativeBuildScript)</SentryNativeBuildInputs>
     <SentryNativeOutputDirectory>$(MSBuildThisFileDirectory)sentry-native\</SentryNativeOutputDirectory>
     <!-- List of runtime identifiers: https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json -->
     <NativeLibRelativePath-win-x64>win-x64</NativeLibRelativePath-win-x64>

--- a/src/Sentry/Platforms/Native/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/Sentry.Native.targets
@@ -87,6 +87,7 @@
   <Target Name="_BuildSentryNativeSDK"
     BeforeTargets="DispatchToInnerBuilds"
     Condition="'$(_SentryIsNet8OrGreater)' == 'true' and '$(CI)' != 'true'"
+    Inputs="$(SentryNativeBuildInputs)"
     Outputs="$(SentryNativeBuildOutputs)">
     <!-- We want a "-Clean" because if the build script changes, previous cmake cache may contain invalid defines. -->
     <Exec Command="pwsh $(SentryNativeBuildScript) -Clean" />

--- a/src/Sentry/Platforms/Native/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/Sentry.Native.targets
@@ -85,7 +85,7 @@
   <!-- Build the Sentry Native SDK (this only runs on local machines because in CI we expect the SDK to be
        built already on each native platform and fetched for the final .net build. -->
   <Target Name="_BuildSentryNativeSDK"
-    BeforeTargets="DispatchToInnerBuilds"
+    BeforeTargets="Build"
     Condition="'$(_SentryIsNet8OrGreater)' == 'true' and '$(CI)' != 'true'"
     Inputs="$(SentryNativeBuildInputs)"
     Outputs="$(SentryNativeBuildOutputs)">

--- a/src/Sentry/Platforms/Native/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/Sentry.Native.targets
@@ -85,11 +85,25 @@
   <!-- Build the Sentry Native SDK (this only runs on local machines because in CI we expect the SDK to be
        built already on each native platform and fetched for the final .net build. -->
   <Target Name="_BuildSentryNativeSDK"
-    BeforeTargets="Build"
-    Condition="'$(_SentryIsNet8OrGreater)' == 'true' and '$(CI)' != 'true'"
     Inputs="$(SentryNativeBuildInputs)"
     Outputs="$(SentryNativeBuildOutputs)">
     <!-- We want a "-Clean" because if the build script changes, previous cmake cache may contain invalid defines. -->
     <Exec Command="pwsh $(SentryNativeBuildScript) -Clean" />
+  </Target>
+
+  <!-- We want to build the sentry-native only once, BEFORE building TFM specific verions of the SDK -->
+  <!-- How to run a target exactly once: https://learn.microsoft.com/en-us/visualstudio/msbuild/run-target-exactly-once?view=vs-2022-->
+  <Target Name="_BuildSentryNativeSDKBeforeOuterBuild"
+    Condition="'$(_SentryIsNet8OrGreater)' == 'true' and '$(CI)' != 'true'"
+    DependsOnTargets="_BuildSentryNativeSDK"
+    BeforeTargets="DispatchToInnerBuilds">
+  </Target>
+
+  <Target Name="_BuildSentryNativeSDKBeforeInnerBuild"
+    Condition="'$(_SentryIsNet8OrGreater)' == 'true' and '$(CI)' != 'true'"
+    BeforeTargets="BeforeBuild">
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+      Targets="_BuildSentryNativeSDK"
+      RemoveProperties="TargetFramework" />
   </Target>
 </Project>

--- a/src/Sentry/Platforms/Native/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/Sentry.Native.targets
@@ -85,9 +85,8 @@
   <!-- Build the Sentry Native SDK (this only runs on local machines because in CI we expect the SDK to be
        built already on each native platform and fetched for the final .net build. -->
   <Target Name="_BuildSentryNativeSDK"
-    BeforeTargets="DispatchToInnerBuilds;BeforeBuild"
+    BeforeTargets="DispatchToInnerBuilds"
     Condition="'$(_SentryIsNet8OrGreater)' == 'true' and '$(CI)' != 'true'"
-    Inputs="$(SentryNativeBuildInputs)"
     Outputs="$(SentryNativeBuildOutputs)">
     <!-- We want a "-Clean" because if the build script changes, previous cmake cache may contain invalid defines. -->
     <Exec Command="pwsh $(SentryNativeBuildScript) -Clean" />

--- a/src/Sentry/Platforms/Native/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/Sentry.Native.targets
@@ -92,7 +92,7 @@
   </Target>
 
   <!-- We want to build the sentry-native only once, BEFORE building TFM specific verions of the SDK -->
-  <!-- How to run a target exactly once: https://learn.microsoft.com/en-us/visualstudio/msbuild/run-target-exactly-once?view=vs-2022-->
+  <!-- How to run a target exactly once: https://learn.microsoft.com/visualstudio/msbuild/run-target-exactly-once-->
   <Target Name="_BuildSentryNativeSDKBeforeOuterBuild"
     Condition="'$(_SentryIsNet8OrGreater)' == 'true' and '$(CI)' != 'true'"
     DependsOnTargets="_BuildSentryNativeSDK"

--- a/src/Sentry/Platforms/Native/Sentry.Native.targets
+++ b/src/Sentry/Platforms/Native/Sentry.Native.targets
@@ -1,10 +1,10 @@
 <Project>
 
   <PropertyGroup>
-    <SentryNativeSourceDirectory>$(MSBuildStartupDirectory)\modules\sentry-native\</SentryNativeSourceDirectory>
+    <SentryNativeSourceDirectory>$(MSBuildThisFileDirectory)..\..\..\..\modules\sentry-native\</SentryNativeSourceDirectory>
     <SentryNativeLibraryName>sentry-native</SentryNativeLibraryName>
-    <SentryNativeBuildScript>$(MSBuildStartupDirectory)/scripts/build-sentry-native.ps1</SentryNativeBuildScript>
-    <SentryNativeBuildInputs>$(MSBuildStartupDirectory)/.git/modules/modules/sentry-native/HEAD;$(MSBuildThisFileDirectory)Sentry.Native.targets;$(SentryNativeBuildScript)</SentryNativeBuildInputs>
+    <SentryNativeBuildScript>$(MSBuildThisFileDirectory)..\..\..\..\scripts\build-sentry-native.ps1</SentryNativeBuildScript>
+    <SentryNativeBuildInputs>$(MSBuildThisFileDirectory)..\..\..\..\.git\modules\modules\sentry-native/HEAD;$(MSBuildThisFileDirectory)Sentry.Native.targets;$(SentryNativeBuildScript)</SentryNativeBuildInputs>
     <SentryNativeOutputDirectory>$(MSBuildThisFileDirectory)sentry-native\</SentryNativeOutputDirectory>
     <!-- List of runtime identifiers: https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json -->
     <NativeLibRelativePath-win-x64>win-x64</NativeLibRelativePath-win-x64>


### PR DESCRIPTION
When building the SDK I keep having the build break on me with.

```
Sentry net8.0 failed with 2 error(s) (3.2s)
  EXEC : CMake error : CMAKE_CXX_COMPILER not set, after EnableLanguage
  /Users/bitfox/Workspace/sentry-unity/src/sentry-dotnet/src/Sentry/Platforms/Native/Sentry.Native.targets(93,5): error MSB3073: The command "pwsh ../../scripts/build-sentry-native.ps1 -Clean" exited with code 1.
Sentry net9.0 failed with 1 error(s) (3.0s)
  /Users/bitfox/Workspace/sentry-unity/src/sentry-dotnet/src/Sentry/Platforms/Native/Sentry.Native.targets(93,5): error MSB3073: The command "pwsh ../../scripts/build-sentry-native.ps1 -Clean" exited with code 1.
```

Digging through it I run into this

```
Sentry net9.0 failed with 1 error(s) (6.1s)
      -- The C compiler identification is AppleClang 17.0.0.17000013
      -- ... a bunch of other flags ...
      -- Build files have been written to: /Users/bitfox/Workspace/sentry-unity/src/sentry-dotnet/modules/sentry-native/build
      [  0%] Building C object CMakeFiles/sentry.dir/vendor/mpack.c.o
      [100%] Linking C static library libsentry.a
      [100%] Built target sentry
      Copying modules/sentry-native/build/libsentry.a to src/Sentry/Platforms/Native/sentry-native/osx/libsentry-native.a
      Copy-Item: /Users/bitfox/Workspace/sentry-unity/src/sentry-dotnet/scripts/build-sentry-native.ps1:88
      Line |
        88 |      Copy-Item -Force -Path $srcFile -Destination $outFile
           |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           | Cannot find path
           | '/Users/bitfox/Workspace/sentry-unity/src/sentry-dotnet/modules/sentry-native/build/libsentry.a' because it does not exist.
      /Users/bitfox/Workspace/sentry-unity/src/sentry-dotnet/src/Sentry/Platforms/Native/Sentry.Native.targets(93,5): error MSB3073: The command "pwsh /Users/bitfox/Workspace/sentry-unity/src/sentry-dotnet/scripts/build-sentry-native.ps1 -Clean" exited with code 1.
    Sentry net8.0 succeeded (6.7s) → src/Sentry/bin/Debug/net8.0/Sentry.dll
      -- The C compiler identification is AppleClang 17.0.0.17000013
      -- ... a bunch of other flags ...
      -- Build files have been written to: /Users/bitfox/Workspace/sentry-unity/src/sentry-dotnet/modules/sentry-native/build
      [ 23%] Building C object CMakeFiles/sentry.dir/vendor/mpack.c.o
      [ 96%] Building C object CMakeFiles/sentry.dir/src/transports/sentry_transport_none.c.o
      Linking C static library libsentry.a
      Built target sentry
      Copying modules/sentry-native/build/libsentry.a to src/Sentry/Platforms/Native/sentry-native/osx/libsentry-native.a
```

looks like building `Sentry` causes the build native target to run in parallel, corrupting the build output and failing.

So instead, we make use of [this article](https://learn.microsoft.com/visualstudio/msbuild/run-target-exactly-once) explaining how to run a target really only once.

While debugging, the resolving the path to the build script kept breaking. So instead of `../..` we can go with `$(MSBuildThisFileDirectory)_and then relative path from here_`.

#skip-changelog
