### PR TITLE
build(deps): bump sentry-cocoa from 8.46.0 to 8.53.2

### DIFF
--- a/modules/sentry-cocoa.properties
+++ b/modules/sentry-cocoa.properties
@@ -1,2 +1,2 @@
-version = 8.46.0
+version = 8.49.2
 repo = https://github.com/getsentry/sentry-cocoa

--- a/modules/sentry-cocoa.properties
+++ b/modules/sentry-cocoa.properties
@@ -1,2 +1,2 @@
-version = 8.51.1
+version = 8.53.2
 repo = https://github.com/getsentry/sentry-cocoa

--- a/modules/sentry-cocoa.properties
+++ b/modules/sentry-cocoa.properties
@@ -1,2 +1,2 @@
-version = 8.49.2
+version = 8.51.1
 repo = https://github.com/getsentry/sentry-cocoa

--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -56,7 +56,6 @@ try
         $buildDir = "test/Sentry.Maui.Device.TestApp/bin/Release/$Tfm/iossimulator-$arch"
         $envValue = $CI ? 'true' : 'false'
         $arguments = @(
-            '-v',
             '--app', "$buildDir/Sentry.Maui.Device.TestApp.app",
             '--target', 'ios-simulator-64',
             '--launch-timeout', '00:10:00',

--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -56,6 +56,7 @@ try
         $buildDir = "test/Sentry.Maui.Device.TestApp/bin/Release/$Tfm/iossimulator-$arch"
         $envValue = $CI ? 'true' : 'false'
         $arguments = @(
+            '-v',
             '--app', "$buildDir/Sentry.Maui.Device.TestApp.app",
             '--target', 'ios-simulator-64',
             '--launch-timeout', '00:10:00',

--- a/scripts/generate-cocoa-bindings.ps1
+++ b/scripts/generate-cocoa-bindings.ps1
@@ -96,6 +96,8 @@ Write-Output "iPhoneSdkVersion: $iPhoneSdkVersion"
 
 ## Imports in the various header files are provided in the "new" style of:
 #     `#import <Sentry/SomeHeader.h>`
+# ...or:
+#     `#import SENTRY_HEADER(SentryHeader)`
 # ...instead of:
 #     `#import "SomeHeader.h"`
 # This causes sharpie to fail resolve those headers
@@ -106,6 +108,7 @@ foreach ($file in $filesToPatch)
     {
         $content = Get-Content -Path $file -Raw
         $content = $content -replace '<Sentry/([^>]+)>', '"$1"'
+        $content = $content -replace '#import SENTRY_HEADER\(([^)]+)\)', '#import "$1.h"'
         Set-Content -Path $file -Value $content
     }
     else
@@ -206,7 +209,7 @@ $Text = $Text -replace '\bISentrySerializable\b', 'SentrySerializable'
 $Text = $Text -replace ': INSCopying,', ':' -replace '\s?[:,] INSCopying', ''
 
 # Remove iOS attributes like [iOS (13, 0)]
-$Text = $Text -replace '\[iOS \(13, 0\)\]\n?', ''
+$Text = $Text -replace '\[iOS \(13,\s?0\)\]\n?', ''
 
 # Fix delegate argument names
 $Text = $Text -replace '(NSError) arg\d', '$1 error'

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -412,6 +412,10 @@ interface SentryEnvelopeItemHeader : SentrySerializable
     [Export ("initWithType:length:filenname:contentType:")]
     NativeHandle Constructor (string type, nuint length, string filename, string contentType);
 
+    // -(instancetype _Nonnull)initWithType:(NSString * _Nonnull)type length:(NSUInteger)length contentType:(NSString * _Nonnull)contentType itemCount:(NSNumber * _Nonnull)itemCount;
+    [Export ("initWithType:length:contentType:itemCount:")]
+    NativeHandle Constructor (string type, nuint length, string contentType, NSNumber itemCount);
+
     // @property (readonly, copy, nonatomic) NSString * _Nonnull type;
     [Export ("type")]
     string Type { get; }
@@ -427,6 +431,10 @@ interface SentryEnvelopeItemHeader : SentrySerializable
     // @property (readonly, copy, nonatomic) NSString * _Nullable contentType;
     [NullAllowed, Export ("contentType")]
     string ContentType { get; }
+
+    // @property (readonly, copy, nonatomic) NSNumber * _Nullable itemCount;
+    [NullAllowed, Export ("itemCount", ArgumentSemantic.Copy)]
+    NSNumber ItemCount { get; }
 
     // @property (copy, nonatomic) NSString * _Nullable platform;
     [NullAllowed, Export ("platform")]
@@ -603,6 +611,20 @@ interface SentryException : SentrySerializable
     // -(instancetype _Nonnull)initWithValue:(NSString * _Nonnull)value type:(NSString * _Nonnull)type;
     [Export ("initWithValue:type:")]
     NativeHandle Constructor (string value, string type);
+}
+
+// @interface SentryFeedbackAPI : NSObject
+[BaseType (typeof(NSObject))]
+[Internal]
+interface SentryFeedbackAPI
+{
+    // -(void)showWidget __attribute__((availability(ios, introduced=13.0)));
+        [Export ("showWidget")]
+    void ShowWidget ();
+
+    // -(void)hideWidget __attribute__((availability(ios, introduced=13.0)));
+        [Export ("hideWidget")]
+    void HideWidget ();
 }
 
 // @interface SentryFrame : NSObject <SentrySerializable>
@@ -1026,6 +1048,23 @@ interface SentryHub
     // -(void)close;
     [Export ("close")]
     void Close ();
+}
+
+// @protocol SentryIntegrationProtocol <NSObject>
+[Protocol]
+[BaseType (typeof(NSObject))]
+[Internal]
+interface SentryIntegrationProtocol
+{
+    // @required -(BOOL)installWithOptions:(SentryOptions * _Nonnull)options __attribute__((swift_name("install(with:)")));
+    [Abstract]
+    [Export ("installWithOptions:")]
+    bool InstallWithOptions (SentryOptions options);
+
+    // @required -(void)uninstall;
+    [Abstract]
+    [Export ("uninstall")]
+    void Uninstall ();
 }
 
 // @interface SentryMeasurementUnit : NSObject <NSCopying>
