### PR TITLE
fix: Permissions for changelog preview workflow

### DIFF
--- a/Sentry-CI-Build-Windows-arm64.slnf
+++ b/Sentry-CI-Build-Windows-arm64.slnf
@@ -3,6 +3,8 @@
     "path": "Sentry.sln",
     "projects": [
       "benchmarks\\Sentry.Benchmarks\\Sentry.Benchmarks.csproj",
+      "modules\\perfview\\src\\FastSerialization\\FastSerialization.csproj",
+      "modules\\perfview\\src\\TraceEvent\\TraceEvent.csproj",
       "samples\\Sentry.Samples.AspNetCore.Basic\\Sentry.Samples.AspNetCore.Basic.csproj",
       "samples\\Sentry.Samples.AspNetCore.Blazor.Server\\Sentry.Samples.AspNetCore.Blazor.Server.csproj",
       "samples\\Sentry.Samples.AspNetCore.Blazor.Wasm\\Sentry.Samples.AspNetCore.Blazor.Wasm.csproj",

--- a/Sentry-CI-Build-Windows.slnf
+++ b/Sentry-CI-Build-Windows.slnf
@@ -3,6 +3,8 @@
     "path": "Sentry.sln",
     "projects": [
       "benchmarks\\Sentry.Benchmarks\\Sentry.Benchmarks.csproj",
+      "modules\\perfview\\src\\FastSerialization\\FastSerialization.csproj",
+      "modules\\perfview\\src\\TraceEvent\\TraceEvent.csproj",
       "samples\\Sentry.Samples.AspNetCore.Basic\\Sentry.Samples.AspNetCore.Basic.csproj",
       "samples\\Sentry.Samples.AspNetCore.Blazor.Server\\Sentry.Samples.AspNetCore.Blazor.Server.csproj",
       "samples\\Sentry.Samples.AspNetCore.Blazor.Wasm\\Sentry.Samples.AspNetCore.Blazor.Wasm.csproj",

--- a/Sentry-CI-Build-macOS.slnf
+++ b/Sentry-CI-Build-macOS.slnf
@@ -3,6 +3,8 @@
     "path": "Sentry.sln",
     "projects": [
       "benchmarks\\Sentry.Benchmarks\\Sentry.Benchmarks.csproj",
+      "modules\\perfview\\src\\FastSerialization\\FastSerialization.csproj",
+      "modules\\perfview\\src\\TraceEvent\\TraceEvent.csproj",
       "samples\\Sentry.Samples.Android\\Sentry.Samples.Android.csproj",
       "samples\\Sentry.Samples.AspNetCore.Basic\\Sentry.Samples.AspNetCore.Basic.csproj",
       "samples\\Sentry.Samples.AspNetCore.Blazor.Server\\Sentry.Samples.AspNetCore.Blazor.Server.csproj",


### PR DESCRIPTION
Not sure how this worked before merging, but it appears to require a permission that it's missing. 

See https://github.com/getsentry/sentry-dotnet/actions/runs/21570267671:
> The workflow is not valid. .github/workflows/changelog-preview.yml (Line: 16, Col: 3): Error calling workflow 'getsentry/craft/.github/workflows/changelog-preview.yml@v2'. The workflow is requesting 'statuses: write', but is only allowed 'statuses: none'.

#skip-changelog