### PR TITLE
chore: Set up dotagents with agent skills for GitHub Copilot

### DIFF
--- a/.github/skills
+++ b/.github/skills
@@ -1,0 +1,1 @@
+.agents/skills


### PR DESCRIPTION
Follow-up to
- #4970
- #4988

---

This enables the skills for GitHub Copilot,
which are managed via https://github.com/getsentry/dotagents locally for this repository.

Similar to the GitHub Copilot symlink for the `AGENTS.md`:
- https://github.com/getsentry/sentry-dotnet/pull/4974/changes#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5

Related GitHub Copilot documentation
- https://docs.github.com/copilot/concepts/agents/about-agent-skills
