### PR TITLE
fix(logs): Structured Logs do not send ParentSpanId when no Span was active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 
 ### Fixes
 
-- Parent-Span-IDs are no longer sent with Structured Logs when recorded without an active Span ([#4565](https://github.com/getsentry/sentry-dotnet/pull/4565))
 - Templates are no longer sent with Structured Logs that have no parameters ([#4544](https://github.com/getsentry/sentry-dotnet/pull/4544))
+- Parent-Span-IDs are no longer sent with Structured Logs when recorded without an active Span ([#4565](https://github.com/getsentry/sentry-dotnet/pull/4565))
 - Upload linked PDBs to fix non-IL-stripped symbolication for iOS ([#4527](https://github.com/getsentry/sentry-dotnet/pull/4527))
 - In MAUI Android apps, generate and inject UUID to APK and upload ProGuard mapping to Sentry with the UUID ([#4532](https://github.com/getsentry/sentry-dotnet/pull/4532))
 - Fixed WASM0001 warning when building Blazor WebAssembly projects ([#4519](https://github.com/getsentry/sentry-dotnet/pull/4519))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Parent-Span-IDs are no longer sent with Structured Logs when recorded without an active Span ([#4565](https://github.com/getsentry/sentry-dotnet/pull/4565))
 - Upload linked PDBs to fix non-IL-stripped symbolication for iOS ([#4527](https://github.com/getsentry/sentry-dotnet/pull/4527))
 - In MAUI Android apps, generate and inject UUID to APK and upload ProGuard mapping to Sentry with the UUID ([#4532](https://github.com/getsentry/sentry-dotnet/pull/4532))
 - Fixed WASM0001 warning when building Blazor WebAssembly projects ([#4519](https://github.com/getsentry/sentry-dotnet/pull/4519))

--- a/src/Sentry.Extensions.Logging/SentryStructuredLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryStructuredLogger.cs
@@ -42,7 +42,7 @@ internal sealed class SentryStructuredLogger : ILogger
         }
 
         var timestamp = _clock.GetUtcNow();
-        var traceHeader = _hub.GetTraceHeader() ?? SentryTraceHeader.Empty;
+        SentryLog.GetTraceIdAndSpanId(_hub, out var traceId, out var spanId);
 
         var level = logLevel.ToSentryLogLevel();
         Debug.Assert(level != default);
@@ -81,11 +81,11 @@ internal sealed class SentryStructuredLogger : ILogger
             }
         }
 
-        SentryLog log = new(timestamp, traceHeader.TraceId, level, message)
+        SentryLog log = new(timestamp, traceId, level, message)
         {
             Template = template,
             Parameters = parameters.DrainToImmutable(),
-            ParentSpanId = traceHeader.SpanId,
+            ParentSpanId = spanId,
         };
 
         log.SetDefaultAttributes(_options, _sdk);

--- a/src/Sentry.Serilog/SentrySink.Structured.cs
+++ b/src/Sentry.Serilog/SentrySink.Structured.cs
@@ -7,7 +7,7 @@ internal sealed partial class SentrySink
 {
     private static void CaptureStructuredLog(IHub hub, SentryOptions options, LogEvent logEvent, string formatted, string? template)
     {
-        GetTraceIdAndSpanId(hub, out var traceId, out var spanId);
+        SentryLog.GetTraceIdAndSpanId(hub, out var traceId, out var spanId);
         GetStructuredLoggingParametersAndAttributes(logEvent, out var parameters, out var attributes);
 
         SentryLog log = new(logEvent.Timestamp, traceId, logEvent.Level.ToSentryLogLevel(), formatted)
@@ -25,28 +25,6 @@ internal sealed partial class SentrySink
         }
 
         hub.Logger.CaptureLog(log);
-    }
-
-    private static void GetTraceIdAndSpanId(IHub hub, out SentryId traceId, out SpanId? spanId)
-    {
-        var span = hub.GetSpan();
-        if (span is not null)
-        {
-            traceId = span.TraceId;
-            spanId = span.SpanId;
-            return;
-        }
-
-        var scope = hub.GetScope();
-        if (scope is not null)
-        {
-            traceId = scope.PropagationContext.TraceId;
-            spanId = scope.PropagationContext.SpanId;
-            return;
-        }
-
-        traceId = SentryId.Empty;
-        spanId = null;
     }
 
     private static void GetStructuredLoggingParametersAndAttributes(LogEvent logEvent, out ImmutableArray<KeyValuePair<string, object>> parameters, out List<KeyValuePair<string, object>> attributes)

--- a/src/Sentry/Internal/DefaultSentryStructuredLogger.cs
+++ b/src/Sentry/Internal/DefaultSentryStructuredLogger.cs
@@ -27,7 +27,7 @@ internal sealed class DefaultSentryStructuredLogger : SentryStructuredLogger, ID
     private protected override void CaptureLog(SentryLogLevel level, string template, object[]? parameters, Action<SentryLog>? configureLog)
     {
         var timestamp = _clock.GetUtcNow();
-        var traceHeader = _hub.GetTraceHeader() ?? SentryTraceHeader.Empty;
+        SentryLog.GetTraceIdAndSpanId(_hub, out var traceId, out var spanId);
 
         string message;
         try
@@ -51,11 +51,11 @@ internal sealed class DefaultSentryStructuredLogger : SentryStructuredLogger, ID
             @params = builder.DrainToImmutable();
         }
 
-        SentryLog log = new(timestamp, traceHeader.TraceId, level, message)
+        SentryLog log = new(timestamp, traceId, level, message)
         {
             Template = template,
             Parameters = @params,
-            ParentSpanId = traceHeader.SpanId,
+            ParentSpanId = spanId,
         };
 
         try

--- a/src/Sentry/SentryLog.cs
+++ b/src/Sentry/SentryLog.cs
@@ -257,4 +257,26 @@ public sealed class SentryLog
 
         writer.WriteEndObject();
     }
+
+    internal static void GetTraceIdAndSpanId(IHub hub, out SentryId traceId, out SpanId? spanId)
+    {
+        var span = hub.GetSpan();
+        if (span is not null)
+        {
+            traceId = span.TraceId;
+            spanId = span.SpanId;
+            return;
+        }
+
+        var scope = hub.GetScope();
+        if (scope is not null)
+        {
+            traceId = scope.PropagationContext.TraceId;
+            spanId = scope.PropagationContext.SpanId;
+            return;
+        }
+
+        traceId = SentryId.Empty;
+        spanId = null;
+    }
 }

--- a/src/Sentry/SentryLog.cs
+++ b/src/Sentry/SentryLog.cs
@@ -6,14 +6,9 @@ using Sentry.Protocol;
 namespace Sentry;
 
 /// <summary>
-/// Represents a Sentry Structured Log.
+/// Represents the Sentry Log protocol.
 /// <para>This API is experimental and it may change in the future.</para>
 /// </summary>
-/// <remarks>
-/// Sentry Docs: <see href="https://docs.sentry.io/product/explore/logs/"/>.
-/// Sentry Developer Documentation: <see href="https://develop.sentry.dev/sdk/telemetry/logs/"/>.
-/// Sentry .NET SDK Docs: <see href="https://docs.sentry.io/platforms/dotnet/logs/"/>.
-/// </remarks>
 [Experimental(DiagnosticId.ExperimentalFeature)]
 [DebuggerDisplay(@"SentryLog \{ Level = {Level}, Message = '{Message}' \}")]
 public sealed class SentryLog

--- a/src/Sentry/SentryLog.cs
+++ b/src/Sentry/SentryLog.cs
@@ -1,5 +1,4 @@
 using Sentry.Extensibility;
-using Sentry.Infrastructure;
 using Sentry.Internal;
 using Sentry.Protocol;
 

--- a/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerTests.cs
@@ -140,7 +140,7 @@ public class SentryStructuredLoggerTests : IDisposable
 
         var log = _fixture.CapturedLogs.Dequeue();
         log.TraceId.Should().Be(scope.PropagationContext.TraceId);
-        log.ParentSpanId.Should().Be(scope.PropagationContext.SpanId);
+        log.ParentSpanId.Should().BeNull();
     }
 
     [Fact]

--- a/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerTests.cs
@@ -51,10 +51,12 @@ public class SentryStructuredLoggerTests : IDisposable
         public void EnableLogs(bool isEnabled) => Options.Value.Experimental.EnableLogs = isEnabled;
         public void SetMinimumLogLevel(LogLevel logLevel) => Options.Value.ExperimentalLogging.MinimumLogLevel = logLevel;
 
-        public void WithTraceHeader(SentryId traceId, SpanId parentSpanId)
+        public void WithActiveSpan(SentryId traceId, SpanId parentSpanId)
         {
-            var traceHeader = new SentryTraceHeader(traceId, parentSpanId, null);
-            Hub.GetTraceHeader().Returns(traceHeader);
+            var span = Substitute.For<ISpan>();
+            span.TraceId.Returns(traceId);
+            span.SpanId.Returns(parentSpanId);
+            Hub.GetSpan().Returns(span);
         }
 
         public SentryStructuredLogger GetSut()
@@ -83,7 +85,7 @@ public class SentryStructuredLoggerTests : IDisposable
     {
         var traceId = SentryId.Create();
         var parentSpanId = SpanId.Create();
-        _fixture.WithTraceHeader(traceId, parentSpanId);
+        _fixture.WithActiveSpan(traceId, parentSpanId);
         var logger = _fixture.GetSut();
 
         EventId eventId = new(123, "EventName");
@@ -127,15 +129,18 @@ public class SentryStructuredLoggerTests : IDisposable
     }
 
     [Fact]
-    public void Log_WithoutTraceHeader_CaptureLog()
+    public void Log_WithoutActiveSpan_CaptureLog()
     {
+        var scope = new Scope(_fixture.Options.Value);
+        _fixture.Hub.GetSpan().Returns((ISpan?)null);
+        _fixture.Hub.SubstituteConfigureScope(scope);
         var logger = _fixture.GetSut();
 
         logger.Log(LogLevel.Information, new EventId(123, "EventName"), new InvalidOperationException("message"), "Message with {Argument}.", "argument");
 
         var log = _fixture.CapturedLogs.Dequeue();
-        log.TraceId.Should().Be(SentryTraceHeader.Empty.TraceId);
-        log.ParentSpanId.Should().Be(SentryTraceHeader.Empty.SpanId);
+        log.TraceId.Should().Be(scope.PropagationContext.TraceId);
+        log.ParentSpanId.Should().Be(scope.PropagationContext.SpanId);
     }
 
     [Fact]

--- a/test/Sentry.Serilog.Tests/SentrySinkTests.Structured.cs
+++ b/test/Sentry.Serilog.Tests/SentrySinkTests.Structured.cs
@@ -112,7 +112,7 @@ public partial class SentrySinkTests
         log.Parameters[1].Should().BeEquivalentTo(new KeyValuePair<string, string>("Sequence", "[41, 42, 43]"));
         log.Parameters[2].Should().BeEquivalentTo(new KeyValuePair<string, string>("Dictionary", """[("key": "value")]"""));
         log.Parameters[3].Should().BeEquivalentTo(new KeyValuePair<string, string>("Structure", """[42, "42"]"""));
-        log.ParentSpanId.Should().Be(withActiveSpan ? _fixture.Hub.GetSpan()!.SpanId : _fixture.Scope.PropagationContext.SpanId);
+        log.ParentSpanId.Should().Be(withActiveSpan ? _fixture.Hub.GetSpan()!.SpanId : null);
 
         log.TryGetAttribute("sentry.environment", out object? environment).Should().BeTrue();
         environment.Should().Be("test-environment");

--- a/test/Sentry.Tests/SentryLogTests.cs
+++ b/test/Sentry.Tests/SentryLogTests.cs
@@ -384,7 +384,7 @@ public class SentryLogTests
     }
 
     [Fact]
-    public void GetTraceIdAndSpanId_WithActiveSpan_ReturnAsOut()
+    public void GetTraceIdAndSpanId_WithActiveSpan_HasBothTraceIdAndSpanId()
     {
         // Arrange
         var span = Substitute.For<ISpan>();
@@ -403,7 +403,7 @@ public class SentryLogTests
     }
 
     [Fact]
-    public void GetTraceIdAndSpanId_WithoutActiveSpan_ReturnAsOut()
+    public void GetTraceIdAndSpanId_WithoutActiveSpan_HasOnlyTraceIdButNoSpanId()
     {
         // Arrange
         var hub = Substitute.For<IHub>();
@@ -417,11 +417,11 @@ public class SentryLogTests
 
         // Assert
         traceId.Should().Be(scope.PropagationContext.TraceId);
-        spanId.Should().Be(scope.PropagationContext.SpanId);
+        spanId.Should().BeNull();
     }
 
     [Fact]
-    public void GetTraceIdAndSpanId_WithoutIds_ReturnAsOut()
+    public void GetTraceIdAndSpanId_WithoutIds_ShouldBeUnreachable()
     {
         // Arrange
         var hub = Substitute.For<IHub>();

--- a/test/Sentry.Tests/SentryStructuredLoggerTests.cs
+++ b/test/Sentry.Tests/SentryStructuredLoggerTests.cs
@@ -55,7 +55,7 @@ public partial class SentryStructuredLoggerTests : IDisposable
             var scope = new Scope();
             Hub.SubstituteConfigureScope(scope);
             TraceId = scope.PropagationContext.TraceId;
-            ParentSpanId = scope.PropagationContext.SpanId;
+            ParentSpanId = null;
         }
 
         public SentryStructuredLogger GetSut() => SentryStructuredLogger.Create(Hub, Options, Clock, BatchSize, BatchTimeout);

--- a/test/Sentry.Tests/SentryStructuredLoggerTests.cs
+++ b/test/Sentry.Tests/SentryStructuredLoggerTests.cs
@@ -26,8 +26,10 @@ public partial class SentryStructuredLoggerTests : IDisposable
 
             Hub.IsEnabled.Returns(true);
 
-            var traceHeader = new SentryTraceHeader(TraceId, ParentSpanId.Value, null);
-            Hub.GetTraceHeader().Returns(traceHeader);
+            var span = Substitute.For<ISpan>();
+            span.TraceId.Returns(TraceId);
+            span.SpanId.Returns(ParentSpanId.Value);
+            Hub.GetSpan().Returns(span);
 
             ExpectedAttributes = new Dictionary<string, string>(1)
             {
@@ -46,11 +48,14 @@ public partial class SentryStructuredLoggerTests : IDisposable
 
         public Dictionary<string, string> ExpectedAttributes { get; }
 
-        public void WithoutTraceHeader()
+        public void WithoutActiveSpan()
         {
-            Hub.GetTraceHeader().Returns((SentryTraceHeader?)null);
-            TraceId = SentryId.Empty;
-            ParentSpanId = SpanId.Empty;
+            Hub.GetSpan().Returns((ISpan?)null);
+
+            var scope = new Scope();
+            Hub.SubstituteConfigureScope(scope);
+            TraceId = scope.PropagationContext.TraceId;
+            ParentSpanId = scope.PropagationContext.SpanId;
         }
 
         public SentryStructuredLogger GetSut() => SentryStructuredLogger.Create(Hub, Options, Clock, BatchSize, BatchTimeout);
@@ -93,9 +98,9 @@ public partial class SentryStructuredLoggerTests : IDisposable
     }
 
     [Fact]
-    public void Log_WithoutTraceHeader_CapturesEnvelope()
+    public void Log_WithoutActiveSpan_CapturesEnvelope()
     {
-        _fixture.WithoutTraceHeader();
+        _fixture.WithoutActiveSpan();
         _fixture.Options.Experimental.EnableLogs = true;
         var logger = _fixture.GetSut();
 


### PR DESCRIPTION
This is a follow-up PR
from https://github.com/getsentry/sentry-dotnet/pull/4462#discussion_r2296973291
that is applying a change we made for the `Serilog` integration of  _Structured Logs_
to the SDK-Logger and the `Microsoft.Extensions.Logging` integration,
when reading values for the attributes `"trace_id"` and `"sentry.trace.parent_span_id"`.

Rather than using the `TraceHeader`,
instead use the currently active Span, or the Propagation Context as a fallback.

~During testing I noticed, that there doesn't seem to be a behavioral difference in Sentry, hence the `#skip-changelog`.~

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Structured Logs now derive `trace_id` from the active span or scope and only include `sentry.trace.parent_span_id` when an active span exists.
> 
> - **Structured Logs behavior**:
>   - Read `trace_id`/`parent_span_id` via `SentryLog.GetTraceIdAndSpanId(...)` from the active `Span`; fall back to scope for `trace_id` only.
>   - Omit `sentry.trace.parent_span_id` when no active span.
> - **Implementations updated**:
>   - `Sentry.Extensions.Logging` logger and `DefaultSentryStructuredLogger` now use the new helper (replacing `GetTraceHeader`).
>   - `Sentry.Serilog` sink uses the helper; removes its local resolver.
>   - Adds helper to `SentryLog` core type.
> - **Tests**: Adjusted to validate new source of IDs and absence of `parent_span_id` without an active span.
> - **Changelog**: Note about not sending Parent-Span-IDs without an active span.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2326d97741195fa1b3d660f3708ab36bf465d6d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->