### PR TITLE
ci: re-enable CodeQL scanning

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,15 +1,13 @@
 name: "CodeQL"
 
 on:
-  workflow_dispatch:
-#  # Temporarily disabled. See https://github.com/getsentry/sentry-dotnet/issues/4736
-#  push:
-#    branches: [ main ]
-#  pull_request:
-#    # The branches below must be a subset of the branches above
-#    branches: [ main ]
-#  schedule:
-#    - cron: '22 5 * * 1'
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  schedule:
+    - cron: '22 5 * * 1'
 
 jobs:
   analyze:


### PR DESCRIPTION
fixes: #4736
- #4736

---

Trying to bring back code scanning,
after we disabled it due to failure (see https://github.com/getsentry/sentry-dotnet/commit/249885330fe9213c89fbcad0b2d0b7038e7afd14),
in order to be able to merge the `version6` branch into `main`.

---

Note to reviewer:
Seems to work again ... please confirm by reviewing the Workflow output.
Maybe the problem was related to something in the `version6` branch only? 🤔