### PR TITLE
test: disabled win-x64 test on win-arm64 too

### DIFF
--- a/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs
+++ b/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs
@@ -119,7 +119,7 @@ public class SamplingTransactionProfilerTests
     {
         if (TestEnvironment.IsGitHubActions)
         {
-            Skip.If(TestEnvironment.IsWinX64, "Flaky in CI on Windows X64.");
+            Skip.If(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Flaky in CI on Windows.");
             Skip.If(RuntimeInformation.IsOSPlatform(OSPlatform.Linux), "Flaky in CI on Linux.");
         }
 

--- a/test/Sentry.Testing/TestEnvironment.cs
+++ b/test/Sentry.Testing/TestEnvironment.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Sentry.Testing;
 
 public static class TestEnvironment
@@ -15,7 +13,4 @@ public static class TestEnvironment
             return isGitHubActions?.Equals("true", StringComparison.OrdinalIgnoreCase) == true;
         }
     }
-
-    public static bool IsWinX64 => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                                   && RuntimeInformation.OSArchitecture == Architecture.X64;
 }


### PR DESCRIPTION
Follow-up to
-  #4383

I noticed a flaky test, disabled on `win-x64` to flake on `win-arm64` too.

Since these two are all of our Windows targets,
I propose to Skip the test for all `win` platforms.

---
Screenshot (I tried to scroll the bar twice already 😉)
<img width="884" height="379" alt="image" src="https://github.com/user-attachments/assets/efc6a0db-c101-4a8d-aa4a-74234c58622a" />
Screenshot (I tried to scroll the bar twice already 😉)

---

Failing build/test:
https://github.com/getsentry/sentry-dotnet/actions/runs/17154733726/job/48668953528
```text
Assert.Null() Failure: Value is not null
Expected: null
Actual:   SamplingTransactionProfiler { OnFinish = Action { Method = Void <Start>b__11_0(), Target = SamplingTransactionProfilerFactory { ··· } } }
   at Sentry.Profiling.Tests.SamplingTransactionProfilerTests.Profiler_WithZeroStartupTimeout_CapturesAfterStartingAsynchronously() in C:\a\sentry-dotnet\sentry-dotnet\test\Sentry.Profiling.Tests\SamplingTransactionProfilerTests.cs:line 128
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```

---
#skip-changelog