### PR TITLE
ci: move from dotnet-format tool to .NET SDK command

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -39,9 +39,9 @@ jobs:
 
       - name: Upload Format Report
         if: ${{ always() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: dotnet-format-report
+          archive: false
           path: ./dotnet-format-report/
           if-no-files-found: ignore
 


### PR DESCRIPTION
### Summary
- Remove `dotnet-format` global tool as it is now included in the .NET SDK
- Additionally, upload a `--report`, similar to build logs and test results
- Merge all three `--exclude` Options into a single space-separated list

### Remarks

[dotnet-format](https://www.nuget.org/packages/dotnet-format) has been marked _deprecated_ on NuGet.org.
It is included as a CLI command [since the the .NET 6.0 SDK](https://github.com/dotnet/format/issues/1268).

[dotnet format](https://learn.microsoft.com/dotnet/core/tools/dotnet-format) supports a `--report` option, that this changeset is uploading as a non-zipped artifact (see #4966).

Unfortunately, this does not fix the automatic removal of an Assertion (see #4911).
`--exclude ./test/Sentry.Tests/AttributeReaderTests.cs` is still required ... this may be a bug in a Diagnostic-Analyzer if `xUnit.net` and it's associated Code-Fix-Provider.

This PR also merges all three `--exclude` options in to a single space-separated list ... see [dotnet format](https://learn.microsoft.com/dotnet/core/tools/dotnet-format).