### PR TITLE
fix: `CaptureFeedback` now supports multiple attachments correctly

### DIFF
--- a/src/Sentry/Protocol/Envelopes/Envelope.cs
+++ b/src/Sentry/Protocol/Envelopes/Envelope.cs
@@ -315,6 +315,13 @@ public sealed class Envelope : ISerializable, IDisposable
         {
             foreach (var attachment in attachments)
             {
+                // Safety check, in case the user forcefully added a null attachment.
+                if (attachment.IsNull())
+                {
+                    logger?.LogWarning("Encountered a null attachment.  Skipping.");
+                    continue;
+                }
+
                 AddEnvelopeItemFromAttachment(items, attachment, logger);
             }
         }

--- a/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/EnvelopeTests.cs
@@ -876,6 +876,37 @@ public class EnvelopeTests
     }
 
     [Fact]
+    public void FromFeedback_NullAttachment_Skipped()
+    {
+        // Arrange
+        var feedback = new SentryFeedback(
+            "Everything is great!",
+            "foo@bar.com",
+            "Someone Nice",
+            "fake-replay-id",
+            "https://www.example.com",
+            SentryId.Create()
+        );
+        var evt = new SentryEvent
+        {
+            Level = SentryLevel.Info,
+            Contexts =
+            {
+                Feedback = feedback
+            }
+        };
+        List<SentryAttachment> attachments = [
+            null!, AttachmentHelper.FakeAttachment("file1.txt")
+        ];
+
+        // Act
+        using var envelope = Envelope.FromFeedback(evt, attachments: attachments);
+
+        // Assert
+        envelope.Items.Count(item => item.TryGetType() == EnvelopeItem.TypeValueAttachment).Should().Be(1);
+    }
+
+    [Fact]
     public async Task Roundtrip_WithSession_Success()
     {
         // Arrange


### PR DESCRIPTION
Follow up on: https://github.com/getsentry/sentry-dotnet/pull/3981

I could not find any source, neither in the dev docs nor on Sentry, for the "only one attachment per feeedback" restriction. The envelop created from a feedback can hold as many attachments as any other and will get processed by Sentry accordingly.

<img width="1092" height="1006" alt="image" src="https://github.com/user-attachments/assets/02b10edc-ba0d-4094-952e-451024be8b44" />
