### PR TITLE
build: allow local `modules/sentry-cocoa` clone for development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,3 +171,26 @@ Once changes to Ben.Demystifier have been merged into the main branch then, the 
 should be updated from the main branch and the `modules/make-internal.sh` script run again (if necessary). This repo 
 should reference the most recent commit on the `internal` branch of Ben.Demystifier then (functionally identical to the
 main branch - the only difference being the changes to member visibility).
+
+## Local Sentry Cocoa SDK checkout
+
+By default, `Sentry.Bindings.Cocoa` downloads a pre-built Sentry Cocoa SDK from
+GitHub Releases. The version is specified in `modules/sentry-cocoa.properties`.
+
+If you want to build an unreleased Sentry Cocoa SDK version from source instead,
+replace the pre-built SDK with [getsentry/sentry-cocoa](https://github.com/getsentry/sentry-cocoa/)
+by cloning it into the `modules/sentry-cocoa` directory:
+
+```sh
+$ rm -rf modules/sentry-cocoa
+$ gh repo clone getsentry/sentry-cocoa modules/sentry-cocoa
+$ dotnet build ... # uses modules/sentry-cocoa as is
+```
+
+To switch back to the pre-built SDK, delete the `modules/sentry-cocoa` directory
+and let the next build download the pre-built SDK again:
+
+```sh
+$ rm -rf modules/sentry-cocoa
+$ dotnet build ... # downloads pre-built Cocoa SDK into modules/sentry-cocoa
+```

--- a/modules/README.md
+++ b/modules/README.md
@@ -15,13 +15,3 @@ To make sure we're not exposing any API from that library externally.
 Fork [getsentry/perfview](https://github.com/getsentry/perfview/).
 Tool from the .NET team which includes several utilities used for profiling .NET code. 
 We use that in our `Sentry.Profiling` package.
-
-### sentry-cocoa
-
-By default, `Sentry.Bindings.Cocoa` downloads a pre-built Sentry Cocoa SDK from
-GitHub Releases. The version is specified in `sentry-cocoa.properties`.
-
-If you want to build an unreleased Sentry Cocoa SDK version from source instead,
-replace the pre-built SDK with [getsentry/sentry-cocoa](https://github.com/getsentry/sentry-cocoa/)
-by cloning it into the `modules/sentry-cocoa` directory. To switch back to the
-pre-built SDK, delete the `modules/sentry-cocoa` directory.

--- a/modules/README.md
+++ b/modules/README.md
@@ -15,3 +15,13 @@ To make sure we're not exposing any API from that library externally.
 Fork [getsentry/perfview](https://github.com/getsentry/perfview/).
 Tool from the .NET team which includes several utilities used for profiling .NET code. 
 We use that in our `Sentry.Profiling` package.
+
+### sentry-cocoa
+
+By default, `Sentry.Bindings.Cocoa` downloads a pre-built Sentry Cocoa SDK from
+GitHub Releases. The version is specified in `sentry-cocoa.properties`.
+
+If you want to build an unreleased Sentry Cocoa SDK version from source instead,
+replace the pre-built SDK with [getsentry/sentry-cocoa](https://github.com/getsentry/sentry-cocoa/)
+by cloning it into the `modules/sentry-cocoa` directory. To switch back to the
+pre-built SDK, delete the `modules/sentry-cocoa` directory.

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -54,13 +54,13 @@ echo "::endgroup::"
 
 # Copy headers - used for generating bindings
 mkdir Carthage/Headers
-find Carthage/Build-ios/Sentry.xcframework/ios-arm64 -name '*.h' -exec cp {} Carthage/Headers \;
+find Carthage/Build-ios/Sentry.xcframework/ios-arm64_arm64e -name '*.h' -exec cp {} Carthage/Headers \;
 
 # Remove anything we don't want to bundle in the nuget package.
 find Carthage/Build* \( -name Headers -o -name PrivateHeaders -o -name Modules \) -exec rm -rf {} +
 rm -rf Carthage/output-*
 
-cp ../../.git/modules/modules/sentry-cocoa/HEAD Carthage/.built-from-sha
+cp .git/HEAD Carthage/.built-from-sha
 echo ""
 
 popd >/dev/null

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -25,6 +25,7 @@ xcodebuild archive -project Sentry.xcodeproj \
     -archivePath ./Carthage/output-ios.xcarchive \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+./scripts/remove-architectures.sh ./Carthage/output-ios.xcarchive arm64e
 xcodebuild archive -project Sentry.xcodeproj \
     -scheme Sentry \
     -configuration Release \
@@ -47,6 +48,7 @@ xcodebuild archive -project Sentry.xcodeproj \
     -archivePath ./Carthage/output-maccatalyst.xcarchive \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+./scripts/remove-architectures.sh ./Carthage/output-maccatalyst.xcarchive arm64e
 xcodebuild -create-xcframework \
     -framework ./Carthage/output-maccatalyst.xcarchive/Products/Library/Frameworks/Sentry.framework \
     -output ./Carthage/Build-maccatalyst/Sentry.xcframework
@@ -54,7 +56,7 @@ echo "::endgroup::"
 
 # Copy headers - used for generating bindings
 mkdir Carthage/Headers
-find Carthage/Build-ios/Sentry.xcframework/ios-arm64_arm64e -name '*.h' -exec cp {} Carthage/Headers \;
+find Carthage/Build-ios/Sentry.xcframework/ios-arm64 -name '*.h' -exec cp {} Carthage/Headers \;
 
 # Remove anything we don't want to bundle in the nuget package.
 find Carthage/Build* \( -name Headers -o -name PrivateHeaders -o -name Modules \) -exec rm -rf {} +

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -11,7 +11,8 @@
     <SentryCocoaFrameworkHeaders>$(SentryCocoaCache)Sentry.framework\</SentryCocoaFrameworkHeaders>
     <SentryCocoaProperties>$([System.IO.File]::ReadAllText("$(MSBuildThisFileDirectory)../../modules/sentry-cocoa.properties"))</SentryCocoaProperties>
     <SentryCocoaVersion>$([System.Text.RegularExpressions.Regex]::Match($(SentryCocoaProperties), 'version\s*=\s*([^\s]+)').Groups[1].Value)</SentryCocoaVersion>
-    <SentryCocoaFramework>$(SentryCocoaCache)Sentry-$(SentryCocoaVersion).xcframework</SentryCocoaFramework>
+    <SentryCocoaFramework Condition="!Exists('$(SentryCocoaCache).git')">$(SentryCocoaCache)Sentry-$(SentryCocoaVersion).xcframework</SentryCocoaFramework>
+    <SentryCocoaFramework Condition="Exists('$(SentryCocoaCache).git')">$(SentryCocoaCache)Carthage\Build-$(TargetPlatformIdentifier)\Sentry.xcframework</SentryCocoaFramework>
     <!-- SentrySpan.g.cs: error CS0108: 'ISentrySpan.Serialize()' hides inherited member 'ISentrySerializable.Serialize()'. Use the new keyword if hiding was intended -->
     <NoWarn>$(NoWarn);CS0108</NoWarn>
   </PropertyGroup>
@@ -52,8 +53,8 @@
   </ItemGroup>
 
   <!-- Downloads and sets up the Cocoa SDK: dotnet msbuild /t:setupCocoaSDK src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj -->
-  <Target Name="_SetupCocoaSDK"
-          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')">
+  <Target Name="_DownloadCocoaSDK"
+          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaCache).git')">
 
     <Message Importance="High" Text="Setting up the Cocoa SDK version '$(SentryCocoaVersion)'." />
 
@@ -84,6 +85,20 @@
           SkipUnchangedFiles="true" />
   </Target>
 
+  <!-- Build the Sentry Cocoa SDK from source -->
+  <Target Name="_BuildCocoaSDK"
+          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)') And Exists('$(SentryCocoaCache).git')"
+          Inputs="..\..\modules\modules\sentry-cocoa\.git\HEAD" Outputs="..\..\modules\sentry-cocoa\Carthage\.built-from-sha">
+
+    <Message Importance="High" Text="Building the Cocoa SDK from source." />
+    <Exec Command="bash ../../scripts/build-sentry-cocoa.sh" IgnoreStandardErrorWarningFormat="true" />
+  </Target>
+
+  <!-- Choose between download and build -->
+  <Target Name="_SetupCocoaSDK"
+          DependsOnTargets="_DownloadCocoaSDK;_BuildCocoaSDK"
+          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')" />
+
   <!-- Setup exactly once: https://learn.microsoft.com/visualstudio/msbuild/run-target-exactly-once -->
   <Target Name="SetupCocoaSDKBeforeOuterBuild" DependsOnTargets="_SetupCocoaSDK"
           Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')"
@@ -102,8 +117,8 @@
 
   <!-- Generate bindings -->
   <Target Name="_GenerateSentryCocoaBindings" AfterTargets="SetupCocoaSDK"
-          Condition="$([MSBuild]::IsOSPlatform('OSX')) and Exists('$(SentryCocoaFrameworkHeaders)')"
-          Inputs="../../modules/sentry-cocoa.properties;../../scripts/generate-cocoa-bindings.ps1"
+          Condition="$([MSBuild]::IsOSPlatform('OSX'))"
+          Inputs="../../modules/sentry-cocoa.properties;../../scripts/generate-cocoa-bindings.ps1;../../modules/sentry-cocoa/Carthage/.built-from-sha"
           Outputs="ApiDefinitions.cs;StructsAndEnums.cs">
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="_InnerGenerateSentryCocoaBindings" Properties="TargetFramework=once" />
   </Target>

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -88,7 +88,7 @@
   <!-- Build the Sentry Cocoa SDK from source -->
   <Target Name="_BuildCocoaSDK"
           Condition="$([MSBuild]::IsOSPlatform('OSX')) And Exists('$(SentryCocoaCache).git')"
-          Inputs="..\..\modules\modules\sentry-cocoa\.git\HEAD" Outputs="..\..\modules\sentry-cocoa\Carthage\.built-from-sha">
+          Inputs="..\..\modules\sentry-cocoa\.git\HEAD" Outputs="..\..\modules\sentry-cocoa\Carthage\.built-from-sha">
 
     <Message Importance="High" Text="Building the Cocoa SDK from source." />
     <Exec Command="bash ../../scripts/build-sentry-cocoa.sh" IgnoreStandardErrorWarningFormat="true" />

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -54,7 +54,7 @@
 
   <!-- Downloads and sets up the Cocoa SDK: dotnet msbuild /t:setupCocoaSDK src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj -->
   <Target Name="_DownloadCocoaSDK"
-          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaCache).git')">
+          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaCache).git') And !Exists('$(SentryCocoaFramework)')">
 
     <Message Importance="High" Text="Setting up the Cocoa SDK version '$(SentryCocoaVersion)'." />
 
@@ -87,7 +87,7 @@
 
   <!-- Build the Sentry Cocoa SDK from source -->
   <Target Name="_BuildCocoaSDK"
-          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)') And Exists('$(SentryCocoaCache).git')"
+          Condition="$([MSBuild]::IsOSPlatform('OSX')) And Exists('$(SentryCocoaCache).git')"
           Inputs="..\..\modules\modules\sentry-cocoa\.git\HEAD" Outputs="..\..\modules\sentry-cocoa\Carthage\.built-from-sha">
 
     <Message Importance="High" Text="Building the Cocoa SDK from source." />
