### PR TITLE
fix: populate Default attributes on structured logs from current scope

### DIFF
--- a/src/Sentry.Extensions.Logging/SentryStructuredLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryStructuredLogger.cs
@@ -87,7 +87,13 @@ internal sealed class SentryStructuredLogger : ILogger
             SpanId = spanId,
         };
 
-        log.SetDefaultAttributes(_options, _sdk);
+        var scope = _hub.GetScope();
+        if (scope?.Sdk is { } scopeSdk)
+        {
+            scopeSdk.Name = _sdk.Name;
+            scopeSdk.Version = _sdk.Version;
+        }
+        log.SetDefaultAttributes(_options, scope);
         log.SetOrigin("auto.log.extensions_logging");
 
         if (_categoryName is not null)

--- a/src/Sentry.Extensions.Logging/SentryStructuredLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryStructuredLogger.cs
@@ -88,12 +88,7 @@ internal sealed class SentryStructuredLogger : ILogger
         };
 
         var scope = _hub.GetScope();
-        if (scope?.Sdk is { } scopeSdk)
-        {
-            scopeSdk.Name = _sdk.Name;
-            scopeSdk.Version = _sdk.Version;
-        }
-        log.SetDefaultAttributes(_options, scope);
+        log.SetDefaultAttributes(_options, scope, _sdk);
         log.SetOrigin("auto.log.extensions_logging");
 
         if (_categoryName is not null)

--- a/src/Sentry.Serilog/SentrySink.Structured.cs
+++ b/src/Sentry.Serilog/SentrySink.Structured.cs
@@ -18,12 +18,7 @@ internal sealed partial class SentrySink
         };
 
         var scope = hub.GetScope();
-        if (scope?.Sdk is { } scopeSdk)
-        {
-            scopeSdk.Name = Sdk.Name;
-            scopeSdk.Version = Sdk.Version;
-        }
-        log.SetDefaultAttributes(options, scope);
+        log.SetDefaultAttributes(options, scope, Sdk);
         log.SetOrigin("auto.log.serilog");
 
         foreach (var attribute in attributes)

--- a/src/Sentry.Serilog/SentrySink.Structured.cs
+++ b/src/Sentry.Serilog/SentrySink.Structured.cs
@@ -17,7 +17,13 @@ internal sealed partial class SentrySink
             SpanId = spanId,
         };
 
-        log.SetDefaultAttributes(options, Sdk);
+        var scope = hub.GetScope();
+        if (scope?.Sdk is { } scopeSdk)
+        {
+            scopeSdk.Name = Sdk.Name;
+            scopeSdk.Version = Sdk.Version;
+        }
+        log.SetDefaultAttributes(options, scope);
         log.SetOrigin("auto.log.serilog");
 
         foreach (var attribute in attributes)

--- a/src/Sentry/Internal/DefaultSentryStructuredLogger.cs
+++ b/src/Sentry/Internal/DefaultSentryStructuredLogger.cs
@@ -75,7 +75,8 @@ internal sealed class DefaultSentryStructuredLogger : SentryStructuredLogger, ID
             return;
         }
 
-        log.SetDefaultAttributes(_options, _hub.GetScope());
+        var scope = _hub.GetScope();
+        log.SetDefaultAttributes(_options, scope, scope?.Sdk);
 
         CaptureLog(log);
     }

--- a/src/Sentry/Internal/DefaultSentryStructuredLogger.cs
+++ b/src/Sentry/Internal/DefaultSentryStructuredLogger.cs
@@ -75,8 +75,7 @@ internal sealed class DefaultSentryStructuredLogger : SentryStructuredLogger, ID
             return;
         }
 
-        var scope = _hub.GetScope();
-        log.SetDefaultAttributes(_options, scope?.Sdk ?? SdkVersion.Instance, scope);
+        log.SetDefaultAttributes(_options, _hub.GetScope());
 
         CaptureLog(log);
     }

--- a/src/Sentry/Internal/DefaultSentryStructuredLogger.cs
+++ b/src/Sentry/Internal/DefaultSentryStructuredLogger.cs
@@ -76,7 +76,7 @@ internal sealed class DefaultSentryStructuredLogger : SentryStructuredLogger, ID
         }
 
         var scope = _hub.GetScope();
-        log.SetDefaultAttributes(_options, scope, scope?.Sdk);
+        log.SetDefaultAttributes(_options, scope);
 
         CaptureLog(log);
     }

