### PR TITLE
ci: fix workflows that always fail for fork PRs

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -1,6 +1,6 @@
 name: Changelog Preview
 on:
-  pull_request:
+  pull_request_target:
     types:
     - opened
     - synchronize
@@ -9,7 +9,7 @@ on:
     - labeled
     - unlabeled
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   statuses: write
 

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -54,5 +54,18 @@ jobs:
       # actions/checkout fetches only a single commit in a detached HEAD state. Therefore
       # we need to pass the current branch, otherwise we can't commit the changes.
       # GITHUB_HEAD_REF is the name of the head branch. GitHub Actions only sets this for PRs.
+      #
+      # For fork PRs we can't push back to the contributor's branch, so we fail the check
+      # instead — prompting the contributor to run dotnet format locally.
       - name: Commit Formatted Code
-        run: ./scripts/commit-formatted-code.sh $GITHUB_HEAD_REF
+        run: |
+          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            if [[ $(git status) != *"nothing to commit"* ]]; then
+              echo "::error::Formatting issues found. Please run the following command locally and push the result:"
+              echo "::error::  dotnet format Sentry.slnx --no-restore --exclude ./modules ./**/*OptionsSetup.cs ./test/Sentry.Tests/AttributeReaderTests.cs"
+              exit 1
+            fi
+            echo "All code formatted correctly."
+          else
+            ./scripts/commit-formatted-code.sh $GITHUB_HEAD_REF
+          fi


### PR DESCRIPTION
Fixes #5062:
- #5062

Two CI workflows failed whenever a PR came from a fork because the pull_request trigger runs in a sandboxed context with no write access and no secrets:

- Changelog Preview: switched pull_request → pull_request_target so the workflow runs in the base repo context and can post PR comments. Also tightened permissions from contents:write to contents:read since the workflow only needs to write to pull-requests.

- Format Code: pull_request_target cannot push to a fork branch anyway, so the fix is fork-aware logic in the commit step. For fork PRs, formatting issues fail the check with a clear message telling the contributor which dotnet format command to run locally. Internal PR behaviour (auto-commit and push) is unchanged.

Warden was also failing but is already resolved — warden.yml was removed because Warden is now a globally-enabled GitHub App with its own credentials, unaffected by fork PR restrictions.

## Testing

Tested here:
- https://github.com/getsentry/sentry-dotnet/pull/5067

Pushed from my own private fork of the Sentry repo.