### PR TITLE
chore: Log logging warning only once

### DIFF
--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -1793,14 +1793,14 @@ public class SentryOptions
                 DiagnosticLogger = new ConsoleDiagnosticLogger(DiagnosticLevel);
                 DiagnosticLogger.LogDebug("Logging enabled with ConsoleDiagnosticLogger and min level: {0}",
                     DiagnosticLevel);
-            }
 
-            if (SettingLocator.GetEnvironment().Equals("production", StringComparison.OrdinalIgnoreCase))
-            {
-                DiagnosticLogger.LogWarning("Sentry option 'Debug' is set to true while Environment is production. " +
-                                            "Be aware this can cause performance degradation and is not advised. " +
-                                            "See https://docs.sentry.io/platforms/dotnet/configuration/diagnostic-logger " +
-                                            "for more information");
+                if (SettingLocator.GetEnvironment().Equals("production", StringComparison.OrdinalIgnoreCase))
+                {
+                    DiagnosticLogger.LogWarning("Sentry option 'Debug' is set to true while Environment is production. " +
+                                                "Be aware this can cause performance degradation and is not advised. " +
+                                                "See https://docs.sentry.io/platforms/dotnet/configuration/diagnostic-logger " +
+                                                "for more information");
+                }
             }
         }
         else


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/2248

Super minor but I had an issue open on the Unity SDK about it: We don't need to warn about setting up debug logging in production twice, right? Only once when actually setting the logger should suffice?

```
Sentry: (Warning) Sentry option 'Debug' is set to true while Environment is production. Be aware this can cause performance degradation and is not advised. See https://docs.sentry.io/platforms/dotnet/configuration/diagnostic-logger for more information 
UnityEngine.DebugLogHandler:Internal_Log(LogType, LogOption, String, Object)
Sentry.Unity.UnityLogger:Log(SentryLevel, String, Exception, Object[])
Sentry.SentrySdk:InitHub(SentryOptions)
Sentry.SentrySdk:Init(SentryOptions)
Sentry.Unity.SentryUnitySdk:Init(SentryUnityOptions)
Sentry.Unity.SentrySdk:Init(SentryUnityOptions)

Sentry: (Debug) DSN read from options: https://huehue@hue.ingest.us.sentry.io/huehuehue 
UnityEngine.DebugLogHandler:Internal_Log(LogType, LogOption, String, Object)
Sentry.Unity.UnityLogger:Log(SentryLevel, String, Exception, Object[])
Sentry.Internal.SettingLocator:GetDsn()
Sentry.SentrySdk:InitHub(SentryOptions)
Sentry.SentrySdk:Init(SentryOptions)
Sentry.Unity.SentryUnitySdk:Init(SentryUnityOptions)
Sentry.Unity.SentrySdk:Init(SentryUnityOptions)

Sentry: (Debug) Initializing Hub for Dsn: 'https://huehue@hue.ingest.us.sentry.io/huehuehue'. 
UnityEngine.DebugLogHandler:Internal_Log(LogType, LogOption, String, Object)
Sentry.Unity.UnityLogger:Log(SentryLevel, String, Exception, Object[])
Sentry.Internal.Hub:.ctor(SentryOptions, ISentryClient, ISessionManager, ISystemClock, IInternalScopeManager, RandomValuesFactory, IReplaySession, ISampleRandHelper, BackpressureMonitor)
Sentry.SentrySdk:InitHub(SentryOptions)
Sentry.SentrySdk:Init(SentryOptions)
Sentry.Unity.SentryUnitySdk:Init(SentryUnityOptions)
Sentry.Unity.SentrySdk:Init(SentryUnityOptions)

Sentry: (Warning) Sentry option 'Debug' is set to true while Environment is production. Be aware this can cause performance degradation and is not advised. See https://docs.sentry.io/platforms/dotnet/configuration/diagnostic-logger for more information 
UnityEngine.DebugLogHandler:Internal_Log(LogType, LogOption, String, Object)
Sentry.Unity.UnityLogger:Log(SentryLevel, String, Exception, Object[])
Sentry.SentryClient:.ctor(SentryOptions, IBackgroundWorker, RandomValuesFactory, ISessionManager, BackpressureMonitor)
Sentry.Internal.Hub:.ctor(SentryOptions, ISentryClient, ISessionManager, ISystemClock, IInternalScopeManager, RandomValuesFactory, IReplaySession, ISampleRandHelper, BackpressureMonitor)
Sentry.SentrySdk:InitHub(SentryOptions)
Sentry.SentrySdk:Init(SentryOptions)
Sentry.Unity.SentryUnitySdk:Init(SentryUnityOptions)
Sentry.Unity.SentrySdk:Init(SentryUnityOptions)
```

#skip-changelog