### PR TITLE
build: switch to sentry-cocoa submodule for managed builds

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - name: Cocoa SDK
-            path: modules/sentry-cocoa.properties
+            path: modules/sentry-cocoa
           - name: Java SDK
             path: scripts/update-java.ps1
           - name: Native SDK

--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,6 @@ test/**/*.apk
 .sentry-native
 **/EnvironmentVariables.g.cs
 
-# Download cache for Cocoa SDK
-modules/sentry-cocoa
-
 # Local Claude Code settings that should not be committed
 .claude/settings.local.json
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "modules/sentry-native"]
 	path = modules/sentry-native
 	url = https://github.com/getsentry/sentry-native.git
+[submodule "modules/sentry-cocoa"]
+	path = modules/sentry-cocoa
+	url = https://github.com/getsentry/sentry-cocoa.git

--- a/modules/sentry-cocoa.properties
+++ b/modules/sentry-cocoa.properties
@@ -1,2 +1,0 @@
-version = 9.9.0
-repo = https://github.com/getsentry/sentry-cocoa

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -5,19 +5,23 @@ pushd "$(dirname "$0")" >/dev/null
 cd ../modules/sentry-cocoa
 
 mkdir -p Carthage
-PID_FILE="$PWD/Carthage/.build.pid"
-trap 'if [[ "$(cat "$PID_FILE" 2>/dev/null)" == "$$" ]]; then rm -f "$PID_FILE"; fi' EXIT
+LOCK_DIR="$PWD/Carthage/.build.lock"
+trap 'if [[ "$(cat "$LOCK_DIR/pid" 2>/dev/null)" == "$$" ]]; then rm -rf "$LOCK_DIR"; fi' EXIT
 
 # Serialize concurrent invocations; parallel xcodebuilds race on DerivedData.
-while ! (set -C; echo $$ > "$PID_FILE") 2>/dev/null; do
-    build_pid=$(cat "$PID_FILE" 2>/dev/null || true)
+while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+    build_pid=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
     if [[ -n "$build_pid" ]] && ! kill -0 "$build_pid" 2>/dev/null; then
         echo "Previous build did not complete (pid $build_pid); cleaning up and retrying" >&2
-        rm -f "$PID_FILE"
+        # Atomically claim the stale dir via rename
+        if mv "$LOCK_DIR" "$LOCK_DIR.stale.$$" 2>/dev/null; then
+            rm -rf "$LOCK_DIR.stale.$$"
+        fi
         continue
     fi
     sleep 2
 done
+echo $$ > "$LOCK_DIR/pid"
 
 current_sha=$(git rev-parse HEAD)
 if [[ -f Carthage/.built-from-sha ]] && [[ "$(cat Carthage/.built-from-sha)" == "$current_sha" ]]; then

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -5,23 +5,24 @@ pushd "$(dirname "$0")" >/dev/null
 cd ../modules/sentry-cocoa
 
 mkdir -p Carthage
-LOCK_DIR="$PWD/Carthage/.build.lock"
-trap 'if [[ "$(cat "$LOCK_DIR/pid" 2>/dev/null)" == "$$" ]]; then rm -rf "$LOCK_DIR"; fi' EXIT
+PID_FILE="$PWD/Carthage/.build.pid"
+trap 'if [[ "$(cat "$PID_FILE" 2>/dev/null)" == "$$" ]]; then rm -f "$PID_FILE"; fi' EXIT
 
 # Serialize concurrent invocations; parallel xcodebuilds race on DerivedData.
-while ! mkdir "$LOCK_DIR" 2>/dev/null; do
-    build_pid=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+TMP_FILE=$(mktemp "$PID_FILE.tmp.XXXXXX")
+echo $$ > "$TMP_FILE"
+while ! ln "$TMP_FILE" "$PID_FILE" 2>/dev/null; do
+    build_pid=$(cat "$PID_FILE" 2>/dev/null || true)
     if [[ -n "$build_pid" ]] && ! kill -0 "$build_pid" 2>/dev/null; then
         echo "Previous build did not complete (pid $build_pid); cleaning up and retrying" >&2
-        # Atomically claim the stale dir via rename
-        if mv "$LOCK_DIR" "$LOCK_DIR.stale.$$" 2>/dev/null; then
-            rm -rf "$LOCK_DIR.stale.$$"
+        if mv "$PID_FILE" "$PID_FILE.stale.$$" 2>/dev/null; then
+            rm -f "$PID_FILE.stale.$$"
         fi
         continue
     fi
     sleep 2
 done
