### PR TITLE
chore: Skip AndroidAssemblyReaderTests on Windows

### DIFF
--- a/Sentry-CI-Build-Windows-arm64.slnf
+++ b/Sentry-CI-Build-Windows-arm64.slnf
@@ -55,7 +55,6 @@
       "src\\Sentry.SourceGenerators\\Sentry.SourceGenerators.csproj",
       "src\\Sentry\\Sentry.csproj",
       "test\\Sentry.Analyzers.Tests\\Sentry.Analyzers.Tests.csproj",
-      "test\\Sentry.Android.AssemblyReader.Tests\\Sentry.Android.AssemblyReader.Tests.csproj",
       "test\\Sentry.AspNet.Tests\\Sentry.AspNet.Tests.csproj",
       "test\\Sentry.AspNetCore.Grpc.Tests\\Sentry.AspNetCore.Grpc.Tests.csproj",
       "test\\Sentry.AspNetCore.Tests\\Sentry.AspNetCore.Tests.csproj",

--- a/Sentry-CI-Build-Windows.slnf
+++ b/Sentry-CI-Build-Windows.slnf
@@ -55,7 +55,6 @@
       "src\\Sentry.SourceGenerators\\Sentry.SourceGenerators.csproj",
       "src\\Sentry\\Sentry.csproj",
       "test\\Sentry.Analyzers.Tests\\Sentry.Analyzers.Tests.csproj",
-      "test\\Sentry.Android.AssemblyReader.Tests\\Sentry.Android.AssemblyReader.Tests.csproj",
       "test\\Sentry.AspNet.Tests\\Sentry.AspNet.Tests.csproj",
       "test\\Sentry.AspNetCore.Grpc.Tests\\Sentry.AspNetCore.Grpc.Tests.csproj",
       "test\\Sentry.AspNetCore.Tests\\Sentry.AspNetCore.Tests.csproj",

--- a/scripts/generate-solution-filters-config.yaml
+++ b/scripts/generate-solution-filters-config.yaml
@@ -96,6 +96,7 @@ filterConfigs:
         - "trimTests"
       patterns:
         - "**/*AndroidTestApp.csproj"
+        - "**/*Sentry.Android.AssemblyReader.Tests.csproj"
         - "**/*DeviceTests*.csproj"
         - "**/*Sentry.Maui.Device.TestApp.csproj"
         - "**/*Sentry.Samples.Android.csproj"
@@ -115,6 +116,7 @@ filterConfigs:
         - "trimTests"
       patterns:
         - "**/*AndroidTestApp.csproj"
+        - "**/*Sentry.Android.AssemblyReader.Tests.csproj"
         - "**/*DeviceTests*.csproj"
         - "**/*Sentry.Maui.Device.TestApp.csproj"
         - "**/*Sentry.Samples.Android.csproj"


### PR DESCRIPTION
Resolves #4091:
- https://github.com/getsentry/sentry-dotnet/issues/4091#issuecomment-3158445772

#skip-changelog