### PR TITLE
Only detect custom session replay masks when necessary

### DIFF
--- a/src/Sentry.Maui/Internal/MauiCustomSessionReplayMaskBinder.cs
+++ b/src/Sentry.Maui/Internal/MauiCustomSessionReplayMaskBinder.cs
@@ -9,12 +9,12 @@ namespace Sentry.Maui.Internal;
 /// <summary>
 /// Masks or unmasks visual elements for session replay recordings
 /// </summary>
-internal class MauiVisualElementEventsBinder : IMauiElementEventBinder
+internal class MauiCustomSessionReplayMaskBinder : IMauiElementEventBinder
 {
     private readonly SentryMauiOptions _options;
     private readonly bool _isEnabled;
 
-    public MauiVisualElementEventsBinder(IOptions<SentryMauiOptions> options)
+    public MauiCustomSessionReplayMaskBinder(IOptions<SentryMauiOptions> options)
     {
         _options = options.Value;
 #if __ANDROID__

--- a/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
+++ b/src/Sentry.Maui/SentryMauiAppBuilderExtensions.cs
@@ -67,7 +67,7 @@ public static class SentryMauiAppBuilderExtensions
         services.AddSingleton<IMauiElementEventBinder, MauiButtonEventsBinder>();
         services.AddSingleton<IMauiElementEventBinder, MauiImageButtonEventsBinder>();
         services.AddSingleton<IMauiElementEventBinder, MauiGestureRecognizerEventsBinder>();
-        services.AddSingleton<IMauiElementEventBinder, MauiVisualElementEventsBinder>();
+        services.AddSingleton<IMauiElementEventBinder, MauiCustomSessionReplayMaskBinder>();
 
         // Resolve the configured options and register any event binders that have been injected by integrations
         var options = new SentryMauiOptions();

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -272,6 +272,30 @@ public partial class SentryOptions
             public double? SessionSampleRate { get; set; }
             public bool MaskAllImages { get; set; } = true;
             public bool MaskAllText { get; set; } = true;
+
+            /// <summary>
+            /// <para>
+            /// Apps with complex user interfaces, consisting of hundreds of visual controls on a single page, may experience
+            /// performance issues due to the overhead of detecting custom masking of visual elements for Session Replays.
+            /// </para>
+            /// <para>
+            /// In such cases you have a few different options:
+            /// <list type="bullet">
+            ///   <item>
+            ///     <description>Disable Session Replays entirely</description>
+            ///   </item>
+            ///   <item>
+            ///     <description>Mask all text and all images</description>
+            ///   </item>
+            ///   <item>
+            ///     <description>Disable custom session replay masks (so nothing gets masked)</description>
+            ///   </item>
+            /// </list>
+            /// Set this option to <c>true</c> to disable custom session replay masks.
+            /// </para>
+            /// </summary>
+            public bool DisableCustomSessionReplayMasks { get; set; } = false;
+
             internal HashSet<Type> MaskedControls { get; } = [];
             internal HashSet<Type> UnmaskedControls { get; } = [];
 

--- a/test/Sentry.Maui.Tests/MauiCustomSessionReplayMaskBinderTests.cs
+++ b/test/Sentry.Maui.Tests/MauiCustomSessionReplayMaskBinderTests.cs
@@ -6,11 +6,11 @@ using View = Android.Views.View;
 
 namespace Sentry.Maui.Tests;
 
-public class MauiVisualElementEventsBinderTests
+public class MauiCustomSessionReplayMaskBinderTests
 {
     private class Fixture
     {
-        public MauiVisualElementEventsBinder Binder { get; }
+        public MauiCustomSessionReplayMaskBinder Binder { get; }
 
         public SentryMauiOptions Options { get; } = new();
 
@@ -21,7 +21,7 @@ public class MauiVisualElementEventsBinderTests
             logger.IsEnabled(Arg.Any<SentryLevel>()).Returns(true);
             Options.DiagnosticLogger = logger;
             var options = Microsoft.Extensions.Options.Options.Create(Options);
-            Binder = new MauiVisualElementEventsBinder(options);
+            Binder = new MauiCustomSessionReplayMaskBinder(options);
         }
     }
 


### PR DESCRIPTION
Resolves #4439:
- https://github.com/getsentry/sentry-dotnet/issues/4439

### Summary

In applications with complex user interfaces consisting of hundreds of controls on any individual page, the overhead of adding and removing events hooks to all of the `VisualElement.Loaded` event can cause significant performance delays. We use this event hook to detect session replay mask settings for individual VisualElements (i.e. custom masks). 

This PR:
1. Adds an option to disable custom masks
2. Only adds hooks if these might be relevant... so if:
    - Session Replays are enabled
    - The replay options don't simply mask all text/images
    - Custom masks have not been disabled