### PR TITLE
fix: sync default tags to native layer

### DIFF
--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -95,8 +95,8 @@ public static partial class SentrySdk
                 o.CacheDirPath = Path.Combine(cacheDirectoryPath, "android");
             }
 
-            // NOTE: Tags in options.DefaultTags should not be passed down, because we already call SetTag on each
-            //       one when sending events, which is relayed through the scope observer.
+            // NOTE: options.DefaultTags are pushed to the scope after the hub initializes (see SentrySdk.InitHub),
+            //       which relays them to the Android SDK via the scope observer so they're attached to native crashes.
 
             if (options.HttpProxy is System.Net.WebProxy proxy)
             {

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -95,8 +95,9 @@ public static partial class SentrySdk
                 o.CacheDirPath = Path.Combine(cacheDirectoryPath, "android");
             }
 
-            // NOTE: options.DefaultTags are pushed to the scope after the hub initializes (see SentrySdk.InitHub),
-            //       which relays them to the Android SDK via the scope observer so they're attached to native crashes.
+            // NOTE: options.DefaultTags are forwarded to the scope observer in SentrySdk.InitHub so the
+            //       Android SDK attaches them to native crashes. The Enricher continues to apply them to
+            //       managed events at send time.
 
             if (options.HttpProxy is System.Net.WebProxy proxy)
             {

--- a/src/Sentry/Platforms/Cocoa/SentrySdk.cs
+++ b/src/Sentry/Platforms/Cocoa/SentrySdk.cs
@@ -50,8 +50,8 @@ public static partial class SentrySdk
         // NOTE: options.CacheDirectoryPath - No option for this in Sentry Cocoa, but caching is still enabled
         // https://github.com/getsentry/sentry-cocoa/issues/1051
 
-        // NOTE: Tags in options.DefaultTags should not be passed down, because we already call SetTag on each
-        //       one when sending events, which is relayed through the scope observer.
+        // NOTE: options.DefaultTags are pushed to the scope after the hub initializes (see SentrySdk.InitHub),
+        //       which relays them to the Cocoa SDK via the scope observer so they're attached to native crashes.
 
         if (options.BeforeBreadcrumbInternal is { } beforeBreadcrumb)
         {

--- a/src/Sentry/Platforms/Cocoa/SentrySdk.cs
+++ b/src/Sentry/Platforms/Cocoa/SentrySdk.cs
@@ -50,8 +50,9 @@ public static partial class SentrySdk
         // NOTE: options.CacheDirectoryPath - No option for this in Sentry Cocoa, but caching is still enabled
         // https://github.com/getsentry/sentry-cocoa/issues/1051
 
-        // NOTE: options.DefaultTags are pushed to the scope after the hub initializes (see SentrySdk.InitHub),
-        //       which relays them to the Cocoa SDK via the scope observer so they're attached to native crashes.
+        // NOTE: options.DefaultTags are forwarded to the scope observer in SentrySdk.InitHub so the
+        //       Cocoa SDK attaches them to native crashes. The Enricher continues to apply them to
+        //       managed events at send time.
 
         if (options.BeforeBreadcrumbInternal is { } beforeBreadcrumb)
         {

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -93,17 +93,14 @@ static partial class SentrySdk
 
         // Default tags are applied per-event by the Enricher to events going through the .NET pipeline,
         // but native crashes are captured and uploaded by the native SDK without going through that pipeline.
-        // Push them to the scope so the scope observer relays them to the native layer and they're attached
-        // to native crash reports.
-        if (options is { EnableScopeSync: true, ScopeObserver: not null } && options.DefaultTags.Count > 0)
+        // Forward them to the scope observer so the native layer attaches them to crash reports.
+        // Bypassing the .NET scope keeps scope.Tags identical between native and non-native apps.
+        if (options is { EnableScopeSync: true, ScopeObserver: { } observer } && options.DefaultTags.Count > 0)
         {
-            hub.ConfigureScope(static (scope, opts) =>
+            foreach (var tag in options.DefaultTags)
             {
-                foreach (var tag in opts.DefaultTags)
-                {
-                    scope.SetTag(tag.Key, tag.Value);
-                }
-            }, options);
+                observer.SetTag(tag.Key, tag.Value);
+            }
         }
 
         // Platform specific check for profiler misconfiguration.

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -91,6 +91,21 @@ static partial class SentrySdk
         }
         options.PostInitCallbacks.Clear();
 
+        // Default tags are applied per-event by the Enricher to events going through the .NET pipeline,
+        // but native crashes are captured and uploaded by the native SDK without going through that pipeline.
+        // Push them to the scope so the scope observer relays them to the native layer and they're attached
+        // to native crash reports.
+        if (options is { EnableScopeSync: true, ScopeObserver: not null } && options.DefaultTags.Count > 0)
+        {
+            hub.ConfigureScope(static (scope, opts) =>
+            {
+                foreach (var tag in opts.DefaultTags)
+                {
+                    scope.SetTag(tag.Key, tag.Value);
+                }
+            }, options);
+        }
+
         // Platform specific check for profiler misconfiguration.
 #if __IOS__
         // No user-facing warning necessary - the integration is part of InitSentryCocoaSdk().

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -1005,6 +1005,7 @@ public class SentrySdkTests : IDisposable
             InitNativeSdks = false,
         };
         options.DefaultTags["env"] = "production";
