### PR TITLE
ci: enable dependabot updates for .github/actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
   open-pull-requests-limit: 2
 
 - package-ecosystem: "github-actions"
-  directory: "/"
+  directories:
+    - "/"
+    - "/.github/actions/*"
   schedule:
     interval: weekly


### PR DESCRIPTION
Solution found in:
- https://github.com/dependabot/dependabot-core/issues/6345

And tested here:
- https://github.com/jpnurmi/dba/blob/main/.github/dependabot.yml
- https://github.com/jpnurmi/dba/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen

Close: #5188