### PR TITLE
feat: Add API to retrieve persisted breadcrumbs on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add `SentrySdk.GetPersistedBreadcrumbs()` API to retrieve breadcrumbs from the previous Android app session ([#4977](https://github.com/getsentry/sentry-dotnet/pull/4977))
+
 ### Fixes
 
 - The SDK now logs a `Warning` instead of an `Error` when being ratelimited ([#4927](https://github.com/getsentry/sentry-dotnet/pull/4927))

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -302,28 +302,35 @@ public static partial class SentrySdk
 
     private static List<Breadcrumb>? ReadPersistedBreadcrumbs(JavaSdk.SentryOptions nativeOptions)
     {
-        var observer = nativeOptions.FindPersistingScopeObserver();
-        if (observer is null)
+        try
         {
-            return null;
-        }
-
-        var result = observer.Read(nativeOptions, "breadcrumbs.json",
-            Java.Lang.Class.FromType(typeof(Java.Util.IList)));
-
-        if (result is not Java.Util.IList javaList)
-        {
-            return null;
-        }
-
-        var breadcrumbs = new List<Breadcrumb>();
-        for (var i = 0; i < javaList.Size(); i++)
-        {
-            if (javaList.Get(i)?.JavaCast<JavaSdk.Breadcrumb>() is { } javaBreadcrumb)
+            var observer = nativeOptions.FindPersistingScopeObserver();
+            if (observer is null)
             {
-                breadcrumbs.Add(javaBreadcrumb.ToBreadcrumb());
+                return null;
             }
+
+            var result = observer.Read(nativeOptions, "breadcrumbs.json",
+                Java.Lang.Class.FromType(typeof(Java.Util.IList)));
+
+            if (result is not Java.Util.IList javaList)
+            {
+                return null;
+            }
+
+            var breadcrumbs = new List<Breadcrumb>();
+            for (var i = 0; i < javaList.Size(); i++)
+            {
+                if (javaList.Get(i)?.JavaCast<JavaSdk.Breadcrumb>() is { } javaBreadcrumb)
+                {
+                    breadcrumbs.Add(javaBreadcrumb.ToBreadcrumb());
+                }
+            }
+            return breadcrumbs;
         }
-        return breadcrumbs;
+        catch (Java.Lang.Exception)
+        {
+            return null;
+        }
     }
 }

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -173,6 +173,11 @@ public static partial class SentrySdk
             o.ConnectionStatusProvider =
                 new AndroidConnectionStatusProvider(AppContext, o, buildInfoProvider, timeProvider, mainHandler).JavaCast<IConnectionStatusProvider>();
             o.AddIntegration(new SystemEventsBreadcrumbsIntegration(AppContext, mainHandler).JavaCast<JavaSdk.IIntegration>());
+
+            // Read persisted breadcrumbs now, inside the options callback, before the SDK starts.
+            // This avoids a race condition with breadcrumb-producing integrations that start writing
+            // to the QueueFile as soon as SentryAndroid.Init() completes.
+            _persistedBreadcrumbs = ReadPersistedBreadcrumbs(o);
         });
 
         // Now initialize the Android SDK (with a logger only if we're debugging)
@@ -185,9 +190,6 @@ public static partial class SentrySdk
         {
             SentryAndroid.Init(AppContext, configuration);
         }
-
-        // Read persisted breadcrumbs from the previous session before they get overwritten
-        _persistedBreadcrumbs = ReadPersistedBreadcrumbs(nativeOptions!);
 
         // Set options for the managed SDK that depend on the Android SDK. (The user will not be able to modify these.)
         options.AddEventProcessor(new AndroidEventProcessor(nativeOptions!));
@@ -302,35 +304,31 @@ public static partial class SentrySdk
 
     private static List<Breadcrumb>? ReadPersistedBreadcrumbs(JavaSdk.SentryOptions nativeOptions)
     {
-        try
-        {
-            var observer = nativeOptions.FindPersistingScopeObserver();
-            if (observer is null)
-            {
-                return null;
-            }
-
-            var result = observer.Read(nativeOptions, "breadcrumbs.json",
-                Java.Lang.Class.FromType(typeof(Java.Util.IList)));
-
-            if (result is not Java.Util.IList javaList)
-            {
-                return null;
-            }
-
-            var breadcrumbs = new List<Breadcrumb>();
-            for (var i = 0; i < javaList.Size(); i++)
-            {
-                if (javaList.Get(i)?.JavaCast<JavaSdk.Breadcrumb>() is { } javaBreadcrumb)
-                {
-                    breadcrumbs.Add(javaBreadcrumb.ToBreadcrumb());
-                }
-            }
-            return breadcrumbs;
-        }
-        catch (Java.Lang.Exception)
+        if (nativeOptions.CacheDirPath is null)
         {
             return null;
         }
+
+        // Create a temporary observer to read breadcrumbs from the previous session's QueueFile.
+        // This must be called before SentryAndroid.Init() completes, to avoid a race condition
+        // with breadcrumb-producing integrations that write to the same QueueFile concurrently.
+        using var observer = new JavaSdk.Cache.PersistingScopeObserver(nativeOptions);
+        var result = observer.Read(nativeOptions, "breadcrumbs.json",
+            Java.Lang.Class.FromType(typeof(Java.Util.IList)));
+
+        if (result is not Java.Util.IList javaList)
+        {
+            return null;
+        }
+
+        var breadcrumbs = new List<Breadcrumb>();
+        for (var i = 0; i < javaList.Size(); i++)
+        {
+            if (javaList.Get(i)?.JavaCast<JavaSdk.Breadcrumb>() is { } javaBreadcrumb)
+            {
+                breadcrumbs.Add(javaBreadcrumb.ToBreadcrumb());
+            }
+        }
+        return breadcrumbs;
     }
 }

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -309,7 +309,7 @@ public static partial class SentrySdk
         }
 
         var result = observer.Read(nativeOptions, "breadcrumbs.json",
-            Java.Lang.Class.FromType(typeof(Java.Util.ArrayList)));
+            Java.Lang.Class.FromType(typeof(Java.Util.IList)));
 
         if (result is not Java.Util.IList javaList)
         {

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -1,5 +1,6 @@
 using Android.Content.PM;
 using Android.OS;
+using Android.Runtime;
 using Sentry.Android;
 using Sentry.Android.Callbacks;
 using Sentry.Android.Extensions;
@@ -22,6 +23,7 @@ namespace Sentry;
 public static partial class SentrySdk
 {
     private static AndroidContext AppContext { get; set; } = Application.Context;
+    private static List<Breadcrumb>? _persistedBreadcrumbs;
 
     private static void InitSentryAndroidSdk(SentryOptions options)
     {
@@ -184,6 +186,9 @@ public static partial class SentrySdk
             SentryAndroid.Init(AppContext, configuration);
         }
 
+        // Read persisted breadcrumbs from the previous session before they get overwritten
+        _persistedBreadcrumbs = ReadPersistedBreadcrumbs(nativeOptions!);
+
         // Set options for the managed SDK that depend on the Android SDK. (The user will not be able to modify these.)
         options.AddEventProcessor(new AndroidEventProcessor(nativeOptions!));
         if (options.Android.LogCatIntegration != LogCatIntegrationType.None)
@@ -285,5 +290,40 @@ public static partial class SentrySdk
         return packageInfo.VersionCode;
 #pragma warning restore CA1422
 #pragma warning restore CS0618
+    }
+
+    /// <summary>
+    /// Retrieves breadcrumbs that were persisted to disk by the Android SDK's scope observer.
+    /// These are breadcrumbs from the previous app session that were saved before the app terminated.
+    /// </summary>
+    /// <returns>A list of persisted breadcrumbs, or an empty list if unavailable.</returns>
+    public static IReadOnlyList<Breadcrumb> GetPersistedBreadcrumbs() =>
+        _persistedBreadcrumbs ?? [];
+
+    private static List<Breadcrumb>? ReadPersistedBreadcrumbs(JavaSdk.SentryOptions nativeOptions)
+    {
+        var observer = nativeOptions.FindPersistingScopeObserver();
+        if (observer is null)
+        {
+            return null;
+        }
+
+        var result = observer.Read(nativeOptions, "breadcrumbs.json",
+            Java.Lang.Class.FromType(typeof(Java.Util.ArrayList)));
+
+        if (result is not Java.Util.IList javaList)
+        {
+            return null;
+        }
+
+        var breadcrumbs = new List<Breadcrumb>();
+        for (var i = 0; i < javaList.Size(); i++)
+        {
+            if (javaList.Get(i)?.JavaCast<JavaSdk.Breadcrumb>() is { } javaBreadcrumb)
+            {
+                breadcrumbs.Add(javaBreadcrumb.ToBreadcrumb());
+            }
+        }
+        return breadcrumbs;
     }
 }


### PR DESCRIPTION
closes #5243

## Summary
- Adds `SentrySdk.GetPersistedBreadcrumbs()` public API that returns breadcrumbs from the previous app session on Android
- Reads from the native Android SDK's `PersistingScopeObserver` during init and caches the result
- No internal binding types are exposed — customers get back .NET `Breadcrumb` objects

### Usage
```csharp
#if __ANDROID__
var breadcrumbs = SentrySdk.GetPersistedBreadcrumbs();
foreach (var breadcrumb in breadcrumbs)
{
    Console.WriteLine($"[{breadcrumb.Timestamp}] {breadcrumb.Category}: {breadcrumb.Message}");
}
#endif
```

## Test plan
- [ ] Verify breadcrumbs are read correctly on Android after a previous session with breadcrumbs
- [ ] Verify empty list is returned when no persisted breadcrumbs exist
- [ ] Verify the API is accessible from a MAUI sample app

🤖 Generated with [Claude Code](https://claude.com/claude-code)