### PR TITLE
test: fix typo in FakeFailingTransport exception message

### DIFF
--- a/test/Sentry.Testing/FakeFailingTransport.cs
+++ b/test/Sentry.Testing/FakeFailingTransport.cs
@@ -6,7 +6,7 @@ internal class FakeFailingTransport : ITransport
         Envelope envelope,
         CancellationToken cancellationToken = default)
     {
-        throw new Exception("Expected transport failure has occured.")
+        throw new Exception("Expected transport failure has occurred.")
         {
             Source = nameof(FakeFailingTransport)
         };


### PR DESCRIPTION
Fixes a spelling typo (`occured` -> `occurred`) in the test fixture's exception message. Test-only change.