### PR TITLE
test(logs): add Assertion for sentry.origin for MAUI

### DIFF
--- a/test/Sentry.Maui.Tests/Internal/SentryMauiStructuredLoggerProviderTests.cs
+++ b/test/Sentry.Maui.Tests/Internal/SentryMauiStructuredLoggerProviderTests.cs
@@ -91,6 +91,9 @@ public class SentryMauiStructuredLoggerProviderTests
 
         capturedLog.TryGetAttribute("sentry.sdk.version", out object? version).Should().BeTrue();
         version.Should().Be(Sentry.Maui.Internal.Constants.SdkVersion);
+
+        capturedLog.TryGetAttribute("sentry.origin", out object? origin).Should().BeTrue();
+        origin.Should().Be("auto.log.extensions_logging");
     }
 
     [Fact]


### PR DESCRIPTION
During #4699 and #4700 I noticed that we were missing one assertion.

This is a follow-up to #4566.
In particular to keep `SentryMauiStructuredLoggerProviderTests.cs` in sync with:
https://github.com/getsentry/sentry-dotnet/blob/18ca31baeb018dd9635a875a7b8cbdab95c691b4/test/Sentry.AspNetCore.Tests/SentryAspNetCoreStructuredLoggerProviderTests.cs#L95-L96

---

#skip-changelog
