### PR TITLE
ci: fix dirty-check for generated Cocoa bindings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,6 +207,11 @@ jobs:
         id: build
         run: dotnet build ${{ matrix.slnf }} -c Release --no-restore --nologo -v:minimal -flp:logfile=build.log -p:CopyLocalLockFileAssemblies=true -bl:build.binlog
 
+      - name: Ensure Cocoa Bindings are up to date
+        if: ${{ runner.os == 'macOS' }}
+        shell: pwsh
+        run: scripts/dirty-check.ps1 -PathToCheck "src/Sentry.Bindings.Cocoa/*.cs" -GuidanceOnFailure "Uncommitted changes to Sentry.Bindings.Cocoa detected. Run `scripts/generate-cocoa-bindings.ps1` locally and commit changes."
+
       - name: Upload build logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,11 +207,6 @@ jobs:
         id: build
         run: dotnet build ${{ matrix.slnf }} -c Release --no-restore --nologo -v:minimal -flp:logfile=build.log -p:CopyLocalLockFileAssemblies=true -bl:build.binlog
 
-      - name: Ensure Cocoa Bindings are up to date
-        if: ${{ runner.os == 'macOS' }}
-        shell: pwsh
-        run: scripts/dirty-check.ps1 -PathToCheck "src/Sentry.Bindings.Cocoa/*.cs" -GuidanceOnFailure "Uncommitted changes to Sentry.Bindings.Cocoa detected. Run `scripts/generate-cocoa-bindings.ps1` locally and commit changes."
-
       - name: Upload build logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v4

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -416,9 +416,9 @@ interface SentryEnvelopeItemHeader : SentrySerializable
     [Export ("initWithType:length:filenname:contentType:")]
     NativeHandle Constructor (string type, nuint length, string filename, string contentType);
 
-    // -(instancetype _Nonnull)initWithType:(NSString * _Nonnull)type length:(NSUInteger)length contentType:(NSString * _Nonnull)contentType itemCount:(NSNumber * _Nonnull)itemCount;
+    // -(instancetype _Nonnull)initWithType:(NSString * _Nonnull)type length:(NSUInteger)length contentType:(NSString * _Nullable)contentType itemCount:(NSNumber * _Nonnull)itemCount;
     [Export ("initWithType:length:contentType:itemCount:")]
-    NativeHandle Constructor (string type, nuint length, string contentType, NSNumber itemCount);
+    NativeHandle Constructor (string type, nuint length, [NullAllowed] string contentType, NSNumber itemCount);
 
     // @property (readonly, copy, nonatomic) NSString * _Nonnull type;
     [Export ("type")]

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -12,7 +12,7 @@
     <SentryCocoaProperties>$([System.IO.File]::ReadAllText("$(MSBuildThisFileDirectory)../../modules/sentry-cocoa.properties"))</SentryCocoaProperties>
     <SentryCocoaVersion>$([System.Text.RegularExpressions.Regex]::Match($(SentryCocoaProperties), 'version\s*=\s*([^\s]+)').Groups[1].Value)</SentryCocoaVersion>
     <SentryCocoaFramework>$(SentryCocoaCache)Sentry-$(SentryCocoaVersion).xcframework</SentryCocoaFramework>
-    <SentryCocoaBindingInputs>../../modules/sentry-cocoa.properties;../../scripts/generate-cocoa-bindings.ps1</SentryCocoaBindingInputs>
+    <SentryCocoaBindingInputs>../../modules/sentry-cocoa.properties;../../scripts/generate-cocoa-bindings.ps1;$(SentryCocoaFrameworkHeaders)**/*.h</SentryCocoaBindingInputs>
     <!-- SentrySpan.g.cs: error CS0108: 'ISentrySpan.Serialize()' hides inherited member 'ISentrySerializable.Serialize()'. Use the new keyword if hiding was intended -->
     <NoWarn>$(NoWarn);CS0108</NoWarn>
   </PropertyGroup>
@@ -20,7 +20,7 @@
   <!-- Override values for local Cocoa SDK builds -->
   <PropertyGroup Condition="Exists('$(SentryCocoaCache).git')">
     <SentryCocoaFramework>$(SentryCocoaCache)Carthage\Build-$(TargetPlatformIdentifier)\Sentry.xcframework</SentryCocoaFramework>
-    <SentryCocoaBindingInputs>../../scripts/generate-cocoa-bindings.ps1;../../modules/sentry-cocoa/Carthage/.built-from-sha</SentryCocoaBindingInputs>
+    <SentryCocoaBindingInputs>../../scripts/generate-cocoa-bindings.ps1;../../modules/sentry-cocoa/Carthage/.built-from-sha;../../modules/sentry-cocoa/Carthage/**/*.h</SentryCocoaBindingInputs>
   </PropertyGroup>
 
   <!-- Build empty assemblies when not on macOS, to pass the solution build. -->

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -20,7 +20,7 @@
   <!-- Override values for local Cocoa SDK builds -->
   <PropertyGroup Condition="Exists('$(SentryCocoaCache).git')">
     <SentryCocoaFramework>$(SentryCocoaCache)Carthage\Build-$(TargetPlatformIdentifier)\Sentry.xcframework</SentryCocoaFramework>
