### PR TITLE
perf: Avoid shallow copies of DSC

### DIFF
--- a/src/Sentry.AspNet/HttpContextExtensions.cs
+++ b/src/Sentry.AspNet/HttpContextExtensions.cs
@@ -113,7 +113,7 @@ public static class HttpContextExtensions
             // See:
             // https://develop.sentry.dev/sdk/performance/dynamic-sampling-context/#freezing-dynamic-sampling-context
             // https://develop.sentry.dev/sdk/performance/dynamic-sampling-context/#unified-propagation-mechanism
-            dynamicSamplingContext = DynamicSamplingContext.Empty;
+            dynamicSamplingContext = DynamicSamplingContext.Empty();
         }
 
         var transaction = SentrySdk.StartTransaction(transactionContext, customSamplingContext, dynamicSamplingContext);

--- a/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryTracingMiddleware.cs
@@ -75,7 +75,7 @@ internal class SentryTracingMiddleware
                 // See:
                 // https://develop.sentry.dev/sdk/performance/dynamic-sampling-context/#freezing-dynamic-sampling-context
                 // https://develop.sentry.dev/sdk/performance/dynamic-sampling-context/#unified-propagation-mechanism
-                dynamicSamplingContext = DynamicSamplingContext.Empty;
+                dynamicSamplingContext = DynamicSamplingContext.Empty();
             }
 
             var transaction = _getHub().StartTransaction(transactionContext, customSamplingContext, dynamicSamplingContext);

--- a/src/Sentry/DynamicSamplingContext.cs
+++ b/src/Sentry/DynamicSamplingContext.cs
@@ -105,7 +105,7 @@ internal class DynamicSamplingContext
         _items["sample_rate"] = sampleRate.ToString(CultureInfo.InvariantCulture);
     }
 
-    internal DynamicSamplingContext Clone() => new(new Dictionary<string, string>(Items));
+    internal DynamicSamplingContext Clone() => new(new Dictionary<string, string>(_items));
 
     public void SetReplayId(IReplaySession? replaySession)
     {

--- a/src/Sentry/DynamicSamplingContext.cs
+++ b/src/Sentry/DynamicSamplingContext.cs
@@ -9,16 +9,18 @@ namespace Sentry;
 /// <seealso href="https://develop.sentry.dev/sdk/performance/dynamic-sampling-context"/>
 internal class DynamicSamplingContext
 {
-    public Dictionary<string, string> Items { get; }
+    private readonly Dictionary<string, string> _items;
+
+    public IReadOnlyDictionary<string, string> Items => _items;
 
     public bool IsEmpty => Items.Count == 0;
 
-    private DynamicSamplingContext(Dictionary<string, string> items) => Items = items;
+    private DynamicSamplingContext(Dictionary<string, string> items) => _items = items;
 
     /// <summary>
     /// Gets an empty <see cref="DynamicSamplingContext"/> that can be used to "freeze" the DSC on a transaction.
     /// </summary>
-    public static DynamicSamplingContext Empty => new(new Dictionary<string, string>());
+    public static DynamicSamplingContext Empty() => new(new Dictionary<string, string>());
 
     private DynamicSamplingContext(SentryId traceId,
         string publicKey,
@@ -93,14 +95,14 @@ internal class DynamicSamplingContext
             items.Add("replay_id", replayId.ToString());
         }
 
-        Items = items;
+        _items = items;
     }
 
     public BaggageHeader ToBaggageHeader() => BaggageHeader.Create(Items, useSentryPrefix: true);
 
     public void SetSampleRate(double sampleRate)
     {
-        Items["sample_rate"] = sampleRate.ToString(CultureInfo.InvariantCulture);
+        _items["sample_rate"] = sampleRate.ToString(CultureInfo.InvariantCulture);
     }
 
     internal DynamicSamplingContext Clone() => new(new Dictionary<string, string>(Items));
@@ -109,7 +111,7 @@ internal class DynamicSamplingContext
     {
         if (replaySession?.ActiveReplayId is { } replayId && replayId != SentryId.Empty)
         {
-            Items["replay_id"] = replayId.ToString();
+            _items["replay_id"] = replayId.ToString();
         }
     }
 

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -193,7 +193,7 @@ internal class Hub : IHub, IDisposable
                 isSampled = SampleRandHelper.IsSampled(sampleRand, samplerSampleRate);
 
                 // Ensure the actual sampleRate is set on the provided DSC (if any) when the TracesSampler reached a sampling decision
-                dynamicSamplingContext = dynamicSamplingContext?.WithSampleRate(samplerSampleRate);
+                dynamicSamplingContext?.SetSampleRate(samplerSampleRate);
             }
         }
 
