### PR TITLE
feat: Propagate W3C + Sentry headers in Sentry.OpenTelemetry.Exporter

### DIFF
--- a/src/Sentry.OpenTelemetry.Exporter/SentryOptionsExtensions.cs
+++ b/src/Sentry.OpenTelemetry.Exporter/SentryOptionsExtensions.cs
@@ -24,12 +24,14 @@ public static class SentryOptionsExtensions
     /// <param name="defaultTextMapPropagator">
     ///     <para>The default TextMapPropagator to be used by OpenTelemetry.</para>
     ///     <para>
-    ///         If this parameter is not supplied, the <see cref="OpenTelemetry.SentryPropagator"/> will be used, which propagates the
-    ///         baggage header as well as Sentry trace headers.
+    ///         If this parameter is not supplied, a <see cref="CompositeTextMapPropagator"/> containing both
+    ///         W3C <c>traceparent</c>/<c>tracestate</c> and
+    ///         <see cref="OpenTelemetry.SentryPropagator"/> (<c>sentry-trace</c> and <c>baggage</c>) will be used.
+    ///         This allows Sentry to interoperate with services that use W3C trace context headers.
     ///     </para>
     ///     <para>
-    ///         The <see cref="OpenTelemetry.SentryPropagator"/> is required for Sentry's OpenTelemetry integration to work, but you
-    ///         could wrap this in a <see cref="CompositeTextMapPropagator"/> if you needed other propagators as well.
+    ///         The <see cref="OpenTelemetry.SentryPropagator"/> is required for Sentry's OpenTelemetry integration to work. Supply
+    ///         a custom propagator only if you need to replace the defaults entirely.
     ///     </para>
     /// </param>
     public static void UseOtlp(this SentryOptions options, TracerProviderBuilder tracerProviderBuilder, Uri? collectorUrl = null, TextMapPropagator? defaultTextMapPropagator = null)

--- a/src/Sentry.OpenTelemetry.Exporter/SentryTracerProviderBuilderExtensions.cs
+++ b/src/Sentry.OpenTelemetry.Exporter/SentryTracerProviderBuilderExtensions.cs
@@ -30,12 +30,14 @@ public static class SentryTracerProviderBuilderExtensions
     /// <param name="defaultTextMapPropagator">
     ///     <para>The default TextMapPropagator to be used by OpenTelemetry.</para>
     ///     <para>
-    ///         If this parameter is not supplied, the <see cref="SentryPropagator"/> will be used, which propagates the
-    ///         baggage header as well as Sentry trace headers.
+    ///         If this parameter is not supplied, a <see cref="CompositeTextMapPropagator"/> containing both
+    ///         <see cref="TraceContextPropagator"/> (W3C <c>traceparent</c>/<c>tracestate</c>) and
+    ///         <see cref="SentryPropagator"/> (<c>sentry-trace</c> and <c>baggage</c>) will be used.
+    ///         This allows Sentry to interoperate with services that use W3C trace context headers.
     ///     </para>
     ///     <para>
-    ///         The <see cref="SentryPropagator"/> is required for Sentry's OpenTelemetry integration to work, but you
-    ///         could wrap this in a <see cref="CompositeTextMapPropagator"/> if you needed other propagators as well.
+    ///         The <see cref="SentryPropagator"/> is required for Sentry's OpenTelemetry integration to work. Supply
+    ///         a custom propagator only if you need to replace the defaults entirely.
     ///     </para>
     /// </param>
     /// <returns>The supplied <see cref="TracerProviderBuilder"/> for chaining.</returns>
@@ -47,7 +49,11 @@ public static class SentryTracerProviderBuilderExtensions
             throw new ArgumentException(MissingDsnWarning, nameof(dsnString));
         }
 
-        defaultTextMapPropagator ??= new SentryPropagator();
+        defaultTextMapPropagator ??= new CompositeTextMapPropagator(new TextMapPropagator[]
+        {
+            new TraceContextPropagator(),
+            new SentryPropagator(),
+        });
         Sdk.SetDefaultTextMapPropagator(defaultTextMapPropagator);
 
         collectorUrl ??= dsn.GetOtlpTracesEndpointUri();

--- a/test/Sentry.OpenTelemetry.Exporter.Tests/SentryTracerProviderBuilderExtensionsTests.cs
+++ b/test/Sentry.OpenTelemetry.Exporter.Tests/SentryTracerProviderBuilderExtensionsTests.cs
@@ -1,3 +1,5 @@
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Trace;
 
@@ -20,6 +22,37 @@ public class SentryTracerProviderBuilderExtensionsTests
         // Assert
         act.Should().Throw<ArgumentException>()
             .WithMessage($"{SentryTracerProviderBuilderExtensions.MissingDsnWarning}*");
+    }
+
+    [Fact]
+    public void AddSentryOtlpExporter_NoCustomPropagator_SetsCompositeDefaultPropagatorWithW3CAndSentry()
+    {
+        // Arrange
+        var tracerProviderBuilder = Substitute.For<TracerProviderBuilder>();
+
+        // Act
+        tracerProviderBuilder.AddSentryOtlpExporter(ValidDsn);
+        var propagator = Propagators.DefaultTextMapPropagator;
+
+        // Assert
+        propagator.Should().BeOfType<CompositeTextMapPropagator>();
+        propagator.Fields.Should().Contain("traceparent", "W3C traceparent header should be propagated by default");
+        propagator.Fields.Should().Contain("sentry-trace", "Sentry trace header should be propagated by default");
+    }
+
+    [Fact]
+    public void AddSentryOtlpExporter_WithCustomPropagator_SetsCustomPropagatorAsDefault()
+    {
+        // Arrange
+        var tracerProviderBuilder = Substitute.For<TracerProviderBuilder>();
+        var customPropagator = Substitute.For<TextMapPropagator>();
+
+        // Act
+        tracerProviderBuilder.AddSentryOtlpExporter(ValidDsn, defaultTextMapPropagator: customPropagator);
+        var propagator = Propagators.DefaultTextMapPropagator;
+
+        // Assert
+        propagator.Should().BeSameAs(customPropagator);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #5210

## Summary

- The default `TextMapPropagator` used by `AddSentryOtlpExporter` (and `UseOtlp`) was previously `SentryPropagator`, meaning only `sentry-trace` and `baggage` headers were propagated out of the box.
- This PR changes the default to a `CompositeTextMapPropagator` containing both `TraceContextPropagator` (W3C `traceparent`/`tracestate`) and `SentryPropagator` (`sentry-trace` + `baggage`).
- Users who pass a custom `defaultTextMapPropagator` are unaffected — the new default only applies when no propagator is supplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)