### PR TITLE
ci: install Mono for Ubuntu (ARM64)

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -76,7 +76,7 @@ runs:
         brew install mono || true
         brew link --overwrite mono
 
-    - name: Install Mono (Linux)
+    - name: Install Mono (Ubuntu)
       if: ${{ runner.os == 'Linux' && !matrix.container }}
       shell: bash
       run: |

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -67,7 +67,7 @@ runs:
         distribution: ${{ runner.os == 'Windows' && runner.arch == 'ARM64' && 'microsoft' || 'temurin' }}
         java-version: '11'
 
-    - name: Install Mono
+    - name: Install Mono (macOS)
       if: runner.os == 'macOS'
       shell: bash
       # Attempt to install Mono, allowing it to fail silently
@@ -75,6 +75,14 @@ runs:
       run: |
         brew install mono || true
         brew link --overwrite mono
+
+    - name: Install Mono (Linux)
+      if: ${{ runner.os == 'Linux' && !matrix.container }}
+      shell: bash
+      run: |
+        sudo apt install -y mono-devel
+        # restore perms for actions/setup-dotnet
+        sudo chmod -R a+rw /usr/share/dotnet
 
     - name: Install .NET SDK
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04 # Pin ubuntu to ensure mono is installed
+          - os: ubuntu-22.04
             rid: linux-x64
           - os: ubuntu-22.04-arm
             rid: linux-arm64
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04 # Pin ubuntu to ensure mono is installed
+          - os: ubuntu-22.04
             rid: linux-x64
             slnf: Sentry-CI-Build-Linux.slnf
           - os: ubuntu-22.04-arm


### PR DESCRIPTION
The latest `ubuntu-22.04-arm` VM image no longer has Mono pre-installed.

P.S. We can let APT install Mono on any Ubuntu runner regardless of its version or architecture. It's a quick no-op on those Ubuntu runners (22.04/x64) that have it pre-installed. This way, we're prepared and can more easily bump to a newer Ubuntu when the time comes.

Close: #4543

#skip-changelog