### PR TITLE
chore: Skip flaky Elapsed_IsValid test on iOS

### DIFF
--- a/test/Sentry.Tests/Internals/SentryStopwatchTests.cs
+++ b/test/Sentry.Tests/Internals/SentryStopwatchTests.cs
@@ -24,9 +24,13 @@ public class SentryStopwatchTests
         current.Should().BeCloseTo(DateTimeOffset.UtcNow, TestPrecision);
     }
 
-    [Fact]
+    [SkippableFact]
     public void Elapsed_IsValid()
     {
+#if IOS
+        Skip.If(TestEnvironment.IsGitHubActions, "Flaky on iOS in CI.");
+#endif
+
         var sleepTime = TimeSpan.FromMilliseconds(100);
 
         var sw = SentryStopwatch.StartNew();


### PR DESCRIPTION
Resolves #4510:
- https://github.com/getsentry/sentry-dotnet/issues/4510

#skip-changelog