### PR TITLE
WIP: Prevent Cocoa SDK from capturing errors that also get captured by .NET

### DIFF
--- a/.github/actions/buildcocoasdk/action.yml
+++ b/.github/actions/buildcocoasdk/action.yml
@@ -1,0 +1,17 @@
+name: Build Native Dependencies
+description: Builds Sentry Cocoa SDK with custom Carthage
+runs:
+  using: composite
+
+  steps:
+    - name: Cache Sentry Cocoa SDK
+      id: cache-sentry-cocoa
+      uses: actions/cache@v3
+      with:
+        path: modules/sentry-cocoa/Carthage
+        key: sentry-cocoa-${{ hashFiles('scripts/build-sentry-cocoa.sh') }}-${{ hashFiles('.git/modules/modules/sentry-cocoa/HEAD') }}
+
+    - name: Build Sentry Cocoa SDK
+      if: ${{ steps.cache-sentry-cocoa.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: scripts/build-sentry-cocoa.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,6 +204,10 @@ jobs:
         if: ${{ !matrix.container }}
         uses: ./.github/actions/buildnative
 
+      - name: Build Cocoa SDK
+        if: runner.os == 'macOS'
+        uses: ./.github/actions/buildcocoasdk
+
       - name: Restore .NET Dependencies
         run: dotnet restore ${{ matrix.slnf }} --nologo
 

--- a/.github/workflows/device-tests-ios.yml
+++ b/.github/workflows/device-tests-ios.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Build Cocoa SDK
+        uses: ./.github/actions/buildcocoasdk
+
       - name: Setup Environment
         uses: ./.github/actions/environment
 

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - name: Cocoa SDK
-            path: modules/sentry-cocoa.properties
+            path: modules/sentry-cocoa
           - name: Java SDK
             path: scripts/update-java.ps1
           - name: Native SDK

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,3 @@ test/**/*.apk
 *.log
 .sentry-native
 **/EnvironmentVariables.g.cs
-
-# Download cache for Cocoa SDK
-modules/sentry-cocoa

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,9 @@
 [submodule "modules/Ben.Demystifier"]
 	path = modules/Ben.Demystifier
 	url = https://github.com/getsentry/Ben.Demystifier
+[submodule "modules/sentry-cocoa"]
+	path = modules/sentry-cocoa
+	url = https://github.com/getsentry/sentry-cocoa.git
 [submodule "modules/perfview"]
 	path = modules/perfview
 	url = https://github.com/getsentry/perfview.git

--- a/Sentry.sln
+++ b/Sentry.sln
@@ -156,9 +156,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SingleFileTestApp", "test\SingleFileTestApp\SingleFileTestApp.csproj", "{162A1CAE-ACEE-45CA-A6D0-7702ADE4D3DE}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "modules", "modules", "{A3CCA27E-4DF8-479D-833C-CAA0950715AA}"
-	ProjectSection(SolutionItems) = preProject
-		modules\sentry-cocoa.properties = modules\sentry-cocoa.properties
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TraceEvent", "modules\perfview\src\TraceEvent\TraceEvent.csproj", "{67269916-C417-4CEE-BD7D-CA66C3830AEE}"
 EndProject

--- a/modules/sentry-cocoa.properties
+++ b/modules/sentry-cocoa.properties
@@ -1,2 +1,0 @@
-version = 8.56.0
-repo = https://github.com/getsentry/sentry-cocoa

--- a/samples/Sentry.Samples.Maui/MainPage.xaml
+++ b/samples/Sentry.Samples.Maui/MainPage.xaml
@@ -56,6 +56,12 @@
                 HorizontalOptions="Center" />
 
             <Button
+                x:Name="NreBtn"
+                Text="NRE"
+                Clicked="OnNreClicked"
+                HorizontalOptions="Center" />
+
+            <Button
                 x:Name="ThrowBackgroundUnhandledBtn"
                 Text="Throw Unhandled .NET Exception on Background Thread (Crash)"
                 SemanticProperties.Hint="Throws an unhandled .NET exception on a background thread, crashing the app."

--- a/samples/Sentry.Samples.Maui/MainPage.xaml.cs
+++ b/samples/Sentry.Samples.Maui/MainPage.xaml.cs
@@ -52,6 +52,24 @@ public partial class MainPage
 #pragma warning restore CS0618
     }
 
+    private void OnNreClicked(object sender, EventArgs e)
+    {
+        Console.WriteLine("### BEGIN OnNreClicked");
+        try
+        {
+            object obj = null;
+            obj.ToString();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"### CATCH {ex}");
+        }
+        finally
+        {
+            Console.WriteLine("### END OnNreClicked");
+        }
+    }
+
     private void OnBackgroundThreadUnhandledExceptionClicked(object sender, EventArgs e)
     {
 #pragma warning disable CS0618

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -54,7 +54,7 @@ echo "::endgroup::"
 
 # Copy headers - used for generating bindings
 mkdir Carthage/Headers
-find Carthage/Build-ios/Sentry.xcframework/ios-arm64 -name '*.h' -exec cp {} Carthage/Headers \;
+find Carthage/Build-ios/Sentry.xcframework/ios-arm64_arm64e -name '*.h' -exec cp {} Carthage/Headers \;
 
 # Remove anything we don't want to bundle in the nuget package.
 find Carthage/Build* \( -name Headers -o -name PrivateHeaders -o -name Modules \) -exec rm -rf {} +

--- a/scripts/generate-cocoa-bindings.ps1
+++ b/scripts/generate-cocoa-bindings.ps1
@@ -4,7 +4,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $RootPath = (Get-Item $PSScriptRoot).Parent.FullName
-$CocoaSdkPath = "$RootPath/modules/sentry-cocoa/Sentry.framework"
+$CocoaSdkPath = "$RootPath/modules/sentry-cocoa"
 $BindingsPath = "$RootPath/src/Sentry.Bindings.Cocoa"
 $BackupPath = "$BindingsPath/obj/_unpatched"
 
@@ -101,7 +101,7 @@ Write-Output "iPhoneSdkVersion: $iPhoneSdkVersion"
 # ...instead of:
 #     `#import "SomeHeader.h"`
 # This causes sharpie to fail resolve those headers
-$filesToPatch = Get-ChildItem -Path "$CocoaSdkPath/Headers" -Filter *.h -Recurse | Select-Object -ExpandProperty FullName
+$filesToPatch = Get-ChildItem -Path "$CocoaSdkPath/Carthage/Headers" -Filter *.h -Recurse | Select-Object -ExpandProperty FullName
 foreach ($file in $filesToPatch)
 {
     if (Test-Path $file)
@@ -116,7 +116,7 @@ foreach ($file in $filesToPatch)
         Write-Host "File not found: $file"
     }
 }
