### PR TITLE
fix: prevent redundant native exceptions on Android/CoreCLR

### DIFF
--- a/integration-test/Directory.Build.targets
+++ b/integration-test/Directory.Build.targets
@@ -1,7 +1,3 @@
 <Project>
   <!-- Don't include parent Directory.Build.targets -->
-
-  <!-- Needed for SetAndroidNdkPreload (buildTransitive doesn't apply via ProjectReference) -->
-  <Import Project="../src/Sentry/buildTransitive/Sentry.props" Condition="Exists('../src/Sentry/buildTransitive/Sentry.props')" />
-  <Import Project="../src/Sentry/buildTransitive/Sentry.targets" Condition="Exists('../src/Sentry/buildTransitive/Sentry.targets')" />
 </Project>

--- a/integration-test/Directory.Build.targets
+++ b/integration-test/Directory.Build.targets
@@ -1,3 +1,7 @@
 <Project>
   <!-- Don't include parent Directory.Build.targets -->
+
+  <!-- Needed for SetAndroidNdkPreload (buildTransitive doesn't apply via ProjectReference) -->
+  <Import Project="../src/Sentry/buildTransitive/Sentry.props" Condition="Exists('../src/Sentry/buildTransitive/Sentry.props')" />
+  <Import Project="../src/Sentry/buildTransitive/Sentry.targets" Condition="Exists('../src/Sentry/buildTransitive/Sentry.targets')" />
 </Project>

--- a/integration-test/android.Tests.ps1
+++ b/integration-test/android.Tests.ps1
@@ -18,10 +18,12 @@ BeforeDiscovery {
 }
 
 $cases = @(
-    @{ configuration = 'Release' }
-    @{ configuration = 'Debug'   }
+    @{ configuration = 'Release'; runtime = 'mono'    }
+    @{ configuration = 'Release'; runtime = 'coreclr' }
+    @{ configuration = 'Debug';   runtime = 'mono'    }
+    @{ configuration = 'Debug';   runtime = 'coreclr' }
 )
-Describe 'MAUI app (<dotnet_version>, <configuration>)' -ForEach $cases -Skip:(-not $script:emulator) {
+Describe 'MAUI app (<dotnet_version>, <configuration>, <runtime>)' -ForEach $cases -Skip:(-not $script:emulator) {
     BeforeAll {
         $tfm = "$dotnet_version-android$(GetAndroidTpv $dotnet_version)"
 
@@ -38,10 +40,12 @@ Describe 'MAUI app (<dotnet_version>, <configuration>)' -ForEach $cases -Skip:(-
         $rid = "android-$arch"
 
         Write-Host "::group::Build Sentry.Maui.Device.IntegrationTestApp.csproj"
+        $useMonoRuntime = if ($runtime -eq 'mono') { 'true' } else { 'false' }
         dotnet build Sentry.Maui.Device.IntegrationTestApp.csproj `
             --configuration $configuration `
             --framework $tfm `
-            --runtime $rid
+            --runtime $rid `
+            -p:UseMonoRuntime=$useMonoRuntime
         | ForEach-Object { Write-Host $_ }
         Write-Host '::endgroup::'
         $LASTEXITCODE | Should -Be 0

--- a/integration-test/android.Tests.ps1
+++ b/integration-test/android.Tests.ps1
@@ -18,11 +18,16 @@ BeforeDiscovery {
 }
 
 $cases = @(
-    @{ configuration = 'Release'; runtime = 'mono'    }
-    @{ configuration = 'Release'; runtime = 'coreclr' }
-    @{ configuration = 'Debug';   runtime = 'mono'    }
-    @{ configuration = 'Debug';   runtime = 'coreclr' }
+    @{ configuration = 'Release'; runtime = 'mono' }
+    @{ configuration = 'Debug';   runtime = 'mono' }
 )
+# CoreCLR on Android requires .NET 10 or later
+if ($dotnet_version -ne 'net9.0') {
+    $cases += @(
+        @{ configuration = 'Release'; runtime = 'coreclr' }
+        @{ configuration = 'Debug';   runtime = 'coreclr' }
+    )
+}
 Describe 'MAUI app (<dotnet_version>, <configuration>, <runtime>)' -ForEach $cases -Skip:(-not $script:emulator) {
     BeforeAll {
         $tfm = "$dotnet_version-android$(GetAndroidTpv $dotnet_version)"

--- a/integration-test/net9-maui/Sentry.Maui.Device.IntegrationTestApp.csproj
+++ b/integration-test/net9-maui/Sentry.Maui.Device.IntegrationTestApp.csproj
@@ -64,4 +64,10 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.5" />
   </ItemGroup>
 
+  <!-- Needed for SetAndroidNdkPreload (buildTransitive doesn't apply via ProjectReference) -->
+  <ImportGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+    <Import Project="..\..\src\Sentry\buildTransitive\Sentry.props" Condition="Exists('..\..\src\Sentry\buildTransitive\Sentry.props')" />
+    <Import Project="..\..\src\Sentry\buildTransitive\Sentry.targets" Condition="Exists('..\..\src\Sentry\buildTransitive\Sentry.targets')" />
+  </ImportGroup>
+
 </Project>

--- a/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
+++ b/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(LatestAndroidTfm);$(PreviousAndroidTfm)</TargetFrameworks>
-    <SentryAndroidSdkVersion>8.38.0</SentryAndroidSdkVersion>
+    <SentryAndroidSdkVersion>8.39.0</SentryAndroidSdkVersion>
     <SentryAndroidSdkDirectory>$(BaseIntermediateOutputPath)sdks\$(TargetFramework)\Sentry\Android\$(SentryAndroidSdkVersion)\</SentryAndroidSdkDirectory>
     <!-- This gets resolved by the DownloadSentryAndroidSdk unless using local maven references -->
     <SentryNativeNdkVersion></SentryNativeNdkVersion>

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -67,6 +67,14 @@ public static partial class SentrySdk
 
             var signalHandlerStrategy = options.Native.ExperimentalOptions.SignalHandlerStrategy;
             if (signalHandlerStrategy == SignalHandlerStrategy.ChainAtStart
+                && Type.GetType("Mono.RuntimeStructs") == null)
+            {
+                options.LogDebug(
+                    "SignalHandlerStrategy.ChainAtStart is not compatible with .NET CoreCLR runtime. " +
+                    "Falling back to SignalHandlerStrategy.Default.");
+                signalHandlerStrategy = SignalHandlerStrategy.Default;
+            }
+            if (signalHandlerStrategy == SignalHandlerStrategy.ChainAtStart
                 && System.Environment.Version is { Major: 10, Minor: 0, Build: < 4 })
             {
                 options.LogWarning(

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -69,9 +69,9 @@ public static partial class SentrySdk
             if (signalHandlerStrategy == SignalHandlerStrategy.ChainAtStart
                 && Type.GetType("Mono.RuntimeStructs") == null)
             {
-                options.LogDebug(
-                    "SignalHandlerStrategy.ChainAtStart is not compatible with .NET CoreCLR runtime. " +
-                    "Falling back to SignalHandlerStrategy.Default.");
+                options.LogInfo(
+                    "Using SignalHandlerStrategy.Default on .NET CoreCLR. " +
+                    "SignalHandlerStrategy.ChainAtStart is only required on the Mono runtime.");
                 signalHandlerStrategy = SignalHandlerStrategy.Default;
             }
             if (signalHandlerStrategy == SignalHandlerStrategy.ChainAtStart

--- a/src/Sentry/buildTransitive/Sentry.props
+++ b/src/Sentry/buildTransitive/Sentry.props
@@ -5,5 +5,6 @@
     <_SentryTargetFrameworkVersion>$([MSBuild]::GetTargetFrameworkVersion($(TargetFramework)))</_SentryTargetFrameworkVersion>
     <_SentryIsNet8OrGreater>$([MSBuild]::VersionGreaterThanOrEquals($(_SentryTargetFrameworkVersion), 8.0))</_SentryIsNet8OrGreater>
     <_SentryIsNet9OrGreater>$([MSBuild]::VersionGreaterThanOrEquals($(_SentryTargetFrameworkVersion), 9.0))</_SentryIsNet9OrGreater>
+    <_SentryIsNet10OrGreater>$([MSBuild]::VersionGreaterThanOrEquals($(_SentryTargetFrameworkVersion), 10.0))</_SentryIsNet10OrGreater>
   </PropertyGroup>
 </Project>

--- a/src/Sentry/buildTransitive/Sentry.targets
+++ b/src/Sentry/buildTransitive/Sentry.targets
@@ -281,6 +281,22 @@
     </ItemGroup>
   </Target>
 
+  <!-- Preload NDK to ensure sentry-native's signal handlers are installed before .NET runtime's.
+       Disabled on Mono until: https://github.com/dotnet/runtime/pull/125835 -->
+  <Target Name="SetAndroidNdkPreload"
+          BeforeTargets="GetAssemblyAttributes"
+          Condition="'$(AndroidApplication)' == 'True'
+            and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'
+            and '$(_SentryIsNet10OrGreater)' == 'true'
+            and '$(UseMonoRuntime)' != 'true'">
+    <ItemGroup>
+      <AssemblyAttribute Include="Android.App.MetaData">
+        <_Parameter1>io.sentry.ndk.preload</_Parameter1>
+        <Value>true</Value>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
+
   <!-- Upload Android ProGuard mapping file to Sentry after the build. -->
   <Target Name="UploadAndroidProGuardMappingFileToSentry" AfterTargets="Build" DependsOnTargets="PrepareSentryCLI"
           Condition="'$(SentryCLI)' != '' and '$(SentryUploadAndroidProGuardMapping)' == 'true' And '$(AndroidProguardMappingFile)' != ''">


### PR DESCRIPTION
> [!NOTE]
> Depends on
> - #5137

Fixes duplicate native exceptions (#3954) on Android by reordering signal handlers to let .NET/CoreCLR handle managed exceptions first, and then chain real native exceptions to Sentry.

**Before**:
```
           ┌───────────────┐     ┌──────────────┐     ┌────────┐
Signal────>│ Sentry Native │────>│ .NET/CoreCLR │────>│ System │
           └───────────────┘     └──────────────┘     └────────┘
```

**After**:
```
           ┌──────────────┐     ┌───────────────┐     ┌────────┐
Signal────>│ .NET/CoreCLR │────>│ Sentry Native │────>│ System │
           └──────────────┘     └───────────────┘     └────────┘
```

Reordering the signal handlers only works with CoreCLR (`UseMonoRuntime=false`, [experimental](https://learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-10?view=net-maui-10.0#experimental-coreclr) in Android .NET 10.0+) for the time being.

With Mono, one will have to opt in for the ["chain at start"](https://github.com/getsentry/sentry-dotnet/pull/4676) signal handler strategy until the following fix has been released:
- https://github.com/dotnet/runtime/pull/125835