### PR TITLE
ci: retry flaky android device tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   build-sentry-native:
-    if: false
     name: sentry-native (${{ matrix.rid }})
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
@@ -74,7 +73,6 @@ jobs:
         shell: pwsh
 
   build:
-    if: false
     needs: build-sentry-native
     name: .NET (${{ matrix.rid }})
     runs-on: ${{ matrix.os }}
@@ -274,7 +272,6 @@ jobs:
           path: integration-test
 
   msbuild:
-    if: false
     needs: build-sentry-native
     name: MSBuild
     runs-on: windows-latest
@@ -319,7 +316,6 @@ jobs:
   # Unsupported Native AOT runtimes should have SentryNative auto-disabled
   # to avoid native library loading errors on startup.
   unsupported-aot:
-    if: false
     needs: build
     name: Unsupported AOT (${{ matrix.rid }})
     runs-on: ${{ matrix.os }}
@@ -359,7 +355,6 @@ jobs:
           path: integration-test/aot.Tests.ps1
 
   trim-analysis:
-    if: false
     needs: build-sentry-native
     name: Trim analysis
     runs-on: macos-15
@@ -402,7 +397,7 @@ jobs:
 
   test-solution-filters:
     runs-on: ubuntu-22.04
-    if: false
+    if: ${{ !startsWith(github.ref_name, 'release/') }}
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build-sentry-native:
+    if: false
     name: sentry-native (${{ matrix.rid }})
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
@@ -73,6 +74,7 @@ jobs:
         shell: pwsh
 
   build:
+    if: false
     needs: build-sentry-native
     name: .NET (${{ matrix.rid }})
     runs-on: ${{ matrix.os }}
@@ -272,6 +274,7 @@ jobs:
           path: integration-test
 
   msbuild:
+    if: false
     needs: build-sentry-native
     name: MSBuild
     runs-on: windows-latest
@@ -316,6 +319,7 @@ jobs:
   # Unsupported Native AOT runtimes should have SentryNative auto-disabled
   # to avoid native library loading errors on startup.
   unsupported-aot:
+    if: false
     needs: build
     name: Unsupported AOT (${{ matrix.rid }})
     runs-on: ${{ matrix.os }}
@@ -355,6 +359,7 @@ jobs:
           path: integration-test/aot.Tests.ps1
 
   trim-analysis:
+    if: false
     needs: build-sentry-native
     name: Trim analysis
     runs-on: macos-15
@@ -397,7 +402,7 @@ jobs:
 
   test-solution-filters:
     runs-on: ubuntu-22.04
-    if: ${{ !startsWith(github.ref_name, 'release/') }}
+    if: false
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -65,6 +65,12 @@ jobs:
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
+      # We don't need the Google APIs, but the default images are not available for 32+
+      ANDROID_EMULATOR_TARGET: google_apis
+      ANDROID_EMULATOR_RAM_SIZE: 2048M
+      ANDROID_EMULATOR_ARCH: x86_64
+      ANDROID_EMULATOR_DISK_SIZE: 4096M
+      ANDROID_EMULATOR_OPTIONS: -no-snapshot-save -no-window -accel on -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
     steps:
       # See https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
       - name: Enable KVM group perms
@@ -88,19 +94,35 @@ jobs:
       # Cached AVD setup per https://github.com/ReactiveCircus/android-emulator-runner/blob/main/README.md
 
       - name: Run Tests
+        id: first-run
+        continue-on-error: true
         timeout-minutes: 40
         uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # Tag: v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
-          # We don't need the Google APIs, but the default images are not available for 32+
-          target: google_apis
+          target: ${{ env.ANDROID_EMULATOR_TARGET }}
           force-avd-creation: false
-          ram-size: 2048M
-          arch: x86_64
-          disk-size: 4096M
-          emulator-options: -no-snapshot-save -no-window -accel on -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          ram-size: ${{ env.ANDROID_EMULATOR_RAM_SIZE }}
+          arch: ${{ env.ANDROID_EMULATOR_ARCH }}
+          disk-size: ${{ env.ANDROID_EMULATOR_DISK_SIZE }}
+          emulator-options: ${{ env.ANDROID_EMULATOR_OPTIONS }}
           disable-animations: false
-          script: pwsh scripts/device-test.ps1 android -Run -Tfm ${{ matrix.tfm }} -Verbose
+          script: pwsh scripts/device-test.ps1 android -Run -Tfm ${{ matrix.tfm }}
+
+      - name: Retry Tests (if previous failed to run)
+        if: steps.first-run.outcome == 'failure'
+        timeout-minutes: 40
+        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # Tag: v2.34.0
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ env.ANDROID_EMULATOR_TARGET }}
+          force-avd-creation: false
+          ram-size: ${{ env.ANDROID_EMULATOR_RAM_SIZE }}
+          arch: ${{ env.ANDROID_EMULATOR_ARCH }}
+          disk-size: ${{ env.ANDROID_EMULATOR_DISK_SIZE }}
+          emulator-options: ${{ env.ANDROID_EMULATOR_OPTIONS }}
+          disable-animations: false
+          script: pwsh scripts/device-test.ps1 android -Run -Tfm ${{ matrix.tfm }}
 
       - name: Upload results
         if: success() || failure()

--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
+  workflow_dispatch:
 
 jobs:
   build:
@@ -99,7 +100,7 @@ jobs:
           disk-size: 4096M
           emulator-options: -no-snapshot-save -no-window -accel on -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
-          script: pwsh scripts/device-test.ps1 android -Run -Tfm ${{ matrix.tfm }}
+          script: pwsh scripts/device-test.ps1 android -Run -Tfm ${{ matrix.tfm }} -Verbose
 
       - name: Upload results
         if: success() || failure()