@@ -1828,6 +1867,11 @@ interface SentrySDK
     [Static]
     [Export ("captureFeedback:")]
     void CaptureFeedback (SentryFeedback feedback);
+
+    // @property (readonly, nonatomic, class) API_AVAILABLE(ios(13.0)) SentryFeedbackAPI * feedback __attribute__((availability(ios, introduced=13.0)));
+        [Static]
+    [Export ("feedback")]
+    SentryFeedbackAPI Feedback { get; }
 
     // +(void)addBreadcrumb:(SentryBreadcrumb * _Nonnull)crumb __attribute__((swift_name("addBreadcrumb(_:)")));
     [Static]

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -427,6 +427,10 @@ interface SentryEnvelopeItemHeader : SentrySerializable
     // @property (readonly, copy, nonatomic) NSString * _Nullable contentType;
     [NullAllowed, Export ("contentType")]
     string ContentType { get; }
+
+    // @property (copy, nonatomic) NSString * _Nullable platform;
+    [NullAllowed, Export ("platform")]
+    string Platform { get; set; }
 }
 
 partial interface Constants
@@ -1522,6 +1526,10 @@ interface SentryOptions
     [Export ("enableCoreDataTracing")]
     bool EnableCoreDataTracing { get; set; }
 
+    // @property (copy, nonatomic) SentryProfilingConfigurationBlock _Nullable configureProfiling;
+    [NullAllowed, Export ("configureProfiling", ArgumentSemantic.Copy)]
+    SentryProfilingConfigurationBlock ConfigureProfiling { get; set; }
+
     // @property (assign, nonatomic) BOOL enableAppLaunchProfiling;
     [Export ("enableAppLaunchProfiling")]
     bool EnableAppLaunchProfiling { get; set; }
@@ -1609,6 +1617,10 @@ interface SentryOptions
         [Export ("configureUserFeedback", ArgumentSemantic.Copy)]
     SentryUserFeedbackConfigurationBlock ConfigureUserFeedback { get; set; }
 }