@@ -97,16 +97,16 @@
   <!-- Choose between download and build -->
   <Target Name="_SetupCocoaSDK"
           DependsOnTargets="_DownloadCocoaSDK;_BuildCocoaSDK"
-          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')" />
+          Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
 
   <!-- Setup exactly once: https://learn.microsoft.com/visualstudio/msbuild/run-target-exactly-once -->
   <Target Name="SetupCocoaSDKBeforeOuterBuild" DependsOnTargets="_SetupCocoaSDK"
-          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')"
+          Condition="$([MSBuild]::IsOSPlatform('OSX'))"
           BeforeTargets="DispatchToInnerBuilds" />
 
   <Target Name="SetupCocoaSDK"
           BeforeTargets="BeforeBuild"
-          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaFramework)')">
+          Condition="$([MSBuild]::IsOSPlatform('OSX'))">
     <!-- Setup exactly once: https://learn.microsoft.com/visualstudio/msbuild/run-target-exactly-once -->
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_SetupCocoaSDK" RemoveProperties="TargetFramework" />
   </Target>

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -11,10 +11,16 @@
     <SentryCocoaFrameworkHeaders>$(SentryCocoaCache)Sentry.framework\</SentryCocoaFrameworkHeaders>
     <SentryCocoaProperties>$([System.IO.File]::ReadAllText("$(MSBuildThisFileDirectory)../../modules/sentry-cocoa.properties"))</SentryCocoaProperties>
     <SentryCocoaVersion>$([System.Text.RegularExpressions.Regex]::Match($(SentryCocoaProperties), 'version\s*=\s*([^\s]+)').Groups[1].Value)</SentryCocoaVersion>
