### PR TITLE
feat(serilog): support restrictedToMinimumLevel when configuring Serilog in code

### DIFF
--- a/src/Sentry.Serilog/SentrySerilogOptions.cs
+++ b/src/Sentry.Serilog/SentrySerilogOptions.cs
@@ -40,4 +40,16 @@ public class SentrySerilogOptions : SentryOptions
     /// Optional <see cref="ITextFormatter"/>
     /// </summary>
     public ITextFormatter? TextFormatter { get; set; }
+
+    /// <summary>
+    /// The minimum level for events passed through the sink. Ignored when <see cref="LevelSwitch"/> is specified.
+    /// </summary>
+    /// <seealso href="https://github.com/serilog/serilog/wiki/Configuration-Basics#overriding-per-sink"/>
+    public LogEventLevel RestrictedToMinimumLevel { get; set; } = LevelAlias.Minimum;
+
+    /// <summary>
+    /// A switch allowing the pass-through minimum level to be changed at runtime.
+    /// </summary>
+    /// <seealso href="https://github.com/serilog/serilog/wiki/Configuration-Basics#overriding-per-sink"/>
+    public LoggingLevelSwitch? LevelSwitch { get; set; }
 }

--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -36,8 +36,8 @@ public static class SentrySinkExtensions
     /// <param name="deduplicateMode">What modes to use for event automatic de-duplication. <seealso cref="SentryOptions.DeduplicateMode"/></param>
     /// <param name="defaultTags">Default tags to add to all events. <seealso cref="SentryOptions.DefaultTags"/></param>
     /// <param name="enableLogs">Whether to send structured logs. <seealso cref="SentryOptions.EnableLogs"/></param>
-    /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
-    /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified. <seealso cref="SentrySerilogOptions.RestrictedToMinimumLevel"/></param>
+    /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime. <seealso cref="SentrySerilogOptions.LevelSwitch"/></param>
     /// <returns><see cref="LoggerConfiguration"/></returns>
     /// <example>This sample shows how each item may be set from within a configuration file:
     /// <code>
@@ -136,9 +136,9 @@ public static class SentrySinkExtensions
             reportAssembliesMode,
             deduplicateMode,
             defaultTags,
-            enableLogs),
+            enableLogs,
             restrictedToMinimumLevel,
-            levelSwitch);
+            levelSwitch));
     }
 
     /// <summary>
@@ -153,8 +153,8 @@ public static class SentrySinkExtensions
     /// <param name="minimumBreadcrumbLevel">Minimum log level to record a breadcrumb. <seealso cref="SentrySerilogOptions.MinimumBreadcrumbLevel"/></param>
     /// <param name="formatProvider">The Serilog format provider. <seealso cref="IFormatProvider"/></param>
     /// <param name="textFormatter">The Serilog text formatter. <seealso cref="ITextFormatter"/></param>
-    /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
-    /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified. <seealso cref="SentrySerilogOptions.RestrictedToMinimumLevel"/></param>
+    /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime. <seealso cref="SentrySerilogOptions.LevelSwitch"/></param>
     /// <returns><see cref="LoggerConfiguration"/></returns>
     /// <example>This sample shows how each item may be set from within a configuration file:
     /// <code>
@@ -191,9 +191,9 @@ public static class SentrySinkExtensions
             minimumEventLevel,
             minimumBreadcrumbLevel,
             formatProvider,
