### PR TITLE
chore: update Roslynator.Analyzers from 4.9.0 to 4.15.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -85,7 +85,7 @@
 
   <ItemGroup>
     <PackageReference Include="UnoptimizedAssemblyDetector" Version="0.1.1" PrivateAssets="All" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.9.0" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Import the root global usings, except for samples. -->


### PR DESCRIPTION
Updates the `Roslynator.Analyzers` dev dependency.

If we'd like, we can additionally add (one or) two new packages, mentioned in [v4.10.0](https://github.com/dotnet/roslynator/releases/tag/v4.10.0)
- https://www.nuget.org/packages/Roslynator.Refactorings
- https://www.nuget.org/packages/Roslynator.CodeFixes
