### PR TITLE
ci(craft): revert temporary removal of new NuGet package for initial release

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -20,5 +20,6 @@ targets:
       nuget:Sentry.Maui:
       nuget:Sentry.NLog:
       nuget:Sentry.OpenTelemetry:
+      nuget:Sentry.OpenTelemetry.Exporter:
       nuget:Sentry.Serilog:
       nuget:Sentry.Profiling:


### PR DESCRIPTION
Follow-up to:
- #5192

Merge after:
- getsentry/publish#8081

#skip-changelog