-            textFormatter),
-            restrictedToMinimumLevel,
-            levelSwitch);
+            textFormatter,
+            restrictedToMinimumLevel: restrictedToMinimumLevel,
+            levelSwitch: levelSwitch));
     }
 
     internal static void ConfigureSentrySerilogOptions(
@@ -221,7 +221,9 @@ public static class SentrySinkExtensions
         ReportAssembliesMode? reportAssembliesMode = null,
         DeduplicateMode? deduplicateMode = null,
         Dictionary<string, string>? defaultTags = null,
-        bool? enableLogs = null)
+        bool? enableLogs = null,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        LoggingLevelSwitch? levelSwitch = null)
     {
         if (dsn is not null)
         {
@@ -338,6 +340,9 @@ public static class SentrySinkExtensions
             sentrySerilogOptions.EnableLogs = enableLogs.Value;
         }
 
+        sentrySerilogOptions.RestrictedToMinimumLevel = restrictedToMinimumLevel;
+        sentrySerilogOptions.LevelSwitch = levelSwitch;
+
         // Serilog-specific items
         sentrySerilogOptions.InitializeSdk = dsn is not null;  // Inferred from the Sentry overload that is used
         if (defaultTags?.Count > 0)
@@ -362,13 +367,9 @@ public static class SentrySinkExtensions
     /// </summary>
     /// <param name="loggerConfiguration">The logger configuration.</param>
     /// <param name="configureOptions">The configure options callback.</param>
-    /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
-    /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
     public static LoggerConfiguration Sentry(
         this LoggerSinkConfiguration loggerConfiguration,
-        Action<SentrySerilogOptions> configureOptions,
-        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-        LoggingLevelSwitch? levelSwitch = null)
+        Action<SentrySerilogOptions> configureOptions)
     {
         var options = new SentrySerilogOptions();
         configureOptions?.Invoke(options);
@@ -379,6 +380,6 @@ public static class SentrySinkExtensions
             sdkDisposable = SentrySdk.Init(options);
         }
 
-        return loggerConfiguration.Sink(new SentrySink(options, sdkDisposable), restrictedToMinimumLevel, levelSwitch);
+        return loggerConfiguration.Sink(new SentrySink(options, sdkDisposable), options.RestrictedToMinimumLevel, options.LevelSwitch);
     }
 }

--- a/src/Sentry.Serilog/SentrySinkExtensions.cs
+++ b/src/Sentry.Serilog/SentrySinkExtensions.cs
@@ -36,6 +36,8 @@ public static class SentrySinkExtensions
     /// <param name="deduplicateMode">What modes to use for event automatic de-duplication. <seealso cref="SentryOptions.DeduplicateMode"/></param>
     /// <param name="defaultTags">Default tags to add to all events. <seealso cref="SentryOptions.DefaultTags"/></param>
     /// <param name="enableLogs">Whether to send structured logs. <seealso cref="SentryOptions.EnableLogs"/></param>
+    /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+    /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
     /// <returns><see cref="LoggerConfiguration"/></returns>
     /// <example>This sample shows how each item may be set from within a configuration file:
     /// <code>
@@ -106,7 +108,9 @@ public static class SentrySinkExtensions
         ReportAssembliesMode? reportAssembliesMode = null,
         DeduplicateMode? deduplicateMode = null,
         Dictionary<string, string>? defaultTags = null,
-        bool? enableLogs = null)
+        bool? enableLogs = null,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        LoggingLevelSwitch? levelSwitch = null)
     {
         return loggerConfiguration.Sentry(o => ConfigureSentrySerilogOptions(o,
             dsn,
@@ -132,7 +136,9 @@ public static class SentrySinkExtensions
             reportAssembliesMode,
             deduplicateMode,
             defaultTags,
-            enableLogs));
+            enableLogs),
+            restrictedToMinimumLevel,
+            levelSwitch);
     }
 
     /// <summary>
@@ -147,6 +153,8 @@ public static class SentrySinkExtensions
     /// <param name="minimumBreadcrumbLevel">Minimum log level to record a breadcrumb. <seealso cref="SentrySerilogOptions.MinimumBreadcrumbLevel"/></param>
     /// <param name="formatProvider">The Serilog format provider. <seealso cref="IFormatProvider"/></param>
     /// <param name="textFormatter">The Serilog text formatter. <seealso cref="ITextFormatter"/></param>
+    /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+    /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
     /// <returns><see cref="LoggerConfiguration"/></returns>
     /// <example>This sample shows how each item may be set from within a configuration file:
     /// <code>
@@ -174,15 +182,18 @@ public static class SentrySinkExtensions
         LogEventLevel? minimumEventLevel = null,
         LogEventLevel? minimumBreadcrumbLevel = null,
         IFormatProvider? formatProvider = null,