--- a/src/Sentry/Internal/DefaultSentryStructuredLogger.cs
+++ b/src/Sentry/Internal/DefaultSentryStructuredLogger.cs
@@ -76,7 +76,7 @@ internal sealed class DefaultSentryStructuredLogger : SentryStructuredLogger, ID
         }
 
         var scope = _hub.GetScope();
-        log.SetDefaultAttributes(_options, scope?.Sdk ?? SdkVersion.Instance);
+        log.SetDefaultAttributes(_options, scope?.Sdk ?? SdkVersion.Instance, scope);
 
         CaptureLog(log);
     }

--- a/src/Sentry/SentryLog.cs
+++ b/src/Sentry/SentryLog.cs
@@ -172,7 +172,7 @@ public sealed class SentryLog
         _attributes[key] = new SentryAttribute(value, "integer");
     }
 
-    internal void SetDefaultAttributes(SentryOptions options, SdkVersion sdk)
+    internal void SetDefaultAttributes(SentryOptions options, SdkVersion sdk, Scope? scope = null)
     {
         var environment = options.SettingLocator.GetEnvironment();
         SetAttribute("sentry.environment", environment);
@@ -190,6 +190,22 @@ public sealed class SentryLog
         if (sdk.Version is { } version)
         {
             SetAttribute("sentry.sdk.version", version);
+        }
+
+        if (scope?.User is { } user)
+        {
+            if (user.Id is { } userId)
+            {
+                SetAttribute("user.id", userId);
+            }
+            if (user.Username is { } username)
+            {
+                SetAttribute("user.name", username);
+            }
+            if (user.Email is { } email)
+            {
+                SetAttribute("user.email", email);
+            }
         }
     }
 

--- a/src/Sentry/SentryLog.cs
+++ b/src/Sentry/SentryLog.cs
@@ -184,12 +184,12 @@ public sealed class SentryLog
             SetAttribute("sentry.release", release);
         }
 
-        sdk ??= scope?.Sdk;
-        if (sdk?.Name is { } name)
+        sdk ??= scope?.Sdk ?? SdkVersion.Instance;
+        if (sdk.Name is { } name)
         {
             SetAttribute("sentry.sdk.name", name);
         }
-        if (sdk?.Version is { } version)
+        if (sdk.Version is { } version)
         {
             SetAttribute("sentry.sdk.version", version);
         }

--- a/src/Sentry/SentryLog.cs
+++ b/src/Sentry/SentryLog.cs
@@ -172,7 +172,7 @@ public sealed class SentryLog
         _attributes[key] = new SentryAttribute(value, "integer");
     }
 
-    internal void SetDefaultAttributes(SentryOptions options, Scope? scope)
+    internal void SetDefaultAttributes(SentryOptions options, Scope? scope, SdkVersion? sdk)
     {
         // Core Attributes
         var environment = options.SettingLocator.GetEnvironment();
@@ -184,12 +184,11 @@ public sealed class SentryLog
             SetAttribute("sentry.release", release);
         }
 
-        var sdk = scope?.Sdk ?? SdkVersion.Instance;
-        if (sdk.Name is { } name)
+        if (sdk?.Name is { } name)
         {
             SetAttribute("sentry.sdk.name", name);
         }
-        if (sdk.Version is { } version)
+        if (sdk?.Version is { } version)
         {
             SetAttribute("sentry.sdk.version", version);
         }

--- a/src/Sentry/SentryLog.cs
+++ b/src/Sentry/SentryLog.cs
@@ -172,8 +172,9 @@ public sealed class SentryLog
         _attributes[key] = new SentryAttribute(value, "integer");
     }
 
-    internal void SetDefaultAttributes(SentryOptions options, SdkVersion sdk, Scope? scope = null)
+    internal void SetDefaultAttributes(SentryOptions options, Scope? scope)
     {
+        // Core Attributes
         var environment = options.SettingLocator.GetEnvironment();
         SetAttribute("sentry.environment", environment);
 
@@ -183,6 +184,7 @@ public sealed class SentryLog
             SetAttribute("sentry.release", release);
         }
 
+        var sdk = scope?.Sdk ?? SdkVersion.Instance;
         if (sdk.Name is { } name)
         {
             SetAttribute("sentry.sdk.name", name);
@@ -192,6 +194,17 @@ public sealed class SentryLog
             SetAttribute("sentry.sdk.version", version);
         }
 
