### PR TITLE
chore: Improve device test output

### DIFF
--- a/scripts/device-test.ps1
+++ b/scripts/device-test.ps1
@@ -93,6 +93,16 @@ try
             xharness $group test $arguments --output-directory=test_output
             if ($LASTEXITCODE -ne 0)
             {
+                $testResultsXml = './test_output/TestResults.xml'
+                if (Test-Path $testResultsXml)
+                {
+                    $failedTests = Select-String -Path $testResultsXml -Pattern 'result="Fail"'
+                    if ($failedTests)
+                    {
+                        Write-Host "`nFailed tests:"
+                        $failedTests | ForEach-Object { Write-Host $_.Line }
+                    }
+                }
                 throw 'xharness run failed with non-zero exit code'
             }
         }
@@ -100,9 +110,12 @@ try
         {
             if ($CI)
             {
-                scripts/parse-xunit2-xml.ps1 (Get-Item ./test_output/*.xml).FullName | Out-File $env:GITHUB_STEP_SUMMARY
+                $xmlFiles = Get-Item ./test_output/*.xml -ErrorAction SilentlyContinue
+                if ($xmlFiles)
+                {
+                    scripts/parse-xunit2-xml.ps1 $xmlFiles.FullName | Out-File $env:GITHUB_STEP_SUMMARY
+                }
             }
-
         }
     }
 }


### PR DESCRIPTION
In the case of a failed test, the script now outputs any lines from `test_output/TestResults.xml` contining the text `result="Fail"`, as a quick summary of any test failures.

Also, on CI, if there is no match for `(Get-Item ./test_output/*.xml).FullName` this resulted in an unrelated error (no such property FullName), which made it hard to identify the root cause. That code now only executes if there are some matching the pattern for the xml files.

#skip-changelog