### PR TITLE
alpine: add gpg for codecov/codecov-action 5.5

### DIFF
--- a/.github/alpine/Dockerfile
+++ b/.github/alpine/Dockerfile
@@ -5,7 +5,7 @@ FROM ${BASE}
 RUN apk update
 
 # common
-RUN apk add bash build-base cmake curl git icu lsb-release-minimal nodejs npm sudo tar wget
+RUN apk add bash build-base cmake curl git gpg icu lsb-release-minimal nodejs npm sudo tar wget
 
 # sentry-native
 RUN apk add curl-dev docker-cli libunwind-dev libunwind-static linux-headers openssl-dev zlib-dev xz-dev xz-static


### PR DESCRIPTION
Install [gpg](https://pkgs.alpinelinux.org/package/v3.21/main/x86_64/gpg) on the Alpine Linux Docker image to resolve the following error in #4472:
```
Error: The following required dependencies are missing: gpg
Please install these dependencies before using this action.
```

#skip-changelog