+        // Server Attributes
+        if (!string.IsNullOrEmpty(options.ServerName))
+        {
+            SetAttribute("server.address", options.ServerName!);
+        }
+        else if (options.SendDefaultPii)
+        {
+            SetAttribute("server.address", Environment.MachineName);
+        }
+
+        // User Attributes
         if (scope?.User is { } user)
         {
             if (user.Id is { } userId)

--- a/src/Sentry/SentryLog.cs
+++ b/src/Sentry/SentryLog.cs
@@ -172,7 +172,7 @@ public sealed class SentryLog
         _attributes[key] = new SentryAttribute(value, "integer");
     }
 
-    internal void SetDefaultAttributes(SentryOptions options, Scope? scope, SdkVersion? sdk)
+    internal void SetDefaultAttributes(SentryOptions options, Scope? scope, SdkVersion? sdk = null)
     {
         // Core Attributes
         var environment = options.SettingLocator.GetEnvironment();
@@ -184,6 +184,7 @@ public sealed class SentryLog
             SetAttribute("sentry.release", release);
         }
 
+        sdk ??= scope?.Sdk;
         if (sdk?.Name is { } name)
         {
             SetAttribute("sentry.sdk.name", name);

--- a/src/Sentry/SentryLog.cs
+++ b/src/Sentry/SentryLog.cs
@@ -133,8 +133,39 @@ public sealed class SentryLog
     /// </summary>
     public void SetAttribute(string key, object value) => Attributes.SetAttribute(key, value);
 
-    internal void SetDefaultAttributes(SentryOptions options, SdkVersion sdk) =>
+    internal void SetDefaultAttributes(SentryOptions options, Scope? scope, SdkVersion? sdk = null)
+    {
+        // Core Attributes
+        sdk ??= scope?.Sdk ?? SdkVersion.Instance;
         Attributes.SetDefaultAttributes(options, sdk);
+
+        // Server Attributes
+        if (!string.IsNullOrEmpty(options.ServerName))
+        {
+            SetAttribute("server.address", options.ServerName!);
+        }
+        else if (options.SendDefaultPii)
+        {
+            SetAttribute("server.address", Environment.MachineName);
+        }
+
+        // User Attributes
+        if (scope?.User is { } user)
+        {
+            if (user.Id is { } userId)
+            {
+                SetAttribute("user.id", userId);
+            }
+            if (user.Username is { } username)
+            {
+                SetAttribute("user.name", username);
+            }
+            if (user.Email is { } email)
+            {
+                SetAttribute("user.email", email);
+            }
+        }
+    }
 
     internal void SetOrigin(string origin) => Attributes.SetAttribute("sentry.origin", origin);
 

--- a/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerProviderTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerProviderTests.cs
@@ -22,6 +22,7 @@ public class SentryStructuredLoggerProviderTests
 
             Options = Microsoft.Extensions.Options.Options.Create(loggingOptions);
             Hub = Substitute.For<IHub>();
+            Hub.SubstituteConfigureScope(new Scope(loggingOptions));
             Clock = new MockClock();
             Sdk = new SdkVersion
             {

--- a/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryStructuredLoggerTests.cs
@@ -31,6 +31,7 @@ public class SentryStructuredLoggerTests : IDisposable
             CategoryName = nameof(CategoryName);
             Options = Microsoft.Extensions.Options.Options.Create(loggingOptions);
             Hub = Substitute.For<IHub>();
+            Hub.SubstituteConfigureScope(new Scope(loggingOptions));
             Clock = new MockClock(new DateTimeOffset(2025, 04, 22, 14, 51, 00, 789, TimeSpan.FromHours(2)));
             Sdk = new SdkVersion
             {

--- a/test/Sentry.Tests/SentryLogTests.cs
+++ b/test/Sentry.Tests/SentryLogTests.cs
@@ -44,11 +44,9 @@ public class SentryLogTests
             Environment = "my-environment",
             Release = "my-release",
         };
-        var sdk = new SdkVersion
-        {
-            Name = "Sentry.Test.SDK",
-            Version = "1.2.3-test+Sentry",
-        };
+        var scope = new Scope(options);
+        scope.Sdk.Name = "Sentry.Test.SDK";
+        scope.Sdk.Version = "1.2.3-test+Sentry";
 
         var log = new SentryLog(Timestamp, TraceId, (SentryLogLevel)24, "message")
         {
@@ -57,7 +55,7 @@ public class SentryLogTests
             SpanId = SpanId,
         };
         log.SetAttribute("attribute", "value");
-        log.SetDefaultAttributes(options, sdk);
+        log.SetDefaultAttributes(options, scope);
 
         log.Timestamp.Should().Be(Timestamp);
         log.TraceId.Should().Be(TraceId);
@@ -77,11 +75,79 @@ public class SentryLogTests
         log.TryGetAttribute("sentry.release", out string release).Should().BeTrue();
         release.Should().Be(options.Release);
         log.TryGetAttribute("sentry.sdk.name", out string name).Should().BeTrue();
-        name.Should().Be(sdk.Name);
+        name.Should().Be(scope.Sdk.Name);
         log.TryGetAttribute("sentry.sdk.version", out string version).Should().BeTrue();
-        version.Should().Be(sdk.Version);
+        version.Should().Be(scope.Sdk.Version);
         log.TryGetAttribute("not-found", out object notFound).Should().BeFalse();
         notFound.Should().BeNull();
+    }
+
+    [Fact]
+    public void SetDefaultAttributes_OptionsServerName_SetsServerAddress()
+    {
+        var options = new SentryOptions { ServerName = "my-server" };
+        var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Info, "message");
+
+        log.SetDefaultAttributes(options, new Scope(options));
+
+        log.TryGetAttribute("server.address", out string address).Should().BeTrue();
+        address.Should().Be("my-server");
+    }
+
+    [Fact]
+    public void SetDefaultAttributes_SendDefaultPii_SetsServerAddressToMachineName()
+    {
+        var options = new SentryOptions { SendDefaultPii = true };
+        var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Info, "message");
+
+        log.SetDefaultAttributes(options, new Scope(options));
+
+        log.TryGetAttribute("server.address", out string address).Should().BeTrue();
+        address.Should().Be(Environment.MachineName);
+    }
+
+    [Fact]
+    public void SetDefaultAttributes_NoServerNameNoPii_OmitsServerAddress()
+    {
+        var options = new SentryOptions();
+        var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Info, "message");
+
+        log.SetDefaultAttributes(options, new Scope(options));
+
+        log.TryGetAttribute("server.address", out object _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SetDefaultAttributes_ScopeUser_SetsUserAttributes()
+    {
+        var options = new SentryOptions();
+        var scope = new Scope(options)
+        {
+            User = new SentryUser { Id = "user-id", Username = "user-name", Email = "user@example.com" },
+        };
+        var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Info, "message");
+
+        log.SetDefaultAttributes(options, scope);
+
+        log.TryGetAttribute("user.id", out string id).Should().BeTrue();
+        id.Should().Be("user-id");
+        log.TryGetAttribute("user.name", out string username).Should().BeTrue();
+        username.Should().Be("user-name");
+        log.TryGetAttribute("user.email", out string email).Should().BeTrue();
+        email.Should().Be("user@example.com");
+    }
+
+    [Fact]
+    public void SetDefaultAttributes_NoScopeUser_OmitsUserAttributes()
+    {
+        var options = new SentryOptions();
+        var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Info, "message");
+
+        log.SetDefaultAttributes(options, new Scope(options));
+
+        log.TryGetAttribute("user.id", out object _).Should().BeFalse();
+        log.TryGetAttribute("user.name", out object _).Should().BeFalse();
+        log.TryGetAttribute("user.email", out object _).Should().BeFalse();
     }
 
     [Theory]
