### PR TITLE
fix: MSB4006 circular dependency involving target "SetupCocoaSDK"

### DIFF
--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -79,6 +79,11 @@
       Condition="Exists('$(SentryCocoaFramework).zip') and !Exists('$(SentryCocoaFramework)')"
       Command="unzip -o $(SentryCocoaFramework).zip -d $(SentryCocoaCache) &amp;&amp; mv $(SentryCocoaCache)Sentry-Dynamic.xcframework $(SentryCocoaFramework)" />
 
+    <!-- Invalidate any stale sanitization stamp left over from a previous extraction.
+         Without this, if the xcframework directory is deleted while the zip survives, the stamp
+         would prevent SanitizeSentryCocoaFramework from running on the freshly extracted framework. -->
+    <Delete Files="$(SentryCocoaFramework).sanitized.stamp" />
+
     <!-- Make a copy of the header files before we butcher these to suite objective sharpie -->
     <MakeDir Directories="$(SentryCocoaFrameworkHeaders)" />
     <ItemGroup>


### PR DESCRIPTION
Resolves #4955:
- #4955

## Explanation

Me and Claude spent a bit of time looking at this. I think we now have a solution that is OK.

### What the original code did

The recursive MSBuild call with `RemoveProperties="TargetFramework" `meant that during an inner build, instead of running `_SetupCocoaSDK` directly, it spawned a separate MSBuild process on the same project with no TargetFramework set. That separate process ran `_SetupCocoaSDK` once in isolation. So across both inner TFM builds, the actual work happened in one subprocess — not in the inner builds themselves.

### What the new code does

`_SetupCocoaSDK` now runs once per inner build (once for `net9.0-ios18.0`, once for `net9.0-maccatalyst18.0`). 

However, every sub-target of `_SetupCocoaSDK` is idempotent and has checks to make sure we're not double handling:
- `_DownloadCocoaSDK` — has Condition="... And !Exists('$(SentryCocoaFramework)')", so ,skips if already downloaded
- `_BuildCocoaSDK` — has Inputs/Outputs incremental build guards, skips if up-to-date
- `_GenerateSentryCocoaBindings` — has Inputs/Outputs, skips if up-to-date
- `SanitizeSentryCocoaFramework` — has "!Exists('$(SentryCocoaFramework).sanitized.stamp"

#skip-changelog