### PR TITLE
ci: Add weekly npm update to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,10 +21,9 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-      interval: weekly
+    interval: weekly
 
 - package-ecosystem: "npm"
   directory: "/"
   schedule:
     interval: "weekly"
-  open-pull-requests-limit: 1


### PR DESCRIPTION
### Summary

Add weekly `npm` update to Dependabot,
as we're in the process of adding local `npm` tools,
for both [dotagents](https://dotagents.sentry.dev/) and [warden](https://warden.sentry.dev/).

### Remarks

Follow-up to:
- #5026
- #5024

No more hiding from JavaScript outside the Browser 😉

This is similar to #5005 ... but for `npm`

See docs: https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories

