### PR TITLE
ci: remove unnecessary "Remove unused applications" for build-sentry-native

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,10 +64,6 @@ jobs:
           key: sentry-native-${{ matrix.rid }}-${{ hashFiles('scripts/build-sentry-native.ps1') }}-${{ hashFiles('.git/modules/modules/sentry-native/HEAD') }}
           enableCrossOsArchive: true
 
-      - name: Remove unused applications
-        if: ${{ !matrix.container }}
-        uses: ./.github/actions/freediskspace
-
       - run: scripts/build-sentry-native.ps1
         if: steps.cache.outputs.cache-hit != 'true'
         shell: pwsh


### PR DESCRIPTION
Unnecessarily slows down sentry-native builds by a few minutes, even when it ends up using a cached build. We could skip this when `cache-hit == true`, but freeing up disk space by removing unused apps is unnecessary for small and quick sentry-native builds, to begin with.

#skip-changelog