### PR TITLE
device-test.ps1: add verbose flag

### DIFF
--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -1,3 +1,4 @@
+[CmdletBinding()] # -Verbose
 param(
     [Parameter(Position = 0, Mandatory = $true)]
     [ValidateNotNullOrEmpty()]


### PR DESCRIPTION
Pass `-v` to XHarness when running `scripts/device-test.ps1 <device> -Run -Verbose` to make test details visible.

Default non-verbose:
```
$ pwsh scripts/device-test.ps1 ios -Run
info: Starting test run for io.sentry.dotnet.maui.device.testapp..
info: Application finished the test run successfully with some failed tests
info: Tests run: 2209 Passed: 2187 Inconclusive: 0 Failed: 2 Ignored: 20
info: Uninstalling the application 'io.sentry.dotnet.maui.device.testapp' from 'iPhone 16'
info: Application 'io.sentry.dotnet.maui.device.testapp' was uninstalled successfully
XHarness exit code: 1 (TESTS_FAILED)
Exception: /Users/jpnurmi/Projects/sentry/sentry-dotnet/scripts/device-test.ps1:103
Line |
 103 |                  throw 'xharness run failed with non-zero exit code'
     |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | xharness run failed with non-zero exit code
```

vs. verbose:

```
$ pwsh scripts/device-test.ps1 ios -Run -Verbose
info: Starting test run for io.sentry.dotnet.maui.device.testapp..
...
dbug: 2025-09-14 18:51:04.875514+0200 Sentry.Maui.Device.TestApp[15614:14582403] Failed tests:
dbug: 2025-09-14 18:51:04.875690+0200 Sentry.Maui.Device.TestApp[15614:14582403] 1)     [FAIL] Sentry.Tests.SentrySdkTests.ProcessOnBeforeSend_NativeErrorSuppression   Test name: Sentry.Tests.SentrySdkTests.ProcessOnBeforeSend_NativeErrorSuppression(suppressNativeErrors: True)   Test case: Sentry.Tests.SentrySdkTests.ProcessOnBeforeSend_NativeErrorSuppression
dbug: Assembly:  [Sentry.Tests, Version=5.15.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0]
dbug: 2025-09-14 18:51:04.875758+0200 Sentry.Maui.Device.TestApp[15614:14582403]    Exception messages: Expected object to be <null>, but found <SentryEvent: 0x600002d30600>.   Exception stack traces:    at FluentAssertions.Execution.XUnit2TestFramework.Throw(String message)
...
info: Application finished the test run successfully with some failed tests
info: Tests run: 2209 Passed: 2188 Inconclusive: 0 Failed: 1 Ignored: 20
info: Uninstalling the application 'io.sentry.dotnet.maui.device.testapp' from 'iPhone 16'
dbug:
dbug: Running /Applications/Xcode.app/Contents/Developer/usr/bin/simctl uninstall 233A8B7F-327E-4B4D-BB44-BE2396FCEB46 io.sentry.dotnet.maui.device.testapp
dbug: Process simctl exited with 0
info: Application 'io.sentry.dotnet.maui.device.testapp' was uninstalled successfully
Exception: /Users/jpnurmi/Projects/sentry/sentry-dotnet/scripts/device-test.ps1:104
Line |
 104 |                  throw 'xharness run failed with non-zero exit code'
     |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | xharness run failed with non-zero exit code
```

#skip-changelog