### PR TITLE
WIP fix: Ensure integration logs have sentry.origin set

### DIFF
--- a/src/Sentry.Extensions.Logging/SentryStructuredLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryStructuredLogger.cs
@@ -89,6 +89,7 @@ internal sealed class SentryStructuredLogger : ILogger
         };
 
         log.SetDefaultAttributes(_options, _sdk);
+        log.SetOrigin("auto");
 
         if (_categoryName is not null)
         {

--- a/src/Sentry.Extensions.Logging/SentryStructuredLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryStructuredLogger.cs
@@ -89,7 +89,7 @@ internal sealed class SentryStructuredLogger : ILogger
         };
 
         log.SetDefaultAttributes(_options, _sdk);
-        log.SetOrigin("auto");
+        log.SetOrigin("auto.logging.dotnet_extension");
 
         if (_categoryName is not null)
         {

--- a/src/Sentry.Serilog/SentrySink.Structured.cs
+++ b/src/Sentry.Serilog/SentrySink.Structured.cs
@@ -18,6 +18,7 @@ internal sealed partial class SentrySink
         };
 
         log.SetDefaultAttributes(options, Sdk);
+        log.SetOrigin("auto");
 
         foreach (var attribute in attributes)
         {

--- a/src/Sentry.Serilog/SentrySink.Structured.cs
+++ b/src/Sentry.Serilog/SentrySink.Structured.cs
@@ -18,7 +18,7 @@ internal sealed partial class SentrySink
         };
 
         log.SetDefaultAttributes(options, Sdk);
-        log.SetOrigin("auto");
+        log.SetOrigin("auto.logging.serilog");
 
         foreach (var attribute in attributes)
         {

--- a/src/Sentry/SentryLog.cs
+++ b/src/Sentry/SentryLog.cs
@@ -199,6 +199,11 @@ public sealed class SentryLog
         }
     }
 
+    internal void SetOrigin(string origin)
+    {
+        SetAttribute("sentry.origin", origin);
+    }
+
     internal void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? logger)
     {
         writer.WriteStartObject();

--- a/test/Sentry.AspNetCore.Tests/SentryAspNetCoreStructuredLoggerProviderTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryAspNetCoreStructuredLoggerProviderTests.cs
@@ -93,7 +93,7 @@ public class SentryAspNetCoreStructuredLoggerProviderTests
         version.Should().Be(SentryMiddleware.NameAndVersion.Version);
 
         capturedLog.TryGetAttribute("sentry.origin", out object? origin).Should().BeTrue();
-        origin.Should().Be("auto");
+        origin.Should().Be("auto.logging.dotnet_extension");
     }
 
     [Fact]

--- a/test/Sentry.AspNetCore.Tests/SentryAspNetCoreStructuredLoggerProviderTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryAspNetCoreStructuredLoggerProviderTests.cs
@@ -91,6 +91,9 @@ public class SentryAspNetCoreStructuredLoggerProviderTests
 
         capturedLog.TryGetAttribute("sentry.sdk.version", out object? version).Should().BeTrue();
         version.Should().Be(SentryMiddleware.NameAndVersion.Version);
+
+        capturedLog.TryGetAttribute("sentry.origin", out object? origin).Should().BeTrue();
+        origin.Should().Be("auto");
     }
 
     [Fact]

--- a/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerProviderTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerProviderTests.cs
@@ -93,7 +93,7 @@ public class SentryStructuredLoggerProviderTests
         version.Should().Be(SentryLoggerProvider.NameAndVersion.Version);
 
         capturedLog.TryGetAttribute("sentry.origin", out object? origin).Should().BeTrue();
-        origin.Should().Be("auto");
+        origin.Should().Be("auto.logging.dotnet_extension");
     }
 
     [Fact]

--- a/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerProviderTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerProviderTests.cs
@@ -91,6 +91,9 @@ public class SentryStructuredLoggerProviderTests
 
         capturedLog.TryGetAttribute("sentry.sdk.version", out object? version).Should().BeTrue();
         version.Should().Be(SentryLoggerProvider.NameAndVersion.Version);
+
+        capturedLog.TryGetAttribute("sentry.origin", out object? origin).Should().BeTrue();
+        origin.Should().Be("auto");
     }
 
     [Fact]

--- a/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerTests.cs
@@ -109,7 +109,7 @@ public class SentryStructuredLoggerTests : IDisposable
         log.ParentSpanId.Should().Be(parentSpanId);
         log.AssertAttribute("sentry.environment", "my-environment");
         log.AssertAttribute("sentry.release", "my-release");
