### PR TITLE
Temporary workaround for GetRuntime_AllProperties failing on WinArm64

### DIFF
--- a/test/Sentry.Tests/PlatformAbstractions/RuntimeInfoTests.cs
+++ b/test/Sentry.Tests/PlatformAbstractions/RuntimeInfoTests.cs
@@ -34,7 +34,7 @@ public class RuntimeInfoTests(ITestOutputHelper output)
         else
         {
             Assert.Equal("Mono", actual.Name);
-            actual.FrameworkInstallation.Should().BeNull("FrameworkInstallation is null");
+            actual.FrameworkInstallation.Should().BeNull("FrameworkInstallation is not null");
         }
 #endif
     }


### PR DESCRIPTION
Temporary workaround for https://github.com/getsentry/sentry-dotnet/issues/4712
- https://github.com/getsentry/sentry-dotnet/issues/4712

#skip-changelog

On WinArm64 specifically, we're seeing this since 2025.11.10:
```
  Error Message:
   Expected object not to be <null> because FrameworkInstallation.Version is null.
```

Possibly coming from here:
https://github.com/getsentry/sentry-dotnet/blob/c87dce7cf0c5fa8ef0df3496eb5573b70fcfd7c5/src/Sentry/PlatformAbstractions/RuntimeInfo.cs#L71

I don't have an ARM64 Windows machine, so it's a little painful to debug and we have quite a bit of work to get version 6 ready for release, so I've disabled that particular assertion on WinArm64 temporarily. We can circle back once version 6 has been released.