-        ITextFormatter? textFormatter = null
-        )
+        ITextFormatter? textFormatter = null,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        LoggingLevelSwitch? levelSwitch = null)
     {
         return loggerConfiguration.Sentry(o => ConfigureSentrySerilogOptions(o,
             null,
             minimumEventLevel,
             minimumBreadcrumbLevel,
             formatProvider,
-            textFormatter));
+            textFormatter),
+            restrictedToMinimumLevel,
+            levelSwitch);
     }
 
     internal static void ConfigureSentrySerilogOptions(
@@ -351,9 +362,13 @@ public static class SentrySinkExtensions
     /// </summary>
     /// <param name="loggerConfiguration">The logger configuration.</param>
     /// <param name="configureOptions">The configure options callback.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+    /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
     public static LoggerConfiguration Sentry(
         this LoggerSinkConfiguration loggerConfiguration,
-        Action<SentrySerilogOptions> configureOptions)
+        Action<SentrySerilogOptions> configureOptions,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        LoggingLevelSwitch? levelSwitch = null)
     {
         var options = new SentrySerilogOptions();
         configureOptions?.Invoke(options);
@@ -364,6 +379,6 @@ public static class SentrySinkExtensions
             sdkDisposable = SentrySdk.Init(options);
         }
 
-        return loggerConfiguration.Sink(new SentrySink(options, sdkDisposable));
+        return loggerConfiguration.Sink(new SentrySink(options, sdkDisposable), restrictedToMinimumLevel, levelSwitch);
     }
 }

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -20,8 +20,8 @@ namespace Serilog
 {
     public static class SentrySinkExtensions
     {
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,
                     string dsn,
@@ -47,6 +47,8 @@ namespace Serilog
                     Sentry.ReportAssembliesMode? reportAssembliesMode = default,
                     Sentry.DeduplicateMode? deduplicateMode = default,
                     System.Collections.Generic.Dictionary<string, string>? defaultTags = null,
-                    bool? enableLogs = default) { }
+                    bool? enableLogs = default,
+                    Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0,
+                    Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
     }
 }

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -11,8 +11,10 @@ namespace Sentry.Serilog
         public SentrySerilogOptions() { }
         public System.IFormatProvider? FormatProvider { get; set; }
         public bool InitializeSdk { get; set; }
+        public Serilog.Core.LoggingLevelSwitch? LevelSwitch { get; set; }
         public Serilog.Events.LogEventLevel MinimumBreadcrumbLevel { get; set; }
         public Serilog.Events.LogEventLevel MinimumEventLevel { get; set; }
+        public Serilog.Events.LogEventLevel RestrictedToMinimumLevel { get; set; }
         public Serilog.Formatting.ITextFormatter? TextFormatter { get; set; }
     }
 }
@@ -20,7 +22,7 @@ namespace Serilog
 {
     public static class SentrySinkExtensions
     {
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -20,8 +20,8 @@ namespace Serilog
 {
     public static class SentrySinkExtensions
     {
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,
                     string dsn,
@@ -47,6 +47,8 @@ namespace Serilog
                     Sentry.ReportAssembliesMode? reportAssembliesMode = default,
                     Sentry.DeduplicateMode? deduplicateMode = default,
                     System.Collections.Generic.Dictionary<string, string>? defaultTags = null,
-                    bool? enableLogs = default) { }
+                    bool? enableLogs = default,
+                    Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0,
+                    Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
     }
 }

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -11,8 +11,10 @@ namespace Sentry.Serilog
         public SentrySerilogOptions() { }
         public System.IFormatProvider? FormatProvider { get; set; }
         public bool InitializeSdk { get; set; }
+        public Serilog.Core.LoggingLevelSwitch? LevelSwitch { get; set; }
         public Serilog.Events.LogEventLevel MinimumBreadcrumbLevel { get; set; }
         public Serilog.Events.LogEventLevel MinimumEventLevel { get; set; }
+        public Serilog.Events.LogEventLevel RestrictedToMinimumLevel { get; set; }
         public Serilog.Formatting.ITextFormatter? TextFormatter { get; set; }
     }
 }
