### PR TITLE
chore: update FluentAssertions from 7.2.0 to 7.2.2

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -56,7 +56,7 @@
 
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <!-- FluentAssertions v8.0.0 changed license; see https://fluentassertions.com/releases/#800 -->
-    <PackageReference Include="FluentAssertions" Version="[7.2.0,8.0.0)" />
+    <PackageReference Include="FluentAssertions" Version="[7.2.2,8.0.0)" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />


### PR DESCRIPTION
What it says on the tin:

Updates the Testing dependency `FluentAssertions` from `7.2.0` to `7.2.2`.
