### PR TITLE
fix: de-duplicate Java.Lang.RuntimeException on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - `InvalidOperationException` potentially thrown during a race condition, especially in concurrent high-volume logging scenarios ([#4428](https://github.com/getsentry/sentry-dotnet/pull/4428))
 - Blocking calls are no longer treated as unhandled crashes ([#4458](https://github.com/getsentry/sentry-dotnet/pull/4458))
 - Only apply Session Replay masks to specific control types when necessary to avoid performance issues in MAUI apps with complex UIs ([#4445](https://github.com/getsentry/sentry-dotnet/pull/4445))
+- De-duplicate Java.Lang.RuntimeException on Android ([#4509](https://github.com/getsentry/sentry-dotnet/pull/4509))
 
 ### Dependencies
 

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -168,6 +168,9 @@ public static partial class SentrySdk
             SentryAndroid.Init(AppContext, configuration);
         }
 
+        // Don't capture Java Runtime exceptions in the managed SDK, since we already capture them in the native SDK
+        options.AddExceptionFilterForType<Java.Lang.RuntimeException>();
+
         // Set options for the managed SDK that depend on the Android SDK. (The user will not be able to modify these.)
         options.AddEventProcessor(new AndroidEventProcessor(nativeOptions!));
         if (options.Android.LogCatIntegration != LogCatIntegrationType.None)

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -168,9 +168,6 @@ public static partial class SentrySdk
             SentryAndroid.Init(AppContext, configuration);
         }
 
-        // Don't capture Java Runtime exceptions in the managed SDK, since we already capture them in the native SDK
-        options.AddExceptionFilterForType<Java.Lang.RuntimeException>();
-
         // Set options for the managed SDK that depend on the Android SDK. (The user will not be able to modify these.)
         options.AddEventProcessor(new AndroidEventProcessor(nativeOptions!));
         if (options.Android.LogCatIntegration != LogCatIntegrationType.None)
@@ -180,6 +177,8 @@ public static partial class SentrySdk
         options.CrashedLastRun = () => JavaSdk.Sentry.IsCrashedLastRun()?.BooleanValue() is true;
         options.EnableScopeSync = true;
         options.ScopeObserver = new AndroidScopeObserver(options);
+        // Don't capture Java Runtime exceptions in the managed SDK, since we already capture them in the native SDK
+        options.AddExceptionFilterForType<Java.Lang.RuntimeException>();
 
         // TODO: Pause/Resume
     }


### PR DESCRIPTION
Java runtime exceptions are caught in two layers:
- Sentry Java SDK
- .NET Java Interop (JNI)

For example, the result of exactly one `CrashType.JavaThread` and one `CrashType.JavaBackgroundThread`:

| Before: 2+2 :x: | After: 1+1 :white_check_mark: |
|---|---|
| <img width="1524" height="639" alt="image" src="https://github.com/user-attachments/assets/b266ff24-2bc6-4a52-b92c-47c59c62e0a0" /> |  <img width="1469" height="312" alt="Screenshot From 2025-09-10 12-46-30" src="https://github.com/user-attachments/assets/9bc81d8d-38dd-44f5-b53e-1d040d8d02f7" /> |

Fixes: #4237