@@ -20,7 +22,7 @@ namespace Serilog
 {
     public static class SentrySinkExtensions
     {
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -20,8 +20,8 @@ namespace Serilog
 {
     public static class SentrySinkExtensions
     {
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,
                     string dsn,
@@ -47,6 +47,8 @@ namespace Serilog
                     Sentry.ReportAssembliesMode? reportAssembliesMode = default,
                     Sentry.DeduplicateMode? deduplicateMode = default,
                     System.Collections.Generic.Dictionary<string, string>? defaultTags = null,
-                    bool? enableLogs = default) { }
+                    bool? enableLogs = default,
+                    Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0,
+                    Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
     }
 }

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -11,8 +11,10 @@ namespace Sentry.Serilog
         public SentrySerilogOptions() { }
         public System.IFormatProvider? FormatProvider { get; set; }
         public bool InitializeSdk { get; set; }
+        public Serilog.Core.LoggingLevelSwitch? LevelSwitch { get; set; }
         public Serilog.Events.LogEventLevel MinimumBreadcrumbLevel { get; set; }
         public Serilog.Events.LogEventLevel MinimumEventLevel { get; set; }
+        public Serilog.Events.LogEventLevel RestrictedToMinimumLevel { get; set; }
         public Serilog.Formatting.ITextFormatter? TextFormatter { get; set; }
     }
 }
@@ -20,7 +22,7 @@ namespace Serilog
 {
     public static class SentrySinkExtensions
     {
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -20,8 +20,8 @@ namespace Serilog
 {
     public static class SentrySinkExtensions
     {
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,
                     string dsn,
@@ -47,6 +47,8 @@ namespace Serilog
                     Sentry.ReportAssembliesMode? reportAssembliesMode = default,
                     Sentry.DeduplicateMode? deduplicateMode = default,
                     System.Collections.Generic.Dictionary<string, string>? defaultTags = null,
-                    bool? enableLogs = default) { }
+                    bool? enableLogs = default,
+                    Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0,
+                    Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
     }
 }

--- a/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Serilog.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -11,8 +11,10 @@ namespace Sentry.Serilog
         public SentrySerilogOptions() { }
         public System.IFormatProvider? FormatProvider { get; set; }
         public bool InitializeSdk { get; set; }
+        public Serilog.Core.LoggingLevelSwitch? LevelSwitch { get; set; }
         public Serilog.Events.LogEventLevel MinimumBreadcrumbLevel { get; set; }
         public Serilog.Events.LogEventLevel MinimumEventLevel { get; set; }
+        public Serilog.Events.LogEventLevel RestrictedToMinimumLevel { get; set; }
         public Serilog.Formatting.ITextFormatter? TextFormatter { get; set; }
     }
 }