--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -61,7 +61,7 @@ jobs:
         tfm: [net9.0]
         # Must be 34+ for new apps and app updates as of August 31, 2024.
         # See https://apilevels.com/
-        api-level: [34, 36]
+        api-level: [36]
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1

--- a/.github/workflows/device-tests-android.yml
+++ b/.github/workflows/device-tests-android.yml
@@ -61,7 +61,7 @@ jobs:
         tfm: [net9.0]
         # Must be 34+ for new apps and app updates as of August 31, 2024.
         # See https://apilevels.com/
-        api-level: [36]
+        api-level: [34, 36]
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1

--- a/.github/workflows/device-tests-ios.yml
+++ b/.github/workflows/device-tests-ios.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   ios-tests:
+    if: false
     runs-on: macos-15
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/device-tests-ios.yml
+++ b/.github/workflows/device-tests-ios.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   ios-tests:
-    if: false
     runs-on: macos-15
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/device-tests-ios.yml
+++ b/.github/workflows/device-tests-ios.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
+  workflow_dispatch:
 
 jobs:
   ios-tests:

--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -33,9 +33,9 @@ try
     {
         $Tfm += '-android'
         $group = 'android'
-        $command = 'run'
         $buildDir = $CI ? 'bin' : "test/Sentry.Maui.Device.TestApp/bin/Release/$Tfm/android-$arch"
         $arguments = @(
+            '--app', "$buildDir/io.sentry.dotnet.maui.device.testapp-Signed.apk",
             '--package-name', 'io.sentry.dotnet.maui.device.testapp',
             '--launch-timeout', '00:10:00',
             '--timeout', '00:25:00',
@@ -52,7 +52,6 @@ try
     {
         $Tfm += '-ios'
         $group = 'apple'
-        $command = 'test'
         # Always use x64 on iOS, since arm64 doesn't support JIT, which is required for tests using NSubstitute
         $arch = 'x64'
         $buildDir = "test/Sentry.Maui.Device.TestApp/bin/Release/$Tfm/iossimulator-$arch"
@@ -66,12 +65,9 @@ try
         )
 
         $udid = Get-IosSimulatorUdid -IosVersion '18.5' -Verbose
-        if ($udid)
-        {
+        if ($udid) {
             $arguments += @('--device', $udid)
-        }
-        else
-        {
+        } else {
             Write-Host "No suitable simulator found; proceeding without a specific --device"
         }
     }
@@ -99,18 +95,11 @@ try
         Remove-Item -Recurse -Force test_output -ErrorAction SilentlyContinue
         try
         {
-            if ($Platform -eq 'android')
-            {
-                xharness android install --app "$buildDir/io.sentry.dotnet.maui.device.testapp-Signed.apk" --package-name io.sentry.dotnet.maui.device.testapp --output-directory test_output
-                adb shell pm grant io.sentry.dotnet.maui.device.testapp android.permission.READ_EXTERNAL_STORAGE
-                adb shell pm grant io.sentry.dotnet.maui.device.testapp android.permission.WRITE_EXTERNAL_STORAGE
-            }
-
             if ($VerbosePreference)
             {
                 $arguments += '-v'
             }
-            xharness $group $command $arguments --output-directory=test_output
+            xharness $group test $arguments --output-directory=test_output
             if ($LASTEXITCODE -ne 0)
             {
                 throw 'xharness run failed with non-zero exit code'

--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -87,7 +87,7 @@ try
         if (!(Get-Command xharness -ErrorAction SilentlyContinue))
         {
             Push-Location ($CI ? $env:RUNNER_TEMP : $IsWindows ? $env:TMP : $IsMacos ? $env:TMPDIR : '/tmp')
-            dotnet tool install Microsoft.DotNet.XHarness.CLI --global --version '10.0.0-prerelease.25412.1' `
+            dotnet tool install Microsoft.DotNet.XHarness.CLI --global --version '10.0.0-prerelease.25466.1' `
                 --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
             Pop-Location
         }

--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -86,7 +86,7 @@ try
     {
         if (!(Get-Command xharness -ErrorAction SilentlyContinue))
         {
-            Push-Location ($CI ? $env:RUNNER_TEMP : $IsWindows ? $env:TMP : $IsMacos ? $env:TMPDIR : '/temp')
+            Push-Location ($CI ? $env:RUNNER_TEMP : $IsWindows ? $env:TMP : $IsMacos ? $env:TMPDIR : '/tmp')
             dotnet tool install Microsoft.DotNet.XHarness.CLI --global --version '10.0.0-prerelease.25412.1' `
                 --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
             Pop-Location


### PR DESCRIPTION
I failed to fix the occasional failure related to external storage permissions in Android device tests, so this PR resorts to mitigating the flakiness:

- Bumps XHarness to the latest `10.0.0-prerelease.25466.1` version from Sep 26:
  https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DotNet.XHarness.CLI/versions/10.0.0-prerelease.25466.1
- Retries Android device tests similar to [iOS device tests](https://github.com/getsentry/sentry-dotnet/blob/934ee4e2868f19873a31b54e0af6047aacf6ad5d/.github/workflows/device-tests-ios.yml#L41-L43). Example where the first attempt failed but retry succeeded:
  https://github.com/getsentry/sentry-dotnet/actions/runs/17944328668/job/51030035564?pr=4553

Bonus:
- Fixes `/temp` vs. `/tmp` for local runs.
- Allows workflow dispatch for debugging device tests straight from a WIP branch without opening PRs.

Hopefully (time will tell) resolves:
- #4536

#skip-changelog