### PR TITLE
ci: fix msbuild cache key and clean up unused matrix properties

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,7 +295,7 @@ jobs:
       - name: Set Environment Variables
         run: echo "CI_PUBLISHING_BUILD=true" >> $GITHUB_ENV
 
-      - name: Download sentry-native (macOS)
+      - name: Download sentry-native (macos)
         uses: actions/cache/restore@v4
         with:
           path: src/Sentry/Platforms/Native/sentry-native


### PR DESCRIPTION
My apologies, I missed one Windows-specific cache key in the separate MSBuild job in:
- https://github.com/getsentry/sentry-dotnet/pull/4349

The old `sentry-native-Windows-<sha1>` cache key will eventually expire.

#skip-changelog