### PR TITLE
alpine: add nodejs & build multi-arch

### DIFF
--- a/.github/alpine/Dockerfile
+++ b/.github/alpine/Dockerfile
@@ -5,7 +5,7 @@ FROM ${BASE}
 RUN apk update
 
 # common
-RUN apk add bash build-base cmake curl git icu lsb-release-minimal sudo tar wget
+RUN apk add bash build-base cmake curl git icu lsb-release-minimal nodejs npm sudo tar wget
 
 # sentry-native
 RUN apk add curl-dev docker-cli libunwind-dev libunwind-static linux-headers openssl-dev zlib-dev xz-dev xz-static

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -31,10 +31,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build ghcr.io/${{ github.repository_owner }}/sentry-dotnet-alpine:${{ matrix.version }}
-        run: docker build --build-arg BASE=alpine:${{ matrix.version }} -t ghcr.io/${{ github.repository_owner }}/sentry-dotnet-alpine:${{ matrix.version }} .
-        working-directory: .github/alpine
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Push ghcr.io/${{ github.repository_owner }}/sentry-dotnet-alpine:${{ matrix.version }}
-        run: docker push ghcr.io/${{ github.repository_owner }}/sentry-dotnet-alpine:${{ matrix.version }}
-        working-directory: .github/alpine
+      - uses: docker/build-push-action@v6
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/${{ github.repository_owner }}/sentry-dotnet-alpine:${{ matrix.version }}
+          context: .github/alpine
+          build-args: |
+            BASE=alpine:${{ matrix.version }}


### PR DESCRIPTION
This PR is a preparation step for adding support for `linux-musl-arm64`:
- https://github.com/getsentry/sentry-dotnet/pull/4365

This makes [sentry-dotnet-alpine](https://github.com/getsentry/sentry-dotnet/pkgs/container/sentry-dotnet-alpine) a multi-arch Docker image that supports both x64 and arm64 architectures. This is done by replacing manual `docker` commands with Docker's official [setup-qemu-action](https://github.com/docker/setup-qemu-action) and [setup-buildx-action](https://github.com/docker/setup-buildx-action) to add `linux/arm64` alongside the existing `linux/amd64` architecture. Furthermore, Node.js is installed for executing JS actions such as `actions/checkout`.

#skip-changelog