### PR TITLE
fix: Memory leak when filtered Activities get garbage collected before `PruneFilteredSpans` runs

### DIFF
--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -140,8 +140,7 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
             spanTracer.StartTimestamp = data.StartTimeUtc;
             // Used to filter out spans that are not recorded when finishing a transaction.
             spanTracer.SetFused(data);
-            // Treat a GC'd activity (null) as filtered — if the activity is gone, we don't want the span in the trace.
-            spanTracer.IsFiltered = () => spanTracer.GetFused<Activity>() is null or { IsAllDataRequested: false, Recorded: false };
+            spanTracer.IsFiltered = () => spanTracer.GetFused<Activity>() is { IsAllDataRequested: false, Recorded: false };
         }
         _map[data.SpanId] = span;
     }

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -134,10 +134,7 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
         };
 
         var span = parentSpan.StartChild(context);
-        // Fuse the Activity on all span types so PruneFilteredSpans can distinguish
-        // unfinished-but-live spans (Recorded: true) from filtered ones (Recorded: false).
-        // Without this, non-SpanTracer spans (e.g. UnsampledSpan) would have a null fused
-        // Activity and be incorrectly pruned before OnEnd fires.
+        // Used to filter out spans that are not recorded when finishing a transaction
         span.SetFused(data);
         if (span is SpanTracer spanTracer)
         {

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -134,12 +134,15 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
         };
 
         var span = parentSpan.StartChild(context);
+        // Fuse the Activity on all span types so PruneFilteredSpans can distinguish
+        // unfinished-but-live spans (Recorded: true) from filtered ones (Recorded: false).
+        // Without this, non-SpanTracer spans (e.g. UnsampledSpan) would have a null fused
+        // Activity and be incorrectly pruned before OnEnd fires.
+        span.SetFused(data);
         if (span is SpanTracer spanTracer)
         {
             spanTracer.Origin = OpenTelemetryOrigin;
             spanTracer.StartTimestamp = data.StartTimeUtc;
-            // Used to filter out spans that are not recorded when finishing a transaction.
-            spanTracer.SetFused(data);
             spanTracer.IsFiltered = () => spanTracer.GetFused<Activity>() is { IsAllDataRequested: false, Recorded: false };
         }
         _map[data.SpanId] = span;

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -140,7 +140,8 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
             spanTracer.StartTimestamp = data.StartTimeUtc;
             // Used to filter out spans that are not recorded when finishing a transaction.
             spanTracer.SetFused(data);
-            spanTracer.IsFiltered = () => spanTracer.GetFused<Activity>() is { IsAllDataRequested: false, Recorded: false };
+            // Treat a GC'd activity (null) as filtered — if the activity is gone, we don't want the span in the trace.
+            spanTracer.IsFiltered = () => spanTracer.GetFused<Activity>() is null or { IsAllDataRequested: false, Recorded: false };
         }
         _map[data.SpanId] = span;
     }
@@ -302,7 +303,9 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
         {
             var (spanId, span) = mappedItem;
             var activity = span.GetFused<Activity>();
-            if (activity is { Recorded: false, IsAllDataRequested: false })
+            // Also prune when the activity has been GC'd (weak ref returns null): the activity is gone, so it
+            // can never call OnEnd, and the span will never be removed otherwise — causing a memory leak.
+            if (activity is null or { Recorded: false, IsAllDataRequested: false })
             {
                 _map.TryRemove(spanId, out _);
             }

--- a/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
@@ -920,6 +920,32 @@ public class SentrySpanProcessorTests : ActivitySourceTests
     }
 
     [Fact]
+    public void PruneFilteredSpans_UnsampledSpanWithRecordedActivity_NotPruned()
+    {
+        // Arrange — Sentry drops the transaction (TracesSampleRate = 0), but OTel still records the Activity.
+        // CreateChildSpan produces an UnsampledSpan. PruneFilteredSpans must not remove it prematurely,
+        // otherwise OnEnd (which fires because Recorded = true) logs a "Span not found" error.
+        _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
+        _fixture.Options.TracesSampleRate = 0.0;
+        var sut = _fixture.GetSut();
+
+        using var parent = Tracer.StartActivity("Parent");
+        sut.OnStart(parent!);
+
+        using var child = Tracer.StartActivity("Child");
+        sut.OnStart(child!);
+
+        sut._map.TryGetValue(child!.SpanId, out var span).Should().BeTrue();
+        span.Should().BeOfType<UnsampledSpan>();
+
+        // Act
+        sut.PruneFilteredSpans(true);
+
+        // Assert — the UnsampledSpan is still live (Recorded = true), so it must not be pruned.
+        sut._map.TryGetValue(child.SpanId, out _).Should().BeTrue();
+    }
+
+    [Fact]
     public void PruneFilteredSpans_GarbageCollectedActivity_Pruned()
     {
         // Arrange

--- a/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
@@ -920,6 +920,26 @@ public class SentrySpanProcessorTests : ActivitySourceTests
     }
 
     [Fact]
+    public void PruneFilteredSpans_GarbageCollectedActivity_Pruned()
+    {
+        // Arrange
+        _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
+        var sut = _fixture.GetSut();
+
+        // Simulate a span whose fused activity has been GC'd (GetFused<Activity>() returns null).
+        // This can happen when a filtered activity is short-lived and collected before PruneFilteredSpans runs.
+        var spanId = ActivitySpanId.CreateRandom();
+        var orphanedSpan = Substitute.For<ISpan>();
+        sut._map[spanId] = orphanedSpan;
+
+        // Act
+        sut.PruneFilteredSpans(true);
+
+        // Assert
+        Assert.False(sut._map.TryGetValue(spanId, out _));
+    }
+
+    [Fact]
     public void PruneFilteredSpans_RecentlyPruned_DoesNothing()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Fixes the memory leak reported in #3550, where spans added via OTel's Instrumentation with a `Filter` callback (e.g. excluding SignalR or health-check endpoints) were retained indefinitely in the `_map` inside `SentrySpanProcessor`.

- OTel does not call `OnEnd` for filtered activities (the bug `PruneFilteredSpans` was added in #3198 to work around).
- `PruneFilteredSpans` identifies filtered spans by resolving the fused `Activity` and checking `{ Recorded: false, IsAllDataRequested: false }`.
- If `GetFused<Activity>()` returns `null` (activity was GC'd before the 5s pruning interval fires), the old pattern match fails silently and the span is never removed — leaking memory.

**Fix:** treat `null` activity as implicitly "filtered" in `PruneFilteredSpans`: prune when `activity is null or { Recorded: false, IsAllDataRequested: false }`.

> [!NOTE]
> The `IsFiltered` lambda on `SpanTracer` is intentionally left unchanged — it's evaluated by `SentryTransaction.Finish` which can run after the Activity is GC'd even for legitimate unfiltered spans, so treating `null` as filtered there would incorrectly drop valid spans from the transaction.
> 1. Addressing that would be more complicated
> 2. I don't want to hold up the much more urgent memory leak fix
> 3. We're going to deprecate the SpanProcessor in v7 anyway so this would be throw away work

Closes #3550

## Test plan

- [x] Added `PruneFilteredSpans_GarbageCollectedActivity_Pruned` — directly inserts a span into `_map` with no fused activity (simulating a null/GC'd activity) and asserts it is pruned
- [x] All existing `PruneFilteredSpans_*` tests still pass
- [x] CI