### PR TITLE
chore: fix missing skill

### DIFF
--- a/agents.toml
+++ b/agents.toml
@@ -34,10 +34,6 @@ name = "create-branch"
 source = "getsentry/skills"
 
 [[skills]]
-name = "create-pr"
-source = "getsentry/skills"
-
-[[skills]]
 name = "find-bugs"
 source = "getsentry/skills"
 


### PR DESCRIPTION
Seeing the following error:

```
./dev.cs aiup
[dev] Installing/updating AI agent files
==> npx @sentry/dotagents install: npx @sentry/dotagents install
Failed to resolve skill "create-pr": Skill "create-pr" not found in getsentry/skills. Tried conventional directories. Use the 'path' field to specify the location explicitly.
```

Seems to be because this skill is missing so removing it from `agents.toml`