### PR TITLE
Increase timeout for xharness from 15 min (default) to 25 min

### DIFF
--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -37,6 +37,7 @@ try
             '--app', "$buildDir/io.sentry.dotnet.maui.device.testapp-Signed.apk",
             '--package-name', 'io.sentry.dotnet.maui.device.testapp',
             '--launch-timeout', '00:10:00',
+            '--timeout', '00:25:00',
             '--instrumentation', 'Sentry.Maui.Device.TestApp.SentryInstrumentation'
         )
 
@@ -58,6 +59,7 @@ try
             '--app', "$buildDir/Sentry.Maui.Device.TestApp.app",
             '--target', 'ios-simulator-64',
             '--launch-timeout', '00:10:00',
+            '--timeout', '00:25:00',
             '--set-env', "CI=$envValue"
         )
 


### PR DESCRIPTION
See this test run on the main branch (times out after 15 minutes):
- https://github.com/getsentry/sentry-dotnet/actions/runs/16981934177

Also note that the iOS Device tests in this PR take 16 minutes 😞 

#skip-changelog