### PR TITLE
ci: use `global.json` for `actions/setup-dotnet`

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -87,9 +87,8 @@ runs:
     - name: Install .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
-          9.0.304
+        global-json-file: global.json
+        dotnet-version: 8.0.x
 
     - name: Install .NET Workloads
       shell: bash


### PR DESCRIPTION
No need to bump the SDK version in both `global.json` and `.github/actions/environment/action.yml` anymore...

#skip-changelog