### PR TITLE
ci: fix/set `MtouchUseLlvm=false` to speed up the macOS build

### DIFF
--- a/integration-test/common.ps1
+++ b/integration-test/common.ps1
@@ -209,6 +209,7 @@ BeforeAll {
       <SentryUploadAndroidProguardMapping>true</SentryUploadAndroidProguardMapping>
       <AndroidLinkTool Condition=`" '`$(AndroidLinkTool)' == '' `">r8</AndroidLinkTool>
       <AndroidDexTool Condition=`" '`$(AndroidDexTool)' == '' `">d8</AndroidDexTool>
+      <MtouchUseLlvm Condition=`"'`$(Configuration)' == 'Release'`">false</MtouchUseLlvm>
   </PropertyGroup>
 </Project>
 "@ | Out-File $name/Directory.Build.props

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <!-- Workaround for hang on compile issue.  See https://github.com/xamarin/xamarin-macios/issues/17825#issuecomment-1478568270. -->
-  <PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <MtouchUseLlvm>false</MtouchUseLlvm>
   </PropertyGroup>
 

--- a/test/Sentry.Maui.Device.TestApp/Directory.Build.props
+++ b/test/Sentry.Maui.Device.TestApp/Directory.Build.props
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <MtouchUseLlvm Condition="'$(Configuration)' == 'Release'">false</MtouchUseLlvm>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reduces the CI round-trip time from 2+ hours to less than 1 hour.

## Samples

The iOS target platform check in `samples/Directory.Build.props` did not work as expected. `Sentry.Samples.Ios` and `Sentry.Samples.Maui` were built with `MtouchUseLlvm=true`. We can remove the redundant iOS target platform check because the property is only applicable to iOS, tvOS, and Mac Catalyst, and never enabled by default on Mac Catalyst.

> ### MtouchUseLlvm
>
> A boolean property that specifies whether AOT compilation should be done using LLVM.
>
> Applicable to iOS, tvOS and Mac Catalyst projects.
>
> Default:
>
> - On iOS and tvOS: enabled for Release builds (where `Configuration="Release"`).
> - On Mac Catalyst: never enabled by default.

https://learn.microsoft.com/en-us/dotnet/ios/building-apps/build-properties#mtouchusellvm

## Tests

The property was already set for `Sentry.Maui.Device.IntegrationTestApp`. Now, it is also set for `Sentry.Maui.Device.TestApp` and the dynamically created `maui-app` integration test.

## See also

- https://github.com/dotnet/maui/issues/25022
- https://github.com/dotnet/macios/issues/17825
