### PR TITLE
fix: `SentryOptions.Native.SuppressSignalAborts` and `SuppressExcBadAccess` on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fail when building Blazor WASM with Profiling. We don't support profiling in Blazor WebAssembly projects. ([#4512](https://github.com/getsentry/sentry-dotnet/pull/4512))
 - Do not overwrite user IP if it is set manually in ASP.NET sdk ([#4513](https://github.com/getsentry/sentry-dotnet/pull/4513))
+- Fix `SentryOptions.Native.SuppressExcBadAccess` and `SentryOptions.Native.SuppressSignalAborts` ([#4521](https://github.com/getsentry/sentry-dotnet/pull/4521))
 
 ## 5.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fail when building Blazor WASM with Profiling. We don't support profiling in Blazor WebAssembly projects. ([#4512](https://github.com/getsentry/sentry-dotnet/pull/4512))
 - Do not overwrite user IP if it is set manually in ASP.NET sdk ([#4513](https://github.com/getsentry/sentry-dotnet/pull/4513))
-- Fix `SentryOptions.Native.SuppressExcBadAccess` and `SentryOptions.Native.SuppressSignalAborts` ([#4521](https://github.com/getsentry/sentry-dotnet/pull/4521))
+- Fix `SentryOptions.Native.SuppressSignalAborts` and `SuppressExcBadAccess` on iOS ([#4521](https://github.com/getsentry/sentry-dotnet/pull/4521))
 
 ## 5.15.0
 

--- a/src/Sentry/Platforms/Cocoa/SentrySdk.cs
+++ b/src/Sentry/Platforms/Cocoa/SentrySdk.cs
@@ -195,15 +195,15 @@ public static partial class SentrySdk
         => ProcessOnBeforeSend(options, evt, CurrentHub);
 
     /// <summary>
-    /// This overload allows us to inject an IHub for testing. During normal execution, the CurrentHub is used.
-    /// However, since this class is static, there's no easy alternative way to inject this when executing tests.
+    /// Apply suppression logic for redundant native `SIGABRT` and `EXC_BAD_ACCESS` crash events
+    /// that have already been captured as managed exceptions by the Sentry.NET SDK to avoid sending
+    /// duplicate events to Sentry - once managed and once native.
+    ///
+    /// The managed exception is what a .NET developer would expect, and it is sent by the Sentry.NET SDK
+    /// But we also get a native SIGABRT since it crashed the application, which is sent by the Sentry Cocoa SDK.
     /// </summary>
-    internal static CocoaSdk.SentryEvent? ProcessOnBeforeSend(SentryOptions options, CocoaSdk.SentryEvent evt, IHub hub)
+    private static bool SuppressNativeCrash(SentryOptions options, CocoaSdk.SentryEvent evt)
     {
-        // When we have an unhandled managed exception, we send that to Sentry twice - once managed and once native.
-        // The managed exception is what a .NET developer would expect, and it is sent by the Sentry.NET SDK
-        // But we also get a native SIGABRT since it crashed the application, which is sent by the Sentry Cocoa SDK.
-
         // There should only be one exception on the event in this case
         if ((options.Native.SuppressSignalAborts || options.Native.SuppressExcBadAccess) && evt.Exceptions?.Length == 1)
         {
@@ -219,7 +219,7 @@ public static partial class SentrySdk
                 // Don't send it
                 options.LogDebug("Discarded {0} error ({1}). Captured as  managed exception instead.", ex.Type,
                     ex.Value);
-                return null!;
+                return true;
             }
 
             // Similar workaround for NullReferenceExceptions. We don't have any easy way to know whether the
@@ -230,10 +230,28 @@ public static partial class SentrySdk
                 // Don't send it
                 options.LogDebug("Discarded {0} error ({1}). Captured as  managed exception instead.", ex.Type,
                     ex.Value);
-                return null!;
+                return true;
             }
         }
 
+        return false;
+    }
+
+    /// <summary>
+    /// This overload allows us to inject an IHub for testing. During normal execution, the CurrentHub is used.
+    /// However, since this class is static, there's no easy alternative way to inject this when executing tests.
+    /// </summary>
+    internal static CocoaSdk.SentryEvent? ProcessOnBeforeSend(SentryOptions options, CocoaSdk.SentryEvent evt, IHub hub)
+    {
+        // Redundant native crash events must be suppressed even if the SDK is
+        // disabled (or not yet fully initialized) to avoid sending duplicates.
+        // https://github.com/getsentry/sentry-dotnet/pull/4521#discussion_r2347616896
+        if (SuppressNativeCrash(options, evt))
+        {
+            return null!;
+        }
+
+        // If the SDK is disabled, there are no event processors or before send to run.
         if (hub is DisabledHub)
         {
             return evt;

--- a/src/Sentry/Platforms/Cocoa/SentrySdk.cs
+++ b/src/Sentry/Platforms/Cocoa/SentrySdk.cs
@@ -200,11 +200,6 @@ public static partial class SentrySdk
     /// </summary>
     internal static CocoaSdk.SentryEvent? ProcessOnBeforeSend(SentryOptions options, CocoaSdk.SentryEvent evt, IHub hub)
     {
-        if (hub is DisabledHub)
-        {
-            return evt;
-        }
-
         // When we have an unhandled managed exception, we send that to Sentry twice - once managed and once native.
         // The managed exception is what a .NET developer would expect, and it is sent by the Sentry.NET SDK
         // But we also get a native SIGABRT since it crashed the application, which is sent by the Sentry Cocoa SDK.
@@ -237,6 +232,11 @@ public static partial class SentrySdk
                     ex.Value);
                 return null!;
             }
+        }
+
+        if (hub is DisabledHub)
+        {
+            return evt;
         }
 
         // We run our SIGABRT checks first before running managed processors.

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -1041,6 +1041,47 @@ public class SentrySdkTests : IDisposable
         }
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ProcessOnBeforeSend_NativeErrorSuppressionBeforeHubInit(bool suppressNativeErrors)
+    {
+        // Arrange
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            DiagnosticLogger = _logger,
+            IsGlobalModeEnabled = true,
+            Debug = true,
+            AutoSessionTracking = false,
+            BackgroundWorker = Substitute.For<IBackgroundWorker>(),
+            InitNativeSdks = false,
+        };
+        options.Native.SuppressExcBadAccess = suppressNativeErrors;
+
+        var scope = new Scope(options);
+        // `SIGABRT` must be filtered out early on startup during
+        // the Cocoa SDK init before the Hub instance has been created
+        var hub = DisabledHub.Instance;
+
+        var evt = new Sentry.CocoaSdk.SentryEvent();
+        var ex = new Sentry.CocoaSdk.SentryException("Not checked", "EXC_BAD_ACCESS");
+        evt.Exceptions = [ex];
+
+        // Act
+        var result = SentrySdk.ProcessOnBeforeSend(options, evt, hub);
+
+        // Assert
+        if (suppressNativeErrors)
+        {
+            result.Should().BeNull();
+        }
+        else
+        {
+            result.Exceptions.First().Type.Should().Be("EXC_BAD_ACCESS");
+        }
+    }
+
     [Fact]
     public void ProcessOnBeforeSend_OptionsBeforeOnSendRuns()
     {


### PR DESCRIPTION
This PR fixes a regression in `SentryOptions.Native.SuppressExcBadAccess` and `SentryOptions.Native.SuppressSignalAborts`. Let `ProcessOnBeforeSend` filter out `SIGABRT` and `EXC_BAD_ACCESS` sent early on startup during the Cocoa SDK init, even before the .NET Hub instance has been created.

Fixes: #4520