+
+// typedef void (^SentryProfilingConfigurationBlock)(SentryProfileOptions * _Nonnull);
+[Internal]
+delegate void SentryProfilingConfigurationBlock (SentryProfileOptions arg0);
 
 // @interface SentryReplayApi : NSObject
 [BaseType (typeof(NSObject))]
@@ -2435,6 +2447,11 @@ interface PrivateSentrySDKOnly
     [Static]
     [Export ("getExtraContext")]
     NSDictionary ExtraContext { get; }
+
+    // +(void)setTrace:(SentryId * _Nonnull)traceId spanId:(SentrySpanId * _Nonnull)spanId;
+    [Static]
+    [Export ("setTrace:spanId:")]
+    void SetTrace (SentryId traceId, SentrySpanId spanId);
 
     // +(uint64_t)startProfilerForTrace:(SentryId * _Nonnull)traceId;
     [Static]

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -384,7 +384,7 @@ interface SentryDsn
     [Export ("getHash")]
     string Hash { get; }
 
-    // -(NSURL * _Nonnull)getStoreEndpoint;
+    // -(NSURL * _Nonnull)getStoreEndpoint __attribute__((deprecated("This endpoint is no longer used")));
     [Export ("getStoreEndpoint")]
     NSUrl StoreEndpoint { get; }
 
@@ -569,13 +569,6 @@ interface SentryEvent : SentrySerializable
     // -(instancetype _Nonnull)initWithError:(NSError * _Nonnull)error;
     [Export ("initWithError:")]
     NativeHandle Constructor (NSError error);
-}
-
-// @interface SentryEventDecodable : SentryEvent
-[BaseType (typeof(SentryEvent))]
-[Internal]
-interface SentryEventDecodable
-{
 }
 
 // @interface SentryException : NSObject <SentrySerializable>
@@ -1652,6 +1645,10 @@ interface SentryOptions
     [Export ("spotlightUrl")]
     string SpotlightUrl { get; set; }
 
+    // @property (readonly, nonatomic) NSObject * _Nonnull _swiftExperimentalOptions;
+    [Export ("_swiftExperimentalOptions")]
+    NSObject _swiftExperimentalOptions { get; }
+
     // @property (copy, nonatomic) API_AVAILABLE(ios(13.0)) SentryUserFeedbackConfigurationBlock configureUserFeedback __attribute__((availability(ios, introduced=13.0)));
         [Export ("configureUserFeedback", ArgumentSemantic.Copy)]
     SentryUserFeedbackConfigurationBlock ConfigureUserFeedback { get; set; }
@@ -2379,33 +2376,6 @@ interface SentryUser : SentrySerializable
     // -(NSUInteger)hash;
     [Export ("hash")]
     nuint Hash { get; }
-}
-
-// @interface SentryUserFeedback : NSObject <SentrySerializable>
-[BaseType (typeof(NSObject))]
-[DisableDefaultCtor]
-[Internal]
-interface SentryUserFeedback : SentrySerializable
-{
-    // -(instancetype _Nonnull)initWithEventId:(SentryId * _Nonnull)eventId;
-    [Export ("initWithEventId:")]
-    NativeHandle Constructor (SentryId eventId);
-
-    // @property (readonly, nonatomic, strong) SentryId * _Nonnull eventId;
-    [Export ("eventId", ArgumentSemantic.Strong)]
-    SentryId EventId { get; }
-
-    // @property (copy, nonatomic) NSString * _Nonnull name;
-    [Export ("name")]
-    string Name { get; set; }
-
-    // @property (copy, nonatomic) NSString * _Nonnull email;
-    [Export ("email")]
-    string Email { get; set; }
-
-    // @property (copy, nonatomic) NSString * _Nonnull comments;
-    [Export ("comments")]
-    string Comments { get; set; }
 }
 
 // @interface SentryScreenFrames : NSObject <NSCopying>

