### PR TITLE
Updated logmessage

### DIFF
--- a/src/Sentry/Internal/AotHelper.cs
+++ b/src/Sentry/Internal/AotHelper.cs
@@ -39,7 +39,7 @@ internal static class AotHelper
         }
 
         // fallback check
-        logger?.LogDebug("Stacktrace fallback");
+        logger?.LogDebug("Falling back to stack trace check for trimming detection");
         var stackTrace = new StackTrace(false);
         return stackTrace.GetFrame(0)?.GetMethod() is null;
     }


### PR DESCRIPTION
With `Debug` enabled, these are the first logs received
```
Sentry: (Debug) Logging enabled with 'UnityLogger' min level: Debug 
Sentry: (Debug) DSN read from options: https://hueee@some.ingest.at.sentry.io/funnynumber 
Sentry: (Debug) Stacktrace fallback 
Sentry: (Debug) This doesn't look like a Native AOT application build. 
Sentry: (Debug) Initializing Hub for Dsn: https://hueee@some.ingest.at.sentry.io/funnynumber. 
Sentry: (Debug) Creating transport. 
```

As a user, I've got no idea what `Stacktrace fallback` means.

#skip-changelog