### PR TITLE
fix: Removed redundant scope sync after transaction finish

### DIFF
--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -818,11 +818,6 @@ public class Scope : IEventLike
             if (ReferenceEquals(_transaction.Value, expectedCurrentTransaction))
             {
                 _transaction.Value = null;
-                if (Options.EnableScopeSync)
-                {
-                    // We have to restore the trace on the native layers to be in sync with the current scope
-                    Options.ScopeObserver?.SetTrace(PropagationContext.TraceId, PropagationContext.SpanId);
-                }
             }
         }
         finally


### PR DESCRIPTION
### Problem Description

When a transaction gets finished it also resets itself on the scope. This triggers a "manual" scope sync to the native layer. After finishing a transaction the `PropagationContext` get renewed to keep new events from having an old trace context. 
The SDK syncs the trace in immediate succession, overwriting itself every time.

### Context

The logs are taken from a Unity game but should apply to anywhere there is a transaction that gets finished
```
Sentry: (Info) Finishing 'app.start' transaction. 
Sentry: (Debug) Attempting to finish Transaction d84ad5b1214e4d44. 
Sentry: (Debug) Finished Transaction d84ad5b1214e4d44. 
Sentry: (Debug) macOS Scope Sync - Setting Trace traceId:d968c8c94a7241e8b9873018d1302e4a spanId:5eba0d6fe7261f58 
Sentry: (Debug) macOS Scope Sync - Setting Trace traceId:bd2de9eb0db946819f59251e313c6471 spanId:e0b7994a40178a9c 
```

After a transaction gets finished it gets reset on the `Scope` and afterwards the `PropagationContext` gets regenerated so that new events don't have a trace context older than the just finished transaction. We even point this out in the comments.

There are two places the transaction gets reset on the scope:
- `UnsampledTransaction` https://github.com/getsentry/sentry-dotnet/blob/6eedb714440bfd4b9f8267eb700f976019b67ff3/src/Sentry/Internal/UnsampledTransaction.cs#L65-L71
- `TransactionTracer` https://github.com/getsentry/sentry-dotnet/blob/6eedb714440bfd4b9f8267eb700f976019b67ff3/src/Sentry/TransactionTracer.cs#L386-L392

### Proposal

The SDK does not need to manually restore the trace context on the native layer, as it gets overwritten basically in the next line.