### PR TITLE
ci: fix Codecov for protected branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,6 +226,8 @@ jobs:
 
       - name: Upload code coverage
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload build and test outputs
         if: failure()


### PR DESCRIPTION
fixes #4093
- getsentry/sentry-dotnet#4093

### Summary
Provide Codecov Token to fix CI step `Upload code coverage` for _protected branches_ such as `main`.

### Remarks
Error from CI workflow `build`:

```text
Upload failed: {"message":"Token required because branch is protected"}
```

Codecov Docs:
> **For public repositories**, a token is required if the upload is for a commit on a protected branch and the repository owner has not disabled token authentication for public repositories.

See also https://docs.codecov.com/docs/codecov-tokens

---
#skip-changelog
