### PR TITLE
test: add missing native crash integration test for Android

### DIFF
--- a/integration-test/android.Tests.ps1
+++ b/integration-test/android.Tests.ps1
@@ -159,7 +159,7 @@ Describe 'MAUI app' -ForEach @(
 
         Dump-ServerErrors -Result $result
         $result.HasErrors() | Should -BeFalse
-        $result.Envelopes() | Should -AnyElementMatch "`"type`":`"SIG[A-Z]+`"" # SIGILL, SIGTRAP
+        $result.Envelopes() | Should -AnyElementMatch "`"type`":`"SIG[A-Z]+`"" # SIGILL (x86_64), SIGTRAP (arm64-v8a)
         $result.Envelopes() | Should -Not -AnyElementMatch "`"type`":`"System.\w+Exception`""
     }
 


### PR DESCRIPTION
This PR adds a missing `CrashType.Native` integration test for Android, because it was missed in #4559 that only added integration tests for:
- iOS: `CrashType.Managed`, `CrashType.Native`, `NullReferenceException`
- Android: `CrashType.Managed`, `CrashType.Java`, `NullReferenceException`

Related to:
- getsentry/sentry-native#1392