### PR TITLE
chore: Suppress Xcode version validation for No-Mobile Solution

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,6 +43,7 @@
 
   <PropertyGroup Condition="'$(SolutionName)' == '.generated.NoMobile'">
     <NO_MOBILE>true</NO_MOBILE>
+    <ValidateXcodeVersion>false</ValidateXcodeVersion>
   </PropertyGroup>
 
   <!-- NO_MOBILE can be passed in via an environment variable or a build property to disable all mobile targets -->


### PR DESCRIPTION
### Summary

Use property `<ValidateXcodeVersion>false</ValidateXcodeVersion>` for the `NO_MOBILE` Solution.

### Remarks

When e.g. building on a macOS with Xcode 26.3 installed, the build produces error:
```
> Xamarin.Shared.Sdk.targets(2370,3): Error  : This version of .NET for macOS (26.2.10191) requires Xcode 26.2. The current version of Xcode is 26.3. Either install Xcode 26.2, or use a different version of .NET for macOS. See https://aka.ms/xcode-requirement for more information.
```

The current macOS/iOS version of .NET is built for Xcode 26.2, but has an identical SDK for Xcode 26.3.
See https://github.com/dotnet/macios/releases/tag/dotnet-10.0.1xx-xcode26.2-10217.

I believe that it is safe to suppress this error for local non-mobile development.
