### PR TITLE
fix: Sentry Cocoa framework version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Crontabs now support day names (MON-SUN) and allow step values and ranges to be combined ([#4407](https://github.com/getsentry/sentry-dotnet/pull/4407))
+- Ensure the correct Sentry Cocoa SDK framework version is used on iOS ([#4411](https://github.com/getsentry/sentry-dotnet/pull/4411))
 
 ### Dependencies
 
@@ -24,7 +25,6 @@
 ### Fixes
 
 - Update `sample_rate` of _Dynamic Sampling Context (DSC)_ when making sampling decisions ([#4374](https://github.com/getsentry/sentry-dotnet/pull/4374))
-- Ensure the correct Sentry Cocoa SDK framework version is used on iOS ([#4411](https://github.com/getsentry/sentry-dotnet/pull/4411))
 
 ## 5.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Update `sample_rate` of _Dynamic Sampling Context (DSC)_ when making sampling decisions ([#4374](https://github.com/getsentry/sentry-dotnet/pull/4374))
+- Ensure the correct Sentry Cocoa SDK framework version is used on iOS ([#4411](https://github.com/getsentry/sentry-dotnet/pull/4411))
 
 ## 5.13.0
 

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -7,9 +7,11 @@
     <IsBindingProject>true</IsBindingProject>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
     <Description>.NET Bindings for the Sentry Cocoa SDK</Description>
-    <SentryCocoaCache>..\..\modules\sentry-cocoa\</SentryCocoaCache>
+    <SentryCocoaCache>$(MSBuildThisFileDirectory)..\..\modules\sentry-cocoa\</SentryCocoaCache>
     <SentryCocoaFrameworkHeaders>$(SentryCocoaCache)Sentry.framework\</SentryCocoaFrameworkHeaders>
-    <SentryCocoaFramework>$(SentryCocoaCache)Sentry-Dynamic.xcframework</SentryCocoaFramework>
+    <SentryCocoaProperties>$([System.IO.File]::ReadAllText("$(MSBuildThisFileDirectory)../../modules/sentry-cocoa.properties"))</SentryCocoaProperties>
+    <SentryCocoaVersion>$([System.Text.RegularExpressions.Regex]::Match($(SentryCocoaProperties), 'version\s*=\s*([^\s]+)').Groups[1].Value)</SentryCocoaVersion>
+    <SentryCocoaFramework>$(SentryCocoaCache)Sentry-$(SentryCocoaVersion).xcframework</SentryCocoaFramework>
   </PropertyGroup>
 
   <!-- Build empty assemblies when not on macOS, to pass the solution build. -->
@@ -47,19 +49,14 @@
 
   <!-- Downloads and sets up the Cocoa SDK: dotnet msbuild /t:setupCocoaSDK src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj -->
   <Target Name="SetupCocoaSDK"
-          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaCache)Sentry-Dynamic.xcframework')"
+          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')"
           BeforeTargets="BeforeBuild">
 
-    <PropertyGroup>
-      <PropertiesContent>$([System.IO.File]::ReadAllText("../../modules/sentry-cocoa.properties"))</PropertiesContent>
-      <CocoaVersion>$([System.Text.RegularExpressions.Regex]::Match($(PropertiesContent), 'version\s*=\s*([^\s]+)').Groups[1].Value)</CocoaVersion>
-    </PropertyGroup>
-
-    <Message Importance="High" Text="Setting up the Cocoa SDK version '$(CocoaVersion)'." />
+    <Message Importance="High" Text="Setting up the Cocoa SDK version '$(SentryCocoaVersion)'." />
 
     <!-- Clean cache if version does not exist to get rid of old versions -->
     <RemoveDir
-      Condition="!Exists('$(SentryCocoaCache)Sentry-Dynamic-$(CocoaVersion).xcframework.zip')"
+      Condition="!Exists('$(SentryCocoaFramework).zip')"
       Directories="$(SentryCocoaCache)" />
 
     <!-- Create cache directory -->
@@ -67,17 +64,17 @@
 
     <!-- Download the Cocoa SDK as pre-built .xcframework -->
     <Exec
-      Condition="!Exists('$(SentryCocoaCache)Sentry-Dynamic-$(CocoaVersion).xcframework.zip')"
-      Command="curl -L https://github.com/getsentry/sentry-cocoa/releases/download/$(CocoaVersion)/Sentry-Dynamic.xcframework.zip -o $(SentryCocoaCache)Sentry-Dynamic-$(CocoaVersion).xcframework.zip" />
+      Condition="!Exists('$(SentryCocoaFramework).zip')"
+      Command="curl -L https://github.com/getsentry/sentry-cocoa/releases/download/$(SentryCocoaVersion)/Sentry-Dynamic.xcframework.zip -o $(SentryCocoaFramework).zip" />
 
     <Exec
-      Condition="!Exists('$(SentryCocoaCache)Sentry-Dynamic.xcframework')"
-      Command="unzip -o $(SentryCocoaCache)Sentry-Dynamic-$(CocoaVersion).xcframework.zip -d $(SentryCocoaCache)" />
+      Condition="Exists('$(SentryCocoaFramework).zip') and !Exists('$(SentryCocoaFramework)')"
+      Command="unzip -o $(SentryCocoaFramework).zip -d $(SentryCocoaCache) &amp;&amp; mv $(SentryCocoaCache)Sentry-Dynamic.xcframework $(SentryCocoaFramework)" />
 
     <!-- Make a copy of the header files before we butcher these to suite objective sharpie -->
     <MakeDir Directories="$(SentryCocoaFrameworkHeaders)" />
     <ItemGroup>
-      <FilesToCopy Include="$(SentryCocoaCache)Sentry-Dynamic.xcframework\ios-arm64_arm64e\Sentry.framework\**\*" />
+      <FilesToCopy Include="$(SentryCocoaFramework)\ios-arm64_arm64e\Sentry.framework\**\*" />
     </ItemGroup>
     <Copy SourceFiles="@(FilesToCopy)"
           DestinationFolder="$(SentryCocoaFrameworkHeaders)%(RecursiveDir)"

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -7,7 +7,7 @@
     <IsBindingProject>true</IsBindingProject>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
     <Description>.NET Bindings for the Sentry Cocoa SDK</Description>
-    <SentryCocoaCache>$(MSBuildThisFileDirectory)..\..\modules\sentry-cocoa\</SentryCocoaCache>
+    <SentryCocoaCache>..\..\modules\sentry-cocoa\</SentryCocoaCache>
     <SentryCocoaFrameworkHeaders>$(SentryCocoaCache)Sentry.framework\</SentryCocoaFrameworkHeaders>
     <SentryCocoaProperties>$([System.IO.File]::ReadAllText("$(MSBuildThisFileDirectory)../../modules/sentry-cocoa.properties"))</SentryCocoaProperties>
     <SentryCocoaVersion>$([System.Text.RegularExpressions.Regex]::Match($(SentryCocoaProperties), 'version\s*=\s*([^\s]+)').Groups[1].Value)</SentryCocoaVersion>
@@ -48,9 +48,7 @@
   </ItemGroup>
 
   <!-- Downloads and sets up the Cocoa SDK: dotnet msbuild /t:setupCocoaSDK src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj -->
-  <Target Name="SetupCocoaSDK"
-          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')"
-          BeforeTargets="BeforeBuild">
+  <Target Name="_SetupCocoaSDK">
 
     <Message Importance="High" Text="Setting up the Cocoa SDK version '$(SentryCocoaVersion)'." />
 
@@ -79,6 +77,18 @@
     <Copy SourceFiles="@(FilesToCopy)"
           DestinationFolder="$(SentryCocoaFrameworkHeaders)%(RecursiveDir)"
           SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- Setup exactly once: https://learn.microsoft.com/en-gb/visualstudio/msbuild/run-target-exactly-once -->
+  <Target Name="SetupCocoaSDKBeforeOuterBuild" DependsOnTargets="_SetupCocoaSDK"
+          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')"
+          BeforeTargets="DispatchToInnerBuilds" />
+
+  <Target Name="SetupCocoaSDK"
+          BeforeTargets="BeforeBuild"
+          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')">
+    <!-- Setup exactly once: https://learn.microsoft.com/en-gb/visualstudio/msbuild/run-target-exactly-once -->
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_SetupCocoaSDK" RemoveProperties="TargetFramework" />
   </Target>
 
   <Target Name="CleanCocoaSDK" AfterTargets="Clean" Condition="$([MSBuild]::IsOSPlatform('OSX'))">

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -48,7 +48,8 @@
   </ItemGroup>
 
   <!-- Downloads and sets up the Cocoa SDK: dotnet msbuild /t:setupCocoaSDK src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj -->
-  <Target Name="_SetupCocoaSDK">
+  <Target Name="_SetupCocoaSDK"
+          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')">
 
     <Message Importance="High" Text="Setting up the Cocoa SDK version '$(SentryCocoaVersion)'." />
 

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -80,7 +80,7 @@
           SkipUnchangedFiles="true" />
   </Target>
 
-  <!-- Setup exactly once: https://learn.microsoft.com/en-gb/visualstudio/msbuild/run-target-exactly-once -->
+  <!-- Setup exactly once: https://learn.microsoft.com/visualstudio/msbuild/run-target-exactly-once -->
   <Target Name="SetupCocoaSDKBeforeOuterBuild" DependsOnTargets="_SetupCocoaSDK"
           Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')"
           BeforeTargets="DispatchToInnerBuilds" />
@@ -88,7 +88,7 @@
   <Target Name="SetupCocoaSDK"
           BeforeTargets="BeforeBuild"
           Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')">
-    <!-- Setup exactly once: https://learn.microsoft.com/en-gb/visualstudio/msbuild/run-target-exactly-once -->
+    <!-- Setup exactly once: https://learn.microsoft.com/visualstudio/msbuild/run-target-exactly-once -->
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_SetupCocoaSDK" RemoveProperties="TargetFramework" />
   </Target>
 


### PR DESCRIPTION
When a consuming app upgrades or downgrades Sentry .NET, it might be left with an incorrect, stale version of the Sentry Cocoa framework in the intermediate output directory.

| Sentry .NET | Sentry Cocoa |
|---|---|
| 5.5.1 | 8.39.0 |
| 5.6.0 | 8.46.0 |
| 5.7.0 | 8.46.0 |
| 5.8.0 | 8.39.0 |

For example, an app built with Sentry .NET 5.5.1 has Sentry Cocoa 8.39 extracted into the intermediate output directory:

```
./obj/Release/net9.0-ios18.0/iossimulator-arm64/Sentry.Bindings.Cocoa.resources.zip/Sentry-Dynamic.xcframework
```

When upgraded to Sentry .NET 5.6.0 without cleaning, the intermediate output directory still contains Sentry Cocoa 8.39 instead of 8.46. Similar problems occur when upgrading from Sentry .NET 5.7.0 to 5.8.0 because `Sentry.Bindings.Cocoa` does not match the stale version of Sentry Cocoa.

This PR tries to fix the problem by changing `Sentry.Bindings.Cocoa` to reference a versioned  framework (`Sentry-<version>.xcframework`) instead of `Sentry-Dynamic.xcframework`.

NOTE: The Xamarin tooling automatically takes care of archiving and extracting `Sentry.Bindings.Cocoa.resources.zip`. It is hard to control the name of the ZIP archive (`$(AssemblyName).resources`), but we can control the name of `Sentry-xxx.xcframework` inside.

<img width="600" src="https://github.com/user-attachments/assets/94b367d0-31fc-4bf0-92e6-cb4d17f49046" />

P.S. Sentry Cocoa bundle version can be checked in `Sentry-Dynamic.xcframework/ios-arm64_x64_64-simulator/Sentry.framework/Info.plist`.

See also:
- #4202
- #4205
- #4207
- #4397

#skip-changelog (already released as [5.14.0-alpha.0](https://www.nuget.org/packages/Sentry/5.14.0-alpha.0))