### PR TITLE
fix: prevent redundant native exceptions on Android/Mono

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Features
 
 - Outbound HTTP requests now show in the Network tab for Android Session Replays ([#4860](https://github.com/getsentry/sentry-dotnet/pull/4860))
+- Allow configuring native signal handler strategy on Android ([#4676](https://github.com/getsentry/sentry-dotnet/pull/4676))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 ### Features
 
 - Outbound HTTP requests now show in the Network tab for Android Session Replays ([#4860](https://github.com/getsentry/sentry-dotnet/pull/4860))
-- Allow configuring native signal handler strategy on Android ([#4676](https://github.com/getsentry/sentry-dotnet/pull/4676))
 
 ### Fixes
 

--- a/integration-test/android.Tests.ps1
+++ b/integration-test/android.Tests.ps1
@@ -177,13 +177,8 @@ Describe 'MAUI app (<dotnet_version>, <configuration>)' -ForEach $cases -Skip:(-
         Dump-ServerErrors -Result $result
         $result.HasErrors() | Should -BeFalse
         $result.Events() | Should -AnyElementMatch "`"type`":`"System.NullReferenceException`""
-        # TODO: fix redundant SIGSEGV in Release (#3954)
-        if ($configuration -eq "Release") {
-            { $result.Events() | Should -Not -AnyElementMatch "`"type`":`"SIGSEGV`"" } | Should -Throw
-        } else {
-            $result.Events() | Should -Not -AnyElementMatch "`"type`":`"SIGSEGV`""
-            $result.Events() | Should -HaveCount 1
-        }
+        $result.Events() | Should -Not -AnyElementMatch "`"type`":`"SIGSEGV`""
+        $result.Events() | Should -HaveCount 1
     }
 
     It 'Delivers battery breadcrumbs in main thread (<configuration>)' {

--- a/integration-test/net9-maui/MauiProgram.cs
+++ b/integration-test/net9-maui/MauiProgram.cs
@@ -14,6 +14,7 @@ public static class MauiProgram
             {
 #if ANDROID
                 options.Dsn = "{{SENTRY_DSN}}";
+                options.Native.SignalHandlerStrategy = Sentry.Android.SignalHandlerStrategy.ChainAtStart;
 #endif
                 options.Debug = false;
                 options.DiagnosticLevel = SentryLevel.Error;

--- a/integration-test/net9-maui/MauiProgram.cs
+++ b/integration-test/net9-maui/MauiProgram.cs
@@ -14,7 +14,7 @@ public static class MauiProgram
             {
 #if ANDROID
                 options.Dsn = "{{SENTRY_DSN}}";
-                options.Native.SignalHandlerStrategy = Sentry.Android.SignalHandlerStrategy.ChainAtStart;
+                options.Native.ExperimentalOptions.SignalHandlerStrategy = Sentry.Android.SignalHandlerStrategy.ChainAtStart;
 #endif
                 options.Debug = false;
                 options.DiagnosticLevel = SentryLevel.Error;

--- a/src/Sentry/Platforms/Android/BindableNativeSentryOptions.cs
+++ b/src/Sentry/Platforms/Android/BindableNativeSentryOptions.cs
@@ -1,3 +1,5 @@
+using Sentry.Android;
+
 // ReSharper disable once CheckNamespace
 namespace Sentry;
 
@@ -24,6 +26,7 @@ internal partial class BindableSentryOptions
         public bool? EnableAutoActivityLifecycleTracing { get; set; }
         public bool? EnableActivityLifecycleTracingAutoFinish { get; set; }
         public bool? EnableUserInteractionTracing { get; set; }
+        public SignalHandlerStrategy? SignalHandlerStrategy { get; set; }
         public bool? AttachThreads { get; set; }
         public TimeSpan? ConnectionTimeout { get; set; }
         public bool? EnableNdk { get; set; }
@@ -66,6 +69,7 @@ internal partial class BindableSentryOptions
             options.EnableAutoActivityLifecycleTracing = EnableAutoActivityLifecycleTracing ?? options.EnableAutoActivityLifecycleTracing;
             options.EnableActivityLifecycleTracingAutoFinish = EnableActivityLifecycleTracingAutoFinish ?? options.EnableActivityLifecycleTracingAutoFinish;
             options.EnableUserInteractionTracing = EnableUserInteractionTracing ?? options.EnableUserInteractionTracing;
+            options.SignalHandlerStrategy = SignalHandlerStrategy ?? options.SignalHandlerStrategy;
             options.AttachThreads = AttachThreads ?? options.AttachThreads;
             options.ConnectionTimeout = ConnectionTimeout ?? options.ConnectionTimeout;
             options.EnableNdk = EnableNdk ?? options.EnableNdk;

--- a/src/Sentry/Platforms/Android/BindableNativeSentryOptions.cs
+++ b/src/Sentry/Platforms/Android/BindableNativeSentryOptions.cs
@@ -26,7 +26,6 @@ internal partial class BindableSentryOptions
         public bool? EnableAutoActivityLifecycleTracing { get; set; }
         public bool? EnableActivityLifecycleTracingAutoFinish { get; set; }
         public bool? EnableUserInteractionTracing { get; set; }
-        public SignalHandlerStrategy? SignalHandlerStrategy { get; set; }
         public bool? AttachThreads { get; set; }
         public TimeSpan? ConnectionTimeout { get; set; }
         public bool? EnableNdk { get; set; }
@@ -43,6 +42,7 @@ internal partial class BindableSentryOptions
         internal class NativeExperimentalOptions
         {
             public NativeSentryReplayOptions SessionReplay { get; set; } = new();
+            public SignalHandlerStrategy? SignalHandlerStrategy { get; set; }
         }
 
         internal class NativeSentryReplayOptions
@@ -69,7 +69,6 @@ internal partial class BindableSentryOptions
             options.EnableAutoActivityLifecycleTracing = EnableAutoActivityLifecycleTracing ?? options.EnableAutoActivityLifecycleTracing;
             options.EnableActivityLifecycleTracingAutoFinish = EnableActivityLifecycleTracingAutoFinish ?? options.EnableActivityLifecycleTracingAutoFinish;
             options.EnableUserInteractionTracing = EnableUserInteractionTracing ?? options.EnableUserInteractionTracing;
-            options.SignalHandlerStrategy = SignalHandlerStrategy ?? options.SignalHandlerStrategy;
             options.AttachThreads = AttachThreads ?? options.AttachThreads;
             options.ConnectionTimeout = ConnectionTimeout ?? options.ConnectionTimeout;
             options.EnableNdk = EnableNdk ?? options.EnableNdk;
@@ -95,6 +94,10 @@ internal partial class BindableSentryOptions
             }
             ExperimentalOptions.SessionReplay.RedactAllText = options.ExperimentalOptions.SessionReplay.MaskAllText;
             ExperimentalOptions.SessionReplay.RedactAllImages = options.ExperimentalOptions.SessionReplay.MaskAllImages;
+            if (ExperimentalOptions.SignalHandlerStrategy is { } signalHandlerStrategy)
+            {
+                options.ExperimentalOptions.SignalHandlerStrategy = signalHandlerStrategy;
+            }
         }
     }
 }

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -273,10 +273,10 @@ public partial class SentryOptions
             /// The default value is <see cref="Android.SignalHandlerStrategy.Default"/>.
             /// </summary>
             /// <remarks>
-            /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.301) are not compatible with
+            /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.103) are not compatible with
             /// <see cref="Android.SignalHandlerStrategy.ChainAtStart"/>. On affected versions,
             /// the SDK automatically falls back to <see cref="Android.SignalHandlerStrategy.Default"/>.
-            /// The issue was resolved in .NET runtime 10.0.4 (.NET SDK 10.0.400). See
+            /// The issue was resolved in .NET runtime 10.0.4 (.NET SDK 10.0.200). See
             /// <see href="https://github.com/dotnet/runtime/pull/123346">dotnet/runtime#123346</see>.
             /// </remarks>
             public SignalHandlerStrategy SignalHandlerStrategy { get; set; } = SignalHandlerStrategy.Default;

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -157,7 +157,7 @@ public partial class SentryOptions
         /// <summary>
         /// Gets or sets the strategy for how Sentry Native's signal handler interacts with the CLR/Mono
         /// signal handler.
-        /// The default value is <c>SignalHandlerStrategy.Default</c> (enabled).
+        /// The default value is <see cref="Android.SignalHandlerStrategy.Default"/>.
         /// </summary>
         /// <remarks>
         /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.301) are not compatible with

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -161,8 +161,8 @@ public partial class SentryOptions
         /// </summary>
         /// <remarks>
         /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.301) are not compatible with
-        /// <see cref="Android.SignalHandlerStrategy.ChainAtStart"/>. On affected versions, the
-        /// SDK automatically falls back to <see cref="Android.SignalHandlerStrategy.Default"/>.
+        /// <see cref="Android.SignalHandlerStrategy.ChainAtStart"/>. Using it on affected
+        /// versions throws an <see cref="InvalidOperationException"/> during initialization.
         /// The issue was resolved in .NET runtime 10.0.4 (.NET SDK 10.0.400). See
         /// <see href="https://github.com/dotnet/runtime/pull/123346">dotnet/runtime#123346</see>.
         /// </remarks>

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -154,20 +154,6 @@ public partial class SentryOptions
         /// </remarks>
         public bool EnableUserInteractionTracing { get; set; } = false;
 
-        /// <summary>
-        /// Gets or sets the strategy for how Sentry Native's signal handler interacts with the CLR/Mono
-        /// signal handler.
-        /// The default value is <see cref="Android.SignalHandlerStrategy.Default"/>.
-        /// </summary>
-        /// <remarks>
-        /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.301) are not compatible with
-        /// <see cref="Android.SignalHandlerStrategy.ChainAtStart"/>. Using it on affected
-        /// versions throws an <see cref="InvalidOperationException"/> during initialization.
-        /// The issue was resolved in .NET runtime 10.0.4 (.NET SDK 10.0.400). See
-        /// <see href="https://github.com/dotnet/runtime/pull/123346">dotnet/runtime#123346</see>.
-        /// </remarks>
-        public SignalHandlerStrategy SignalHandlerStrategy { get; set; } = SignalHandlerStrategy.Default;
-
         // ---------- From SentryOptions.java ----------
 
         /// <summary>
@@ -280,6 +266,20 @@ public partial class SentryOptions
         public class NativeExperimentalOptions
         {
             public NativeSentryReplayOptions SessionReplay { get; set; } = new();
+
+            /// <summary>
+            /// Gets or sets the strategy for how Sentry Native's signal handler interacts with the CLR/Mono
+            /// signal handler.
+            /// The default value is <see cref="Android.SignalHandlerStrategy.Default"/>.
+            /// </summary>
+            /// <remarks>
+            /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.301) are not compatible with
+            /// <see cref="Android.SignalHandlerStrategy.ChainAtStart"/>. Using it on affected
+            /// versions throws an <see cref="InvalidOperationException"/> during initialization.
+            /// The issue was resolved in .NET runtime 10.0.4 (.NET SDK 10.0.400). See
+            /// <see href="https://github.com/dotnet/runtime/pull/123346">dotnet/runtime#123346</see>.
+            /// </remarks>
+            public SignalHandlerStrategy SignalHandlerStrategy { get; set; } = SignalHandlerStrategy.Default;
         }
 
         public class NativeSentryReplayOptions

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -1,3 +1,5 @@
+using Sentry.Android;
+
 // ReSharper disable once CheckNamespace
 namespace Sentry;
 
@@ -151,6 +153,19 @@ public partial class SentryOptions
         /// See https://docs.sentry.io/platforms/android/performance/instrumentation/automatic-instrumentation/#user-interaction-instrumentation
         /// </remarks>
         public bool EnableUserInteractionTracing { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the strategy for how Sentry Native's signal handler interacts with the CLR/Mono
+        /// signal handler.
+        /// The default value is <c>SignalHandlerStrategy.Default</c> (enabled).
+        /// </summary>
+        /// <remarks>
+        /// When set to <see cref="Android.SignalHandlerStrategy.ChainAtStart"/>, .NET runtimes
+        /// 10.0.100–10.0.301 shipped in .NET SDKs 10.0.0–10.0.3 will crash. The issue was fixed in
+        /// <see href="https://github.com/dotnet/runtime/pull/123346">dotnet/runtime#123346</see>,
+        /// which shipped as .NET runtime 10.0.400 in .NET SDK 10.0.4.
+        /// </remarks>
+        public SignalHandlerStrategy SignalHandlerStrategy { get; set; } = SignalHandlerStrategy.Default;
 
         // ---------- From SentryOptions.java ----------
 

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -274,8 +274,8 @@ public partial class SentryOptions
             /// </summary>
             /// <remarks>
             /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.301) are not compatible with
-            /// <see cref="Android.SignalHandlerStrategy.ChainAtStart"/>. Using it on affected
-            /// versions throws an <see cref="InvalidOperationException"/> during initialization.
+            /// <see cref="Android.SignalHandlerStrategy.ChainAtStart"/>. On affected versions,
+            /// the SDK automatically falls back to <see cref="Android.SignalHandlerStrategy.Default"/>.
             /// The issue was resolved in .NET runtime 10.0.4 (.NET SDK 10.0.400). See
             /// <see href="https://github.com/dotnet/runtime/pull/123346">dotnet/runtime#123346</see>.
             /// </remarks>

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -160,10 +160,11 @@ public partial class SentryOptions
         /// The default value is <c>SignalHandlerStrategy.Default</c> (enabled).
         /// </summary>
         /// <remarks>
-        /// When set to <see cref="Android.SignalHandlerStrategy.ChainAtStart"/>, .NET runtimes
-        /// 10.0.100–10.0.301 shipped in .NET SDKs 10.0.0–10.0.3 will crash. The issue was fixed in
-        /// <see href="https://github.com/dotnet/runtime/pull/123346">dotnet/runtime#123346</see>,
-        /// which shipped as .NET runtime 10.0.400 in .NET SDK 10.0.4.
+        /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.301) are not compatible with
+        /// <see cref="Android.SignalHandlerStrategy.ChainAtStart"/>. On affected versions, the
+        /// SDK automatically falls back to <see cref="Android.SignalHandlerStrategy.Default"/>.
+        /// The issue was resolved in .NET runtime 10.0.4 (.NET SDK 10.0.400). See
+        /// <see href="https://github.com/dotnet/runtime/pull/123346">dotnet/runtime#123346</see>.
         /// </remarks>
         public SignalHandlerStrategy SignalHandlerStrategy { get; set; } = SignalHandlerStrategy.Default;
 

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -64,7 +64,11 @@ public static partial class SentrySdk
             o.ServerName = options.ServerName;
             o.SessionTrackingIntervalMillis = (long)options.AutoSessionTrackingInterval.TotalMilliseconds;
             o.ShutdownTimeoutMillis = (long)options.ShutdownTimeout.TotalMilliseconds;
-            o.SetNativeHandlerStrategy(JavaSdk.Android.Core.NdkHandlerStrategy.SentryHandlerStrategyDefault);
+            o.SetNativeHandlerStrategy(options.Native.SignalHandlerStrategy switch
+            {
+                SignalHandlerStrategy.ChainAtStart => NdkHandlerStrategy.SentryHandlerStrategyChainAtStart,
+                _ => NdkHandlerStrategy.SentryHandlerStrategyDefault
+            });
 
             if (options.CacheDirectoryPath is { } cacheDirectoryPath)
             {

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -64,7 +64,7 @@ public static partial class SentrySdk
             o.ServerName = options.ServerName;
             o.SessionTrackingIntervalMillis = (long)options.AutoSessionTrackingInterval.TotalMilliseconds;
             o.ShutdownTimeoutMillis = (long)options.ShutdownTimeout.TotalMilliseconds;
-            var signalHandlerStrategy = options.Native.SignalHandlerStrategy;
+            var signalHandlerStrategy = options.Native.ExperimentalOptions.SignalHandlerStrategy;
             if (signalHandlerStrategy == SignalHandlerStrategy.ChainAtStart
                 && System.Environment.Version is { Major: 10, Minor: 0, Build: < 4 })
             {

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -64,7 +64,17 @@ public static partial class SentrySdk
             o.ServerName = options.ServerName;
             o.SessionTrackingIntervalMillis = (long)options.AutoSessionTrackingInterval.TotalMilliseconds;
             o.ShutdownTimeoutMillis = (long)options.ShutdownTimeout.TotalMilliseconds;
-            o.SetNativeHandlerStrategy(options.Native.SignalHandlerStrategy switch
+            var signalHandlerStrategy = options.Native.SignalHandlerStrategy;
+            if (signalHandlerStrategy == SignalHandlerStrategy.ChainAtStart
+                && System.Environment.Version is { Major: 10, Minor: 0, Build: < 4 })
+            {
+                options.LogWarning(
+                    "SignalHandlerStrategy.ChainAtStart is not compatible with .NET runtime {0}. " +
+                    "Falling back to SignalHandlerStrategy.Default. Update to .NET runtime 10.0.4 or later.",
+                    System.Environment.Version);
+                signalHandlerStrategy = SignalHandlerStrategy.Default;
+            }
+            o.SetNativeHandlerStrategy(signalHandlerStrategy switch
             {
                 SignalHandlerStrategy.ChainAtStart => NdkHandlerStrategy.SentryHandlerStrategyChainAtStart,
                 _ => NdkHandlerStrategy.SentryHandlerStrategyDefault

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -68,11 +68,10 @@ public static partial class SentrySdk
             if (signalHandlerStrategy == SignalHandlerStrategy.ChainAtStart
                 && System.Environment.Version is { Major: 10, Minor: 0, Build: < 4 })
             {
-                options.LogWarning(
-                    "SignalHandlerStrategy.ChainAtStart is not compatible with .NET runtime {0}. " +
-                    "Falling back to SignalHandlerStrategy.Default. Update to .NET runtime 10.0.4 or later.",
-                    System.Environment.Version);
-                signalHandlerStrategy = SignalHandlerStrategy.Default;
+                var msg = $"SignalHandlerStrategy.ChainAtStart is not compatible with .NET runtime " +
+                    $"{System.Environment.Version}. Update to .NET runtime 10.0.4 or later.";
+                options.LogFatal(msg);
+                throw new InvalidOperationException(msg);
             }
             o.SetNativeHandlerStrategy(signalHandlerStrategy switch
             {

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -68,10 +68,11 @@ public static partial class SentrySdk
             if (signalHandlerStrategy == SignalHandlerStrategy.ChainAtStart
                 && System.Environment.Version is { Major: 10, Minor: 0, Build: < 4 })
             {
-                var msg = $"SignalHandlerStrategy.ChainAtStart is not compatible with .NET runtime " +
-                    $"{System.Environment.Version}. Update to .NET runtime 10.0.4 or later.";
-                options.LogFatal(msg);
-                throw new InvalidOperationException(msg);
+                options.LogWarning(
+                    "SignalHandlerStrategy.ChainAtStart is not compatible with .NET runtime {0}. " +
+                    "Falling back to SignalHandlerStrategy.Default. Update to .NET runtime 10.0.4 or later.",
+                    System.Environment.Version);
+                signalHandlerStrategy = SignalHandlerStrategy.Default;
             }
             o.SetNativeHandlerStrategy(signalHandlerStrategy switch
             {

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -64,6 +64,7 @@ public static partial class SentrySdk
             o.ServerName = options.ServerName;
             o.SessionTrackingIntervalMillis = (long)options.AutoSessionTrackingInterval.TotalMilliseconds;
             o.ShutdownTimeoutMillis = (long)options.ShutdownTimeout.TotalMilliseconds;
+
             var signalHandlerStrategy = options.Native.ExperimentalOptions.SignalHandlerStrategy;
             if (signalHandlerStrategy == SignalHandlerStrategy.ChainAtStart
                 && System.Environment.Version is { Major: 10, Minor: 0, Build: < 4 })

--- a/src/Sentry/Platforms/Android/SignalHandlerStrategy.cs
+++ b/src/Sentry/Platforms/Android/SignalHandlerStrategy.cs
@@ -1,0 +1,25 @@
+namespace Sentry.Android;
+
+/// <summary>
+/// Defines how Sentry Native's signal handler interacts with the CLR/Mono
+/// signal handler.
+/// </summary>
+public enum SignalHandlerStrategy
+{
+    /// <summary>
+    /// Invokes the CLR/Mono signal handler at the end of Sentry Native's signal
+    /// handler.
+    /// </summary>
+    Default,
+    /// <summary>
+    /// Invokes the CLR/Mono signal handler at the start of Sentry Native's
+    /// signal handler.
+    /// </summary>
+    /// <remarks>
+    /// .NET runtimes 10.0.100–10.0.301 shipped in .NET SDKs 10.0.0–10.0.3 crash when used
+    /// with this option. The issue was fixed in
+    /// <see href="https://github.com/dotnet/runtime/pull/123346">dotnet/runtime#123346</see>,
+    /// which shipped as .NET runtime 10.0.400 in .NET SDK 10.0.4.
+    /// </remarks>
+    ChainAtStart
+}

--- a/src/Sentry/Platforms/Android/SignalHandlerStrategy.cs
+++ b/src/Sentry/Platforms/Android/SignalHandlerStrategy.cs
@@ -21,10 +21,10 @@ public enum SignalHandlerStrategy
     /// <see cref="Default"/>.
     /// </summary>
     /// <remarks>
-    /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.301) are not compatible with
+    /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.103) are not compatible with
     /// this strategy. On affected versions, the SDK automatically falls back to
     /// <see cref="Default"/>. The issue was resolved in .NET runtime 10.0.4
-    /// (.NET SDK 10.0.400). See
+    /// (.NET SDK 10.0.200). See
     /// <see href="https://github.com/dotnet/runtime/pull/123346">dotnet/runtime#123346</see>.
     /// </remarks>
     ChainAtStart

--- a/src/Sentry/Platforms/Android/SignalHandlerStrategy.cs
+++ b/src/Sentry/Platforms/Android/SignalHandlerStrategy.cs
@@ -20,9 +20,9 @@ public enum SignalHandlerStrategy
     /// </summary>
     /// <remarks>
     /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.301) are not compatible with
-    /// this strategy. On affected versions, the SDK automatically falls back to
-    /// <see cref="Default"/>. The issue was resolved in .NET runtime 10.0.4
-    /// (.NET SDK 10.0.400). See
+    /// this strategy. Using it on affected versions throws an
+    /// <see cref="System.InvalidOperationException"/> during initialization.
+    /// The issue was resolved in .NET runtime 10.0.4 (.NET SDK 10.0.400). See
     /// <see href="https://github.com/dotnet/runtime/pull/123346">dotnet/runtime#123346</see>.
     /// </remarks>
     ChainAtStart

--- a/src/Sentry/Platforms/Android/SignalHandlerStrategy.cs
+++ b/src/Sentry/Platforms/Android/SignalHandlerStrategy.cs
@@ -16,10 +16,11 @@ public enum SignalHandlerStrategy
     /// signal handler.
     /// </summary>
     /// <remarks>
-    /// .NET runtimes 10.0.100–10.0.301 shipped in .NET SDKs 10.0.0–10.0.3 crash when used
-    /// with this option. The issue was fixed in
-    /// <see href="https://github.com/dotnet/runtime/pull/123346">dotnet/runtime#123346</see>,
-    /// which shipped as .NET runtime 10.0.400 in .NET SDK 10.0.4.
+    /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.301) are not compatible with
+    /// this strategy. On affected versions, the SDK automatically falls back to
+    /// <see cref="Default"/>. The issue was resolved in .NET runtime 10.0.4
+    /// (.NET SDK 10.0.400). See
+    /// <see href="https://github.com/dotnet/runtime/pull/123346">dotnet/runtime#123346</see>.
     /// </remarks>
     ChainAtStart
 }

--- a/src/Sentry/Platforms/Android/SignalHandlerStrategy.cs
+++ b/src/Sentry/Platforms/Android/SignalHandlerStrategy.cs
@@ -22,9 +22,9 @@ public enum SignalHandlerStrategy
     /// </summary>
     /// <remarks>
     /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.301) are not compatible with
-    /// this strategy. Using it on affected versions throws an
-    /// <see cref="System.InvalidOperationException"/> during initialization.
-    /// The issue was resolved in .NET runtime 10.0.4 (.NET SDK 10.0.400). See
+    /// this strategy. On affected versions, the SDK automatically falls back to
+    /// <see cref="Default"/>. The issue was resolved in .NET runtime 10.0.4
+    /// (.NET SDK 10.0.400). See
     /// <see href="https://github.com/dotnet/runtime/pull/123346">dotnet/runtime#123346</see>.
     /// </remarks>
     ChainAtStart

--- a/src/Sentry/Platforms/Android/SignalHandlerStrategy.cs
+++ b/src/Sentry/Platforms/Android/SignalHandlerStrategy.cs
@@ -16,7 +16,9 @@ public enum SignalHandlerStrategy
     /// <summary>
     /// Sentry Native invokes the .NET runtime's signal handler first, then captures the
     /// native crash. This avoids duplicate crash reports from both the native signal and
-    /// the managed exception.
+    /// the managed exception. This strategy is supported on Android 8.0 (API level 26)
+    /// and later; on older versions, Sentry Native silently falls back to
+    /// <see cref="Default"/>.
     /// </summary>
     /// <remarks>
     /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.301) are not compatible with

--- a/src/Sentry/Platforms/Android/SignalHandlerStrategy.cs
+++ b/src/Sentry/Platforms/Android/SignalHandlerStrategy.cs
@@ -7,13 +7,16 @@ namespace Sentry.Android;
 public enum SignalHandlerStrategy
 {
     /// <summary>
-    /// Invokes the CLR/Mono signal handler at the end of Sentry Native's signal
-    /// handler.
+    /// Sentry Native captures the crash first, then invokes the .NET runtime's signal
+    /// handler. The runtime may convert the same signal into a managed exception (e.g.,
+    /// <c>SIGSEGV</c> into <c>NullReferenceException</c>), which can result in duplicate
+    /// crash reports.
     /// </summary>
     Default,
     /// <summary>
-    /// Invokes the CLR/Mono signal handler at the start of Sentry Native's
-    /// signal handler.
+    /// Sentry Native invokes the .NET runtime's signal handler first, then captures the
+    /// native crash. This avoids duplicate crash reports from both the native signal and
+    /// the managed exception.
     /// </summary>
     /// <remarks>
     /// .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.301) are not compatible with


### PR DESCRIPTION
Experimental opt-in Android-only solution for:
- #3954

According to our newly introduced Android integration tests, `CHAIN_AT_START` works on `android-arm64` and `android-x64` in both `Release` and `Debug` configurations, but we'd like to validate the fix further in real-world conditions. To that end, we're making it opt-in initially so customers can try it on more devices, platforms, and configurations before considering it as the new default.

<!--
> [!NOTE]
> Depends on:
> - getsentry/sentry-native#1392
> - getsentry/sentry-native#1579
> - getsentry/sentry-native#1572
> - #5069

> TODO:
> - [x] `sentry-native`: [0.12.0](https://github.com/getsentry/sentry-native/releases/tag/0.12.0)
> - [x] `sentry-native-ndk`: [0.12.0](https://central.sonatype.com/artifact/io.sentry/sentry-native-ndk/0.12.0)
> - [x] `sentry-android-core`: [8.2.6](https://central.sonatype.com/artifact/io.sentry/sentry-android-core/8.26.0)
-->

## Changelog Entry

- fix: prevent redundant native exceptions on Android/Mono
  - Note: opt in by setting `options.Native.ExperimentalOptions.SignalHandlerStrategy` to `Sentry.Android.SignalHandlerStrategy.ChainAtStart`