### PR TITLE
chore: Disable flaky Profiler_AfterTimeout_Stops in CI

### DIFF
--- a/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs
+++ b/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs
@@ -166,7 +166,7 @@ public class SamplingTransactionProfilerTests
     [SkippableFact]
     public async Task Profiler_AfterTimeout_Stops()
     {
-        Skip.If(TestEnvironment.IsGitHubActions && RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Flaky in CI on Windows");
+        Skip.If(TestEnvironment.IsGitHubActions, "Flaky in CI");
 
         SampleProfilerSession? session = null;
         SkipIfFailsInCI(() => session = SampleProfilerSession.StartNew(_testOutputLogger));


### PR DESCRIPTION
Resolves #4548
- https://github.com/getsentry/sentry-dotnet/issues/4548

#skip-changelog