-echo $$ > "$LOCK_DIR/pid"
+rm -f "$TMP_FILE"
 
 current_sha=$(git rev-parse HEAD)
 if [[ -f Carthage/.built-from-sha ]] && [[ "$(cat Carthage/.built-from-sha)" == "$current_sha" ]]; then

--- a/scripts/build-sentry-cocoa.sh
+++ b/scripts/build-sentry-cocoa.sh
@@ -4,7 +4,28 @@ set -euo pipefail
 pushd "$(dirname "$0")" >/dev/null
 cd ../modules/sentry-cocoa
 
-rm -rf Carthage
+mkdir -p Carthage
+PID_FILE="$PWD/Carthage/.build.pid"
+trap 'if [[ "$(cat "$PID_FILE" 2>/dev/null)" == "$$" ]]; then rm -f "$PID_FILE"; fi' EXIT
+
+# Serialize concurrent invocations; parallel xcodebuilds race on DerivedData.
+while ! (set -C; echo $$ > "$PID_FILE") 2>/dev/null; do
+    build_pid=$(cat "$PID_FILE" 2>/dev/null || true)
+    if [[ -n "$build_pid" ]] && ! kill -0 "$build_pid" 2>/dev/null; then
+        echo "Previous build did not complete (pid $build_pid); cleaning up and retrying" >&2
+        rm -f "$PID_FILE"
+        continue
+    fi
+    sleep 2
+done
+
+current_sha=$(git rev-parse HEAD)
+if [[ -f Carthage/.built-from-sha ]] && [[ "$(cat Carthage/.built-from-sha)" == "$current_sha" ]]; then
+    popd >/dev/null
+    exit 0
+fi
+
+rm -rf Carthage/output-*.xcarchive Carthage/Build-* Carthage/Headers Carthage/.built-from-sha
 
 # Grabbing the first SDK versions
 sdks=$(xcodebuild -showsdks)
@@ -62,7 +83,7 @@ find Carthage/Build-ios/Sentry.xcframework/ios-arm64 -name '*.h' -exec cp {} Car
 find Carthage/Build* \( -name Headers -o -name PrivateHeaders -o -name Modules \) -exec rm -rf {} +
 rm -rf Carthage/output-*
 
-cp .git/HEAD Carthage/.built-from-sha
+echo "$current_sha" > Carthage/.built-from-sha
 echo ""
 
 popd >/dev/null

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -158,6 +158,10 @@ interface SentryBaggage
     [NullAllowed, Export("replayId", ArgumentSemantic.Strong)]
     string ReplayId { get; set; }
 
+    // @property (readonly, nonatomic) NSString * _Nullable orgId;
+    [NullAllowed, Export("orgId")]
+    string OrgId { get; }
+
     // -(instancetype _Nonnull)initWithTraceId:(SentryId * _Nonnull)traceId publicKey:(NSString * _Nonnull)publicKey releaseName:(NSString * _Nullable)releaseName environment:(NSString * _Nullable)environment transaction:(NSString * _Nullable)transaction sampleRate:(NSString * _Nullable)sampleRate sampled:(NSString * _Nullable)sampled replayId:(NSString * _Nullable)replayId;
     [Export("initWithTraceId:publicKey:releaseName:environment:transaction:sampleRate:sampled:replayId:")]
     NativeHandle Constructor(SentryId traceId, string publicKey, [NullAllowed] string releaseName, [NullAllowed] string environment, [NullAllowed] string transaction, [NullAllowed] string sampleRate, [NullAllowed] string sampled, [NullAllowed] string replayId);
@@ -165,6 +169,10 @@ interface SentryBaggage
     // -(instancetype _Nonnull)initWithTraceId:(SentryId * _Nonnull)traceId publicKey:(NSString * _Nonnull)publicKey releaseName:(NSString * _Nullable)releaseName environment:(NSString * _Nullable)environment transaction:(NSString * _Nullable)transaction sampleRate:(NSString * _Nullable)sampleRate sampleRand:(NSString * _Nullable)sampleRand sampled:(NSString * _Nullable)sampled replayId:(NSString * _Nullable)replayId;
     [Export("initWithTraceId:publicKey:releaseName:environment:transaction:sampleRate:sampleRand:sampled:replayId:")]
     NativeHandle Constructor(SentryId traceId, string publicKey, [NullAllowed] string releaseName, [NullAllowed] string environment, [NullAllowed] string transaction, [NullAllowed] string sampleRate, [NullAllowed] string sampleRand, [NullAllowed] string sampled, [NullAllowed] string replayId);
