### PR TITLE
fix: iOS device tests timeout when installing the test app

### DIFF
--- a/scripts/device-test-utils.ps1
+++ b/scripts/device-test-utils.ps1
@@ -29,11 +29,11 @@ function Get-AndroidEmulatorId
 function Get-IosSimulatorUdid {
     [CmdletBinding()]
     param(
-        [string]$IosVersion = '26.0',
+        [string]$IosVersion = '26.2',
         [string[]]$PreferredDeviceTypes = @(
-            'com.apple.CoreSimulator.SimDeviceType.iPhone-XS',
-            'com.apple.CoreSimulator.SimDeviceType.iPhone-17',
-            'com.apple.CoreSimulator.SimDeviceType.iPhone-16'
+            'com.apple.CoreSimulator.SimDeviceType.iPhone-11',
+            'com.apple.CoreSimulator.SimDeviceType.iPhone-16',
+            'com.apple.CoreSimulator.SimDeviceType.iPhone-17'
         ),
         [string[]]$PreferredStates = @('Shutdown','Booted')
     )


### PR DESCRIPTION
fixes: #5095
- #5095 

@Flash0ver this worked on both attempts to install the application using `xcrun simctl install` and I didn't have to rerun any jobs (for once), which at the very least isn't any worse than the current behaviour. I'd recommend we merge this ASAP and see how it performs over the next couple of days. It's a minor change and we can always roll it back if we eventually feel it's worsened the situation. 