-    <SentryCocoaFramework Condition="!Exists('$(SentryCocoaCache).git')">$(SentryCocoaCache)Sentry-$(SentryCocoaVersion).xcframework</SentryCocoaFramework>
-    <SentryCocoaFramework Condition="Exists('$(SentryCocoaCache).git')">$(SentryCocoaCache)Carthage\Build-$(TargetPlatformIdentifier)\Sentry.xcframework</SentryCocoaFramework>
+    <SentryCocoaFramework>$(SentryCocoaCache)Sentry-$(SentryCocoaVersion).xcframework</SentryCocoaFramework>
+    <SentryCocoaBindingInputs>../../modules/sentry-cocoa.properties;../../scripts/generate-cocoa-bindings.ps1</SentryCocoaBindingInputs>
     <!-- SentrySpan.g.cs: error CS0108: 'ISentrySpan.Serialize()' hides inherited member 'ISentrySerializable.Serialize()'. Use the new keyword if hiding was intended -->
     <NoWarn>$(NoWarn);CS0108</NoWarn>
+  </PropertyGroup>
+
+  <!-- Override values for local Cocoa SDK builds -->
+  <PropertyGroup Condition="Exists('$(SentryCocoaCache).git')">
+    <SentryCocoaFramework>$(SentryCocoaCache)Carthage\Build-$(TargetPlatformIdentifier)\Sentry.xcframework</SentryCocoaFramework>
+    <SentryCocoaBindingInputs>../../scripts/generate-cocoa-bindings.ps1;../../modules/sentry-cocoa/Carthage/.built-from-sha</SentryCocoaBindingInputs>
   </PropertyGroup>
 
   <!-- Build empty assemblies when not on macOS, to pass the solution build. -->
