### PR TITLE
chore(deps): bump coverlet.collector to avoid vulnerability warnings

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -65,7 +65,7 @@
     <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 
   <!-- these are needed because the versions that are brought in transitively have vulnerability warnings -->


### PR DESCRIPTION
JetBrains Rider keeps nagging even if we have explicitly pinned the transitive `Newtonsoft.Json` dependency. Is it ok to bump the version for tests to get rid of the vulnerability warnings?

<img width="887" height="255" alt="image" src="https://github.com/user-attachments/assets/313fad85-9c4d-4c82-a8c0-c72cae550a4a" />

<img width="1461" height="356" alt="image" src="https://github.com/user-attachments/assets/8c6b3502-21b0-4912-8d3d-3592fa485988" />