### PR TITLE
fix: ConcurrentBag memory leak (shows whhen profiling is enabled)

### DIFF
--- a/src/Sentry/Internal/ConcurrentBagLite.cs
+++ b/src/Sentry/Internal/ConcurrentBagLite.cs
@@ -6,7 +6,7 @@ namespace Sentry.Internal;
 /// We're using this to avoid the same class of memory leak that <see cref="ConcurrentQueueLite{T}"/>
 /// was introduced to avoid. See https://github.com/getsentry/sentry-dotnet/issues/5113
 /// </summary>
-internal class ConcurrentBagLite<T> : IEnumerable<T>
+internal class ConcurrentBagLite<T> : IReadOnlyCollection<T>
 {
     private readonly List<T> _items;
 

--- a/src/Sentry/Internal/ConcurrentBagLite.cs
+++ b/src/Sentry/Internal/ConcurrentBagLite.cs
@@ -1,0 +1,73 @@
+namespace Sentry.Internal;
+
+/// <summary>
+/// A minimal replacement for <see cref="ConcurrentBag{T}"/>.
+///
+/// We're using this to avoid the same class of memory leak that <see cref="ConcurrentQueueLite{T}"/>
+/// was introduced to avoid. See https://github.com/getsentry/sentry-dotnet/issues/5113
+/// </summary>
+internal class ConcurrentBagLite<T> : IEnumerable<T>
+{
+    private readonly List<T> _items;
+
+    public ConcurrentBagLite()
+    {
+        _items = new List<T>();
+    }
+
+    public ConcurrentBagLite(IEnumerable<T> collection)
+    {
+        _items = new List<T>(collection);
+    }
+
+    public void Add(T item)
+    {
+        lock (_items)
+        {
+            _items.Add(item);
+        }
+    }
+
+    public int Count
+    {
+        get
+        {
+            lock (_items)
+            {
+                return _items.Count;
+            }
+        }
+    }
+
+    public bool IsEmpty => Count == 0;
+
+    public void Clear()
+    {
+        lock (_items)
+        {
+            _items.Clear();
+        }
+    }
+
+    public T[] ToArray()
+    {
+        lock (_items)
+        {
+            return _items.ToArray();
+        }
+    }
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        // Return a snapshot to avoid holding the lock during iteration
+        // and to prevent InvalidOperationException if the collection is modified.
+        T[] snapshot;
+        lock (_items)
+        {
+            snapshot = _items.ToArray();
+        }
+        return ((IEnumerable<T>)snapshot).GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/Sentry/Internal/ConcurrentQueueLite.cs
+++ b/src/Sentry/Internal/ConcurrentQueueLite.cs
@@ -6,7 +6,7 @@ namespace Sentry.Internal;
 /// We're using this due to a memory leak that happens when using ConcurrentQueue in the BackgroundWorker.
 /// See https://github.com/getsentry/sentry-dotnet/issues/2516
 /// </summary>
-internal class ConcurrentQueueLite<T>
+internal class ConcurrentQueueLite<T> : IReadOnlyCollection<T>
 {
     private readonly List<T> _queue = new();
 
@@ -74,4 +74,18 @@ internal class ConcurrentQueueLite<T>
             return _queue.ToArray();
         }
     }
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        // Return a snapshot to avoid holding the lock during iteration
+        // and to prevent InvalidOperationException if the collection is modified.
+        T[] snapshot;
+        lock (_queue)
+        {
+            snapshot = _queue.ToArray();
+        }
+        return ((IEnumerable<T>)snapshot).GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/Sentry/Internal/UnsampledTransaction.cs
+++ b/src/Sentry/Internal/UnsampledTransaction.cs
@@ -12,11 +12,7 @@ internal sealed class UnsampledTransaction : NoOpTransaction
     // Although it's a little bit wasteful to create separate individual class instances here when all we're going to
     // report to sentry is the span count (in the client report), SDK users may refer to things like
     // `ITransaction.Spans.Count`, so we create an actual collection
-#if NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-    private readonly ConcurrentBag<ISpan> _spans = [];
-#else
-    private ConcurrentBag<ISpan> _spans = [];
-#endif
+    private readonly ConcurrentBagLite<ISpan> _spans = new();
 
     private readonly IHub _hub;
     private readonly ITransactionContext _context;
@@ -117,10 +113,6 @@ internal sealed class UnsampledTransaction : NoOpTransaction
 
     private void ReleaseSpans()
     {
-#if NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         _spans.Clear();
-#else
-        _spans = [];
-#endif
     }
 }

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -51,29 +51,29 @@ public class Scope : IEventLike
     /// </summary>
     internal bool HasEvaluated => _hasEvaluated;
 