@@ -88,7 +94,7 @@
   <!-- Build the Sentry Cocoa SDK from source -->
   <Target Name="_BuildCocoaSDK"
           Condition="$([MSBuild]::IsOSPlatform('OSX')) And Exists('$(SentryCocoaCache).git')"
-          Inputs="..\..\modules\sentry-cocoa\.git\HEAD" Outputs="..\..\modules\sentry-cocoa\Carthage\.built-from-sha">
+          Inputs="..\..\modules\sentry-cocoa\.git\HEAD;..\..\scripts\build-sentry-cocoa.sh" Outputs="..\..\modules\sentry-cocoa\Carthage\.built-from-sha">
 
     <Message Importance="High" Text="Building the Cocoa SDK from source." />
     <Exec Command="bash ../../scripts/build-sentry-cocoa.sh" IgnoreStandardErrorWarningFormat="true" />
@@ -118,7 +124,7 @@
   <!-- Generate bindings -->
   <Target Name="_GenerateSentryCocoaBindings" AfterTargets="SetupCocoaSDK"
           Condition="$([MSBuild]::IsOSPlatform('OSX'))"
-          Inputs="../../modules/sentry-cocoa.properties;../../scripts/generate-cocoa-bindings.ps1;../../modules/sentry-cocoa/Carthage/.built-from-sha"
+          Inputs="$(SentryCocoaBindingInputs)"
           Outputs="ApiDefinitions.cs;StructsAndEnums.cs">
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="_InnerGenerateSentryCocoaBindings" Properties="TargetFramework=once" />
   </Target>