@@ -207,12 +207,12 @@ internal class Hub : IHub, IDisposable
             if (context.IsSampled is null && _options.TracesSampleRate is not null)
             {
                 // Ensure the actual sampleRate is set on the provided DSC (if any) when not IsSampled upstream but the TracesSampleRate reached a sampling decision
-                dynamicSamplingContext = dynamicSamplingContext?.WithSampleRate(_options.TracesSampleRate.Value);
+                dynamicSamplingContext?.SetSampleRate(_options.TracesSampleRate.Value);
             }
         }
 
         // Make sure there is a replayId (if available) on the provided DSC (if any).
-        dynamicSamplingContext = dynamicSamplingContext?.WithReplayId(_replaySession);
+        dynamicSamplingContext?.SetReplayId(_replaySession);
 
         if (isSampled is false)
         {

--- a/test/Sentry.Tests/DynamicSamplingContextTests.cs
+++ b/test/Sentry.Tests/DynamicSamplingContextTests.cs
@@ -25,7 +25,7 @@ public class DynamicSamplingContextTests
     [Fact]
     public void EmptyContext()
     {
-        var dsc = DynamicSamplingContext.Empty;
+        var dsc = DynamicSamplingContext.Empty();
 
         Assert.True(dsc.IsEmpty);
     }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -760,7 +760,6 @@ public partial class HubTests
             transactionTracer.SampleRate.Should().Be(expectedSampleRate);
             if (expectedDscOverwritten)
             {
-                transactionTracer.DynamicSamplingContext.Should().NotBeSameAs(originalDsc);
                 transactionTracer.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc.CloneWithSampleRate(expectedSampleRate));
             }
             else
@@ -774,7 +773,6 @@ public partial class HubTests
             unsampledTransaction.SampleRate.Should().Be(expectedSampleRate);
             if (expectedDscOverwritten)
             {
-                unsampledTransaction.DynamicSamplingContext.Should().NotBeSameAs(originalDsc);
                 unsampledTransaction.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc.CloneWithSampleRate(expectedSampleRate));
             }
             else
@@ -882,7 +880,7 @@ public partial class HubTests
         var hub = _fixture.GetSut();
 
         // Act
-        var transaction = hub.StartTransaction(transactionContext, new Dictionary<string, object>(), DynamicSamplingContext.Empty);
+        var transaction = hub.StartTransaction(transactionContext, new Dictionary<string, object>(), DynamicSamplingContext.Empty());
 
         // Assert
         var transactionTracer = transaction.Should().BeOfType<TransactionTracer>().Subject;
@@ -919,7 +917,6 @@ public partial class HubTests
         transactionTracer.IsSampled.Should().BeTrue();
         transactionTracer.SampleRate.Should().Be(0.4);
         transactionTracer.SampleRand.Should().Be(0.1234);
-        transactionTracer.DynamicSamplingContext.Should().NotBeSameAs(originalDsc);
         transactionTracer.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc.CloneWithSampleRate(0.4));
     }
 
@@ -954,7 +951,6 @@ public partial class HubTests
             transactionTracer.IsSampled.Should().BeTrue();
             transactionTracer.SampleRate.Should().Be(sampleRate);
             transactionTracer.SampleRand.Should().Be(0.1234);
-            transactionTracer.DynamicSamplingContext.Should().NotBeSameAs(originalDsc);
             transactionTracer.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc.CloneWithSampleRate(sampleRate));
         }
         else
@@ -963,7 +959,6 @@ public partial class HubTests
             unsampledTransaction.IsSampled.Should().BeFalse();
             unsampledTransaction.SampleRate.Should().Be(sampleRate);
             unsampledTransaction.SampleRand.Should().Be(0.1234);
-            unsampledTransaction.DynamicSamplingContext.Should().NotBeSameAs(originalDsc);
             unsampledTransaction.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc.CloneWithSampleRate(sampleRate));
         }
     }
