### PR TITLE
ci: bump craft minVersion to 2.26.3 to enable auto versioning

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-minVersion: 1.1.1
+minVersion: 2.26.3
 changelogPolicy: auto
 targets:
   - name: nuget


### PR DESCRIPTION
Fixes #5205

Bumps `minVersion` in `.craft.yml` from `1.1.1` to `2.26.3`. The `auto` versioning strategy (used via `craft prepare auto`) was introduced in craft 2.14.0 and requires `minVersion >= 2.14.0` to be declared in `.craft.yml` as a safety guard. Setting it to the current latest (2.26.3) rather than just the minimum.

#skip-changelog