### PR TITLE
ci: pin danger action to full-length commit SHA

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -8,4 +8,4 @@ jobs:
   danger:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/danger@v3
+      - uses: getsentry/github-workflows/danger@13be9bec4ec5cd67061b747972b996e9c80f4f3b # 3.1.0


### PR DESCRIPTION
I noticed that the "Danger" action is not pinned to the full-length commit SHA.
This is a follow-up to issue #4540 (PR #4562).