@@ -118,7 +184,7 @@ public class SentryLogTests
         };
 
         var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Trace, "message");
-        log.SetDefaultAttributes(options, new SdkVersion());
+        log.SetDefaultAttributes(options, new Scope(options));
 
         var envelope = Envelope.FromLog(new StructuredLog([log]));
 
@@ -196,7 +262,10 @@ public class SentryLogTests
         log.SetAttribute("boolean-attribute", true);
         log.SetAttribute("integer-attribute", 3);
         log.SetAttribute("double-attribute", 4.4);
-        log.SetDefaultAttributes(options, new SdkVersion { Name = "Sentry.Test.SDK", Version = "1.2.3-test+Sentry" });
+        var scope = new Scope(options);
+        scope.Sdk.Name = "Sentry.Test.SDK";
+        scope.Sdk.Version = "1.2.3-test+Sentry";
+        log.SetDefaultAttributes(options, scope);
 
         var envelope = EnvelopeItem.FromLog(new StructuredLog([log]));
 

--- a/test/Sentry.Tests/SentryLogTests.cs
+++ b/test/Sentry.Tests/SentryLogTests.cs
@@ -44,11 +44,9 @@ public class SentryLogTests
             Environment = "my-environment",
             Release = "my-release",
         };
-        var sdk = new SdkVersion
-        {
-            Name = "Sentry.Test.SDK",
-            Version = "1.2.3-test+Sentry",
-        };
+        var scope = new Scope(options);
+        scope.Sdk.Name = "Sentry.Test.SDK";
+        scope.Sdk.Version = "1.2.3-test+Sentry";
 
         var log = new SentryLog(Timestamp, TraceId, (SentryLogLevel)24, "message")
         {
@@ -57,7 +55,7 @@ public class SentryLogTests
             SpanId = SpanId,
         };
         log.SetAttribute("attribute", "value");
