### PR TITLE
ci: Add weekly .NET SDK update to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,8 @@ updates:
   directory: "/test"
   schedule:
     interval: weekly
-  open-pull-requests-limit: 2 
-  
+  open-pull-requests-limit: 2
+
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
### Summary

Add weekly .NET SDK update to Dependabot.

See announcement / changelog:
https://github.blog/changelog/2024-11-19-dependabot-can-now-perform-version-updates-for-the-net-sdk/

### Remarks

Similar to #5000, this should help us capture issues with new versions of tooling earlier.
