### PR TITLE
Update Twitter badge to X badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ Consider taking a look at the __[samples](https://github.com/getsentry/sentry-do
 [![Discussions](https://img.shields.io/github/discussions/getsentry/sentry-dotnet.svg)](https://github.com/getsentry/sentry-dotnet/discussions)
 [![Discord Chat](https://img.shields.io/discord/621778831602221064?logo=discord&logoColor=ffffff&color=7389D8)](https://discord.gg/PXa5Apfe7K)
 [![Stack Overflow](https://img.shields.io/badge/stack%20overflow-sentry-green.svg)](http://stackoverflow.com/questions/tagged/sentry)
-[![Twitter Follow](https://img.shields.io/twitter/follow/getsentry?label=getsentry&style=social)](https://twitter.com/intent/follow?screen_name=getsentry)
+[![X Follow](https://img.shields.io/twitter/follow/sentry?label=sentry&style=social)](https://x.com/intent/follow?screen_name=sentry)


### PR DESCRIPTION
We were still using the twitter name instead of X and using the incorrect X link.

This PR fixes the correct redirect and the new brand name

#skip-changelog.