-        log.SetDefaultAttributes(options, sdk);
+        log.SetDefaultAttributes(options, scope);
 
         log.Timestamp.Should().Be(Timestamp);
         log.TraceId.Should().Be(TraceId);
@@ -73,9 +71,72 @@ public class SentryLogTests
         log.Attributes.ShouldContain<string>("attribute", "value");
         log.Attributes.ShouldContain<string>("sentry.environment", options.Environment);
         log.Attributes.ShouldContain<string>("sentry.release", options.Release);
-        log.Attributes.ShouldContain<string>("sentry.sdk.name", sdk.Name);
-        log.Attributes.ShouldContain<string>("sentry.sdk.version", sdk.Version);
+        log.Attributes.ShouldContain<string>("sentry.sdk.name", scope.Sdk.Name);
+        log.Attributes.ShouldContain<string>("sentry.sdk.version", scope.Sdk.Version);
         log.Attributes.ShouldNotContain<object>("not-found");
+    }
+
+    [Fact]
+    public void SetDefaultAttributes_OptionsServerName_SetsServerAddress()
+    {
+        var options = new SentryOptions { ServerName = "my-server" };
+        var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Info, "message");
+
+        log.SetDefaultAttributes(options, new Scope(options));
+
+        log.Attributes.ShouldContain("server.address", "my-server");
+    }
+
+    [Fact]
+    public void SetDefaultAttributes_SendDefaultPii_SetsServerAddressToMachineName()
+    {
+        var options = new SentryOptions { SendDefaultPii = true };
+        var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Info, "message");
+
+        log.SetDefaultAttributes(options, new Scope(options));
+
+        log.Attributes.ShouldContain("server.address", Environment.MachineName);
+    }
+
+    [Fact]
+    public void SetDefaultAttributes_NoServerNameNoPii_OmitsServerAddress()
+    {
+        var options = new SentryOptions();
+        var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Info, "message");
+
+        log.SetDefaultAttributes(options, new Scope(options));
+
+        log.Attributes.ShouldNotContain<string>("server.address");
+    }
+
+    [Fact]
+    public void SetDefaultAttributes_ScopeUser_SetsUserAttributes()
+    {
+        var options = new SentryOptions();
+        var scope = new Scope(options)
+        {
+            User = new SentryUser { Id = "user-id", Username = "user-name", Email = "user@example.com" },
+        };
+        var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Info, "message");
+
+        log.SetDefaultAttributes(options, scope);
+
+        log.Attributes.ShouldContain("user.id", "user-id");
+        log.Attributes.ShouldContain("user.name", "user-name");
+        log.Attributes.ShouldContain("user.email", "user@example.com");
+    }
+
+    [Fact]
+    public void SetDefaultAttributes_NoScopeUser_OmitsUserAttributes()
+    {
+        var options = new SentryOptions();
+        var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Info, "message");
+
+        log.SetDefaultAttributes(options, new Scope(options));
+
+        log.Attributes.ShouldNotContain<string>("user.id");
+        log.Attributes.ShouldNotContain<string>("user.name");
+        log.Attributes.ShouldNotContain<string>("user.email");
     }
 
     [Theory]