+
+    // -(instancetype _Nonnull)initWithTraceId:(SentryId * _Nonnull)traceId publicKey:(NSString * _Nonnull)publicKey releaseName:(NSString * _Nullable)releaseName environment:(NSString * _Nullable)environment transaction:(NSString * _Nullable)transaction sampleRate:(NSString * _Nullable)sampleRate sampleRand:(NSString * _Nullable)sampleRand sampled:(NSString * _Nullable)sampled replayId:(NSString * _Nullable)replayId orgId:(NSString * _Nullable)orgId;
+    [Export("initWithTraceId:publicKey:releaseName:environment:transaction:sampleRate:sampleRand:sampled:replayId:orgId:")]
+    NativeHandle Constructor(SentryId traceId, string publicKey, [NullAllowed] string releaseName, [NullAllowed] string environment, [NullAllowed] string transaction, [NullAllowed] string sampleRate, [NullAllowed] string sampleRand, [NullAllowed] string sampled, [NullAllowed] string replayId, [NullAllowed] string orgId);
 
     // -(NSString * _Nonnull)toHTTPHeaderWithOriginalBaggage:(NSDictionary * _Nullable)originalBaggage;
     [Export("toHTTPHeaderWithOriginalBaggage:")]
@@ -1368,6 +1376,10 @@ interface SentryTraceContext : SentrySerializable
     [NullAllowed, Export("replayId")]
     string ReplayId { get; }
 
+    // @property (readonly, nonatomic) NSString * _Nullable orgId;
+    [NullAllowed, Export("orgId")]
+    string OrgId { get; }
+
     // -(SentryBaggage * _Nonnull)toBaggage;
     [Export("toBaggage")]
     SentryBaggage ToBaggage();
@@ -1656,6 +1668,11 @@ interface PrivateSentrySDKOnly
     [Static]
     [Export("setLogOutput:")]
     void SetLogOutput(Action<NSString> output);
+
+    // +(void)ignoreNextSignal:(int)signum;
+    [Static]
+    [Export("ignoreNextSignal:")]
+    void IgnoreNextSignal(int signum);
 }
 
 // @interface SentryOptions : NSObject
@@ -1987,6 +2004,18 @@ interface SentryOptions
     [Export("spotlightUrl")]
     string SpotlightUrl { get; set; }
 
+    // @property (nonatomic) BOOL strictTraceContinuation;
+    [Export("strictTraceContinuation")]
+    bool StrictTraceContinuation { get; set; }
+
+    // @property (copy, nonatomic) NSString * _Nullable orgId;
+    [NullAllowed, Export("orgId")]
+    string OrgId { get; set; }
+
+    // @property (readonly, copy, nonatomic) NSString * _Nullable effectiveOrgId;
+    [NullAllowed, Export("effectiveOrgId")]
+    string EffectiveOrgId { get; }
+
     // @property (nonatomic, strong) SentryExperimentalOptions * _Nonnull experimental;
     [Export("experimental", ArgumentSemantic.Strong)]
     SentryExperimentalOptions Experimental { get; set; }
@@ -2129,6 +2158,10 @@ interface SentryDsn
     // -(NSURL * _Nonnull)getEnvelopeEndpoint __attribute__((warn_unused_result("")));
     [Export("getEnvelopeEndpoint")]
     NSUrl EnvelopeEndpoint { get; }
+
+    // @property (readonly, copy, nonatomic) NSString * _Nullable orgId;
+    [NullAllowed, Export("orgId")]
+    string OrgId { get; }
 }
 
 // @interface SentryExperimentalOptions : NSObject

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -11,7 +11,6 @@ using CoreFoundation;
 using CoreGraphics;
 using Foundation;
 using ObjCRuntime;
-using Sentry;
 using UIKit;
 
 namespace Sentry.CocoaSdk;

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -8,17 +8,17 @@
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
     <Description>.NET Bindings for the Sentry Cocoa SDK</Description>
     <SentryCocoaCache>..\..\modules\sentry-cocoa\</SentryCocoaCache>