-        log.AssertAttribute("sentry.origin", "auto");
+        log.AssertAttribute("sentry.origin", "auto.logging.dotnet_extension");
         log.AssertAttribute("sentry.sdk.name", "SDK Name");
         log.AssertAttribute("sentry.sdk.version", "SDK Version");
         log.AssertAttribute("category.name", _fixture.CategoryName);

--- a/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerTests.cs
@@ -109,6 +109,7 @@ public class SentryStructuredLoggerTests : IDisposable
         log.ParentSpanId.Should().Be(parentSpanId);
         log.AssertAttribute("sentry.environment", "my-environment");
         log.AssertAttribute("sentry.release", "my-release");
+        log.AssertAttribute("sentry.origin", "auto");
         log.AssertAttribute("sentry.sdk.name", "SDK Name");
         log.AssertAttribute("sentry.sdk.version", "SDK Version");
         log.AssertAttribute("category.name", _fixture.CategoryName);

--- a/test/Sentry.Serilog.Tests/SentrySinkTests.Structured.cs
+++ b/test/Sentry.Serilog.Tests/SentrySinkTests.Structured.cs
@@ -118,6 +118,8 @@ public partial class SentrySinkTests
         environment.Should().Be("test-environment");
         log.TryGetAttribute("sentry.release", out object? release).Should().BeTrue();
         release.Should().Be("test-release");
+        log.TryGetAttribute("sentry.origin", out object? origin).Should().BeTrue();
+        origin.Should().Be("auto");
         log.TryGetAttribute("sentry.sdk.name", out object? sdkName).Should().BeTrue();
         sdkName.Should().Be(SentrySink.SdkName);
         log.TryGetAttribute("sentry.sdk.version", out object? sdkVersion).Should().BeTrue();

--- a/test/Sentry.Serilog.Tests/SentrySinkTests.Structured.cs
+++ b/test/Sentry.Serilog.Tests/SentrySinkTests.Structured.cs
@@ -119,7 +119,7 @@ public partial class SentrySinkTests
         log.TryGetAttribute("sentry.release", out object? release).Should().BeTrue();
         release.Should().Be("test-release");
         log.TryGetAttribute("sentry.origin", out object? origin).Should().BeTrue();
-        origin.Should().Be("auto");
+        origin.Should().Be("auto.logging.serilog");
         log.TryGetAttribute("sentry.sdk.name", out object? sdkName).Should().BeTrue();
         sdkName.Should().Be(SentrySink.SdkName);
         log.TryGetAttribute("sentry.sdk.version", out object? sdkVersion).Should().BeTrue();

--- a/test/Sentry.Tests/SentryLogTests.cs
+++ b/test/Sentry.Tests/SentryLogTests.cs
@@ -53,6 +53,9 @@ public class SentryLogTests
         log.Parameters.Should().BeEquivalentTo(new KeyValuePair<string, object>[] { new("param", "params"), });
         log.ParentSpanId.Should().Be(ParentSpanId);
 
+        // should only show up in sdk integrations
+        log.TryGetAttribute("sentry.origin", out object origin).Should().BeFalse();
+
         log.TryGetAttribute("attribute", out object attribute).Should().BeTrue();
         attribute.Should().Be("value");
         log.TryGetAttribute("sentry.environment", out string environment).Should().BeTrue();


### PR DESCRIPTION
Fixes #4560

# Problem

According to our [SDK specification](https://develop.sentry.dev/sdk/telemetry/logs/#sdk-integration-attributes), we have to set `sentry.origin` whenever a log is sent from an integration.

# Solution

`sentry-dotnet` has a few integrations that send out logs. This PR affects the following integrations:
- `Sentry.Extensions.Logging`
- `Sentry.Serilog`

And affects other integrations that use `Sentry.Extensions.Logging` transitively.

# Comparison

Before, logs from `Sentry.Serilog` didn't have `sentry.origin`:
<img width="1076" height="297" alt="image" src="https://github.com/user-attachments/assets/eb0e2543-c927-4b1a-ad1b-fbf010a23cb1" />

After, logs from `Sentry.Serilog` has `sentry.origin` populated:
<img width="1075" height="303" alt="Screenshot 2025-09-25 at 4 14 59 PM" src="https://github.com/user-attachments/assets/472fa19c-9e32-4383-b97f-78373c904a33" />