@@ -112,7 +173,7 @@ public class SentryLogTests
         };
 
         var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Trace, "message");
-        log.SetDefaultAttributes(options, new SdkVersion());
+        log.SetDefaultAttributes(options, new Scope(options));
 
         var envelope = Envelope.FromLog(new StructuredLog([log]));
 
@@ -190,7 +251,10 @@ public class SentryLogTests
         log.SetAttribute("boolean-attribute", true);
         log.SetAttribute("integer-attribute", 3);
         log.SetAttribute("double-attribute", 4.4);
-        log.SetDefaultAttributes(options, new SdkVersion { Name = "Sentry.Test.SDK", Version = "1.2.3-test+Sentry" });
+        var scope = new Scope(options);
+        scope.Sdk.Name = "Sentry.Test.SDK";
+        scope.Sdk.Version = "1.2.3-test+Sentry";
+        log.SetDefaultAttributes(options, scope);
 
         var envelope = EnvelopeItem.FromLog(new StructuredLog([log]));
 

--- a/test/Sentry.Tests/SentryStructuredLoggerTests.cs
+++ b/test/Sentry.Tests/SentryStructuredLoggerTests.cs
@@ -245,6 +245,58 @@ public partial class SentryStructuredLoggerTests : IDisposable
         entry.Args.Should().BeEquivalentTo([nameof(SentryLog)]);
     }
 
+    [Fact]
+    public void Log_WithScopeUser_SetsUserAttributes()
+    {
+        var scope = new Scope();
+        scope.User = new SentryUser { Id = "user-id", Username = "user-name", Email = "user@example.com" };
+        _fixture.Hub.SubstituteConfigureScope(scope);
+
+        SentryLog capturedLog = null!;
+        _fixture.Options.EnableLogs = true;
+        _fixture.Options.SetBeforeSendLog((SentryLog log) =>
+        {
+            capturedLog = log;
+            return log;
+        });
+        var logger = _fixture.GetSut();
+
+        logger.LogInfo("A message");
+        logger.Flush();
+
+        capturedLog.Should().NotBeNull();
+        capturedLog.TryGetAttribute("user.id", out string? userId).Should().BeTrue();
+        userId.Should().Be("user-id");
+        capturedLog.TryGetAttribute("user.name", out string? userName).Should().BeTrue();
+        userName.Should().Be("user-name");
+        capturedLog.TryGetAttribute("user.email", out string? userEmail).Should().BeTrue();
+        userEmail.Should().Be("user@example.com");
+    }
+
+    [Fact]
+    public void Log_WithoutScopeUser_DoesNotSetUserAttributes()
+    {
+        var scope = new Scope();
+        _fixture.Hub.SubstituteConfigureScope(scope);
+
+        SentryLog capturedLog = null!;
+        _fixture.Options.EnableLogs = true;
+        _fixture.Options.SetBeforeSendLog((SentryLog log) =>
+        {
+            capturedLog = log;
+            return log;
+        });
+        var logger = _fixture.GetSut();
+
+        logger.LogInfo("A message");
+        logger.Flush();
+
+        capturedLog.Should().NotBeNull();
+        capturedLog.TryGetAttribute("user.id", out object? _).Should().BeFalse();
+        capturedLog.TryGetAttribute("user.name", out object? _).Should().BeFalse();
+        capturedLog.TryGetAttribute("user.email", out object? _).Should().BeFalse();
+    }
+
     private static void ConfigureLog(SentryLog log)
     {
         log.SetAttribute("attribute-key", "attribute-value");

--- a/test/Sentry.Tests/SentryStructuredLoggerTests.cs
+++ b/test/Sentry.Tests/SentryStructuredLoggerTests.cs
@@ -289,9 +289,9 @@ public partial class SentryStructuredLoggerTests : IDisposable
         logger.Flush();
 
         capturedLog.Should().NotBeNull();
-        capturedLog.TryGetAttribute("user.id", out object? _).Should().BeFalse();
-        capturedLog.TryGetAttribute("user.name", out object? _).Should().BeFalse();
-        capturedLog.TryGetAttribute("user.email", out object? _).Should().BeFalse();
+        capturedLog.Attributes.ShouldNotContain<object>("user.id");
+        capturedLog.Attributes.ShouldNotContain<object>("user.name");
+        capturedLog.Attributes.ShouldNotContain<object>("user.email");
     }
 
     private static void ConfigureLog(SentryLog log)

