### PR TITLE
build: fix Pack of Compiler-Extension

### DIFF
--- a/src/Sentry.Compiler.Extensions/Sentry.Compiler.Extensions.csproj
+++ b/src/Sentry.Compiler.Extensions/Sentry.Compiler.Extensions.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -189,7 +189,6 @@
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false"
                       PrivateAssets="all"
-                      Pack="true"
                       SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
supersedes #4307

---

Since `Sentry.6.0.0-*` pre-release, our Source Generator was missing from the `Sentry` NuGet package.

**Result**
<img width="705" height="498" alt="image" src="https://github.com/user-attachments/assets/90f944b3-e58a-40d0-9e4c-d55760ded8a3" />

---

#skip-changelog