### PR TITLE
ignore Android binding warnings 

### DIFF
--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -6,6 +6,24 @@
     <!-- This gets resolved by the DownloadSentryAndroidSdk target -->
     <SentryNativeNdkVersion></SentryNativeNdkVersion>
     <Description>.NET Bindings for the Sentry Android SDK</Description>
+
+    <!-- Treat Android binding generator warnings as errors -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+    
+    <!-- Android binding warnings - these are largely unavoidable due to Java interface circular dependencies -->
+    <!-- Only suppress warnings that are confirmed to be expected/unavoidable -->
+    <!-- BG8801: Invalid parameter types - caused by circular interface dependencies in Sentry Java SDK -->
+    <!-- BG8C01: Invalid base interface - interfaces reference types removed by Metadata.xml -->
+    <!-- BG8701: Invalid return types - return types reference unresolvable interfaces -->
+    <!-- BG8800/BG8700: Unknown/Invalid types - types intentionally removed by Metadata.xml -->
+    <!-- BG8605/BG8606: Missing Java types - Compose UI types not available in our binding context -->
+    <!-- BG8604: Missing ancestor types - nested types whose parents are removed -->
+    <!-- BG8502: Interface invalidation - cascade effect from other binding issues -->
+    <!-- BG8401/BG8400: Field/property conflicts - resolved individually in Metadata.xml where needed -->
+    <NoWarn>$(NoWarn);BG8801;BG8C01;BG8701;BG8800;BG8700;BG8605;BG8606;BG8604;BG8502;BG8401;BG8400;BG8503;BG8C00</NoWarn>
+    
+    <!-- Any NEW Android binding warning types should break the build to ensure they're reviewed -->
   </PropertyGroup>
 
   <!-- Use a separate readme, and don't add the changelog to the nuget. -->

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -18,8 +18,6 @@
     <!-- BG8502: Interface invalidation - cascade effect from other binding issues -->
     <!-- BG8401/BG8400: Field/property conflicts - resolved individually in Metadata.xml where needed -->
     <NoWarn>$(NoWarn);BG8801;BG8C01;BG8701;BG8800;BG8700;BG8605;BG8606;BG8604;BG8502;BG8401;BG8400;BG8503;BG8C00</NoWarn>
-    
-    <!-- Any NEW Android binding warning types should break the build to ensure they're reviewed -->
   </PropertyGroup>
 
   <!-- Use a separate readme, and don't add the changelog to the nuget. -->

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -17,6 +17,7 @@
     <!-- BG8604: Missing ancestor types - nested types whose parents are removed -->
     <!-- BG8502: Interface invalidation - cascade effect from other binding issues -->
     <!-- BG8401/BG8400: Field/property conflicts - resolved individually in Metadata.xml where needed -->
+    <!-- BG8C00: Base interface not found -->
     <NoWarn>$(NoWarn);BG8801;BG8C01;BG8701;BG8800;BG8700;BG8605;BG8606;BG8604;BG8502;BG8401;BG8400;BG8503;BG8C00</NoWarn>
   </PropertyGroup>
 

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -7,10 +7,6 @@
     <SentryNativeNdkVersion></SentryNativeNdkVersion>
     <Description>.NET Bindings for the Sentry Android SDK</Description>
 
-    <!-- Treat Android binding generator warnings as errors -->
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsAsErrors />
-    
     <!-- Android binding warnings - these are largely unavoidable due to Java interface circular dependencies -->
     <!-- Only suppress warnings that are confirmed to be expected/unavoidable -->
     <!-- BG8801: Invalid parameter types - caused by circular interface dependencies in Sentry Java SDK -->

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -15,7 +15,7 @@
     <!-- BG8800/BG8700: Unknown/Invalid types - types intentionally removed by Metadata.xml -->
     <!-- BG8605/BG8606: Missing Java types - Compose UI types not available in our binding context -->
     <!-- BG8604: Missing ancestor types - nested types whose parents are removed -->
-    <!-- BG8502: Interface invalidation - cascade effect from other binding issues -->
+    <!-- BG8502/BG8503: Interface invalidation - cascade effect from other binding issues -->
     <!-- BG8401/BG8400: Field/property conflicts - resolved individually in Metadata.xml where needed -->
     <!-- BG8C00: Base interface not found -->
     <NoWarn>$(NoWarn);BG8801;BG8C01;BG8701;BG8800;BG8700;BG8605;BG8606;BG8604;BG8502;BG8401;BG8400;BG8503;BG8C00</NoWarn>


### PR DESCRIPTION
Building now creates lots of warnings.

> Build succeeded with 1524 warning(s) in 5.4s

Even though the solution had TreatWarningAsErrors, the build passes, which means these warnings are not 'normal' and sneak in and grow over time.

I'm ignoring all warnings that we can't take action (trusting Cursor pretty much on those claims).
But after a few iterations, I couldn't get these types of warnings to break the build, so if new ones are introduced, it'll take someone paying attention and ignoring them explicitly.

Before:

```
obj/Debug/net9.0-android35.0/api.xml(5156,8): warning BG8701: Invalid return type 'io.sentry.IScope' for member 'Sentry.JavaSdk.Scopes.GetGlobalScope ()'.
      obj/Debug/net9.0-android35.0/api.xml(5157,8): warning BG8701: Invalid return type 'io.sentry.IScope' for member 'Sentry.JavaSdk.Scopes.GetIsolationScope (
      )'.
      obj/Debug/net9.0-android35.0/api.xml(5160,8): warning BG8701: Invalid return type 'io.sentry.IScopes' for member 'Sentry.JavaSdk.Scopes.GetParentScopes ()
      '.
      obj/Debug/net9.0-android35.0/api.xml(5162,8): warning BG8701: Invalid return type 'io.sentry.IScope' for member 'Sentry.JavaSdk.Scopes.GetScope ()'.
      obj/Debug/net9.0-android35.0/api.xml(5167,10): warning BG8801: Invalid parameter type 'io.sentry.IScopes' for member 'Sentry.JavaSdk.Scopes.IsAncestorOf (
      Sentry.JavaSdk.IScopes)'.
      obj/Debug/net9.0-android35.0/api.xml(5219,10): warning BG8801: Invalid parameter type 'io.sentry.ScopeCallback' for member 'Sentry.JavaSdk.Scopes.WithIsol
      ationScope (Sentry.JavaSdk.IScopeCallback)'.
      obj/Debug/net9.0-android35.0/api.xml(5222,10): warning BG8801: Invalid parameter type 'io.sentry.ScopeCallback' for member 'Sentry.JavaSdk.Scopes.WithScop
      e (Sentry.JavaSdk.IScopeCallback)'.
      obj/Debug/net9.0-android35.0/api.xml(5062,10): warning BG8801: Invalid parameter type 'io.sentry.IScope' for member 'Sentry.JavaSdk.Scopes.Scopes (Sentry.
      JavaSdk.IScope, io.sentry.IScope, io.sentry.IScope, java.lang.String)'.
      obj/
```

Cursors claims:
Turns out there's not much we can do about these, so we'll ignore them

- ~Enable TreatWarningsAsErrors for Android bindings project~ reverted
- Suppress expected/unavoidable Android binding warnings (BG8xxx codes)
- These warnings are caused by Java interface circular dependencies in Sentry SDK
- Warnings are documented with explanations for each type
- ~New warning types will now break the build for review~ not true
- Analyzed 1528 warnings and confirmed they're due to binding limitations
- Solution preserves existing Metadata.xml strategic type removals

#skip-changelog