### PR TITLE
Alexsohn/fix/proguard UUID error when transitively building

### DIFF
--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -271,11 +271,11 @@
     <Warning Condition="'$(_SentryCLIExitCode)' != '0'" Text="Sentry CLI could not upload debug files." />
   </Target>
 
-  <Target Name="UpdateAndroidMetadata" BeforeTargets="GetAssemblyAttributes"
-          Condition="
-            $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'
+  <Target Name="UpdateAndroidMetadata"
+          BeforeTargets="GetAssemblyAttributes"
+          Condition="'$(AndroidApplication)' == 'true'
+            and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'
             and '$(SentryUploadAndroidProGuardMapping)' == 'true'">
-
     <ItemGroup>
       <AssemblyAttribute Include="Android.App.MetaData">
         <_Parameter1>io.sentry.proguard-uuid</_Parameter1>


### PR DESCRIPTION
Fixes #4597
- #4597

# Problem

The setup described in #4597 is the following:
- Project A
  - MAUI app
  - AndroidLinkTool set to r8 (enables ProGuard)
  - references project B and C
- Project B
  - Targets `net9.0-android`
  - AndroidLinkTool set to r8 (enables ProGuard)
  - references project C
- Project C
  - a simple class library
 
Then the build will fail on `_ManifestMerger` step, due to duplicated Android manifest metadata `sentry.proguard-uuid`.

This was caused by `sentry.proguard-uuid` being set up every time an Android project is built. So in the reproducible example above, `sentry.proguard-uuid` would be set in Project A and B.

# Solution
I added a check to ensure `sentry.proguard-uuid` is set only when the property `AndroidApplication` is set to `true`, which is set t.
