### PR TITLE
chore: remove invalid and obsolete Dependabot filter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,3 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  ignore:
-  - dependency-name: "gradle/actions/setup-gradle"
-    versions: ['>= 6.0.0'] # license change: the bundled 'gradle-actions-caching' component is licensed and governed by a separate license (no longer MIT)


### PR DESCRIPTION
### Summary

Remove now obsolete, and also invalid in the first place, filter rule for Dependabot.

### Remarks

Added in #5086, because Action `gradle/actions/setup-gradle` in version `v6.0.0` changed the license of the the bundled 'gradle-actions-caching' component from MIT to a proprietary/commercial license.

However, `v6.1.0` of the Action has added a non-default opt-in to replace this "Enhanced" Caching Component with a "Basic" open-source MIT-based version, to which we have switched to in #5130.

So the Dependabot `ignore` is no longer needed.
Also, it did not work in the first place!
