### PR TITLE
feat(logs): rework method overloads of Structured Logger

### DIFF
--- a/samples/Sentry.Samples.Console.Basic/Program.cs
+++ b/samples/Sentry.Samples.Console.Basic/Program.cs
@@ -37,7 +37,7 @@ SentrySdk.Init(options =>
     // This option tells Sentry to capture 100% of traces. You still need to start transactions and spans.
     options.TracesSampleRate = 1.0;
 
-    // This option enables Sentry Logs created via SentrySdk.Logger.
+    // This option enables Sentry Logs created via SentrySdk.Experimental.Logger.
     options.Experimental.EnableLogs = true;
     options.Experimental.SetBeforeSendLog(static log =>
     {
@@ -94,7 +94,8 @@ async Task SecondFunction()
         SentrySdk.CaptureException(exception);
         span.Finish(exception);
 
-        SentrySdk.Experimental.Logger.LogError("Error with message: {0}", [exception.Message], static log => log.SetAttribute("method", nameof(SecondFunction)));
+        SentrySdk.Experimental.Logger.LogError(static log => log.SetAttribute("method", nameof(SecondFunction)),
+            "Error with message: {0}", exception.Message);
     }
 
     span.Finish();
@@ -108,7 +109,8 @@ async Task ThirdFunction()
         // Simulate doing some work
         await Task.Delay(100);
 
-        SentrySdk.Experimental.Logger.LogFatal("Crash imminent!", [], static log => log.SetAttribute("suppress", true));
+        SentrySdk.Experimental.Logger.LogFatal(static log => log.SetAttribute("suppress", true),
+            "Crash imminent!");
 
         // This is an example of an unhandled exception.  It will be captured automatically.
         throw new InvalidOperationException("Something happened that crashed the app!");

--- a/src/Sentry/SentryStructuredLogger.Format.cs
+++ b/src/Sentry/SentryStructuredLogger.Format.cs
@@ -1,0 +1,156 @@
+using Sentry.Infrastructure;
+
+namespace Sentry;
+
+public abstract partial class SentryStructuredLogger
+{
+    /// <summary>
+    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Trace"/>, when enabled and sampled.
+    /// <para>This API is experimental and it may change in the future.</para>
+    /// </summary>
+    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    [Experimental(DiagnosticId.ExperimentalFeature)]
+    public void LogTrace(string template, params object[] parameters)
+    {
+        CaptureLog(SentryLogLevel.Trace, template, parameters, null);
+    }
+
+    /// <summary>
+    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Trace"/>, when enabled and sampled.
+    /// <para>This API is experimental and it may change in the future.</para>
+    /// </summary>
+    /// <param name="configureLog">A delegate to set attributes on the <see cref="SentryLog"/>. When the delegate throws an <see cref="Exception"/> during invocation, the log will not be captured.</param>
+    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    [Experimental(DiagnosticId.ExperimentalFeature)]
+    public void LogTrace(Action<SentryLog> configureLog, string template, params object[] parameters)
+    {
+        CaptureLog(SentryLogLevel.Trace, template, parameters, configureLog);
+    }
+
+    /// <summary>
+    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Debug"/>, when enabled and sampled.
+    /// <para>This API is experimental and it may change in the future.</para>
+    /// </summary>
+    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    [Experimental(DiagnosticId.ExperimentalFeature)]
+    public void LogDebug(string template, params object[] parameters)
+    {
+        CaptureLog(SentryLogLevel.Debug, template, parameters, null);
+    }
+
+    /// <summary>
+    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Debug"/>, when enabled and sampled.
+    /// <para>This API is experimental and it may change in the future.</para>
+    /// </summary>
+    /// <param name="configureLog">A delegate to set attributes on the <see cref="SentryLog"/>. When the delegate throws an <see cref="Exception"/> during invocation, the log will not be captured.</param>
+    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    [Experimental(DiagnosticId.ExperimentalFeature)]
+    public void LogDebug(Action<SentryLog> configureLog, string template, params object[] parameters)
+    {
+        CaptureLog(SentryLogLevel.Debug, template, parameters, configureLog);
+    }
+
+    /// <summary>
+    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Info"/>, when enabled and sampled.
+    /// <para>This API is experimental and it may change in the future.</para>
+    /// </summary>
+    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    [Experimental(DiagnosticId.ExperimentalFeature)]
+    public void LogInfo(string template, params object[] parameters)
+    {
+        CaptureLog(SentryLogLevel.Info, template, parameters, null);
+    }
+
+    /// <summary>
+    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Info"/>, when enabled and sampled.
+    /// <para>This API is experimental and it may change in the future.</para>
+    /// </summary>
+    /// <param name="configureLog">A delegate to set attributes on the <see cref="SentryLog"/>. When the delegate throws an <see cref="Exception"/> during invocation, the log will not be captured.</param>
+    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    [Experimental(DiagnosticId.ExperimentalFeature)]
+    public void LogInfo(Action<SentryLog> configureLog, string template, params object[] parameters)
+    {
+        CaptureLog(SentryLogLevel.Info, template, parameters, configureLog);
+    }
+
+    /// <summary>
+    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Warning"/>, when enabled and sampled.
+    /// <para>This API is experimental and it may change in the future.</para>
+    /// </summary>
+    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    [Experimental(DiagnosticId.ExperimentalFeature)]
+    public void LogWarning(string template, params object[] parameters)
+    {
+        CaptureLog(SentryLogLevel.Warning, template, parameters, null);
+    }
+
+    /// <summary>
+    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Warning"/>, when enabled and sampled.
+    /// <para>This API is experimental and it may change in the future.</para>
+    /// </summary>
+    /// <param name="configureLog">A delegate to set attributes on the <see cref="SentryLog"/>. When the delegate throws an <see cref="Exception"/> during invocation, the log will not be captured.</param>
+    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    [Experimental(DiagnosticId.ExperimentalFeature)]
+    public void LogWarning(Action<SentryLog> configureLog, string template, params object[] parameters)
+    {
+        CaptureLog(SentryLogLevel.Warning, template, parameters, configureLog);
+    }
+
+    /// <summary>
+    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Error"/>, when enabled and sampled.
+    /// <para>This API is experimental and it may change in the future.</para>
+    /// </summary>
+    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    [Experimental(DiagnosticId.ExperimentalFeature)]
+    public void LogError(string template, params object[] parameters)
+    {
+        CaptureLog(SentryLogLevel.Error, template, parameters, null);
+    }
+
+    /// <summary>
+    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Error"/>, when enabled and sampled.
+    /// <para>This API is experimental and it may change in the future.</para>
+    /// </summary>
+    /// <param name="configureLog">A delegate to set attributes on the <see cref="SentryLog"/>. When the delegate throws an <see cref="Exception"/> during invocation, the log will not be captured.</param>
+    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    [Experimental(DiagnosticId.ExperimentalFeature)]
+    public void LogError(Action<SentryLog> configureLog, string template, params object[] parameters)
+    {
+        CaptureLog(SentryLogLevel.Error, template, parameters, configureLog);
+    }
+
+    /// <summary>
+    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Fatal"/>, when enabled and sampled.
+    /// <para>This API is experimental and it may change in the future.</para>
+    /// </summary>
+    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    [Experimental(DiagnosticId.ExperimentalFeature)]
+    public void LogFatal(string template, params object[] parameters)
+    {
+        CaptureLog(SentryLogLevel.Fatal, template, parameters, null);
+    }
+
+    /// <summary>
+    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Fatal"/>, when enabled and sampled.
+    /// <para>This API is experimental and it may change in the future.</para>
+    /// </summary>
+    /// <param name="configureLog">A delegate to set attributes on the <see cref="SentryLog"/>. When the delegate throws an <see cref="Exception"/> during invocation, the log will not be captured.</param>
+    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
+    [Experimental(DiagnosticId.ExperimentalFeature)]
+    public void LogFatal(Action<SentryLog> configureLog, string template, params object[] parameters)
+    {
+        CaptureLog(SentryLogLevel.Fatal, template, parameters, configureLog);
+    }
+}

--- a/src/Sentry/SentryStructuredLogger.cs
+++ b/src/Sentry/SentryStructuredLogger.cs
@@ -8,7 +8,7 @@ namespace Sentry;
 /// <para>This API is experimental and it may change in the future.</para>
 /// </summary>
 [Experimental(DiagnosticId.ExperimentalFeature)]
-public abstract class SentryStructuredLogger
+public abstract partial class SentryStructuredLogger
 {
     internal static SentryStructuredLogger Create(IHub hub, SentryOptions options, ISystemClock clock)
         => Create(hub, options, clock, 100, TimeSpan.FromSeconds(5));
@@ -45,82 +45,4 @@ public abstract class SentryStructuredLogger
     /// Clears all buffers for this logger and causes any buffered logs to be sent by the underlying <see cref="ISentryClient"/>.
     /// </summary>
     protected internal abstract void Flush();
-
-    /// <summary>
-    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Trace"/>, when enabled and sampled.
-    /// <para>This API is experimental and it may change in the future.</para>
-    /// </summary>
-    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
-    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
-    /// <param name="configureLog">A delegate to set attributes on the <see cref="SentryLog"/>. When the delegate throws an <see cref="Exception"/> during invocation, the log will not be captured.</param>
-    [Experimental(DiagnosticId.ExperimentalFeature)]
-    public void LogTrace(string template, object[]? parameters = null, Action<SentryLog>? configureLog = null)
-    {
-        CaptureLog(SentryLogLevel.Trace, template, parameters, configureLog);
-    }
-
-    /// <summary>
-    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Debug"/>, when enabled and sampled.
-    /// <para>This API is experimental and it may change in the future.</para>
-    /// </summary>
-    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
-    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
-    /// <param name="configureLog">A delegate to set attributes on the <see cref="SentryLog"/>. When the delegate throws an <see cref="Exception"/> during invocation, the log will not be captured.</param>
-    [Experimental(DiagnosticId.ExperimentalFeature)]
-    public void LogDebug(string template, object[]? parameters = null, Action<SentryLog>? configureLog = null)
-    {
-        CaptureLog(SentryLogLevel.Debug, template, parameters, configureLog);
-    }
-
-    /// <summary>
-    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Info"/>, when enabled and sampled.
-    /// <para>This API is experimental and it may change in the future.</para>
-    /// </summary>
-    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
-    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
-    /// <param name="configureLog">A delegate to set attributes on the <see cref="SentryLog"/>. When the delegate throws an <see cref="Exception"/> during invocation, the log will not be captured.</param>
-    [Experimental(DiagnosticId.ExperimentalFeature)]
-    public void LogInfo(string template, object[]? parameters = null, Action<SentryLog>? configureLog = null)
-    {
-        CaptureLog(SentryLogLevel.Info, template, parameters, configureLog);
-    }
-
-    /// <summary>
-    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Warning"/>, when enabled and sampled.
-    /// <para>This API is experimental and it may change in the future.</para>
-    /// </summary>
-    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
-    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
-    /// <param name="configureLog">A delegate to set attributes on the <see cref="SentryLog"/>. When the delegate throws an <see cref="Exception"/> during invocation, the log will not be captured.</param>
-    [Experimental(DiagnosticId.ExperimentalFeature)]
-    public void LogWarning(string template, object[]? parameters = null, Action<SentryLog>? configureLog = null)
-    {
-        CaptureLog(SentryLogLevel.Warning, template, parameters, configureLog);
-    }
-
-    /// <summary>
-    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Error"/>, when enabled and sampled.
-    /// <para>This API is experimental and it may change in the future.</para>
-    /// </summary>
-    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
-    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
-    /// <param name="configureLog">A delegate to set attributes on the <see cref="SentryLog"/>. When the delegate throws an <see cref="Exception"/> during invocation, the log will not be captured.</param>
-    [Experimental(DiagnosticId.ExperimentalFeature)]
-    public void LogError(string template, object[]? parameters = null, Action<SentryLog>? configureLog = null)
-    {
-        CaptureLog(SentryLogLevel.Error, template, parameters, configureLog);
-    }
-
-    /// <summary>
-    /// Creates and sends a structured log to Sentry, with severity <see cref="SentryLogLevel.Fatal"/>, when enabled and sampled.
-    /// <para>This API is experimental and it may change in the future.</para>
-    /// </summary>
-    /// <param name="template">A formattable <see langword="string"/>. When incompatible with the <paramref name="parameters"/>, the log will not be captured. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
-    /// <param name="parameters">The arguments to the <paramref name="template"/>. See <see href="https://learn.microsoft.com/dotnet/api/system.string.format">System.String.Format</see>.</param>
-    /// <param name="configureLog">A delegate to set attributes on the <see cref="SentryLog"/>. When the delegate throws an <see cref="Exception"/> during invocation, the log will not be captured.</param>
-    [Experimental(DiagnosticId.ExperimentalFeature)]
-    public void LogFatal(string template, object[]? parameters = null, Action<SentryLog>? configureLog = null)
-    {
-        CaptureLog(SentryLogLevel.Fatal, template, parameters, configureLog);
-    }
 }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -993,17 +993,29 @@ namespace Sentry
         protected abstract void CaptureLog(Sentry.SentryLog log);
         protected abstract void Flush();
         [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
-        public void LogDebug(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
+        public void LogDebug(string template, params object[] parameters) { }
         [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
-        public void LogError(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
+        public void LogDebug(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
         [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
-        public void LogFatal(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
+        public void LogError(string template, params object[] parameters) { }
         [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
-        public void LogInfo(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
+        public void LogError(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
         [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
-        public void LogTrace(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
+        public void LogFatal(string template, params object[] parameters) { }
         [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
-        public void LogWarning(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
+        public void LogFatal(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
+        [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
+        public void LogInfo(string template, params object[] parameters) { }
+        [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
+        public void LogInfo(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
+        [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
+        public void LogTrace(string template, params object[] parameters) { }
+        [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
+        public void LogTrace(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
+        [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
+        public void LogWarning(string template, params object[] parameters) { }
+        [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
+        public void LogWarning(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
     }
     public sealed class SentryThread : Sentry.ISentryJsonSerializable
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -993,17 +993,29 @@ namespace Sentry
         protected abstract void CaptureLog(Sentry.SentryLog log);
         protected abstract void Flush();
         [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
-        public void LogDebug(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
+        public void LogDebug(string template, params object[] parameters) { }
         [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
-        public void LogError(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
+        public void LogDebug(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
         [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
-        public void LogFatal(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
+        public void LogError(string template, params object[] parameters) { }
         [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
-        public void LogInfo(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
+        public void LogError(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
         [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
-        public void LogTrace(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
+        public void LogFatal(string template, params object[] parameters) { }
         [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
-        public void LogWarning(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
+        public void LogFatal(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
+        [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
+        public void LogInfo(string template, params object[] parameters) { }
+        [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
+        public void LogInfo(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
+        [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
+        public void LogTrace(string template, params object[] parameters) { }
+        [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
+        public void LogTrace(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
+        [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
+        public void LogWarning(string template, params object[] parameters) { }
+        [System.Diagnostics.CodeAnalysis.Experimental("SENTRY0001")]
+        public void LogWarning(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
     }
     public sealed class SentryThread : Sentry.ISentryJsonSerializable
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -952,12 +952,18 @@ namespace Sentry
     {
         protected abstract void CaptureLog(Sentry.SentryLog log);
         protected abstract void Flush();
-        public void LogDebug(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
-        public void LogError(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
-        public void LogFatal(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
-        public void LogInfo(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
-        public void LogTrace(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
-        public void LogWarning(string template, object[]? parameters = null, System.Action<Sentry.SentryLog>? configureLog = null) { }
+        public void LogDebug(string template, params object[] parameters) { }
+        public void LogDebug(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
+        public void LogError(string template, params object[] parameters) { }
+        public void LogError(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
+        public void LogFatal(string template, params object[] parameters) { }
+        public void LogFatal(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
+        public void LogInfo(string template, params object[] parameters) { }
+        public void LogInfo(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
+        public void LogTrace(string template, params object[] parameters) { }
+        public void LogTrace(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
+        public void LogWarning(string template, params object[] parameters) { }
+        public void LogWarning(System.Action<Sentry.SentryLog> configureLog, string template, params object[] parameters) { }
     }
     public sealed class SentryThread : Sentry.ISentryJsonSerializable
     {

--- a/test/Sentry.Tests/SentryStructuredLoggerTests.Format.cs
+++ b/test/Sentry.Tests/SentryStructuredLoggerTests.Format.cs
@@ -1,0 +1,143 @@
+#nullable enable
+
+namespace Sentry.Tests;
+
+public partial class SentryStructuredLoggerTests
+{
+    [Theory]
+    [InlineData(SentryLogLevel.Trace)]
+    [InlineData(SentryLogLevel.Debug)]
+    [InlineData(SentryLogLevel.Info)]
+    [InlineData(SentryLogLevel.Warning)]
+    [InlineData(SentryLogLevel.Error)]
+    [InlineData(SentryLogLevel.Fatal)]
+    public void Log_Enabled_CapturesEnvelope(SentryLogLevel level)
+    {
+        _fixture.Options.Experimental.EnableLogs = true;
+        var logger = _fixture.GetSut();
+
+        Envelope envelope = null!;
+        _fixture.Hub.CaptureEnvelope(Arg.Do<Envelope>(arg => envelope = arg));
+
+        logger.Log(level, "Template string with arguments: {0}, {1}, {2}, {3}", "string", true, 1, 2.2);
+        logger.Flush();
+
+        _fixture.Hub.Received(1).CaptureEnvelope(Arg.Any<Envelope>());
+        _fixture.AssertEnvelopeWithoutAttributes(envelope, level);
+    }
+
+    [Theory]
+    [InlineData(SentryLogLevel.Trace)]
+    [InlineData(SentryLogLevel.Debug)]
+    [InlineData(SentryLogLevel.Info)]
+    [InlineData(SentryLogLevel.Warning)]
+    [InlineData(SentryLogLevel.Error)]
+    [InlineData(SentryLogLevel.Fatal)]
+    public void Log_Disabled_DoesNotCaptureEnvelope(SentryLogLevel level)
+    {
+        _fixture.Options.Experimental.EnableLogs.Should().BeFalse();
+        var logger = _fixture.GetSut();
+
+        logger.Log(level, "Template string with arguments: {0}, {1}, {2}, {3}", "string", true, 1, 2.2);
+        logger.Flush();
+
+        _fixture.Hub.Received(0).CaptureEnvelope(Arg.Any<Envelope>());
+    }
+
+    [Theory]
+    [InlineData(SentryLogLevel.Trace)]
+    [InlineData(SentryLogLevel.Debug)]
+    [InlineData(SentryLogLevel.Info)]
+    [InlineData(SentryLogLevel.Warning)]
+    [InlineData(SentryLogLevel.Error)]
+    [InlineData(SentryLogLevel.Fatal)]
+    public void Log_ConfigureLog_Enabled_CapturesEnvelope(SentryLogLevel level)
+    {
+        _fixture.Options.Experimental.EnableLogs = true;
+        var logger = _fixture.GetSut();
+
+        Envelope envelope = null!;
+        _fixture.Hub.CaptureEnvelope(Arg.Do<Envelope>(arg => envelope = arg));
+
+        logger.Log(level, ConfigureLog, "Template string with arguments: {0}, {1}, {2}, {3}", "string", true, 1, 2.2);
+        logger.Flush();
+
+        _fixture.Hub.Received(1).CaptureEnvelope(Arg.Any<Envelope>());
+        _fixture.AssertEnvelope(envelope, level);
+    }
+
+    [Theory]
+    [InlineData(SentryLogLevel.Trace)]
+    [InlineData(SentryLogLevel.Debug)]
+    [InlineData(SentryLogLevel.Info)]
+    [InlineData(SentryLogLevel.Warning)]
+    [InlineData(SentryLogLevel.Error)]
+    [InlineData(SentryLogLevel.Fatal)]
+    public void Log_ConfigureLog_Disabled_DoesNotCaptureEnvelope(SentryLogLevel level)
+    {
+        _fixture.Options.Experimental.EnableLogs.Should().BeFalse();
+        var logger = _fixture.GetSut();
+
+        logger.Log(level, ConfigureLog, "Template string with arguments: {0}, {1}, {2}, {3}", "string", true, 1, 2.2);
+        logger.Flush();
+
+        _fixture.Hub.Received(0).CaptureEnvelope(Arg.Any<Envelope>());
+    }
+}
+
+file static class SentryStructuredLoggerExtensions
+{
+    public static void Log(this SentryStructuredLogger logger, SentryLogLevel level, string template, params object[] parameters)
+    {
+        switch (level)
+        {
+            case SentryLogLevel.Trace:
+                logger.LogTrace(template, parameters);
+                break;
+            case SentryLogLevel.Debug:
+                logger.LogDebug(template, parameters);
+                break;
+            case SentryLogLevel.Info:
+                logger.LogInfo(template, parameters);
+                break;
+            case SentryLogLevel.Warning:
+                logger.LogWarning(template, parameters);
+                break;
+            case SentryLogLevel.Error:
+                logger.LogError(template, parameters);
+                break;
+            case SentryLogLevel.Fatal:
+                logger.LogFatal(template, parameters);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(level), level, null);
+        }
+    }
+
+    public static void Log(this SentryStructuredLogger logger, SentryLogLevel level, Action<SentryLog> configureLog, string template, params object[] parameters)
+    {
+        switch (level)
+        {
+            case SentryLogLevel.Trace:
+                logger.LogTrace(configureLog, template, parameters);
+                break;
+            case SentryLogLevel.Debug:
+                logger.LogDebug(configureLog, template, parameters);
+                break;
+            case SentryLogLevel.Info:
+                logger.LogInfo(configureLog, template, parameters);
+                break;
+            case SentryLogLevel.Warning:
+                logger.LogWarning(configureLog, template, parameters);
+                break;
+            case SentryLogLevel.Error:
+                logger.LogError(configureLog, template, parameters);
+                break;
+            case SentryLogLevel.Fatal:
+                logger.LogFatal(configureLog, template, parameters);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(level), level, null);
+        }
+    }
+}


### PR DESCRIPTION
Revising the `Log{Level}` methods of the _Structured Logger_.