### PR TITLE
Fix typo in unit test name

### DIFF
--- a/test/Sentry.Tests/Internals/AggregateExceptionTests.cs
+++ b/test/Sentry.Tests/Internals/AggregateExceptionTests.cs
@@ -2,7 +2,7 @@ using Sentry.PlatformAbstractions;
 
 namespace Sentry.Tests.Internals;
 
-public class AgggregateExceptionTests
+public class AggregateExceptionTests
 {
     private static readonly string DefaultAggregateExceptionMessage = new AggregateException().Message;
 


### PR DESCRIPTION
This PR fixes a typo in unit test class name: `AgggregateExceptionTests` => `AggregateExceptionTests`

#skip-changelog