-$privateHeaderFile = "$CocoaSdkPath/PrivateHeaders/PrivatesHeader.h"
+$privateHeaderFile = "$CocoaSdkPath/Carthage/Headers/PrivatesHeader.h"
 if (Test-Path $privateHeaderFile)
 {
     $content = Get-Content -Path $privateHeaderFile -Raw
@@ -133,9 +133,9 @@ else
 # Generate bindings
 Write-Output 'Generating bindings with Objective Sharpie.'
 sharpie bind -sdk $iPhoneSdkVersion `
-    -scope "$CocoaSdkPath" `
-    "$CocoaSdkPath/Headers/Sentry.h" `
-    "$CocoaSdkPath/PrivateHeaders/PrivateSentrySDKOnly.h" `
+    -scope "$CocoaSdkPath/Carthage/Headers" `
+    "$CocoaSdkPath/Carthage/Headers/Sentry.h" `
+    "$CocoaSdkPath/Carthage/Headers/PrivateSentrySDKOnly.h" `
     -o $BindingsPath `
     -c -Wno-objc-property-no-attribute
 

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -7,7 +7,6 @@
 using System;
 using Foundation;
 using ObjCRuntime;
-using Sentry;
 using UIKit;
 
 namespace Sentry.CocoaSdk;

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -7,11 +7,8 @@
     <IsBindingProject>true</IsBindingProject>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
     <Description>.NET Bindings for the Sentry Cocoa SDK</Description>
-    <SentryCocoaCache>..\..\modules\sentry-cocoa\</SentryCocoaCache>
-    <SentryCocoaFrameworkHeaders>$(SentryCocoaCache)Sentry.framework\</SentryCocoaFrameworkHeaders>
-    <SentryCocoaProperties>$([System.IO.File]::ReadAllText("$(MSBuildThisFileDirectory)../../modules/sentry-cocoa.properties"))</SentryCocoaProperties>
-    <SentryCocoaVersion>$([System.Text.RegularExpressions.Regex]::Match($(SentryCocoaProperties), 'version\s*=\s*([^\s]+)').Groups[1].Value)</SentryCocoaVersion>
-    <SentryCocoaFramework>$(SentryCocoaCache)Sentry-$(SentryCocoaVersion).xcframework</SentryCocoaFramework>
+    <SentryCocoaSdkDirectory>..\..\modules\sentry-cocoa\</SentryCocoaSdkDirectory>
+    <SentryCocoaFramework>$(SentryCocoaSdkDirectory)Carthage\Build-$(TargetPlatformIdentifier)\Sentry.xcframework</SentryCocoaFramework>
     <!-- SentrySpan.g.cs: error CS0108: 'ISentrySpan.Serialize()' hides inherited member 'ISentrySerializable.Serialize()'. Use the new keyword if hiding was intended -->
     <NoWarn>$(NoWarn);CS0108</NoWarn>
   </PropertyGroup>
@@ -51,60 +48,18 @@
     <None Include="buildTransitive\Sentry.Bindings.Cocoa.targets" Pack="true" PackagePath="buildTransitive\Sentry.Bindings.Cocoa.targets" />
   </ItemGroup>
 
-  <!-- Downloads and sets up the Cocoa SDK: dotnet msbuild /t:setupCocoaSDK src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj -->
-  <Target Name="_SetupCocoaSDK"
-          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')">
-
-    <Message Importance="High" Text="Setting up the Cocoa SDK version '$(SentryCocoaVersion)'." />
-
-    <!-- Clean cache if version does not exist to get rid of old versions -->
-    <RemoveDir
-      Condition="!Exists('$(SentryCocoaFramework).zip')"
-      Directories="$(SentryCocoaCache)" />
-
-    <!-- Create cache directory -->
-    <MakeDir Condition="!Exists('$(SentryCocoaCache)')" Directories="$(SentryCocoaCache)" />
-
-    <!-- Download the Cocoa SDK as pre-built .xcframework -->
-    <Exec
-      Condition="!Exists('$(SentryCocoaFramework).zip')"
-      Command="curl -L https://github.com/getsentry/sentry-cocoa/releases/download/$(SentryCocoaVersion)/Sentry-Dynamic.xcframework.zip -o $(SentryCocoaFramework).zip" />
-
-    <Exec
-      Condition="Exists('$(SentryCocoaFramework).zip') and !Exists('$(SentryCocoaFramework)')"
-      Command="unzip -o $(SentryCocoaFramework).zip -d $(SentryCocoaCache) &amp;&amp; mv $(SentryCocoaCache)Sentry-Dynamic.xcframework $(SentryCocoaFramework)" />
-
-    <!-- Make a copy of the header files before we butcher these to suite objective sharpie -->
-    <MakeDir Directories="$(SentryCocoaFrameworkHeaders)" />
-    <ItemGroup>
-      <FilesToCopy Include="$(SentryCocoaFramework)\ios-arm64\Sentry.framework\**\*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(FilesToCopy)"
-          DestinationFolder="$(SentryCocoaFrameworkHeaders)%(RecursiveDir)"
-          SkipUnchangedFiles="true" />
+  <!-- Build the Sentry Cocoa SDK -->
+  <Target Name="_BuildSentryCocoaSDK" BeforeTargets="DispatchToInnerBuilds;BeforeBuild" Condition="'$(CI)' != 'true' and $([MSBuild]::IsOSPlatform('OSX'))"
+    Inputs="..\..\.git\modules\modules\sentry-cocoa\HEAD" Outputs="..\..\modules\sentry-cocoa\Carthage\.built-from-sha">
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="_InnerBuildSentryCocoaSDK" Properties="TargetFramework=once" />
   </Target>
-
-  <!-- Setup exactly once: https://learn.microsoft.com/visualstudio/msbuild/run-target-exactly-once -->
-  <Target Name="SetupCocoaSDKBeforeOuterBuild" DependsOnTargets="_SetupCocoaSDK"
-          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')"
-          BeforeTargets="DispatchToInnerBuilds" />
-
-  <Target Name="SetupCocoaSDK"
-          BeforeTargets="BeforeBuild"
-          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')">
-    <!-- Setup exactly once: https://learn.microsoft.com/visualstudio/msbuild/run-target-exactly-once -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_SetupCocoaSDK" RemoveProperties="TargetFramework" />
-  </Target>
-
-  <Target Name="CleanCocoaSDK" AfterTargets="Clean" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-    <RemoveDir Directories="$(SentryCocoaCache)" ContinueOnError="true" />
+  <Target Name="_InnerBuildSentryCocoaSDK">
+    <Exec Command="../../scripts/build-sentry-cocoa.sh" />
   </Target>
 
   <!-- Generate bindings -->
-  <Target Name="_GenerateSentryCocoaBindings" AfterTargets="SetupCocoaSDK"
-          Condition="$([MSBuild]::IsOSPlatform('OSX')) and Exists('$(SentryCocoaFrameworkHeaders)')"
-          Inputs="../../modules/sentry-cocoa.properties;../../scripts/generate-cocoa-bindings.ps1"
-          Outputs="ApiDefinitions.cs;StructsAndEnums.cs">
+  <Target Name="_GenerateSentryCocoaBindings" AfterTargets="_BuildSentryCocoaSDK" Condition="$([MSBuild]::IsOSPlatform('OSX'))"
+          Inputs="..\..\modules\sentry-cocoa\Carthage\.built-from-sha" Outputs="ApiDefinitions.cs;StructsAndEnums.cs">
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="_InnerGenerateSentryCocoaBindings" Properties="TargetFramework=once" />
   </Target>
   <Target Name="_InnerGenerateSentryCocoaBindings">

--- a/src/Sentry.Bindings.Cocoa/StructsAndEnums.cs
+++ b/src/Sentry.Bindings.Cocoa/StructsAndEnums.cs
@@ -7,7 +7,6 @@
 using System.Runtime.InteropServices;
 using Foundation;
 using ObjCRuntime;
-using Sentry;
 
 namespace Sentry.CocoaSdk;
 


### PR DESCRIPTION
Test bed for:
- #3954
- getsentry/sentry-cocoa#6193

#skip-changelog