### PR TITLE
chore: bump testing dependencies

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -64,7 +64,7 @@
 
   <!-- only non-platform-specific projects should include these packages -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)'==''">
-    <PackageReference Include="Verify.Xunit" Version="30.5.0" />
+    <PackageReference Include="Verify.Xunit" Version="31.0.5" />
     <PackageReference Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />


### PR DESCRIPTION
Update `test` dependencies, that don't require additional changes.

See also ... for updates requiring additional changes:
- #4864
- #4866