--- a/test/Sentry.Tests/SentryStructuredLoggerTests.cs
+++ b/test/Sentry.Tests/SentryStructuredLoggerTests.cs
@@ -265,12 +265,9 @@ public partial class SentryStructuredLoggerTests : IDisposable
         logger.Flush();
 
         capturedLog.Should().NotBeNull();
-        capturedLog.TryGetAttribute("user.id", out string? userId).Should().BeTrue();
-        userId.Should().Be("user-id");
-        capturedLog.TryGetAttribute("user.name", out string? userName).Should().BeTrue();
-        userName.Should().Be("user-name");
-        capturedLog.TryGetAttribute("user.email", out string? userEmail).Should().BeTrue();
-        userEmail.Should().Be("user@example.com");
+        capturedLog.Attributes.ShouldContain("user.id", "user-id");
+        capturedLog.Attributes.ShouldContain("user.name", "user-name");
+        capturedLog.Attributes.ShouldContain("user.email", "user@example.com");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #5209

## Problem

When a user is set on the current scope via `SentrySdk.ConfigureScope`, the user attributes (`user.id`, `user.name`, `user.email`) were not being included on structured logs, despite being [documented as automatic](https://docs.sentry.io/platforms/dotnet/logs/#user-attributes).

The root cause was in `DefaultSentryStructuredLogger.CaptureLog` — the scope was fetched but only used to retrieve the SDK version. The scope's user was never consulted.

Although the initial report only called out the missing user attributes, we should ensure all of the expected [Default Attributes](https://docs.sentry.io/platforms/dotnet/logs/#default-attributes) are set correctly:
- Core Attributes
- User Attributes
- Server Attributes
- Integration Attributes

Then Message Template Attributes are [already handled correctly](https://github.com/getsentry/sentry-dotnet/blob/8ba1b3e4b92763973a65a2ad0dad892c9516cfff/src/Sentry/SentryLog.cs#L251-L256). 

## Audit

All three log emission paths set the default attributes per the [docs](https://docs.sentry.io/platforms/dotnet/logs/#default-attributes):

| Attribute | `DefaultSentryStructuredLogger` (direct API) | `Sentry.Extensions.Logging` | `Sentry.Serilog` |
|---|---|---|---|
| `sentry.environment` | ✅ `SetDefaultAttributes` | ✅ | ✅ |
| `sentry.release` | ✅ `SetDefaultAttributes` (when non-null) | ✅ | ✅ |
| `sentry.sdk.name` / `sentry.sdk.version` | ✅ from `scope.Sdk` | ✅ from `_sdk` override | ✅ from `Sdk` override |
| `server.address` | ✅ `SetDefaultAttributes` | ✅ | ✅ |
| `user.id` / `user.name` / `user.email` | ✅ `SetDefaultAttributes` | ✅ | ✅ |
| `sentry.origin` | ❌ not set (intentional) | ✅ `auto.log.extensions_logging` | ✅ `auto.log.serilog` |
| `sentry.message.template` / `sentry.message.parameter.X` | ✅ written in `SentryLog.WriteTo` | ✅ | ✅ |

- **`sentry.environment`** — set unconditionally in `SentryLog.SetDefaultAttributes` via `options.SettingLocator.GetEnvironment()`. That call always returns a value (defaults to `"production"` or `"debug"` when nothing is configured), so this attribute is always present.
- **`sentry.release`** — set in `SentryLog.SetDefaultAttributes` when `options.SettingLocator.GetRelease()` returns non-null (falls back to the `SENTRY_RELEASE` env var, then `ApplicationVersionLocator`).
- **`sentry.origin`** — *not* set by `SetDefaultAttributes`. Each integration calls `log.SetOrigin(...)` itself after `SetDefaultAttributes`:
  - `Sentry.Extensions.Logging/SentryStructuredLogger.cs` → `"auto.log.extensions_logging"`
  - `Sentry.Serilog/SentrySink.Structured.cs` → `"auto.log.serilog"`

  Direct `SentrySdk.Logger.LogInfo(...)` calls (via `DefaultSentryStructuredLogger`) do not set `sentry.origin`, which matches the docs: *"added when generated by an SDK integration"*.

> [!NOTE]
> `Sentry.NLog` and `Sentry.Log4Net` don't have structured-log paths yet.