+    <SentryCocoaProperties>$(MSBuildThisFileDirectory)..\..\modules\sentry-cocoa.properties</SentryCocoaProperties>
     <SentryCocoaFrameworkHeaders>$(SentryCocoaCache)Sentry.framework\</SentryCocoaFrameworkHeaders>
     <!-- SentrySpan.g.cs: error CS0108: 'ISentrySpan.Serialize()' hides inherited member 'ISentrySerializable.Serialize()'. Use the new keyword if hiding was intended -->
     <NoWarn>$(NoWarn);CS0108</NoWarn>
   </PropertyGroup>
 
   <!-- Released Cocoa SDK builds -->
-  <PropertyGroup Condition="!Exists('$(SentryCocoaCache).git')">
-    <SentryCocoaProperties>$([System.IO.File]::ReadAllText("$(MSBuildThisFileDirectory)../../modules/sentry-cocoa.properties"))</SentryCocoaProperties>
-    <SentryCocoaVersion>$([System.Text.RegularExpressions.Regex]::Match($(SentryCocoaProperties), 'version\s*=\s*([^\s]+)').Groups[1].Value)</SentryCocoaVersion>
+  <PropertyGroup Condition="Exists('$(SentryCocoaProperties)') And !Exists('$(SentryCocoaCache).git')">
+    <SentryCocoaVersion>$([System.Text.RegularExpressions.Regex]::Match($([System.IO.File]::ReadAllText('$(SentryCocoaProperties)')), 'version\s*=\s*([^\s]+)').Groups[1].Value)</SentryCocoaVersion>
     <SentryCocoaFramework>$(SentryCocoaCache)Sentry-$(SentryCocoaVersion).xcframework</SentryCocoaFramework>
-    <SentryCocoaBindingInputs>../../modules/sentry-cocoa.properties;../../scripts/generate-cocoa-bindings.ps1;$(SentryCocoaFrameworkHeaders)**/*.h</SentryCocoaBindingInputs>
+    <SentryCocoaBindingInputs>$(SentryCocoaProperties);../../scripts/generate-cocoa-bindings.ps1;$(SentryCocoaFrameworkHeaders)**/*.h</SentryCocoaBindingInputs>
   </PropertyGroup>
 
   <!-- Override values for local Cocoa SDK builds -->
@@ -68,7 +68,7 @@
 
   <!-- Downloads and sets up the Cocoa SDK: dotnet msbuild /t:setupCocoaSDK src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj -->
   <Target Name="_DownloadCocoaSDK"
-          Condition="$([MSBuild]::IsOSPlatform('OSX')) And !Exists('$(SentryCocoaCache).git') And !Exists('$(SentryCocoaFramework)')">
+          Condition="$([MSBuild]::IsOSPlatform('OSX')) And Exists('$(SentryCocoaProperties)') And !Exists('$(SentryCocoaCache).git') And !Exists('$(SentryCocoaFramework)')">
 
     <Message Importance="High" Text="Setting up the Cocoa SDK version '$(SentryCocoaVersion)'." />
 

--- a/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
+++ b/src/Sentry.Bindings.Cocoa/Sentry.Bindings.Cocoa.csproj
@@ -9,18 +9,28 @@
     <Description>.NET Bindings for the Sentry Cocoa SDK</Description>
     <SentryCocoaCache>..\..\modules\sentry-cocoa\</SentryCocoaCache>
     <SentryCocoaFrameworkHeaders>$(SentryCocoaCache)Sentry.framework\</SentryCocoaFrameworkHeaders>
