### PR TITLE
test(aot): build with (MSBuild)TreatWarningsAsErrors to catch warnings

### DIFF
--- a/integration-test/aot.Tests.ps1
+++ b/integration-test/aot.Tests.ps1
@@ -52,8 +52,16 @@ Console.WriteLine("Hello, Sentry!");
     It 'Aot' {
         $rid = $env:RuntimeIdentifier
         $baseImage = $env:ContainerBaseImage
-        $publishArgs = @('-c', 'Release')
-        if ($rid) {
+        # To exclude specific warnings without disabling warnings-as-errors entirely, add:
+        #   '-p:WarningsNotAsErrors=CS####;IL####'        # compiler/analyzer warnings (CS, IL2###, IL3###)
+        #   '-p:MSBuildWarningsNotAsErrors=MSB####'       # MSBuild task warnings (MSB###)
+        $publishArgs = @(
+            '-c', 'Release',
+            '-p:TreatWarningsAsErrors=true',
+            '-p:MSBuildTreatWarningsAsErrors=true'
+        )
+        if ($rid)
+        {
             Write-Host "Environment RuntimeIdentifier: $rid"
             $publishArgs += @('-r', $rid)
         }
@@ -69,11 +77,6 @@ Console.WriteLine("Hello, Sentry!");
             $rid = (Get-ChildItem -Path "bin/Release/$tfm" -Directory | Select-Object -First 1).Name
         }
         & "bin/Release/$tfm/$rid/publish/hello-sentry" | Write-Host
-        $LASTEXITCODE | Should -Be 0
-    }
-
-    It 'MSBuildTreatWarningsAsErrors' -Skip:(!$IsWindows) {
-        dotnet publish -c Release -p:MSBuildTreatWarningsAsErrors=true | Write-Host
         $LASTEXITCODE | Should -Be 0
     }
 

--- a/integration-test/aot.Tests.ps1
+++ b/integration-test/aot.Tests.ps1
@@ -72,6 +72,11 @@ Console.WriteLine("Hello, Sentry!");
         $LASTEXITCODE | Should -Be 0
     }
 
+    It 'MSBuildTreatWarningsAsErrors' -Skip:(!$IsWindows) {
+        dotnet publish -c Release -p:MSBuildTreatWarningsAsErrors=true | Write-Host
+        $LASTEXITCODE | Should -Be 0
+    }
+
     It 'Container' -Skip:(!$IsLinux -or !(Get-Command docker -ErrorAction SilentlyContinue)) {
         dotnet publish -p:EnableSdkContainerSupport=true -t:PublishContainer | Write-Host
         $LASTEXITCODE | Should -Be 0


### PR DESCRIPTION
Depends on the PDB fix coming in sentry-native 0.13.6:
- https://github.com/getsentry/sentry-dotnet/pull/5128

This PR turns on `(MSBuild)TreatWarningsAsErrors` for the Native AOT integration test, to prevent such Native AOT warnings slipping in again in the future (mostly via sentry-native updates) that would make projects using `(MSBuild)TreatWarningsAsErrors` fail to publish.

See also: #5122

#skip-changelog