### PR TITLE
fix: prevent redundant native exceptions on iOS

### DIFF
--- a/integration-test/ios.Tests.ps1
+++ b/integration-test/ios.Tests.ps1
@@ -11,12 +11,14 @@ BeforeDiscovery {
     $script:simulator = Get-IosSimulatorUdid -PreferredStates @('Booted')
 }
 
-Describe 'iOS app (<tfm>, <configuration>)' -ForEach @(
+Describe 'iOS app (<tfm>, <configuration>, <runtime>)' -ForEach @(
     # Note: we can't run against net10 and net9 becaus .NET 10 requires Xcode 26.2 and .NET 9 requires Xcode 26.0.
     # The macOS GitHub Actions runners only have Xcode 26.1+ installed and no support for Xcode 26.2 is planned for
     # net9.0-ios: https://github.com/dotnet/macios/issues/24199#issuecomment-3819021247
-    @{ tfm = "net10.0-ios26.2"; configuration = "Release" }
-    @{ tfm = "net10.0-ios26.2"; configuration = "Debug" }
+    #
+    # TODO: add coreclr when available
+    @{ tfm = "net10.0-ios26.2"; configuration = "Release"; runtime = "mono" }
+    @{ tfm = "net10.0-ios26.2"; configuration = "Debug";   runtime = "mono" }
 ) -Skip:(-not $script:simulator) {
     BeforeAll {
         . $PSScriptRoot/../scripts/device-test-utils.ps1
@@ -29,10 +31,12 @@ Describe 'iOS app (<tfm>, <configuration>)' -ForEach @(
         $rid = "iossimulator-$arch"
 
         Write-Host "::group::Build Sentry.Maui.Device.IntegrationTestApp.csproj"
+        $useMonoRuntime = if ($runtime -eq 'mono') { 'true' } else { 'false' }
         dotnet build Sentry.Maui.Device.IntegrationTestApp.csproj `
             --configuration $configuration `
             --framework $tfm `
-            --runtime $rid
+            --runtime $rid `
+            -p:UseMonoRuntime=$useMonoRuntime
         | ForEach-Object { Write-Host $_ }
         Write-Host '::endgroup::'
         $LASTEXITCODE | Should -Be 0
@@ -90,7 +94,7 @@ Describe 'iOS app (<tfm>, <configuration>)' -ForEach @(
         UninstallIosApp
     }
 
-    It 'captures managed crash (<configuration>)' {
+    It 'captures managed crash (<configuration>, <runtime>)' {
         $result = Invoke-SentryServer {
             param([string]$url)
             RunIosApp -Dsn $url -TestArg "Managed"
@@ -99,12 +103,11 @@ Describe 'iOS app (<tfm>, <configuration>)' -ForEach @(
 
         $result.HasErrors() | Should -BeFalse
         $result.Envelopes() | Should -AnyElementMatch "`"type`":`"System.ApplicationException`""
-        # TODO: fix redundant SIGABRT (#3954)
-        { $result.Envelopes() | Should -Not -AnyElementMatch "`"type`":`"SIGABRT`"" } | Should -Throw
-        { $result.Envelopes() | Should -HaveCount 1 } | Should -Throw
+        $result.Envelopes() | Should -Not -AnyElementMatch "`"type`":`"(EXC_[A-Z_]+|SIG[A-Z]+)`""
+        $result.Envelopes() | Should -HaveCount 1
     }
 
-    It 'captures native crash (<configuration>)' {
+    It 'captures native crash (<configuration>, <runtime>)' {
         $result = Invoke-SentryServer {
             param([string]$url)
             RunIosApp -Dsn $url -TestArg "Native"
@@ -112,12 +115,12 @@ Describe 'iOS app (<tfm>, <configuration>)' -ForEach @(
         }
 
         $result.HasErrors() | Should -BeFalse
-        $result.Envelopes() | Should -AnyElementMatch "`"type`":`"EXC_[A-Z_]+`""
+        $result.Envelopes() | Should -AnyElementMatch "`"type`":`"(EXC_[A-Z_]+|SIG[A-Z]+)`""
         $result.Envelopes() | Should -Not -AnyElementMatch "`"type`":`"System.\w+Exception`""
         $result.Envelopes() | Should -HaveCount 1
     }
 
-    It 'captures null reference exception (<configuration>)' {
+    It 'captures null reference exception (<configuration>, <runtime>)' {
         $result = Invoke-SentryServer {
             param([string]$url)
             RunIosApp -Dsn $url -TestArg "NullReferenceException"
@@ -126,12 +129,7 @@ Describe 'iOS app (<tfm>, <configuration>)' -ForEach @(
 
         $result.HasErrors() | Should -BeFalse
         $result.Envelopes() | Should -AnyElementMatch "`"type`":`"System.NullReferenceException`""
-        # TODO: fix redundant EXC_BAD_ACCESS in Release (#3954)
-        if ($configuration -eq 'Release') {
-            { $result.Envelopes() | Should -Not -AnyElementMatch "`"type`":`"EXC_BAD_ACCESS`"" } | Should -Throw
-        } else {
-            $result.Envelopes() | Should -Not -AnyElementMatch "`"type`":`"EXC_BAD_ACCESS`""
-            $result.Envelopes() | Should -HaveCount 1
-        }
+        $result.Envelopes() | Should -Not -AnyElementMatch "`"type`":`"(EXC_[A-Z_]+|SIG[A-Z]+)`""
+        $result.Envelopes() | Should -HaveCount 1
     }
 }

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -50,7 +50,8 @@ xcodebuild archive -project Sentry.xcodeproj \
     -sdk "$ios_sdk" \
     -archivePath ./Carthage/output-ios.xcarchive \
     SKIP_INSTALL=NO \
-    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    GCC_PREPROCESSOR_DEFINITIONS='$(inherited) SENTRY_CRASH_MANAGED_RUNTIME=1'
 ./scripts/remove-architectures.sh ./Carthage/output-ios.xcarchive arm64e
 xcodebuild archive -project Sentry.xcodeproj \
     -scheme Sentry \
@@ -58,7 +59,8 @@ xcodebuild archive -project Sentry.xcodeproj \
     -sdk "$ios_simulator_sdk" \
     -archivePath ./Carthage/output-iossimulator.xcarchive \
     SKIP_INSTALL=NO \
-    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    GCC_PREPROCESSOR_DEFINITIONS='$(inherited) SENTRY_CRASH_MANAGED_RUNTIME=1'
 xcodebuild -create-xcframework \
     -framework ./Carthage/output-ios.xcarchive/Products/Library/Frameworks/Sentry.framework \
     -framework ./Carthage/output-iossimulator.xcarchive/Products/Library/Frameworks/Sentry.framework \
@@ -73,7 +75,8 @@ xcodebuild archive -project Sentry.xcodeproj \
     -destination 'generic/platform=macOS,variant=Mac Catalyst' \
     -archivePath ./Carthage/output-maccatalyst.xcarchive \
     SKIP_INSTALL=NO \
-    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    GCC_PREPROCESSOR_DEFINITIONS='$(inherited) SENTRY_CRASH_MANAGED_RUNTIME=1'
 ./scripts/remove-architectures.sh ./Carthage/output-maccatalyst.xcarchive arm64e
 xcodebuild -create-xcframework \
     -framework ./Carthage/output-maccatalyst.xcarchive/Products/Library/Frameworks/Sentry.framework \

--- a/src/Sentry/Platforms/Cocoa/RuntimeAdapter.cs
+++ b/src/Sentry/Platforms/Cocoa/RuntimeAdapter.cs
@@ -6,6 +6,8 @@ internal interface IRuntime
 {
     internal event MarshalManagedExceptionHandler MarshalManagedException;
     internal event MarshalObjectiveCExceptionHandler MarshalObjectiveCException;
+    bool IsMono { get; }
+    void IgnoreNextSignal(int signal);
 }
 
 internal sealed class RuntimeAdapter : IRuntime
@@ -20,6 +22,10 @@ internal sealed class RuntimeAdapter : IRuntime
 
     public event MarshalManagedExceptionHandler? MarshalManagedException;
     public event MarshalObjectiveCExceptionHandler? MarshalObjectiveCException;
+
+    public bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
+
+    public void IgnoreNextSignal(int signal) => SentryCocoaHybridSdk.IgnoreNextSignal(signal);
 
     [SecurityCritical]
     private void OnMarshalManagedException(object sender, MarshalManagedExceptionEventArgs e) => MarshalManagedException?.Invoke(this, e);

--- a/src/Sentry/Platforms/Cocoa/RuntimeAdapter.cs
+++ b/src/Sentry/Platforms/Cocoa/RuntimeAdapter.cs
@@ -6,8 +6,8 @@ internal interface IRuntime
 {
     internal event MarshalManagedExceptionHandler MarshalManagedException;
     internal event MarshalObjectiveCExceptionHandler MarshalObjectiveCException;
-    bool IsMono { get; }
-    void IgnoreNextSignal(int signal);
+    public bool IsMono { get; }
+    public void IgnoreNextSignal(int signal);
 }
 
 internal sealed class RuntimeAdapter : IRuntime

--- a/src/Sentry/Platforms/Cocoa/RuntimeAdapter.cs
+++ b/src/Sentry/Platforms/Cocoa/RuntimeAdapter.cs
@@ -6,8 +6,8 @@ internal interface IRuntime
 {
     internal event MarshalManagedExceptionHandler MarshalManagedException;
     internal event MarshalObjectiveCExceptionHandler MarshalObjectiveCException;
-    public bool IsMono { get; }
-    public void IgnoreNextSignal(int signal);
+    internal bool IsMono { get; }
+    internal void IgnoreNextSignal(int signal);
 }
 
 internal sealed class RuntimeAdapter : IRuntime

--- a/src/Sentry/Platforms/Cocoa/RuntimeMarshalManagedExceptionIntegration.cs
+++ b/src/Sentry/Platforms/Cocoa/RuntimeMarshalManagedExceptionIntegration.cs
@@ -43,6 +43,25 @@ internal class RuntimeMarshalManagedExceptionIntegration : ISdkIntegration
 
             // This is likely a terminal exception so try to send the crash report before shutting down
             _hub?.Flush();
+
+            // Under Mono, Disable/UnwindNativeCode call mono_raise_exception which can unwind into
+            // a managed catch and never hit abort(). The thread-local ignore flag would then linger
+            // and silently swallow an unrelated later SIGABRT on this thread, so skip arming it. See
+            // https://github.com/dotnet/macios/blob/be8a2ca1057242f745ef58011a02ffe21326d180/runtime/runtime.m#L2215
+            var isMono = Type.GetType("Mono.Runtime") != null;
+            if (isMono && e.ExceptionMode is MarshalManagedExceptionMode.Disable
+                                          or MarshalManagedExceptionMode.UnwindNativeCode)
+            {
+                return;
+            }
+
+            // Otherwise the runtime will call abort() after we return — directly via
+            // xamarin_assertion_message, or indirectly via the uncaught-NSException handler for
+            // ThrowObjectiveCException. Tell SentryCrash to ignore that SIGABRT so we don't emit a
+            // duplicate native crash for an exception we've already captured. See
+            // https://github.com/dotnet/macios/blob/be8a2ca1057242f745ef58011a02ffe21326d180/runtime/runtime.m#L2285
+            const int SIGABRT = 6;
+            SentryCocoaHybridSdk.IgnoreNextSignal(SIGABRT);
         }
     }
 }

--- a/src/Sentry/Platforms/Cocoa/RuntimeMarshalManagedExceptionIntegration.cs
+++ b/src/Sentry/Platforms/Cocoa/RuntimeMarshalManagedExceptionIntegration.cs
@@ -48,9 +48,8 @@ internal class RuntimeMarshalManagedExceptionIntegration : ISdkIntegration
             // a managed catch and never hit abort(). The thread-local ignore flag would then linger
             // and silently swallow an unrelated later SIGABRT on this thread, so skip arming it. See
             // https://github.com/dotnet/macios/blob/be8a2ca1057242f745ef58011a02ffe21326d180/runtime/runtime.m#L2215
-            var isMono = Type.GetType("Mono.Runtime") != null;
-            if (isMono && e.ExceptionMode is MarshalManagedExceptionMode.Disable
-                                          or MarshalManagedExceptionMode.UnwindNativeCode)
+            if (_runtime.IsMono && e.ExceptionMode is MarshalManagedExceptionMode.Disable
+                                                   or MarshalManagedExceptionMode.UnwindNativeCode)
             {
                 return;
             }
@@ -61,7 +60,7 @@ internal class RuntimeMarshalManagedExceptionIntegration : ISdkIntegration
             // duplicate native crash for an exception we've already captured. See
             // https://github.com/dotnet/macios/blob/be8a2ca1057242f745ef58011a02ffe21326d180/runtime/runtime.m#L2285
             const int SIGABRT = 6;
-            SentryCocoaHybridSdk.IgnoreNextSignal(SIGABRT);
+            _runtime.IgnoreNextSignal(SIGABRT);
         }
     }
 }

--- a/test/Sentry.Tests/Platforms/iOS/RuntimeMarshalManagedExceptionIntegrationTests.cs
+++ b/test/Sentry.Tests/Platforms/iOS/RuntimeMarshalManagedExceptionIntegrationTests.cs
@@ -66,5 +66,61 @@ public class RuntimeMarshalManagedExceptionIntegrationTests
 
         _fixture.Runtime.Received().MarshalManagedException += sut.Handle;
     }
+
+    [Theory]
+    [InlineData(MarshalManagedExceptionMode.Default)]
+    [InlineData(MarshalManagedExceptionMode.ThrowObjectiveCException)]
+    [InlineData(MarshalManagedExceptionMode.Abort)]
+    public void Handle_Mono_AbortingMode_IgnoresSigabrt(MarshalManagedExceptionMode mode)
+    {
+        _fixture.Runtime.IsMono.Returns(true);
+        var sut = _fixture.GetSut();
+        sut.Register(_fixture.Hub, SentryOptions);
+
+        sut.Handle(this, new MarshalManagedExceptionEventArgs { Exception = new Exception(), ExceptionMode = mode });
+
+        _fixture.Runtime.Received(1).IgnoreNextSignal(6);
+    }
+
+    [Theory]
+    [InlineData(MarshalManagedExceptionMode.Disable)]
+    [InlineData(MarshalManagedExceptionMode.UnwindNativeCode)]
+    public void Handle_Mono_NonAbortingMode_DoesNotIgnoreSigabrt(MarshalManagedExceptionMode mode)
+    {
+        _fixture.Runtime.IsMono.Returns(true);
+        var sut = _fixture.GetSut();
+        sut.Register(_fixture.Hub, SentryOptions);
+
+        sut.Handle(this, new MarshalManagedExceptionEventArgs { Exception = new Exception(), ExceptionMode = mode });
+
+        _fixture.Runtime.DidNotReceive().IgnoreNextSignal(Arg.Any<int>());
+    }
+
+    [Theory]
+    [InlineData(MarshalManagedExceptionMode.Disable)]
+    [InlineData(MarshalManagedExceptionMode.UnwindNativeCode)]
+    [InlineData(MarshalManagedExceptionMode.ThrowObjectiveCException)]
+    [InlineData(MarshalManagedExceptionMode.Abort)]
+    public void Handle_CoreCLR_AnyMode_IgnoresSigabrt(MarshalManagedExceptionMode mode)
+    {
+        _fixture.Runtime.IsMono.Returns(false);
+        var sut = _fixture.GetSut();
+        sut.Register(_fixture.Hub, SentryOptions);
+
+        sut.Handle(this, new MarshalManagedExceptionEventArgs { Exception = new Exception(), ExceptionMode = mode });
+
+        _fixture.Runtime.Received(1).IgnoreNextSignal(6);
+    }
+
+    [Fact]
+    public void Handle_NoException_DoesNotIgnoreSigabrt()
+    {
+        var sut = _fixture.GetSut();
+        sut.Register(_fixture.Hub, SentryOptions);
+
+        sut.Handle(this, new MarshalManagedExceptionEventArgs());
+
+        _fixture.Runtime.DidNotReceive().IgnoreNextSignal(Arg.Any<int>());
+    }
 }
 #endif

--- a/test/Sentry.Tests/Platforms/iOS/RuntimeMarshalManagedExceptionIntegrationTests.cs
+++ b/test/Sentry.Tests/Platforms/iOS/RuntimeMarshalManagedExceptionIntegrationTests.cs
@@ -97,6 +97,7 @@ public class RuntimeMarshalManagedExceptionIntegrationTests
     }
 
     [Theory]
+    [InlineData(MarshalManagedExceptionMode.Default)]
     [InlineData(MarshalManagedExceptionMode.Disable)]
     [InlineData(MarshalManagedExceptionMode.UnwindNativeCode)]
     [InlineData(MarshalManagedExceptionMode.ThrowObjectiveCException)]


### PR DESCRIPTION
<!--
> [!NOTE]
> Depends on sentry-cocoa 9.10.0 + modules/sentry-cocoa submodule:
> - getsentry/sentry-cocoa#6193
> - getsentry/sentry-dotnet#5131
-->

Fixes duplicate native exceptions (#3954) on iOS by reordering signal handlers to let .NET/Mono handle managed exceptions first, and then chain real native exceptions to Sentry.

**Before**:
```
           ┌──────────────┐     ┌───────────┐     ┌────────┐
Signal────>│ Sentry Cocoa │────>│ .NET/Mono │────>│ System │
           └──────────────┘     └───────────┘     └────────┘
```

**After**:
```
           ┌───────────┐     ┌──────────────┐     ┌────────┐
Signal────>│ .NET/Mono │────>│ Sentry Cocoa │────>│ System │
           └───────────┘     └──────────────┘     └────────┘
```
<!--
**Good news**: the re-ordered signal handlers are working as expected.

**Bad news**: The early signal handler installation in getsentry/sentry-cocoa#6193 is guarded behind a `SENTRY_CRASH_MANAGED_RUNTIME` compile-time flag to avoid affecting normal Cocoa SDK users. iOS integration tests were happily passing while developing with a local `modules/sentry-cocoa` clone, but I do realize now that this cannot work with the pre-built `Sentry.xcframework` release bundles built without `SENTRY_CRASH_MANAGED_RUNTIME`... 🤦
-->