@@ -999,7 +994,6 @@ public partial class HubTests
             transactionTracer.IsSampled.Should().BeTrue();
             transactionTracer.SampleRate.Should().Be(sampleRate);
             transactionTracer.SampleRand.Should().Be(0.1234);
-            transactionTracer.DynamicSamplingContext.Should().NotBeSameAs(originalDsc);
             transactionTracer.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc.CloneWithSampleRate(sampleRate));
         }
         else
@@ -1008,7 +1002,6 @@ public partial class HubTests
             unsampledTransaction.IsSampled.Should().BeFalse();
             unsampledTransaction.SampleRate.Should().Be(sampleRate);
             unsampledTransaction.SampleRand.Should().Be(0.1234);
-            unsampledTransaction.DynamicSamplingContext.Should().NotBeSameAs(originalDsc);
             unsampledTransaction.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc.CloneWithSampleRate(sampleRate));
         }
     }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -743,6 +743,7 @@ public partial class HubTests
             {"sentry-sample_rate", "0.5"},
             {"sentry-sample_rand", "0.1234"},
         }).CreateDynamicSamplingContext();
+        var originalDsc = dsc?.Clone();
 
         _fixture.Options.TracesSampler = _ => tracesSampler;
         _fixture.Options.TracesSampleRate = tracesSampleRate;
@@ -759,12 +760,12 @@ public partial class HubTests
             transactionTracer.SampleRate.Should().Be(expectedSampleRate);
             if (expectedDscOverwritten)
             {
-                transactionTracer.DynamicSamplingContext.Should().NotBeSameAs(dsc);
-                transactionTracer.DynamicSamplingContext.Should().BeEquivalentTo(dsc.ReplaceSampleRate(expectedSampleRate));
+                transactionTracer.DynamicSamplingContext.Should().NotBeSameAs(originalDsc);
+                transactionTracer.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc.CloneWithSampleRate(expectedSampleRate));
             }
             else
             {
-                transactionTracer.DynamicSamplingContext.Should().BeSameAs(dsc);
+                transactionTracer.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc);
             }
         }
         else
@@ -773,12 +774,12 @@ public partial class HubTests
             unsampledTransaction.SampleRate.Should().Be(expectedSampleRate);
             if (expectedDscOverwritten)
             {
-                unsampledTransaction.DynamicSamplingContext.Should().NotBeSameAs(dsc);
-                unsampledTransaction.DynamicSamplingContext.Should().BeEquivalentTo(dsc.ReplaceSampleRate(expectedSampleRate));
+                unsampledTransaction.DynamicSamplingContext.Should().NotBeSameAs(originalDsc);
+                unsampledTransaction.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc.CloneWithSampleRate(expectedSampleRate));
             }
             else
             {
-                unsampledTransaction.DynamicSamplingContext.Should().BeSameAs(dsc);
+                unsampledTransaction.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc);
             }
         }
     }
@@ -814,12 +815,12 @@ public partial class HubTests
         transactionTracer.IsSampled.Should().BeTrue();
         transactionTracer.DynamicSamplingContext.Should().NotBeNull();
 
-        var expectedDsc = dsc.ReplaceSampleRate(_fixture.Options.TracesSampleRate.Value);
+        var expectedDsc = dsc.CloneWithSampleRate(_fixture.Options.TracesSampleRate.Value);
         if (replaySessionIsActive)
         {
             // We overwrite the replay_id when we have an active replay session
             // Otherwise we propagate whatever was in the baggage header
-            expectedDsc = expectedDsc.ReplaceReplayId(_fixture.ReplaySession);
+            expectedDsc = expectedDsc.CloneWithReplayId(_fixture.ReplaySession);
         }
         transactionTracer.DynamicSamplingContext.Should().BeEquivalentTo(expectedDsc);
     }
@@ -905,6 +906,7 @@ public partial class HubTests
             {"sentry-sample_rate", "0.5"}, // Required in the baggage header, but ignored by sampling logic
             {"sentry-sample_rand", "0.1234"}
         }).CreateDynamicSamplingContext(dummyReplaySession);