-    private readonly Lazy<ConcurrentBag<ISentryEventExceptionProcessor>> _lazyExceptionProcessors =
+    private readonly Lazy<ConcurrentBagLite<ISentryEventExceptionProcessor>> _lazyExceptionProcessors =
         new(LazyThreadSafetyMode.PublicationOnly);
 
     /// <summary>
     /// A list of exception processors.
     /// </summary>
-    internal ConcurrentBag<ISentryEventExceptionProcessor> ExceptionProcessors => _lazyExceptionProcessors.Value;
+    internal ConcurrentBagLite<ISentryEventExceptionProcessor> ExceptionProcessors => _lazyExceptionProcessors.Value;
 
-    private readonly Lazy<ConcurrentBag<ISentryEventProcessor>> _lazyEventProcessors =
+    private readonly Lazy<ConcurrentBagLite<ISentryEventProcessor>> _lazyEventProcessors =
         new(LazyThreadSafetyMode.PublicationOnly);
 
-    private readonly Lazy<ConcurrentBag<ISentryTransactionProcessor>> _lazyTransactionProcessors =
+    private readonly Lazy<ConcurrentBagLite<ISentryTransactionProcessor>> _lazyTransactionProcessors =
         new(LazyThreadSafetyMode.PublicationOnly);
 
     /// <summary>
     /// A list of event processors.
     /// </summary>
-    internal ConcurrentBag<ISentryEventProcessor> EventProcessors => _lazyEventProcessors.Value;
+    internal ConcurrentBagLite<ISentryEventProcessor> EventProcessors => _lazyEventProcessors.Value;
 
     /// <summary>
     /// A list of event processors.
     /// </summary>
-    internal ConcurrentBag<ISentryTransactionProcessor> TransactionProcessors => _lazyTransactionProcessors.Value;
+    internal ConcurrentBagLite<ISentryTransactionProcessor> TransactionProcessors => _lazyTransactionProcessors.Value;
 
     /// <summary>
     /// An event that fires when the scope evaluates.
@@ -278,11 +278,7 @@ public class Scope : IEventLike
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string> Tags => _tags;
 
-#if NETSTANDARD2_0 || NETFRAMEWORK
-    private ConcurrentBag<SentryAttachment> _attachments = new();
-#else
-    private readonly ConcurrentBag<SentryAttachment> _attachments = new();
-#endif
+    private readonly ConcurrentBagLite<SentryAttachment> _attachments = new();
 
     /// <summary>
     /// Attachments.
@@ -435,11 +431,7 @@ public class Scope : IEventLike
     /// </summary>
     public void ClearAttachments()
     {
-#if NETSTANDARD2_0 || NETFRAMEWORK
-        Interlocked.Exchange(ref _attachments, new());
-#else
         _attachments.Clear();
-#endif
         if (Options.EnableScopeSync)
         {
             Options.ScopeObserver?.ClearAttachments();

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -259,11 +259,7 @@ public class Scope : IEventLike
     /// <inheritdoc />
     public IReadOnlyList<string> Fingerprint { get; set; } = Array.Empty<string>();
 
-#if NETSTANDARD2_0 || NETFRAMEWORK
-    private ConcurrentQueue<Breadcrumb> _breadcrumbs = new();
-#else
-    private readonly ConcurrentQueue<Breadcrumb> _breadcrumbs = new();
-#endif
+    private readonly ConcurrentQueueLite<Breadcrumb> _breadcrumbs = new();
 
     /// <inheritdoc />
     public IReadOnlyCollection<Breadcrumb> Breadcrumbs => _breadcrumbs;
@@ -443,12 +439,7 @@ public class Scope : IEventLike
     /// </summary>
     public void ClearBreadcrumbs()
     {
-#if NETSTANDARD2_0 || NETFRAMEWORK
-        // No Clear method on ConcurrentQueue for these target frameworks
-        Interlocked.Exchange(ref _breadcrumbs, new());
-#else
         _breadcrumbs.Clear();
-#endif
     }
 
     /// <summary>

--- a/src/Sentry/SdkVersion.cs
+++ b/src/Sentry/SdkVersion.cs
@@ -1,4 +1,5 @@
 using Sentry.Extensibility;
+using Sentry.Internal;
 using Sentry.Internal.Extensions;
 using Sentry.Reflection;
 
@@ -19,8 +20,8 @@ public sealed class SdkVersion : ISentryJsonSerializable
 
     internal static SdkVersion Instance => InstanceLazy.Value;
 
-    internal ConcurrentBag<SentryPackage> InternalPackages { get; set; } = new();
-    internal ConcurrentBag<string> Integrations { get; set; } = new();
+    internal ConcurrentBagLite<SentryPackage> InternalPackages { get; set; } = new();
+    internal ConcurrentBagLite<string> Integrations { get; set; } = new();
 
     /// <summary>
     /// SDK packages.
@@ -104,8 +105,8 @@ public sealed class SdkVersion : ISentryJsonSerializable
 
         return new SdkVersion
         {
-            InternalPackages = new ConcurrentBag<SentryPackage>(packages),
-            Integrations = new ConcurrentBag<string>(integrations),
+            InternalPackages = new ConcurrentBagLite<SentryPackage>(packages),
+            Integrations = new ConcurrentBagLite<string>(integrations),
             Name = name,
             Version = version
         };

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -148,7 +148,7 @@ public sealed class TransactionTracer : IBaseTracer, ITransactionTracer
         set => _fingerprint = value;
     }
 
-    private readonly ConcurrentBag<Breadcrumb> _breadcrumbs = new();
+    private readonly ConcurrentBagLite<Breadcrumb> _breadcrumbs = new();
 
     /// <inheritdoc />
     public IReadOnlyCollection<Breadcrumb> Breadcrumbs => _breadcrumbs;
@@ -165,11 +165,7 @@ public sealed class TransactionTracer : IBaseTracer, ITransactionTracer
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string> Tags => _tags;
 
-#if NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-    private readonly ConcurrentBag<ISpan> _spans = new();
-#else
-    private ConcurrentBag<ISpan> _spans = new();
-#endif
+    private readonly ConcurrentBagLite<ISpan> _spans = new();
 
     /// <inheritdoc />
     public IReadOnlyCollection<ISpan> Spans => _spans;
@@ -428,11 +424,7 @@ public sealed class TransactionTracer : IBaseTracer, ITransactionTracer
 
     private void ReleaseSpans()
     {
-#if NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         _spans.Clear();
-#else
-        _spans = new ConcurrentBag<ISpan>();
-#endif
         _activeSpanTracker.Clear();
     }
 

--- a/test/Sentry.DiagnosticSource.Tests/SentrySqlListenerTests.cs
+++ b/test/Sentry.DiagnosticSource.Tests/SentrySqlListenerTests.cs
@@ -120,11 +120,10 @@ public class SentrySqlListenerTests
                 }));
 
         // Assert