### PR DESCRIPTION
### Motivation
1. **Local development**: To make it easier to develop locally against an unreleased version of the Sentry Cocoa SDK without reverting https://github.com/getsentry/sentry-dotnet/commit/d179ec9157934e9fbaa0e00860e6c1e090029414 as done in https://github.com/getsentry/sentry-dotnet/pull/4537
2. **Integration testing**: To be able to implement an [integration test](https://github.com/getsentry/sentry-cocoa/blob/main/.github/workflows/test-cross-platform.yml#L35) for https://github.com/getsentry/sentry-cocoa/pull/6193, Sentry .NET would need to be able to run against an unreleased version of the Sentry Cocoa SDK
3. **C# binding updates**: To allow easier experimenting with C# bindings ahead of time for unreleased Sentry Cocoa SDK versions. Due to the ongoing efforts to convert Obj-C types to Swift, it would be nice to be able to test the impact on the C# bindings.

### Instructions

To switch to local development mode, replace the pre-built Sentry Cocoa SDK in `modules/sentry-cocoa` with a clone of `getsentry/sentry-cocoa`:
```sh
$ rm -rf modules/sentry-cocoa
$ gh repo clone getsentry/sentry-cocoa modules/sentry-cocoa
$ dotnet build ...
```

To switch back to a pre-built Sentry Cocoa SDK, delete the `modules/sentry-cocoa` clone and let `Sentry.Bindings.Cocoa.csproj` download the version declared in `modules/sentry-cocoa.properties`:
```sh
$ rm -rf modules/sentry-cocoa
$ dotnet build ...
```

#skip-changelog (for internal development purposes only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable using a local `modules/sentry-cocoa` clone by choosing between downloading prebuilt SDK or building from source, updating bindings generation and docs.
> 
> - **Build system (Sentry.Bindings.Cocoa)**
>   - Add conditional local checkout support: use `modules/sentry-cocoa/.git` to switch between prebuilt `xcframework` and source build (`Carthage/Build-*/Sentry.xcframework`).
>   - New targets: `_DownloadCocoaSDK` (prebuilt), `_BuildCocoaSDK` (runs `scripts/build-sentry-cocoa.sh`), combined in `_SetupCocoaSDK` and invoked unconditionally on macOS.
>   - Override properties for local builds and unify binding inputs via `SentryCocoaBindingInputs`.
> - **Scripts**
>   - `scripts/build-sentry-cocoa.sh`: copy headers from `ios-arm64_arm64e`; write build marker from `.git/HEAD` to `Carthage/.built-from-sha`.
>   - `scripts/generate-cocoa-bindings.ps1`: support both local clone (use `Carthage/Headers`) and downloaded framework paths; update header patching and `sharpie` inputs accordingly.
> - **Docs**
>   - `CONTRIBUTING.md`: add instructions for switching between prebuilt SDK and local `getsentry/sentry-cocoa` clone in `modules/sentry-cocoa`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59da77de5762620d11d8db8f2a1ad5bccf0a5f18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->