+        var originalDsc = dsc.Clone();
 
         _fixture.Options.TracesSampleRate = 0.4;
         var hub = _fixture.GetSut();
@@ -917,8 +919,8 @@ public partial class HubTests
         transactionTracer.IsSampled.Should().BeTrue();
         transactionTracer.SampleRate.Should().Be(0.4);
         transactionTracer.SampleRand.Should().Be(0.1234);
-        transactionTracer.DynamicSamplingContext.Should().NotBeSameAs(dsc);
-        transactionTracer.DynamicSamplingContext.Should().BeEquivalentTo(dsc.ReplaceSampleRate(0.4));
+        transactionTracer.DynamicSamplingContext.Should().NotBeSameAs(originalDsc);
+        transactionTracer.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc.CloneWithSampleRate(0.4));
     }
 
     [Theory]
@@ -937,6 +939,7 @@ public partial class HubTests
             {"sentry-sample_rate", "0.5"},
             {"sentry-sample_rand", "0.1234"}
         }).CreateDynamicSamplingContext(_fixture.ReplaySession);
+        var originalDsc = dsc.Clone();
 
         _fixture.Options.TracesSampler = _ => sampleRate;
         var hub = _fixture.GetSut();
@@ -951,8 +954,8 @@ public partial class HubTests
             transactionTracer.IsSampled.Should().BeTrue();
             transactionTracer.SampleRate.Should().Be(sampleRate);
             transactionTracer.SampleRand.Should().Be(0.1234);
-            transactionTracer.DynamicSamplingContext.Should().NotBeSameAs(dsc);
-            transactionTracer.DynamicSamplingContext.Should().BeEquivalentTo(dsc.ReplaceSampleRate(sampleRate));
+            transactionTracer.DynamicSamplingContext.Should().NotBeSameAs(originalDsc);
+            transactionTracer.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc.CloneWithSampleRate(sampleRate));
         }
         else
         {
@@ -960,8 +963,8 @@ public partial class HubTests
             unsampledTransaction.IsSampled.Should().BeFalse();
             unsampledTransaction.SampleRate.Should().Be(sampleRate);
             unsampledTransaction.SampleRand.Should().Be(0.1234);
-            unsampledTransaction.DynamicSamplingContext.Should().NotBeSameAs(dsc);
-            unsampledTransaction.DynamicSamplingContext.Should().BeEquivalentTo(dsc.ReplaceSampleRate(sampleRate));
+            unsampledTransaction.DynamicSamplingContext.Should().NotBeSameAs(originalDsc);
+            unsampledTransaction.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc.CloneWithSampleRate(sampleRate));
         }
     }
 
@@ -981,6 +984,7 @@ public partial class HubTests
             {"sentry-sample_rate", "0.5"}, // Static sampling ignores this and uses options.TracesSampleRate instead
             {"sentry-sample_rand", "0.1234"}
         }).CreateDynamicSamplingContext(dummyReplaySession);
+        var originalDsc = dsc.Clone();
 
         _fixture.Options.TracesSampleRate = sampleRate;
         var hub = _fixture.GetSut();
@@ -995,8 +999,8 @@ public partial class HubTests
             transactionTracer.IsSampled.Should().BeTrue();
             transactionTracer.SampleRate.Should().Be(sampleRate);
             transactionTracer.SampleRand.Should().Be(0.1234);
-            transactionTracer.DynamicSamplingContext.Should().NotBeSameAs(dsc);
-            transactionTracer.DynamicSamplingContext.Should().BeEquivalentTo(dsc.ReplaceSampleRate(sampleRate));
+            transactionTracer.DynamicSamplingContext.Should().NotBeSameAs(originalDsc);
+            transactionTracer.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc.CloneWithSampleRate(sampleRate));
         }
         else
         {
@@ -1004,8 +1008,8 @@ public partial class HubTests
             unsampledTransaction.IsSampled.Should().BeFalse();
             unsampledTransaction.SampleRate.Should().Be(sampleRate);
             unsampledTransaction.SampleRand.Should().Be(0.1234);
-            unsampledTransaction.DynamicSamplingContext.Should().NotBeSameAs(dsc);
-            unsampledTransaction.DynamicSamplingContext.Should().BeEquivalentTo(dsc.ReplaceSampleRate(sampleRate));
+            unsampledTransaction.DynamicSamplingContext.Should().NotBeSameAs(originalDsc);
+            unsampledTransaction.DynamicSamplingContext.Should().BeEquivalentTo(originalDsc.CloneWithSampleRate(sampleRate));
         }
     }
 
