### PR TITLE
fix(otel): skip SentrySpanProcessor when performance monitoring is disabled

### DIFF
--- a/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -48,11 +48,22 @@ public static class TracerProviderBuilderExtensions
         var hub = services.GetService<IHub>() ?? SentrySdk.CurrentHub;
         if (hub.IsEnabled)
         {
+            var options = hub.GetSentryOptions();
+            if (options is { IsPerformanceMonitoringEnabled: false })
+            {
+                var logger = services.GetService<IDiagnosticLogger>();
+                logger?.LogInfo(
+                    "Sentry performance monitoring is disabled (TracesSampleRate is 0 and no TracesSampler " +
+                    "is configured). Skipping SentrySpanProcessor registration to avoid memory overhead " +
+                    "from unsampled transactions.");
+                return DisabledSpanProcessor.Instance;
+            }
+
             return new SentrySpanProcessor(hub, enrichers);
         }
 
-        var logger = services.GetService<IDiagnosticLogger>();
-        logger?.LogWarning("Sentry is disabled so no OpenTelemetry spans will be sent to Sentry.");
+        var disabledLogger = services.GetService<IDiagnosticLogger>();
+        disabledLogger?.LogWarning("Sentry is disabled so no OpenTelemetry spans will be sent to Sentry.");
         return DisabledSpanProcessor.Instance;
     }
 }

--- a/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Sentry.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -51,8 +51,7 @@ public static class TracerProviderBuilderExtensions
             var options = hub.GetSentryOptions();
             if (options is { IsPerformanceMonitoringEnabled: false })
             {
-                var logger = services.GetService<IDiagnosticLogger>();
-                logger?.LogInfo(
+                options.DiagnosticLogger?.LogInfo(
                     "Sentry performance monitoring is disabled (TracesSampleRate is 0 and no TracesSampler " +
                     "is configured). Skipping SentrySpanProcessor registration to avoid memory overhead " +
                     "from unsampled transactions.");
@@ -62,8 +61,8 @@ public static class TracerProviderBuilderExtensions
             return new SentrySpanProcessor(hub, enrichers);
         }
 
-        var disabledLogger = services.GetService<IDiagnosticLogger>();
-        disabledLogger?.LogWarning("Sentry is disabled so no OpenTelemetry spans will be sent to Sentry.");
+        var logger = services.GetService<IDiagnosticLogger>();
+        logger?.LogWarning("Sentry is disabled so no OpenTelemetry spans will be sent to Sentry.");
         return DisabledSpanProcessor.Instance;
     }
 }

--- a/test/Sentry.OpenTelemetry.Tests/TracerProviderBuilderExtensionsTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/TracerProviderBuilderExtensionsTests.cs
@@ -15,7 +15,15 @@ public class TracerProviderBuilderExtensionsTests
         public SentryOptions GetOptions(string dsn = "https://123@o456.ingest.sentry.io/789") => new()
         {
             Instrumenter = Instrumenter.OpenTelemetry,
-            Dsn = dsn
+            Dsn = dsn,
+            TracesSampleRate = 1.0
+        };
+
+        public SentryOptions GetOptionsWithTracingDisabled(string dsn = "https://123@o456.ingest.sentry.io/789") => new()
+        {
+            Instrumenter = Instrumenter.OpenTelemetry,
+            Dsn = dsn,
+            TracesSampleRate = 0.0
         };
 
         public IServiceProvider GetServiceProvider() => ServiceProvider;
@@ -90,5 +98,24 @@ public class TracerProviderBuilderExtensionsTests
 
         // Assert
         result.Should().BeOfType<DisabledSpanProcessor>(); // FluentAssertions
+    }
+
+    [Fact]
+    public void ImplementationFactory_WithTracingDisabled_ReturnsDisabledSpanProcessor()
+    {
+        // Arrange
+        var fixture = new Fixture();
+        SentryClientExtensions.SentryOptionsForTestingOnly = fixture.GetOptionsWithTracingDisabled();
+        fixture.Hub.IsEnabled.Returns(true);
+        var services = fixture.GetServiceProvider();
+
+        // Act
+        var result = TracerProviderBuilderExtensions.ImplementationFactory(services);
+
+        // Assert
+        // When TracesSampleRate = 0 and no TracesSampler is configured, registering SentrySpanProcessor
+        // would create UnsampledTransaction + UnsampledSpan objects per Activity that accumulate in
+        // ThreadLocal storage and are never released, causing a managed memory leak.
+        result.Should().BeOfType<DisabledSpanProcessor>();
     }
 }


### PR DESCRIPTION
## Summary

Fixes #5184

When `TracesSampleRate = 0` and no `TracesSampler` is configured, `AddSentry()` on the OTel `TracerProvider` previously still registered `SentrySpanProcessor`. For every `Activity.Stop()` the processor created an `UnsampledTransaction` with child `UnsampledSpan` objects stored in `ThreadLocal<ConcurrentBag<ISpan>>`. These accumulated and were never released, causing a sustained managed memory leak under load.

This is related to the fix in #4717 (which addressed `UnsampledTransaction.Finish()` not releasing child spans in the `SentryTracingMiddleware` path), but the OTel `SentrySpanProcessor` path still requires users to manually guard against registering the processor when tracing is disabled.

## Changes

- `ImplementationFactory` in `TracerProviderBuilderExtensions` now checks `IsPerformanceMonitoringEnabled` before creating a `SentrySpanProcessor`. When tracing is off it returns `DisabledSpanProcessor` instead, and logs an `Info` message explaining why.
- Existing tests updated: `GetOptions()` in the fixture now sets `TracesSampleRate = 1.0` (the existing tests exercise the tracing-enabled path, so this is the correct baseline).
- New test: `ImplementationFactory_WithTracingDisabled_ReturnsDisabledSpanProcessor` verifies the fix directly.

## Before / After

**Before** — users had to guard manually:
```csharp
if (tracesSampleRate > 0) {
    services.AddOpenTelemetry().WithTracing(b => b.AddSentry());
}
```

**After** — `AddSentry()` is safe to call unconditionally; it no-ops when tracing is disabled:
```csharp
services.AddOpenTelemetry().WithTracing(b => b.AddSentry());
```