### PR TITLE
ref(logs): shorten `Microsoft.Extensions.Logging` attribute names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
 - Experimental _Structured Logs_:
   - Remove `IDisposable` from `SentryStructuredLogger`. Disposal is intended through the owning `IHub` instance ([#4424](https://github.com/getsentry/sentry-dotnet/pull/4424))
   - Ensure all buffered logs are sent to Sentry when the application terminates unexpectedly ([#4425](https://github.com/getsentry/sentry-dotnet/pull/4425))
-  - Remove `IDisposable` from `SentryStructuredLogger`. Disposal is intended through the owning `IHub` instance. ([#4424](https://github.com/getsentry/sentry-dotnet/pull/4424))
-  - Ensure all buffered logs are sent to Sentry when the application terminates unexpectedly. ([#4425](https://github.com/getsentry/sentry-dotnet/pull/4425))
   - `InvalidOperationException` potentially thrown during a race condition, especially in concurrent high-volume logging scenarios ([#4428](https://github.com/getsentry/sentry-dotnet/pull/4428))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## Unreleased
 
+### Features
+
+- Experimental _Structured Logs_:
+  - Shorten the `key` names of `Microsoft.Extensions.Logging` attributes ([#4450](https://github.com/getsentry/sentry-dotnet/pull/4450))
+
 ### Fixes
 
 - Experimental _Structured Logs_:
-  - Remove `IDisposable` from `SentryStructuredLogger`. Disposal is intended through the owning `IHub` instance. ([#4424](https://github.com/getsentry/sentry-dotnet/pull/4424))
-  - Ensure all buffered logs are sent to Sentry when the application terminates unexpectedly. ([#4425](https://github.com/getsentry/sentry-dotnet/pull/4425))
+  - Remove `IDisposable` from `SentryStructuredLogger`. Disposal is intended through the owning `IHub` instance ([#4424](https://github.com/getsentry/sentry-dotnet/pull/4424))
+  - Ensure all buffered logs are sent to Sentry when the application terminates unexpectedly ([#4425](https://github.com/getsentry/sentry-dotnet/pull/4425))
 
 ### Dependencies
 

--- a/src/Sentry.Extensions.Logging/SentryStructuredLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryStructuredLogger.cs
@@ -92,15 +92,15 @@ internal sealed class SentryStructuredLogger : ILogger
 
         if (_categoryName is not null)
         {
-            log.SetAttribute("microsoft.extensions.logging.category_name", _categoryName);
+            log.SetAttribute("category.name", _categoryName);
         }
         if (eventId.Name is not null || eventId.Id != 0)
         {
-            log.SetAttribute("microsoft.extensions.logging.event.id", eventId.Id);
+            log.SetAttribute("event.id", eventId.Id);
         }
         if (eventId.Name is not null)
         {
-            log.SetAttribute("microsoft.extensions.logging.event.name", eventId.Name);
+            log.SetAttribute("event.name", eventId.Name);
         }
 
         _hub.Logger.CaptureLog(log);

--- a/test/Sentry.AspNetCore.Tests/SentryAspNetCoreStructuredLoggerProviderTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryAspNetCoreStructuredLoggerProviderTests.cs
@@ -83,7 +83,7 @@ public class SentryAspNetCoreStructuredLoggerProviderTests
         logger.LogInformation("message");
 
         Assert.NotNull(capturedLog);
-        capturedLog.TryGetAttribute("microsoft.extensions.logging.category_name", out object? categoryName).Should().BeTrue();
+        capturedLog.TryGetAttribute("category.name", out object? categoryName).Should().BeTrue();
         categoryName.Should().Be(typeof(SentryAspNetCoreStructuredLoggerProviderTests).FullName);
 
         capturedLog.TryGetAttribute("sentry.sdk.name", out object? name).Should().BeTrue();

--- a/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerProviderTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerProviderTests.cs
@@ -83,7 +83,7 @@ public class SentryStructuredLoggerProviderTests
         logger.LogInformation("message");
 
         Assert.NotNull(capturedLog);
-        capturedLog.TryGetAttribute("microsoft.extensions.logging.category_name", out object? categoryName).Should().BeTrue();
+        capturedLog.TryGetAttribute("category.name", out object? categoryName).Should().BeTrue();
         categoryName.Should().Be(typeof(SentryStructuredLoggerProviderTests).FullName);
 
         capturedLog.TryGetAttribute("sentry.sdk.name", out object? name).Should().BeTrue();

--- a/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerTests.cs
@@ -111,9 +111,9 @@ public class SentryStructuredLoggerTests : IDisposable
         log.AssertAttribute("sentry.release", "my-release");
         log.AssertAttribute("sentry.sdk.name", "SDK Name");
         log.AssertAttribute("sentry.sdk.version", "SDK Version");
-        log.AssertAttribute("microsoft.extensions.logging.category_name", "CategoryName");
-        log.AssertAttribute("microsoft.extensions.logging.event.id", 123);
-        log.AssertAttribute("microsoft.extensions.logging.event.name", "EventName");
+        log.AssertAttribute("category.name", _fixture.CategoryName);
+        log.AssertAttribute("event.id", eventId.Id);
+        log.AssertAttribute("event.name", eventId.Name!);
     }
 
     [Fact]
@@ -192,7 +192,7 @@ public class SentryStructuredLoggerTests : IDisposable
         logger.Log(LogLevel.Information, new EventId(123, "EventName"), new InvalidOperationException("message"), "Message with {Argument}.", "argument");
 
         var log = _fixture.CapturedLogs.Dequeue();
-        log.TryGetAttribute("microsoft.extensions.logging.category_name", out object? _).Should().BeFalse();
+        log.TryGetAttribute("category.name", out object? _).Should().BeFalse();
     }
 
     [Fact]
@@ -216,8 +216,8 @@ public class SentryStructuredLoggerTests : IDisposable
         logger.Log(LogLevel.Information, new InvalidOperationException("message"), "Message with {Argument}.", "argument");
 
         var log = _fixture.CapturedLogs.Dequeue();
-        log.TryGetAttribute("microsoft.extensions.logging.event.id", out object? _).Should().BeFalse();
-        log.TryGetAttribute("microsoft.extensions.logging.event.name", out object? _).Should().BeFalse();
+        log.TryGetAttribute("event.id", out object? _).Should().BeFalse();
+        log.TryGetAttribute("event.name", out object? _).Should().BeFalse();
     }
 
     [Fact]
@@ -228,8 +228,8 @@ public class SentryStructuredLoggerTests : IDisposable
         logger.Log(LogLevel.Information, new EventId(0, "EventName"), new InvalidOperationException("message"), "Message with {Argument}.", "argument");
 
         var log = _fixture.CapturedLogs.Dequeue();
-        log.AssertAttribute("microsoft.extensions.logging.event.id", 0);
-        log.AssertAttribute("microsoft.extensions.logging.event.name", "EventName");
+        log.AssertAttribute("event.id", 0);
+        log.AssertAttribute("event.name", "EventName");
     }
 
     [Fact]
@@ -240,8 +240,8 @@ public class SentryStructuredLoggerTests : IDisposable
         logger.Log(LogLevel.Information, new EventId(123), new InvalidOperationException("message"), "Message with {Argument}.", "argument");
 
         var log = _fixture.CapturedLogs.Dequeue();
-        log.AssertAttribute("microsoft.extensions.logging.event.id", 123);
-        log.TryGetAttribute("microsoft.extensions.logging.event.name", out object? _).Should().BeFalse();
+        log.AssertAttribute("event.id", 123);
+        log.TryGetAttribute("event.name", out object? _).Should().BeFalse();
     }
 
     [Theory]

--- a/test/Sentry.Maui.Tests/Internal/SentryMauiStructuredLoggerProviderTests.cs
+++ b/test/Sentry.Maui.Tests/Internal/SentryMauiStructuredLoggerProviderTests.cs
@@ -83,7 +83,7 @@ public class SentryMauiStructuredLoggerProviderTests
         logger.LogInformation("message");
 
         Assert.NotNull(capturedLog);
-        capturedLog.TryGetAttribute("microsoft.extensions.logging.category_name", out object? categoryName).Should().BeTrue();
+        capturedLog.TryGetAttribute("category.name", out object? categoryName).Should().BeTrue();
         categoryName.Should().Be(typeof(SentryMauiStructuredLoggerProviderTests).FullName);
 
         capturedLog.TryGetAttribute("sentry.sdk.name", out object? name).Should().BeTrue();


### PR DESCRIPTION
_Sentry Structured Logs_
After an internal discussion, we would like to shorten the `key` names of the `Microsoft.Extensions.Logging` related attributes.

By removing the `"microsoft.extensions.logging"` prefix.

See also:
https://github.com/open-telemetry/semantic-conventions/issues/372

### Changes
| from | to |
| --- | --- |
| `"microsoft.extensions.logging.category_name"` | `"category.name"` |
| `"microsoft.extensions.logging.event.id"` | `"event.id"` |
| `"microsoft.extensions.logging.event.name"` | `"event.name"` |
