### PR TITLE
fix: Handled is no longer set to false for blocking calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Remove `IDisposable` from `SentryStructuredLogger`. Disposal is intended through the owning `IHub` instance ([#4424](https://github.com/getsentry/sentry-dotnet/pull/4424))
   - Ensure all buffered logs are sent to Sentry when the application terminates unexpectedly ([#4425](https://github.com/getsentry/sentry-dotnet/pull/4425))
   - `InvalidOperationException` potentially thrown during a race condition, especially in concurrent high-volume logging scenarios ([#4428](https://github.com/getsentry/sentry-dotnet/pull/4428))
+- Blocking calls are no longer treated as unhandled crashes ([#4458](https://github.com/getsentry/sentry-dotnet/pull/4458))
 
 ### Dependencies
 

--- a/src/Sentry/Ben.BlockingDetector/BlockingMonitor.cs
+++ b/src/Sentry/Ben.BlockingDetector/BlockingMonitor.cs
@@ -70,7 +70,6 @@ namespace Sentry.Ben.BlockingDetector
                             Mechanism = new Mechanism
                             {
                                 Type = "BlockingCallDetector",
-                                Handled = false,
                                 Description = "Blocking calls can cause ThreadPool starvation.",
                                 Source = detectionSource.ToString()
                             },


### PR DESCRIPTION
Resolves #4263:
- https://github.com/getsentry/sentry-dotnet/issues/4263 

The 'handled' property is now omitted from the mechanism for blocking call detection events, so they are not treated as unhandled crashes in Sentry UI.