### PR TITLE
ci: install zstd for win arm64 straight from github releases

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -27,9 +27,7 @@ runs:
     # zstd is needed for cross OS actions/cache but missing from windows-11-arm
     # https://github.com/actions/partner-runner-images/issues/99
     - name: Install zstd on Windows ARM64
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      shell: pwsh
-      run: choco install zstandard
+      uses: ./.github/actions/install-zstd
 
     # See https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#xcode
     - name: Pin the Xcode Version

--- a/.github/actions/install-zstd/action.yml
+++ b/.github/actions/install-zstd/action.yml
@@ -1,0 +1,26 @@
+name: Install zstd on Windows ARM64
+description: |
+  zstd is needed for cross OS actions/cache but missing from windows-11-arm
+  (https://github.com/actions/partner-runner-images/issues/99). Once the issue
+  is resolved, this action can be removed.
+inputs:
+  version:
+    description: 'zstd version'
+    required: false
+    default: '1.5.7'
+
+runs:
+  using: composite
+  steps:
+    - name: Install zstd
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      shell: pwsh
+      env:
+        ZSTD_VERSION: ${{ inputs.version }}
+      run: |
+        $url = "https://github.com/facebook/zstd/releases/download/v$env:ZSTD_VERSION/zstd-v$env:ZSTD_VERSION-win64.zip"
+        $installDir = "$env:RUNNER_TOOL_CACHE\zstd-v$env:ZSTD_VERSION-win64"
+        Invoke-WebRequest -OutFile "$env:TEMP\zstd.zip" -Uri $url
+        Expand-Archive -Path "$env:TEMP\zstd.zip" -DestinationPath $env:RUNNER_TOOL_CACHE -Force
+        echo "$installDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        & "$installDir\zstd.exe" --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,7 @@ jobs:
       # zstd is needed for cross OS actions/cache but missing from windows-11-arm
       # https://github.com/actions/partner-runner-images/issues/99
       - name: Install zstd on Windows ARM64
-        if: runner.os == 'Windows' && runner.arch == 'ARM64'
-        shell: pwsh
-        run: choco install zstandard
+        uses: ./.github/actions/install-zstd
 
       - uses: actions/cache@v4
         id: cache


### PR DESCRIPTION
Essentially does the same as what Chocolatey did under the hood <sup>[1]</sup>, but replaces Chocolatey API requests with one blazing-fast direct GitHub HTTP request.

| Before | After |
|---|---|
| <img width="2073" height="2067" alt="image" src="https://github.com/user-attachments/assets/53369141-b7da-418f-8797-df0b936a70e0" /> | <img width="2101" height="804" alt="image" src="https://github.com/user-attachments/assets/6e87e12c-0d99-4016-ac0e-6763fe5e5624" /> |

References:
1. https://community.chocolatey.org/packages/zstandard#files

Fixes: #4368

#skip-changelog