### PR TITLE
fix: `IsTrimmed` is `false` for Unity

### DIFF
--- a/src/Sentry/Internal/AotHelper.cs
+++ b/src/Sentry/Internal/AotHelper.cs
@@ -12,7 +12,12 @@ internal static class AotHelper
 
     static AotHelper()
     {
-        IsTrimmed = CheckIsTrimmed();
+        IsTrimmed =
+#if SENTRY_UNITY
+            false;
+#else
+            CheckIsTrimmed();
+#endif
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026: RequiresUnreferencedCode", Justification = AvoidAtRuntime)]


### PR DESCRIPTION
I'm running into edge cases where Unity games running on older versions falsely register as an AOT build.

#skip-changelog