### PR TITLE
Fix Sentry.Maui.Device.IntegrationTestApp for .NET 10 / version6

### DIFF
--- a/integration-test/net9-maui/Sentry.Maui.Device.IntegrationTestApp.csproj
+++ b/integration-test/net9-maui/Sentry.Maui.Device.IntegrationTestApp.csproj
@@ -10,6 +10,7 @@
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <SelfContained>true</SelfContained>
 
     <!-- Speed up CI build -->
     <MtouchUseLlvm>false</MtouchUseLlvm>


### PR DESCRIPTION
`SelfContained=true` helps for:

```
error NETSDK1112: The runtime pack for Microsoft.Android.Runtime.35.android-x64 was not downloaded. Try running a NuGet restore.
```

https://github.com/getsentry/sentry-dotnet/actions/runs/18515891743/job/52775923191?pr=4634

#skip-changelog