### PR TITLE
ci(craft): temporary remove new NuGet package for initial release

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -20,6 +20,5 @@ targets:
       nuget:Sentry.Maui:
       nuget:Sentry.NLog:
       nuget:Sentry.OpenTelemetry:
-      nuget:Sentry.OpenTelemetry.Exporter:
       nuget:Sentry.Serilog:
       nuget:Sentry.Profiling:


### PR DESCRIPTION
### Summary

Temporary remove `nuget:Sentry.OpenTelemetry.Exporter` from Craft.

### Remarks

I ran into a chicken-or-the-egg problem when trying to publish release `6.5.0` which includes a new SDK / NuGet package:
1. getsentry/sentry-dotnet#4899
   - added to package `.craft.yml`
   - `nuget:Sentry.OpenTelemetry.Exporter:`
1. getsentry/publish#8066
   - publish `6.5.0`
   - but fails: https://github.com/getsentry/publish/actions/runs/25371915505
   - because `Sentry.OpenTelemetry.Exporter` does not exist yet
1. getsentry/sentry-release-registry#234
   - manually added `Sentry.OpenTelemetry.Exporter` to `sentry-release-registry`
1. getsentry/publish#8066
   - publish `6.5.0` again
   - but fails again: https://github.com/getsentry/publish/actions/runs/25375816412
   - because `Sentry.OpenTelemetry.Exporter` now already exists

To fix the issue:
1. remove `nuget:Sentry.OpenTelemetry.Exporter:` from `.craft.yml`
   - this PR
1. publish the release again
   - getsentry/publish#8081
1. add `nuget:Sentry.OpenTelemetry.Exporter:` to `.craft.yml`
   - getsentry/sentry-dotnet#5193

---

Instead - for the next time we publish a new package - before we publish the new package, we should do:
- #5195

---

#skip-changelog
