### PR TITLE
chore: Update Polyfill from 1.32.0 to 1.33.2

### DIFF
--- a/src/Sentry.Analyzers/Sentry.Analyzers.csproj
+++ b/src/Sentry.Analyzers/Sentry.Analyzers.csproj
@@ -24,7 +24,7 @@
     https://github.com/SimonCropp/Polyfill
   -->
   <ItemGroup>
-    <PackageReference Include="Polyfill" Version="1.34.0" PrivateAssets="all" />
+    <PackageReference Include="Polyfill" Version="1.33.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -65,7 +65,7 @@
     https://github.com/SimonCropp/Polyfill
   -->
   <ItemGroup>
-    <PackageReference Include="Polyfill" Version="1.34.0" PrivateAssets="all" />
+    <PackageReference Include="Polyfill" Version="1.33.2" PrivateAssets="all" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
### Summary

Update `Polyfill` to the latest version possible without a **Breaking Change** for our scenario.

### Remarks

Replacement for #4879, as updating to a newer version yields a possible Dependency-Breaking Change for .NET Framework applications.

Follow-up: #5006, targeted for our next **Major** release.

Changes: https://github.com/SimonCropp/Polyfill/compare/1.32.0...1.33.1
The only notable change is a bug-fix for a Polyfill-method, that we _currently_ don't seem to be impacted by:
- `public static Task<string> ReadLineAsync(this TextReader target, CancellationToken cancellationToken)`

So we can actually take or leave this PR.
I'd still like to take it, should we start using the impacted method between now and #5006.