-        var spans = fixture.Spans.Where(s => s.Operation != "abc");
+        var spans = fixture.Spans.Where(s => s.Operation != "abc").ToList();
         Assert.NotEmpty(spans);
 
-        var firstSpan = fixture.Spans.OrderByDescending(x => x.StartTimestamp).First();
-        Assert.True(GetValidator(key)(firstSpan));
+        Assert.True(GetValidator(key)(spans[0]));
     }
 
     [Theory]

--- a/test/Sentry.Tests/Internals/ConcurrentBagLiteTests.cs
+++ b/test/Sentry.Tests/Internals/ConcurrentBagLiteTests.cs
@@ -1,0 +1,137 @@
+namespace Sentry.Tests.Internals;
+
+public class ConcurrentBagLiteTests
+{
+    [Fact]
+    public void Add_Test()
+    {
+        // Arrange
+        var bag = new ConcurrentBagLite<int>();
+
+        // Act
+        bag.Add(1);
+
+        // Assert
+        bag.Count.Should().Be(1);
+
+        // Act
+        bag.Add(2);
+        bag.Add(3);
+
+        // Assert
+        bag.Count.Should().Be(3);
+        var items = bag.ToArray();
+        items.Should().BeEquivalentTo([1, 2, 3]);
+    }
+
+    [Fact]
+    public void Ctor_FromCollection_Test()
+    {
+        // Arrange & Act
+        var bag = new ConcurrentBagLite<int>(new[] { 1, 2, 3 });
+
+        // Assert
+        bag.Count.Should().Be(3);
+        bag.ToArray().Should().BeEquivalentTo([1, 2, 3]);
+    }
+
+    [Fact]
+    public void Count_EmptyBag_Test()
+    {
+        // Arrange
+        var bag = new ConcurrentBagLite<int>();
+
+        // Act & Assert
+        bag.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void IsEmpty_Test()
+    {
+        // Arrange
+        var bag = new ConcurrentBagLite<int>();
+
+        // Act & Assert
+        bag.IsEmpty.Should().BeTrue();
+        bag.Add(1);
+        bag.IsEmpty.Should().BeFalse();
+        bag.Clear();
+        bag.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Clear_Test()
+    {
+        // Arrange
+        var bag = new ConcurrentBagLite<int>();
+        bag.Add(1);
+        bag.Add(2);
+        bag.Add(3);
+
+        // Act
+        bag.Clear();
+
+        // Assert
+        bag.Count.Should().Be(0);
+        bag.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetEnumerator_Test()
+    {
+        // Arrange
+        var bag = new ConcurrentBagLite<int>();
+        bag.Add(1);
+        bag.Add(2);
+        bag.Add(3);
+
+        // Act
+        var items = bag.ToList();
+
+        // Assert
+        items.Should().BeEquivalentTo([1, 2, 3]);
+    }
+
+    [Fact]
+    public void GetEnumerator_Snapshot_DoesNotThrowOnConcurrentModification()
+    {
+        // Arrange
+        var bag = new ConcurrentBagLite<int>();
+        bag.Add(1);
+        bag.Add(2);
+
+        // Act
+        using var enumerator = bag.GetEnumerator();
+        bag.Add(3); // modify after enumerator created — should not throw when iterating snapshot
+
+        var items = new List<int>();
+        while (enumerator.MoveNext())
+        {
+            items.Add(enumerator.Current);
+        }
+
+        // Assert
+        items.Should().BeEquivalentTo([1, 2]);
+    }
+
+    [Fact]
+    public async Task TestConcurrency()
+    {
+        // Arrange
+        var bag = new ConcurrentBagLite<int>();
+        var count = 100;
+        var tasks = new Task[count];
+
+        // Act
+        for (var i = 0; i < count; i++)
+        {
+            var toAdd = i;
+            tasks[i] = Task.Run(() => bag.Add(toAdd));
+        }
+        await Task.WhenAll(tasks);
+
+        // Assert
+        bag.Count.Should().Be(count);
+        bag.ToArray().Should().BeEquivalentTo(Enumerable.Range(0, count));
+    }
+}

--- a/test/Sentry.Tests/Protocol/SdkVersionTests.cs
+++ b/test/Sentry.Tests/Protocol/SdkVersionTests.cs
@@ -46,12 +46,12 @@ public class SdkVersionTests
             {
               "packages": [
                 {
-                  "name": "Sentry",
-                  "version": "1.0"
-                },
-                {
                   "name": "Sentry.AspNetCore",
                   "version": "2.0"
+                },
+                {
+                  "name": "Sentry",
+                  "version": "1.0"
                 }
               ],
               "name": "Sentry.Test.SDK",
@@ -78,7 +78,7 @@ public class SdkVersionTests
         var sdk = new SdkVersion();
         sdk.AddPackage("b", "2");
         sdk.AddPackage("a", "1");
-        yield return new object[] { (sdk, """{"packages":[{"name":"a","version":"1"},{"name":"b","version":"2"}]}""") };
+        yield return new object[] { (sdk, """{"packages":[{"name":"b","version":"2"},{"name":"a","version":"1"}]}""") };
     }
 
     [Fact]
@@ -98,12 +98,12 @@ public class SdkVersionTests
 {
    ""packages"": [
         {
-            ""name"": ""Bar"",
-            ""version"": ""Beta""
-        },
-        {
             ""name"": ""Foo"",
             ""version"": ""Alpha""
+        },
+        {
+            ""name"": ""Bar"",
+            ""version"": ""Beta""
         }
     ],
     ""name"": ""Sentry.Test.SDK"",


### PR DESCRIPTION
fixes: #5113
fixes: #4721

Fixes memory leaks caused by `ConcurrentBag` and `ConcurrentQueue`.

## Why ConcurrentBag leaks
ConcurrentBag is backed by a ThreadLocal<ThreadLocalList> — internally it keeps a per-thread linked list. Every thread that ever touches the bag allocates a ThreadLocalList node that stays attached to the bag for the bag's lifetime, even after that thread has died. In a high-throughput app (profiler + ASP.NET Core thread pool), each bag instance accumulates stranded per-thread slots, and each SdkVersion instance carries that weight.

## Why the profiler amplifies it
Every SentryEvent, SentryTransaction, Scope, and TransactionTracer allocates its own SdkVersion → two fresh ConcurrentBag instances. AddPackage gets called on most of these from multiple callsites (SentryMiddleware.cs:252, Enricher.cs:72, Scope.cs:527). The profiler drives the event/transaction throughput way up, so both the count of bags and the per-bag thread-local overhead explode.

There's also one hotter target: NoOpTransaction.cs:14 returns SdkVersion.Instance (the singleton) as its Sdk. Any code path that ends up calling AddPackage on a NoOpTransaction's Sdk writes into that singleton bag forever.

## The fix pattern
Same as https://github.com/getsentry/sentry-dotnet/pull/3432: replace `ConcurrentBag` with a simpler lock-backed list (as suggested in https://github.com/getsentry/sentry-dotnet/issues/4721).

# Testing

Memory does keep growing in the process but this seems to be just because I have loads of memory so the GC doesn't bother kicking in. If I force a GC then memory is released again:
<img width="1480" height="253" alt="image" src="https://github.com/user-attachments/assets/4d667c82-8924-42c0-aa3d-a603258fb409" />

As far as I can tell then, there are no remaining memory leaks in the [minimal repro](https://github.com/getsentry/sentry-dotnet/issues/5113#issuecomment-4225368488) that @kanadaj provided.