-    <SentryCocoaBindingInputs>../../scripts/generate-cocoa-bindings.ps1;../../modules/sentry-cocoa/Carthage/.built-from-sha;../../modules/sentry-cocoa/Carthage/**/*.h</SentryCocoaBindingInputs>
+    <SentryCocoaBindingInputs>../../scripts/generate-cocoa-bindings.ps1;$(SentryCocoaCache)Carthage/.built-from-sha;$(SentryCocoaCache)Carthage/**/*.h</SentryCocoaBindingInputs>
   </PropertyGroup>
 
   <!-- Build empty assemblies when not on macOS, to pass the solution build. -->


### PR DESCRIPTION
Fix the dirty-check which ensures that the committed versions of `src/Sentry.Bindings.Cocoa/ApiDefinitions.cs` and `StructsAndDefinitions.cs` are up-to-date after Cocoa SDK updates, as they are automatically re-generated by the build system:

https://github.com/getsentry/sentry-dotnet/blob/ad849d4aa01a4282f4691d74568b5dfe16cb774e/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj#L132-L134

The problem was that `sentry-cocoa.properties` and `generate-cocoa-bindings.ps1` alone were not sufficient inputs for MSBuild to trigger `_GenerateSentryCocoaBindings`, so the bindings were not re-generated in the CI. Adding framework headers, which are the effective sources for the bindings, helps. With this change, the [build / .NET (macos)](https://github.com/getsentry/sentry-dotnet/actions/runs/18279399095/job/52038859517?pr=4600) CI job fails with:
```
Generating bindings with Objective Sharpie.
[...]
  Done.
  Patching /Users/runner/work/sentry-dotnet/sentry-dotnet/src/Sentry.Bindings.Cocoa/StructsAndEnums.cs
  Patching /Users/runner/work/sentry-dotnet/sentry-dotnet/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
  diff --git a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
  index f33b1c6..2c076dd 100644
  --- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
  +++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
  @@ -416,9 +416,9 @@ interface SentryEnvelopeItemHeader : SentrySerializable
       [Export ("initWithType:length:filenname:contentType:")]
       NativeHandle Constructor (string type, nuint length, string filename, string contentType);
   
  -    // -(instancetype _Nonnull)initWithType:(NSString * _Nonnull)type length:(NSUInteger)length contentType:(NSString * _Nonnull)contentType itemCount:(NSNumber * _Nonnull)itemCount;
  +    // -(instancetype _Nonnull)initWithType:(NSString * _Nonnull)type length:(NSUInteger)length contentType:(NSString * _Nullable)contentType itemCount:(NSNumber * _Nonnull)itemCount;
       [Export ("initWithType:length:contentType:itemCount:")]
  -    NativeHandle Constructor (string type, nuint length, string contentType, NSNumber itemCount);
  +    NativeHandle Constructor (string type, nuint length, [NullAllowed] string contentType, NSNumber itemCount);
   
       // @property (readonly, copy, nonatomic) NSString * _Nonnull type;
       [Export ("type")]
  Write-Error: /Users/runner/work/sentry-dotnet/sentry-dotnet/scripts/dirty-check.ps1:14
  Line |
    14 |      Write-Error "$GuidanceOnFailure"
       |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       | Dirty files detected.
/Users/runner/work/sentry-dotnet/sentry-dotnet/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj(134,5): error MSB3073: The command "pwsh ../../scripts/dirty-check.ps1 -PathToCheck /Users/runner/work/sentry-dotnet/sentry-dotnet/src/Sentry.Bindings.Cocoa/" exited with code 1. [TargetFramework=once]
```

Came up in:
- https://github.com/getsentry/sentry-dotnet/pull/4533#discussion_r2404737869

#skip-changelog