### PR TITLE
ref: cleanup unused code after merge

### DIFF
--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -1854,31 +1854,6 @@ public class SentryOptions
         }
     }
 
-    internal string? TryGetDsnSpecificCacheDirectoryPath()
-    {
-        if (string.IsNullOrWhiteSpace(CacheDirectoryPath))
-        {
-            return null;
-        }
-
-        // DSN must be set to use caching
-        if (string.IsNullOrWhiteSpace(Dsn))
-        {
-            return null;
-        }
-#if IOS || ANDROID // on iOS or Android the app is already sandboxed so there's no risk of sending data from 1 app to another Sentry's DSN
-        return Path.Combine(CacheDirectoryPath, "Sentry");
-#else
-        return Path.Combine(CacheDirectoryPath, "Sentry", Dsn.GetHashString());
-#endif
-    }
-
-    internal string? TryGetProcessSpecificCacheDirectoryPath()
-    {
-        // In the future, this will most likely contain process ID
-        return TryGetDsnSpecificCacheDirectoryPath();
-    }
-
     internal static List<StringOrRegex> GetDefaultInAppExclude() =>
     [
         "System",


### PR DESCRIPTION
I believe we were left with some now unused code after merges between
- #4498
- #4706

Removing code again from `SentryOptions`, that was removed in #4498, but accidentally restored in #4706.