@@ -20,7 +22,7 @@ namespace Serilog
 {
     public static class SentrySinkExtensions
     {
-        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
+        public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, System.Action<Sentry.Serilog.SentrySerilogOptions> configureOptions) { }
         public static Serilog.LoggerConfiguration Sentry(this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration, Serilog.Events.LogEventLevel? minimumEventLevel = default, Serilog.Events.LogEventLevel? minimumBreadcrumbLevel = default, System.IFormatProvider? formatProvider = null, Serilog.Formatting.ITextFormatter? textFormatter = null, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
         public static Serilog.LoggerConfiguration Sentry(
                     this Serilog.Configuration.LoggerSinkConfiguration loggerConfiguration,

--- a/test/Sentry.Serilog.Tests/Sentry.Serilog.Tests.csproj
+++ b/test/Sentry.Serilog.Tests/Sentry.Serilog.Tests.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\src\Sentry.Serilog\Sentry.Serilog.csproj" />
 
     <Using Include="Serilog" />
+    <Using Include="Serilog.Core" />
     <Using Include="Serilog.Events" />
     <Using Include="Serilog.Context" />
     <Using Include="Serilog.Formatting.Display" />

--- a/test/Sentry.Serilog.Tests/SentrySerilogSinkExtensionsTests.cs
+++ b/test/Sentry.Serilog.Tests/SentrySerilogSinkExtensionsTests.cs
@@ -133,22 +133,30 @@ public class SentrySerilogSinkExtensionsTests
     [Fact]
     public void Sentry_WithRestrictedToMinimumLevel_ConfigureOptions_FiltersLogsBelow()
     {
-        // Verify RestrictedToMinimumLevel can be set via the options callback (e.g. for MAUI users)
+        // Arrange
+        var hub = Substitute.For<IHub>();
+        hub.IsEnabled.Returns(true);
+        var options = new SentrySerilogOptions
+        {
+            InitializeSdk = false,
+            MinimumBreadcrumbLevel = LogEventLevel.Verbose,
+            MinimumEventLevel = LogEventLevel.Verbose,
+            RestrictedToMinimumLevel = LogEventLevel.Error,
+        };
+        var sink = new SentrySink(options, () => hub, null, new MockClock());
         using var logger = new LoggerConfiguration()
-            .WriteTo.Sentry(o =>
-            {
-                o.InitializeSdk = false;
-                o.MinimumBreadcrumbLevel = LogEventLevel.Debug;
-                o.MinimumEventLevel = LogEventLevel.Debug;
-                o.RestrictedToMinimumLevel = LogEventLevel.Error;
-            })
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(sink, options.RestrictedToMinimumLevel, options.LevelSwitch)
             .CreateLogger();
 
-        // Below RestrictedToMinimumLevel — Serilog filters this before it reaches the sink
-        logger.Warning("This should be filtered by Serilog before reaching the sink");
+        // Act
+        logger.Warning("Below threshold");
+        logger.Error("At threshold");
 
-        // At or above RestrictedToMinimumLevel — should reach the sink
-        logger.Error("This should reach the sink");
+        // Assert: Warning is filtered by Serilog before reaching the sink; only Error gets through
+        hub.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
+        hub.DidNotReceive().CaptureEvent(Arg.Is<SentryEvent>(e =>
+            e.Message.Message == "Below threshold"));
     }
 
     [Fact]

--- a/test/Sentry.Serilog.Tests/SentrySerilogSinkExtensionsTests.cs
+++ b/test/Sentry.Serilog.Tests/SentrySerilogSinkExtensionsTests.cs
@@ -29,6 +29,8 @@ public class SentrySerilogSinkExtensionsTests
         public bool InitializeSdk { get; } = false;
         public LogEventLevel MinimumEventLevel { get; } = LogEventLevel.Verbose;
         public LogEventLevel MinimumBreadcrumbLevel { get; } = LogEventLevel.Fatal;
+        public LogEventLevel RestrictedToMinimumLevel { get; } = LogEventLevel.Warning;
+        public LoggingLevelSwitch LevelSwitch { get; } = new(LogEventLevel.Error);
 
         public static SentrySerilogOptions GetSut() => new();
     }
@@ -98,7 +100,8 @@ public class SentrySerilogSinkExtensionsTests
             _fixture.SampleRate, _fixture.Release, _fixture.Environment, _fixture.MaxQueueItems,
             _fixture.ShutdownTimeout, _fixture.DecompressionMethods, _fixture.RequestBodyCompressionLevel,
             _fixture.RequestBodyCompressionBuffered, _fixture.Debug, _fixture.DiagnosticLevel,
-            _fixture.ReportAssembliesMode, _fixture.DeduplicateMode, null, _fixture.EnableLogs);
+            _fixture.ReportAssembliesMode, _fixture.DeduplicateMode, null, _fixture.EnableLogs,
+            _fixture.RestrictedToMinimumLevel, _fixture.LevelSwitch);
 
         // Compare individual properties
         Assert.Equal(_fixture.SendDefaultPii, sut.SendDefaultPii);
@@ -123,24 +126,28 @@ public class SentrySerilogSinkExtensionsTests
         Assert.True(sut.InitializeSdk);
         Assert.Equal(_fixture.MinimumEventLevel, sut.MinimumEventLevel);
         Assert.Equal(_fixture.MinimumBreadcrumbLevel, sut.MinimumBreadcrumbLevel);
+        Assert.Equal(_fixture.RestrictedToMinimumLevel, sut.RestrictedToMinimumLevel);
+        Assert.Same(_fixture.LevelSwitch, sut.LevelSwitch);
     }
 
     [Fact]
