### PR TITLE
chore(deps): bump Microsoft.AspNetCore.Server.Kestrel.Core to 2.3.6

### DIFF
--- a/test/Sentry.AspNetCore.TestUtils/Sentry.AspNetCore.TestUtils.csproj
+++ b/test/Sentry.AspNetCore.TestUtils/Sentry.AspNetCore.TestUtils.csproj
@@ -36,8 +36,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
 
-    <!-- This is needed because the version that is brought in transitively also has a vulnerability warning -->
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.25" />
+    <!-- https://github.com/advisories/GHSA-5rrx-jjjq-q2r5 -->
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" />
     <!-- https://github.com/advisories/GHSA-vmch-3w2x-vhgq -->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.1.40" />
 


### PR DESCRIPTION
See [Microsoft Security Advisory CVE-2025-55315: .NET Security Feature Bypass Vulnerability](https://github.com/advisories/GHSA-5rrx-jjjq-q2r5).

> ```
> D:\a\sentry-dotnet\sentry-dotnet\test\Sentry.AspNetCore.TestUtils\Sentry.AspNetCore.TestUtils.csproj : error NU1904: Warning As Error: Package 'Microsoft.AspNetCore.Server.Kestrel.Core' 2.1.25 has a known critical severity vulnerability, https://github.com/advisories/GHSA-5rrx-jjjq-q2r5 [D:\a\sentry-dotnet\sentry-dotnet\Sentry-CI-Build-Windows.slnf]
> ```
https://github.com/getsentry/sentry-dotnet/actions/runs/18529128444/job/52807115247

#skip-changelog (only used in tests)