@@ -1255,7 +1259,7 @@ public partial class HubTests
         baggage.Members.Should().Equal([
             new KeyValuePair<string, string>("sentry-trace_id", "43365712692146d08ee11a729dfbcaca"),
             new KeyValuePair<string, string>("sentry-public_key", "d4d82fc1c2c4032a83f3a29aa3a3aff"),
-            new KeyValuePair<string, string>("sentry-sample_rate", isSampled ? "1" : "0.0"),
+            new KeyValuePair<string, string>("sentry-sample_rate", isSampled ? "1" : "0"),
             new KeyValuePair<string, string>("sentry-sample_rand", sampleRand!.Value.ToString(CultureInfo.InvariantCulture)),
         ]);
     }
@@ -2409,63 +2413,19 @@ internal partial class HubTestsJsonContext : JsonSerializerContext
 #nullable enable
 file static class DynamicSamplingContextExtensions
 {
-    public static DynamicSamplingContext ReplaceSampleRate(this DynamicSamplingContext? dsc, double sampleRate)
+    public static DynamicSamplingContext CloneWithSampleRate(this DynamicSamplingContext? dsc, double sampleRate)
     {
         Assert.NotNull(dsc);
-
-        var value = sampleRate.ToString(CultureInfo.InvariantCulture);
-        return dsc.Replace("sentry-sample_rate", value);
+        var newDsc = dsc.Clone();
+        newDsc.SetSampleRate(sampleRate);
+        return newDsc;
     }
 
-    public static DynamicSamplingContext ReplaceReplayId(this DynamicSamplingContext? dsc, IReplaySession replaySession)
+    public static DynamicSamplingContext CloneWithReplayId(this DynamicSamplingContext? dsc, IReplaySession replaySession)
     {
         Assert.NotNull(dsc);
-
-        if (!replaySession.ActiveReplayId.HasValue)
-        {
-            throw new InvalidOperationException($"No {nameof(IReplaySession.ActiveReplayId)}.");
-        }
-
-        var value = replaySession.ActiveReplayId.Value.ToString();
-        return dsc.Replace("sentry-replay_id", value);
-    }
-
-    private static DynamicSamplingContext Replace(this DynamicSamplingContext dsc, string key, string newValue)
-    {
-        var items = dsc.ToBaggageHeader().Members.ToList();
-        var index = items.FindSingleIndex(key);
-
-        var oldValue = items[index].Value;
-        if (oldValue == newValue)
-        {
-            throw new InvalidOperationException($"{key} already is {oldValue}.");
-        }
-
-        items[index] = new KeyValuePair<string, string>(key, newValue);
-
-        var baggage = BaggageHeader.Create(items);
-        var dynamicSamplingContext = DynamicSamplingContext.CreateFromBaggageHeader(baggage, null);
-        if (dynamicSamplingContext is null)
-        {
-            throw new InvalidOperationException($"Invalid {nameof(BaggageHeader)}: {baggage}");
-        }
-
-        return dynamicSamplingContext;
-    }
-
-    private static int FindSingleIndex(this List<KeyValuePair<string, string>> items, string key)
-    {
-        var index = items.FindIndex(item => item.Key == key);
-        if (index == -1)
-        {
-            throw new InvalidOperationException($"{key} not found.");
-        }
-
-        if (items.FindLastIndex(item => item.Key == key) != index)
-        {
-            throw new InvalidOperationException($"Duplicate {key} found.");
-        }
-
-        return index;
+        var newDsc = dsc.Clone();
+        newDsc.SetReplayId(replaySession);
+        return newDsc;
     }
 }


### PR DESCRIPTION
Resolves #4381
- https://github.com/getsentry/sentry-dotnet/issues/4381

#skip-changelog

> [!NOTE]
> A bunch of the tests had to be changed as they assumed the setting the sample rate or replay id on a DSC would return a copy of the DSC (not modify the original DSC). Our own code doesn't need to make such assumptions (or preserve the "original" DSC for future comparisons, as the tests are doing). 