### PR TITLE
build(deps): bump getsentry/github-workflows/sentry-cli/integration-test from 2.14.1 to 3.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,7 +284,7 @@ jobs:
 #        if: ${{ (matrix.rid != 'linux-musl-x64') && (matrix.rid != 'linux-musl-arm64') }}
         # TODO: Re-enable once we have resolved https://github.com/getsentry/sentry-dotnet/issues/4788
         if: ${{ (matrix.rid != 'linux-musl-x64') }}
-        uses: getsentry/github-workflows/sentry-cli/integration-test@a5e409bd5bad4c295201cdcfe862b17c50b29ab7 # v2.14.1
+        uses: getsentry/github-workflows/sentry-cli/integration-test@95603f4efe938315ff0dd427a1f2bb40b1889a92 # 3.2.0
         with:
           path: integration-test
 
@@ -293,7 +293,7 @@ jobs:
 #      # by passing it as parameter to aot.Tests.ps1 via an environment variable
 #      - name: Integration test (musl)
 #        if: ${{ (matrix.rid == 'linux-musl-x64') || (matrix.rid == 'linux-musl-arm64') }}
-#        uses: getsentry/github-workflows/sentry-cli/integration-test@v2
+#        uses: getsentry/github-workflows/sentry-cli/integration-test@95603f4efe938315ff0dd427a1f2bb40b1889a92 # 3.2.0
 #        env:
 #          ContainerBaseImage: 'mcr.microsoft.com/dotnet/nightly/runtime-deps:10.0-preview-alpine3.22'
 #        with:
@@ -332,7 +332,7 @@ jobs:
         run: msbuild Sentry-CI-Build-Windows.slnf -t:Restore,Build,Pack -p:Configuration=Release --nologo -v:minimal -flp:logfile=msbuild.log -p:CopyLocalLockFileAssemblies=true -bl:msbuild.binlog
 
       - name: Test MSBuild
-        uses: getsentry/github-workflows/sentry-cli/integration-test@a5e409bd5bad4c295201cdcfe862b17c50b29ab7 # v2.14.1
+        uses: getsentry/github-workflows/sentry-cli/integration-test@95603f4efe938315ff0dd427a1f2bb40b1889a92 # 3.2.0
         with:
           path: integration-test/msbuild.Tests.ps1
 
@@ -381,7 +381,7 @@ jobs:
           path: src
 
       - name: Test AOT
-        uses: getsentry/github-workflows/sentry-cli/integration-test@a5e409bd5bad4c295201cdcfe862b17c50b29ab7 # v2.14.1
+        uses: getsentry/github-workflows/sentry-cli/integration-test@95603f4efe938315ff0dd427a1f2bb40b1889a92 # 3.2.0
         env:
           RuntimeIdentifier: ${{ matrix.rid }}
         with:

--- a/.github/workflows/device-tests-ios.yml
+++ b/.github/workflows/device-tests-ios.yml
@@ -49,14 +49,14 @@ jobs:
         id: first-integration-test-run
         continue-on-error: true
         timeout-minutes: 40
-        uses: getsentry/github-workflows/sentry-cli/integration-test@a5e409bd5bad4c295201cdcfe862b17c50b29ab7 # v2.14.1
+        uses: getsentry/github-workflows/sentry-cli/integration-test@95603f4efe938315ff0dd427a1f2bb40b1889a92 # 3.2.0
         with:
           path: integration-test/ios.Tests.ps1
 
       - name: Retry Integration Tests (if previous failed to run)
         if: steps.first-integration-test-run.outcome == 'failure'
         timeout-minutes: 40
-        uses: getsentry/github-workflows/sentry-cli/integration-test@a5e409bd5bad4c295201cdcfe862b17c50b29ab7 # v2.14.1
+        uses: getsentry/github-workflows/sentry-cli/integration-test@95603f4efe938315ff0dd427a1f2bb40b1889a92 # 3.2.0
         with:
           path: integration-test/ios.Tests.ps1
 


### PR DESCRIPTION
Related
- #4837
- #4750

Changes
- [3.0.0](https://github.com/getsentry/github-workflows/releases/tag/3.0.0)
- [3.1.0](https://github.com/getsentry/github-workflows/releases/tag/3.1.0)
- [3.2.0](https://github.com/getsentry/github-workflows/releases/tag/3.2.0)