-    public void Sentry_WithRestrictedToMinimumLevel_FiltersLogsBelow()
+    public void Sentry_WithRestrictedToMinimumLevel_ConfigureOptions_FiltersLogsBelow()
     {
+        // Verify RestrictedToMinimumLevel can be set via the options callback (e.g. for MAUI users)
         using var logger = new LoggerConfiguration()
             .WriteTo.Sentry(o =>
             {
                 o.InitializeSdk = false;
                 o.MinimumBreadcrumbLevel = LogEventLevel.Debug;
                 o.MinimumEventLevel = LogEventLevel.Debug;
-            }, restrictedToMinimumLevel: LogEventLevel.Error)
+                o.RestrictedToMinimumLevel = LogEventLevel.Error;
+            })
             .CreateLogger();
 
-        // Below restrictedToMinimumLevel — should not reach the sink
+        // Below RestrictedToMinimumLevel — Serilog filters this before it reaches the sink
         logger.Warning("This should be filtered by Serilog before reaching the sink");
 
-        // At or above restrictedToMinimumLevel — should reach the sink
+        // At or above RestrictedToMinimumLevel — should reach the sink
         logger.Error("This should reach the sink");
     }
 

--- a/test/Sentry.Serilog.Tests/SentrySerilogSinkExtensionsTests.cs
+++ b/test/Sentry.Serilog.Tests/SentrySerilogSinkExtensionsTests.cs
@@ -125,6 +125,40 @@ public class SentrySerilogSinkExtensionsTests
         Assert.Equal(_fixture.MinimumBreadcrumbLevel, sut.MinimumBreadcrumbLevel);
     }
 
+    [Fact]
+    public void Sentry_WithRestrictedToMinimumLevel_FiltersLogsBelow()
+    {
+        using var logger = new LoggerConfiguration()
+            .WriteTo.Sentry(o =>
+            {
+                o.InitializeSdk = false;
+                o.MinimumBreadcrumbLevel = LogEventLevel.Debug;
+                o.MinimumEventLevel = LogEventLevel.Debug;
+            }, restrictedToMinimumLevel: LogEventLevel.Error)
+            .CreateLogger();
+
+        // Below restrictedToMinimumLevel — should not reach the sink
+        logger.Warning("This should be filtered by Serilog before reaching the sink");
+
+        // At or above restrictedToMinimumLevel — should reach the sink
+        logger.Error("This should reach the sink");
+    }
+
+    [Fact]
+    public void Sentry_WithRestrictedToMinimumLevel_NoDsn_ParameterIsAccepted()
+    {
+        // Verify the no-DSN overload accepts restrictedToMinimumLevel without throwing
+        var ex = Record.Exception(() =>
+            new LoggerConfiguration()
+                .WriteTo.Sentry(
+                    minimumBreadcrumbLevel: LogEventLevel.Verbose,
+                    minimumEventLevel: LogEventLevel.Error,
+                    restrictedToMinimumLevel: LogEventLevel.Warning)
+                .CreateLogger());
+
+        Assert.Null(ex);
+    }
+
     private static void AssertEqualDeep(object expected, object actual)
     {
         var serializedLeftObject = JsonSerializer.Serialize(expected);


### PR DESCRIPTION
## Summary

Fixes #4957

- Added `RestrictedToMinimumLevel` and `LevelSwitch` options to `SentrySerilogOptions`, plus matching `restrictedToMinimumLevel` and `levelSwitch` parameters on the two parameterized `Sentry()` extension method overloads on `LoggerSinkConfiguration`
- These are passed through to Serilog's underlying `Sink()` call, enabling per-sink minimum level filtering to be set in code
- Previously, per-sink minimum levels could only be configured via `appsettings.json`; this change unblocks MAUI users who configure Serilog in code

## Usage

```csharp
.WriteTo.Sentry(o =>
{
    o.MinimumBreadcrumbLevel = LogEventLevel.Debug;
    o.MinimumEventLevel = LogEventLevel.Error;
    // Only Warning and higher reach the Sentry sink
    o.RestrictedToMinimumLevel = LogEventLevel.Warning;
})
```

## Docs

- getsentry/sentry-docs#18740

🤖 Generated with [Claude Code](https://claude.com/claude-code)
