### PR TITLE
chore: ignore local Claude settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ test/**/*.apk
 
 # Download cache for Cocoa SDK
 modules/sentry-cocoa
+
+# Local Claude Code settings that should not be committed
+.claude/settings.local.json


### PR DESCRIPTION
Ignore .claude/settings.local.json as these are local settings not intended for version control.

#skip-changelog