### PR TITLE
build: fix Build of Compiler-Extension

### DIFF
--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -188,8 +188,7 @@
     <ProjectReference Include="..\Sentry.Compiler.Extensions\Sentry.Compiler.Extensions.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false"
-                      PrivateAssets="all"
-                      SetTargetFramework="TargetFramework=netstandard2.0" />
+                      PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Follow-up to #4800,
as it was causing a build error ... sometimes:

```
dotnet build

Build FAILED.

CSC : error CS2012: Cannot open 'D:\a\sentry-dotnet\sentry-dotnet\src\Sentry.Compiler.Extensions\obj\Release\netstandard2.0\Sentry.Compiler.Extensions.dll' for writing -- The process cannot access the file 'D:\a\sentry-dotnet\sentry-dotnet\src\Sentry.Compiler.Extensions\obj\Release\netstandard2.0\Sentry.Compiler.Extensions.dll' because it is being used by another process.; file may be locked by 'VBCSCompiler' (8484) [D:\a\sentry-dotnet\sentry-dotnet\src\Sentry.Compiler.Extensions\Sentry.Compiler.Extensions.csproj]
    0 Warning(s)
    1 Error(s)
```