### PR TITLE
test(integration): prevent auto-relaunch on Android

### DIFF
--- a/integration-test/net9-maui/App.xaml.cs
+++ b/integration-test/net9-maui/App.xaml.cs
@@ -102,8 +102,6 @@ public partial class App : Application
         SentrySdk.Close();
 
 #if ANDROID
-        // prevent auto-restart
-        Platform.CurrentActivity?.FinishAffinity();
         Process.KillProcess(Process.MyPid());
 #elif IOS
         System.Environment.Exit(0);

--- a/integration-test/net9-maui/MainPage.xaml.cs
+++ b/integration-test/net9-maui/MainPage.xaml.cs
@@ -5,12 +5,10 @@ public partial class MainPage : ContentPage
     public MainPage()
     {
         InitializeComponent();
-    }
 
-    protected override void OnAppearing()
-    {
-        base.OnAppearing();
-
-        App.OnAppearing();
+        this.Loaded += (s, e) =>
+        {
+            App.OnAppearing();
+        };
     }
 }


### PR DESCRIPTION
Fixes the behavior described in https://github.com/getsentry/sentry-dotnet/pull/4750#issuecomment-3578727992.

### Problem

[`Page.OnAppearing`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.controls.page.onappearing?view=net-maui-10.0#microsoft-maui-controls-page-onappearing) was originally chosen for triggering test crashes because it seemed like a good place for doing it as soon as the app is visible and fully up and running. However, it turns out to be a bit too early in the sense that it causes Android to try re-launch the process. Each restarted process re-triggers the test crash, which results in intermittent extra envelopes causing test assertion failures.

### Solution

Delaying the test crash until [`VisualElement.Loaded`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.controls.visualelement.loaded?view=net-maui-10.0#microsoft-maui-controls-visualelement-loaded) prevents the undesired auto-relaunch behavior on Android.