### PR TITLE
ci(danger): disable Danger check

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   danger:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: getsentry/github-workflows/danger@747c4c2906d373f5cd809abe94a7fd732a2421a7 # 3.2.1


### PR DESCRIPTION
Now with #4818, which should automatically generate `CHANGELOG` entries on release (via the PR title or a section in the PR description, we want to disable the changelog-validation of our [danger](https://github.com/getsentry/github-workflows/blob/main/danger/README.md) action / workflow.

For example, #4899 still asks us to `Please consider adding a changelog entry for the next release.`.
Also, we had to still manually update the CHANGELOG: see getsentry/publish#7429

For that, we need to update the [Danger Composite Action](https://github.com/getsentry/github-workflows/tree/main/danger).

This PR temporarily disabled the Danger workflow.
