### PR TITLE
fix: Generate and inject uuid to apk and upload proguard with that uuid

### DIFF
--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -18,6 +18,7 @@
 
   <PropertyGroup>
     <SentryAttributesFile>Sentry.Attributes$(MSBuildProjectExtension.Replace('proj', ''))</SentryAttributesFile>
+    <ProguardUuid>$([System.Guid]::NewGuid())</ProguardUuid>
   </PropertyGroup>
 
   <Target Name="_SentryEnsureAndroidEnableAssemblyCompressionDisabled"
@@ -125,11 +126,17 @@
       <SentrySetCommitReleaseOptions Condition="'$(SentryOrg)' != ''">$(SentrySetCommitReleaseOptions) --org $(SentryOrg)</SentrySetCommitReleaseOptions>
       <SentrySetCommitReleaseOptions Condition="'$(SentryProject)' != ''">$(SentrySetCommitReleaseOptions) --project $(SentryProject)</SentrySetCommitReleaseOptions>
 
+      <SentryProguardOptions Condition="'$(ProguardUuid)' != ''">$(SentryProguardOptions) --uuid &quot;$(ProguardUuid)&quot;</SentryProguardOptions>
+      <SentryProguardOptions Condition="'$(ApplicationId)' != ''">$(SentryProguardOptions) --app-id &quot;$(ApplicationId)&quot;</SentryProguardOptions>
+      <SentryProguardOptions Condition="'$(ApplicationDisplayVersion)' != ''">$(SentryProguardOptions) --version &quot;$(ApplicationDisplayVersion)&quot;</SentryProguardOptions>
+      <SentryProguardOptions Condition="'$(ApplicationVersion)' != ''">$(SentryProguardOptions) --version-code &quot;$(ApplicationVersion)&quot;</SentryProguardOptions>
+      <SentryProguardOptions Condition="'$(SentryProguardOptions.Trim())' != ''">$(SentryProguardOptions.trim())</SentryProguardOptions>
+
       <SentryCLIUploadOptions Condition="'$(SentryOrg)' != ''">$(SentryCLIUploadOptions) --org $(SentryOrg)</SentryCLIUploadOptions>
       <SentryCLIUploadOptions Condition="'$(SentryProject)' != ''">$(SentryCLIUploadOptions) --project $(SentryProject)</SentryCLIUploadOptions>
       <SentryCLIDebugFilesUploadCommand>$(SentryCLIBaseCommand) debug-files upload</SentryCLIDebugFilesUploadCommand>
       <SentryCLIDebugFilesUploadCommand Condition="'$(SentryCLIUploadOptions.Trim())' != ''">$(SentryCLIDebugFilesUploadCommand) $(SentryCLIUploadOptions.Trim())</SentryCLIDebugFilesUploadCommand>
-      <SentryCLIProGuardMappingUploadCommand>$(SentryCLIBaseCommand) upload-proguard</SentryCLIProGuardMappingUploadCommand>
+      <SentryCLIProGuardMappingUploadCommand>$(SentryCLIBaseCommand) upload-proguard $(SentryProguardOptions)</SentryCLIProGuardMappingUploadCommand>
       <SentryCLIProGuardMappingUploadCommand Condition="'$(SentryCLIUploadOptions.Trim())' != ''">$(SentryCLIProGuardMappingUploadCommand) $(SentryCLIUploadOptions.Trim())</SentryCLIProGuardMappingUploadCommand>
     </PropertyGroup>
 
@@ -265,6 +272,16 @@
       </Exec>
     <!-- } -->
     <Warning Condition="'$(_SentryCLIExitCode)' != '0'" Text="Sentry CLI could not upload debug files." />
+  </Target>
+
+  <Target Name="UpdateAndroidMetadata" BeforeTargets="GetAssemblyAttributes">
+
+    <ItemGroup>
+      <AssemblyAttribute Include="Android.App.MetaData">
+        <_Parameter1>io.sentry.proguard-uuid</_Parameter1>
+        <Value>$(ProguardUuid)</Value>
+      </AssemblyAttribute>
+    </ItemGroup>
   </Target>
 
   <!-- Upload Android Proguard mapping file to Sentry after the build. -->

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -70,8 +70,7 @@
       <UseSentryCLI Condition="
         '$(UseSentryCLI)' == ''
         and ('$(SentryUploadSymbols)' == 'true' or '$(SentryUploadSources)' == 'true' or $(SentryUploadAndroidProguardMapping) == 'true' or $(SentryCreateRelease) == 'true' or $(SentrySetCommits) == 'true')
-        and '$(MSBuildProjectName)' != 'Sentry'
-        and !$(MSBuildProjectName.StartsWith('Sentry.'))">true</UseSentryCLI>
+        ">true</UseSentryCLI>
     </PropertyGroup>
   </Target>
 
@@ -274,7 +273,7 @@
     <Warning Condition="'$(_SentryCLIExitCode)' != '0'" Text="Sentry CLI could not upload debug files." />
   </Target>
 
-  <Target Name="UpdateAndroidMetadata" BeforeTargets="GetAssemblyAttributes">
+  <Target Name="UpdateAndroidMetadata" BeforeTargets="GetAssemblyAttributes" Condition="'$(SentryUploadAndroidProguardMapping)' == 'true'">
 
     <ItemGroup>
       <AssemblyAttribute Include="Android.App.MetaData">


### PR DESCRIPTION
fixes #3872 

# Problem

We were not automatically injecting uuid to the MAUI Android apk, so developers would have to manually go in and edit `AndroidManifest.xml`.

# Solution

As proposed by @rafalka, we can inject the uuid to the Apk, and upload the proguard file with the same uuid.

## Before

Before the fix, running  in the MAUI project would upload the proguard file with the uuid, but it won't inject the uuid to the Android app.

## After

We should now see the proguard file in Sentry with some uuid:

<img width="1389" height="227" alt="image" src="https://github.com/user-attachments/assets/05622d01-5705-41ea-a44b-782d55e5b9d6" />

If we open the resulting APK in Android studio to inspect it's `AndroidManifest.xml`, we can see that it correctly set the `meta-data` field:

<img width="558" height="84" alt="image" src="https://github.com/user-attachments/assets/bba377c6-4266-45f0-81d9-d611acda76f5" />

## Testing method

To test this change using our `samples/Sentry.Samples.Maui`, we need to modify `src/Sentry/buildTransitive/Sentry.targets` file. If not using our sample MAUI project, ignore this step.

We have to remove the check whether this is a Sentry project or not. So delete the `and [...]` in line 72-73:

https://github.com/getsentry/sentry-dotnet/blob/7061fb92d58ecd138228e3689a97c72fdab3b6e4/src/Sentry/buildTransitive/Sentry.targets#L69-L73

Next, ensure `SentryUploadAndroidProguardMapping` is set to true in your MAUI project's .csproj file:

```
    <SentryUploadAndroidProguardMapping>true</SentryUploadAndroidProguardMapping>
```

In the same file, enable Proguard. This is what I used:

```
  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
    <AndroidLinkTool>r8</AndroidLinkTool>
    <AndroidLinkMode>Full</AndroidLinkMode>
    <AndroidEnableProguard>true</AndroidEnableProguard>
  </PropertyGroup>
```

Run `dotnet publish -f net9.0-android35.0 -c Release` in the MAUI project root.
