### PR TITLE
ci: update actions/cache to v5 in buildnative action

### DIFF
--- a/.github/actions/buildnative/action.yml
+++ b/.github/actions/buildnative/action.yml
@@ -14,7 +14,7 @@ runs:
           echo "JAVA_HOME_21=$JAVA_HOME_21_X64" >> $GITHUB_ENV
         fi
 
-    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: cache-c
       with:
         path: lib/sentrysupplemental/bin
@@ -35,7 +35,7 @@ runs:
       shell: cmd
       run: lib\sentrysupplemental\build.cmd
 
-    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: cache-android
       with:
         path: lib/sentry-android-supplemental/bin


### PR DESCRIPTION
## Summary

- Upgrades `actions/cache` from v3.5.0 (Node 16) to v5.0.5 (Node 20) in `.github/actions/buildnative/action.yml`
- This was the last remaining action using Node 16 in the repo; all others were updated in earlier PRs
- Eliminates the Node.js 16 deprecation warnings that were logged during CI runs

Fixes #3096

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)