+    <!-- SentrySpan.g.cs: error CS0108: 'ISentrySpan.Serialize()' hides inherited member 'ISentrySerializable.Serialize()'. Use the new keyword if hiding was intended -->
+    <NoWarn>$(NoWarn);CS0108</NoWarn>
+  </PropertyGroup>
+
+  <!-- Released Cocoa SDK builds -->
+  <PropertyGroup Condition="!Exists('$(SentryCocoaCache).git')">
     <SentryCocoaProperties>$([System.IO.File]::ReadAllText("$(MSBuildThisFileDirectory)../../modules/sentry-cocoa.properties"))</SentryCocoaProperties>
     <SentryCocoaVersion>$([System.Text.RegularExpressions.Regex]::Match($(SentryCocoaProperties), 'version\s*=\s*([^\s]+)').Groups[1].Value)</SentryCocoaVersion>
     <SentryCocoaFramework>$(SentryCocoaCache)Sentry-$(SentryCocoaVersion).xcframework</SentryCocoaFramework>
     <SentryCocoaBindingInputs>../../modules/sentry-cocoa.properties;../../scripts/generate-cocoa-bindings.ps1;$(SentryCocoaFrameworkHeaders)**/*.h</SentryCocoaBindingInputs>
-    <!-- SentrySpan.g.cs: error CS0108: 'ISentrySpan.Serialize()' hides inherited member 'ISentrySerializable.Serialize()'. Use the new keyword if hiding was intended -->
-    <NoWarn>$(NoWarn);CS0108</NoWarn>
   </PropertyGroup>
 
   <!-- Override values for local Cocoa SDK builds -->
   <PropertyGroup Condition="Exists('$(SentryCocoaCache).git')">
     <SentryCocoaFramework>$(SentryCocoaCache)Carthage\Build-$(TargetPlatformIdentifier)\Sentry.xcframework</SentryCocoaFramework>
     <SentryCocoaBindingInputs>../../scripts/generate-cocoa-bindings.ps1;$(SentryCocoaCache)Carthage/.built-from-sha;$(SentryCocoaCache)Carthage/**/*.h</SentryCocoaBindingInputs>
+    <!-- Resolve path to modules/sentry-cocoa/.git -->
+    <SentryCocoaGitFile>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory), $(SentryCocoaCache).git))</SentryCocoaGitFile>
+    <!-- Standalone clone: .git is a directory -->
+    <SentryCocoaGitDir Condition="Exists('$(SentryCocoaCache).git\HEAD')">.git</SentryCocoaGitDir>
+    <!-- Submodule: .git is a file pointing at the real gitdir -->
+    <SentryCocoaGitDir Condition="'$(SentryCocoaGitDir)' == ''">$([System.IO.File]::ReadAllText('$(SentryCocoaGitFile)').Trim().Replace('gitdir: ', ''))</SentryCocoaGitDir>
   </PropertyGroup>
 
   <!-- Build empty assemblies when not on macOS, to pass the solution build. -->
@@ -97,7 +107,7 @@
   <!-- Build the Sentry Cocoa SDK from source -->
   <Target Name="_BuildCocoaSDK"
           Condition="$([MSBuild]::IsOSPlatform('OSX')) And Exists('$(SentryCocoaCache).git')"
-          Inputs="..\..\modules\sentry-cocoa\.git\HEAD;..\..\scripts\build-sentry-cocoa.sh" Outputs="..\..\modules\sentry-cocoa\Carthage\.built-from-sha">
+          Inputs="$(SentryCocoaCache)$(SentryCocoaGitDir)\HEAD;..\..\scripts\build-sentry-cocoa.sh" Outputs="..\..\modules\sentry-cocoa\Carthage\.built-from-sha">
 
     <Message Importance="High" Text="Building the Cocoa SDK from source." />
     <Exec Command="bash ../../scripts/build-sentry-cocoa.sh" IgnoreStandardErrorWarningFormat="true" />
@@ -125,7 +135,8 @@
           Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
 
   <Target Name="CleanCocoaSDK" AfterTargets="Clean" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-    <RemoveDir Directories="$(SentryCocoaCache)" ContinueOnError="true" />
+    <RemoveDir Directories="$(SentryCocoaCache)Carthage;$(SentryCocoaFramework);$(SentryCocoaFrameworkHeaders)" ContinueOnError="true" />
+    <Delete Files="$(SentryCocoaFramework).zip;$(SentryCocoaFramework).sanitized.stamp" ContinueOnError="true" />
   </Target>
 
   <!-- Generate bindings -->

--- a/src/Sentry.Bindings.Cocoa/StructsAndEnums.cs
+++ b/src/Sentry.Bindings.Cocoa/StructsAndEnums.cs
@@ -9,7 +9,6 @@
 using System.Runtime.InteropServices;
 using Foundation;
 using ObjCRuntime;
-using Sentry;
 
 namespace Sentry.CocoaSdk;
 


### PR DESCRIPTION
Allows building sentry-cocoa with `SENTRY_CRASH_MANAGED_RUNTIME` for eliminating duplicate native exceptions on iOS:
- getsentry/sentry-dotnet#5126

Note: The old `.properties` -based release download is left intact to make it easy to switch back in the future if we ever get an official managed build variant...

#skip-changelog