--- a/src/Sentry.Bindings.Cocoa/SwiftApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/SwiftApiDefinitions.cs
@@ -248,6 +248,33 @@ interface SentryRRWebEvent : SentrySerializable
     new NSDictionary<NSString, NSObject> Serialize();
 }
 
+// @interface SentryUserFeedback : NSObject <SentrySerializable>
+[BaseType(typeof(NSObject))]
+[DisableDefaultCtor]
+[Internal]
+interface SentryUserFeedback : SentrySerializable
+{
+    // @property (nonatomic, readonly, strong) SentryId * _Nonnull eventId;
+    [Export("eventId", ArgumentSemantic.Strong)]
+    SentryId EventId { get; }
+
+    // @property (nonatomic, copy) NSString * _Nonnull name;
+    [Export("name")]
+    string Name { get; set; }
+
+    // @property (nonatomic, copy) NSString * _Nonnull email;
+    [Export("email")]
+    string Email { get; set; }
+
+    // @property (nonatomic, copy) NSString * _Nonnull comments;
+    [Export("comments")]
+    string Comments { get; set; }
+
+    // - (nonnull instancetype)initWithEventId:(SentryId * _Nonnull)eventId OBJC_DESIGNATED_INITIALIZER;
+    [Export("initWithEventId:")]
+    NativeHandle Constructor(SentryId eventId);
+}
+
 [BaseType(typeof(NSObject), Name = "_TtC6Sentry31SentryUserFeedbackConfiguration")]
 [DisableDefaultCtor]
 [Internal]

--- a/src/Sentry.Bindings.Cocoa/SwiftApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/SwiftApiDefinitions.cs
@@ -66,6 +66,30 @@ interface SentryId
     nuint Hash { get; }
 }
 
+// @interface SentryProfileOptions : NSObject
+[BaseType(typeof(NSObject), Name = "_TtC6Sentry20SentryProfileOptions")]
+[DisableDefaultCtor]
+[Internal]
+interface SentryProfileOptions
+{
+    // @property(nonatomic) enum SentryProfileLifecycle lifecycle;
+    [Export("lifecycle", ArgumentSemantic.Assign)]
+    SentryProfileLifecycle Lifecycle { get; set; }
+
+    // @property(nonatomic) float sessionSampleRate;
+    [Export("sessionSampleRate")]
+    float SessionSampleRate { get; set; }
+
+    // @property(nonatomic) BOOL profileAppStarts;
+    [Export("profileAppStarts")]
+    bool ProfileAppStarts { get; set; }
+
+    // - (nonnull instancetype) init OBJC_DESIGNATED_INITIALIZER;
+    [Export("init")]
+    [DesignatedInitializer]
+    NativeHandle Constructor();
+}
+
 // @interface SentrySessionReplayIntegration : SentryBaseIntegration
 [BaseType (typeof(NSObject))]
 [Internal]

--- a/src/Sentry.Bindings.Cocoa/SwiftStructsAndEnums.cs
+++ b/src/Sentry.Bindings.Cocoa/SwiftStructsAndEnums.cs
@@ -30,6 +30,13 @@ internal enum SentryLevel : ulong
 }
 
 [Native]
+internal enum SentryProfileLifecycle : long
+{
+    Manual = 0,
+    Trace = 1
+}
+
+[Native]
 internal enum SentryReplayQuality : long
 {
     Low = 0,


### PR DESCRIPTION
Bumps `sentry-cocoa` from [8.46.0](https://github.com/getsentry/sentry-cocoa/releases/tag/8.46.0) (Mar 1, 2025) to [8.53.2](https://github.com/getsentry/sentry-cocoa/releases/tag/8.53.2) (Jul 9, 2025):
- [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8532)
- [commits](https://github.com/getsentry/sentry-cocoa/compare/8.46.0...8.53.2)

Tested locally with:
- `Sentry.Samples.Ios` on `iossimulator-arm64`
- `Sentry.Samples.Maui` on `iossimulator-arm64`
- `pwsh scripts/device-test.ps1 ios -Run`

See also:
- https://github.com/getsentry/sentry-dotnet/pull/4411
- https://github.com/getsentry/sentry-dotnet/pull/4442