### PR TITLE
Revert changes to BaseRequestPayloadExtractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Native AOT: don't load SentryNative on unsupported platforms ([#4347](https://github.com/getsentry/sentry-dotnet/pull/4347))
+- Fixed issue introduced in release 5.12.0 that might prevent other middleware or user code from reading request bodies ([#4373](https://github.com/getsentry/sentry-dotnet/pull/4373))
 
 ### Dependencies
 

--- a/src/Sentry/Extensibility/BaseRequestPayloadExtractor.cs
+++ b/src/Sentry/Extensibility/BaseRequestPayloadExtractor.cs
@@ -18,16 +18,12 @@ public abstract class BaseRequestPayloadExtractor : IRequestPayloadExtractor
             return null;
         }
 
-        if (request.Body is not { CanRead: true } || !IsSupported(request))
+        if (request.Body == null
+            || !request.Body.CanSeek
+            || !request.Body.CanRead
+            || !IsSupported(request))
         {
             return null;
-        }
-
-        if (!request.Body.CanSeek)
-        {
-            // When RequestDecompression is enabled, the RequestDecompressionMiddleware will store a SizeLimitedStream
-            // in the request body after decompression. Seek operations throw an exception, but we can still read the stream
-            return DoExtractPayLoad(request);
         }
 
         var originalPosition = request.Body.Position;


### PR DESCRIPTION
Resolves #4353
- https://github.com/getsentry/sentry-dotnet/issues/4353

### Explanation

It doesn't look like the changes to `BaseRequestPayloadExtractor` were ever required. When I put a breakpoint [here](https://github.com/getsentry/sentry-dotnet/blob/cb205ca4b2ee4cf0b38b59a4103bd8aa7e15bb88/src/Sentry/Extensibility/BaseRequestPayloadExtractor.cs#L21-L24) I see the stream is of type `FileBufferingReadStream` (indicating the `EnableBuffering` middleware is doing [what it's supposed to](https://github.com/dotnet/aspnetcore/blob/9d4270cd93259b2ad6740bd8bb8315615ce93c94/src/Http/Http/src/Internal/BufferingHelper.cs#L13-L24)). 

### Sanity check

There are already [various unit tests](https://github.com/getsentry/sentry-dotnet/blob/c5db0917fe5adc3228662be0a2633d18de6227dd/test/Sentry.AspNetCore.Tests/RequestDecompressionMiddleware/RequestDecompressionMiddlewareTests.cs#L114) for this but , as a sanity check, you can post a compressed body to the following program with something like:
```
echo -n 'your message here' | gzip | curl -X POST http://localhost:8080/message \
  --data-binary @- \
  -H "Content-Encoding: gzip" \
  -H "Content-Type: text/plain"
```

```csharp
using Sentry.Extensibility;

var builder = WebApplication.CreateBuilder(args);

builder.WebHost.UseSentry(options =>
{
    // Log debug information about the Sentry SDK
    options.MaxRequestBodySize = RequestSize.Always;
    options.SendDefaultPii = true;
});

builder.Services.AddRequestDecompression();

var app = builder.Build();

app.UseRequestDecompression();

app.MapPost("message", _ =>
{
    // This is an example of a POST endpoint that captures the request body
    // and sends it to Sentry.
    SentrySdk.CaptureMessage("Hello from a POST endpoint!");

    return Task.CompletedTask;
});
```