### PR TITLE
Move opentelemetry initialisation to servicebuilder in AzureFunctions sample

### DIFF
--- a/samples/Sentry.Samples.OpenTelemetry.AzureFunctions/Program.cs
+++ b/samples/Sentry.Samples.OpenTelemetry.AzureFunctions/Program.cs
@@ -12,7 +12,6 @@ var host = new HostBuilder()
         {
             builder
                 .AddSentry() // <-- Configure OpenTelemetry to send traces to Sentry
-                .AddAspNetCoreInstrumentation() // Instrument ASP.NET Core
                 .AddHttpClientInstrumentation(); // From OpenTelemetry.Instrumentation.Http... adds automatic tracing for outgoing HTTP requests
         });
     })

--- a/samples/Sentry.Samples.OpenTelemetry.AzureFunctions/Sentry.Samples.OpenTelemetry.AzureFunctions.csproj
+++ b/samples/Sentry.Samples.OpenTelemetry.AzureFunctions/Sentry.Samples.OpenTelemetry.AzureFunctions.csproj
@@ -12,7 +12,6 @@
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
         <PackageReference Include="OpenTelemetry" Version="1.14.0" />
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry-dotnet/pull/4763 to properly fix the Azure Functions sample application. 

@Flash0ver  apologies... I'm not sure why something so simple proved to be so difficult. Possibly early onset dementia.

#skip-changelog