### PR TITLE
ci: re-enable List vulnerable packages

### DIFF
--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -30,6 +30,6 @@ jobs:
       - name: List vulnerable packages
         shell: bash
         run: |
-          dotnet package list --project ${{ github.workspace }}/Sentry.sln --vulnerable --include-transitive | tee vulnerable.txt
+          dotnet package list --project Sentry.sln --vulnerable --include-transitive --no-restore | tee vulnerable.txt
           # https://github.com/getsentry/sentry-dotnet/issues/2814
           # ! grep 'has the following vulnerable packages' vulnerable.txt


### PR DESCRIPTION
Noticed during https://github.com/getsentry/sentry-dotnet/pull/4715#issuecomment-3557785837 that we previously disabled this workflow.

Do not fail workflow yet, since we still have vulnerable dependencies, that we need to review and update.
A related issue is: #4616

**Changes**
- enable "List vulnerable packages" workflow again (on `pull_request` and on _daily_ `schedule`)
  - but do not fail the workflow run yet
  - after #4757, we still have one vulnerable package left: #4616
- change to "noun first" form, introduced in .NET 10
- add `--no-restore`, since we do an explicit `dotnet restore` in the preceding step
