### PR TITLE
Skip EventPipeSession_ReceivesExpectedCLREvents in CI

### DIFF
--- a/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs
+++ b/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs
@@ -181,13 +181,14 @@ public class SamplingTransactionProfilerTests
         }
     }
 
-
     /// <summary>
     /// Guards regression of https://github.com/microsoft/perfview/issues/2155
     /// </summary>
     [SkippableFact]
     public async Task EventPipeSession_ReceivesExpectedCLREvents()
     {
+        Skip.If(TestEnvironment.IsGitHubActions, "Flaky on CI");
+
         SampleProfilerSession? session = null;
         SkipIfFailsInCI(() => session = SampleProfilerSession.StartNew(_testOutputLogger));
         using (session)


### PR DESCRIPTION
See https://github.com/getsentry/sentry-dotnet/issues/4371

This is still failing. E.g.
- https://github.com/getsentry/sentry-dotnet/actions/runs/16663024037?pr=4400

#skip-changelog