+        options.DefaultTags["region"] = "us-east-1";
 
         // Act
         SentrySdk.InitHub(options);

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -968,6 +968,52 @@ public class SentrySdkTests : IDisposable
 #endif
 
     [Fact]
+    public void InitHub_DefaultTagsWithScopeSync_RelayedToScopeObserver()
+    {
+        // Arrange
+        var observer = Substitute.For<IScopeObserver>();
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            ScopeObserver = observer,
+            EnableScopeSync = true,
+            BackgroundWorker = Substitute.For<IBackgroundWorker>(),
+            InitNativeSdks = false,
+        };
+        options.DefaultTags["env"] = "production";
+        options.DefaultTags["region"] = "us-east-1";
+
+        // Act
+        SentrySdk.InitHub(options);
+
+        // Assert
+        observer.Received(1).SetTag("env", "production");
+        observer.Received(1).SetTag("region", "us-east-1");
+    }
+
+    [Fact]
+    public void InitHub_DefaultTagsWithoutScopeSync_NotRelayedToScopeObserver()
+    {
+        // Arrange
+        var observer = Substitute.For<IScopeObserver>();
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            ScopeObserver = observer,
+            EnableScopeSync = false,
+            BackgroundWorker = Substitute.For<IBackgroundWorker>(),
+            InitNativeSdks = false,
+        };
+        options.DefaultTags["env"] = "production";
+
+        // Act
+        SentrySdk.InitHub(options);
+
+        // Assert
+        observer.DidNotReceive().SetTag(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
     public void InitHub_DebugEnabled_DebugLogsLogged()
     {
         var options = new SentryOptions


### PR DESCRIPTION
Came up through and resolves https://github.com/getsentry/sentry-unity/issues/2668

### The Problem

When a user sets `DefaultTags` on the options, these tags do not make it to native events from Android or iOS. This is not only an issue for Unity but affects C# Android and iOS app as well.
The comment seems to be out of date and prior to the addition of the extensive native support the SDK has now.
```
// NOTE: Tags in options.DefaultTags should not be passed down, because we already call SetTag on each
//       one when sending events, which is relayed through the scope observer.
```

### Context

When a user sets the `DefaultTags` on the options, in the regular processing pipeline, these get applied by the `Enricher` on each individual event.
https://github.com/getsentry/sentry-dotnet/blob/af4ebc3d09c0969366310d4e6584d523a7fb143b/src/Sentry/Internal/Enricher.cs#L104

I don't know what the grand design here was, and why tags are not getting applied to the scope instead. Maybe this comes from one of the other integrations, or behaviour outside of having a `GlobalScope`? If not, we could move it out of the `Enricher` in general. Happy to follow up on this if that's the case.

### Proposal

During initialization, and if scope sync is enabled, and if there is a `ScopeObserver`, we set those tags, making them available on the native layer. The regular flow inside the C# processing stays preserved. 


Sample events taken from the Unity SDK with `options.DefaultTags.Add("my", "tag");`:
- [managed](https://sentry-sdks.sentry.io/issues/6770060527/events/bbd3051c173a46dcb99654be08327b73/)
- [native](https://sentry-sdks.sentry.io/issues/7467622769/events/19e96c3e7006475ee955312b905d060c/) 