### PR TITLE
Bump .NET SDK to version 9.0.304

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -81,7 +81,7 @@ runs:
       with:
         dotnet-version: |
           8.0.x
-          9.0.301
+          9.0.304
 
     - name: Install .NET Workloads
       shell: bash

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "9.0.301",
-    "workloadVersion": "9.0.301",
+    "version": "9.0.304",
+    "workloadVersion": "9.0.304",
     "rollForward": "disable",
     "allowPrerelease": false
   }


### PR DESCRIPTION
Version 9.0.301 that we previously had pinned is flagged as needing a security patch. We could bump one version but figured we may as well just go all the way to the latest, in that case.

May also have some impact on https://github.com/getsentry/sentry-dotnet/issues/4474#issuecomment-3251564162 (although I don't think so).

#skip-changelog