### PR TITLE
chore: Remove redundant transform

### DIFF
--- a/src/Sentry.Bindings.Android/Transforms/Metadata.xml
+++ b/src/Sentry.Bindings.Android/Transforms/Metadata.xml
@@ -111,7 +111,7 @@
   -->
   <remove-node path="/api/package[@name='io.sentry']/interface[@name='BackfillingEventProcessor']" />
   <remove-node path="/api/package[@name='io.sentry.android.core']/class[@name='AnrV2EventProcessor']" />
-  
+
   <!--
     SentryEvent.serialize() expects an parameter which implements IObjectWriter.
     JsonObjectWriter implements IObjectWriter in Java, but somehow this is not reflected in the generated binding.
@@ -163,6 +163,4 @@
   <!-- Remove UpdateStatus to avoid CS0108 for conflicting _members fields in nested subclasses -->
   <remove-node path="/api/package[@name='io.sentry']/class[@name='UpdateStatus']" />
 
-  <!-- error CS0050: Inconsistent accessibility: return type 'INetworkBody' is less accessible than method 'NetworkBody.FromXxx' -->
-  <remove-node path="/api/package[@name='io.sentry.util.network']/interface[@name='NetworkBody']" />
 </metadata>


### PR DESCRIPTION
Removes a redundant transform from the android bindings project, as this causes build warnings that just create noise.

#skip-changelog