### PR TITLE
perf: avoid MeasurementUnit enum boxing allocations

### DIFF
--- a/src/Sentry/MeasurementUnit.cs
+++ b/src/Sentry/MeasurementUnit.cs
@@ -19,22 +19,41 @@ public readonly partial struct MeasurementUnit : IEquatable<MeasurementUnit>
         Custom = 4
     }
 
-    private static readonly string[] DurationNames = CreateLowercaseNames<Duration>();
+    private static readonly string[] DurationNames =
+    [
+        "nanosecond",
+        "microsecond",
+        "millisecond",
+        "second",
+        "minute",
+        "hour",
+        "day",
+        "week"
+    ];
 
-    private static readonly string[] InformationNames = CreateLowercaseNames<Information>();
+    private static readonly string[] InformationNames =
+    [
+        "bit",
+        "byte",
+        "kilobyte",
+        "kibibyte",
+        "megabyte",
+        "mebibyte",
+        "gigabyte",
+        "gibibyte",
+        "terabyte",
+        "tebibyte",
+        "petabyte",
+        "pebibyte",
+        "exabyte",
+        "exbibyte"
+    ];
 
-    private static readonly string[] FractionNames = CreateLowercaseNames<Fraction>();
-
-    private static string[] CreateLowercaseNames<T>() where T : struct, Enum
-    {
-        var names = Enum.GetNames<T>();
-        for (var i = 0; i < names.Length; i++)
-        {
-            names[i] = names[i].ToLowerInvariant();
-        }
-
-        return names;
-    }
+    private static readonly string[] FractionNames =
+    [
+        "ratio",
+        "percent"
+    ];
 
     private MeasurementUnit(Duration unit)
     {

--- a/src/Sentry/MeasurementUnit.cs
+++ b/src/Sentry/MeasurementUnit.cs
@@ -21,9 +21,9 @@ public readonly partial struct MeasurementUnit : IEquatable<MeasurementUnit>
 
     private static readonly string[] DurationNames = Enum.GetNames<Duration>();
 
-    private static readonly string[] InformationNames =   Enum.GetNames<Information>();
+    private static readonly string[] InformationNames = Enum.GetNames<Information>();
 
-    private static readonly string[] FractionNames =  Enum.GetNames<Fraction>();
+    private static readonly string[] FractionNames = Enum.GetNames<Fraction>();
 
     private MeasurementUnit(Duration unit)
     {

--- a/src/Sentry/MeasurementUnit.cs
+++ b/src/Sentry/MeasurementUnit.cs
@@ -19,41 +19,11 @@ public readonly partial struct MeasurementUnit : IEquatable<MeasurementUnit>
         Custom = 4
     }
 
-    private static readonly string[] DurationNames =
-    [
-        "nanosecond",
-        "microsecond",
-        "millisecond",
-        "second",
-        "minute",
-        "hour",
-        "day",
-        "week"
-    ];
+    private static readonly string[] DurationNames = Enum.GetNames<Duration>();
 
-    private static readonly string[] InformationNames =
-    [
-        "bit",
-        "byte",
-        "kilobyte",
-        "kibibyte",
-        "megabyte",
-        "mebibyte",
-        "gigabyte",
-        "gibibyte",
-        "terabyte",
-        "tebibyte",
-        "petabyte",
-        "pebibyte",
-        "exabyte",
-        "exbibyte"
-    ];
+    private static readonly string[] InformationNames =   Enum.GetNames<Information>();
 
-    private static readonly string[] FractionNames =
-    [
-        "ratio",
-        "percent"
-    ];
+    private static readonly string[] FractionNames =  Enum.GetNames<Fraction>();
 
     private MeasurementUnit(Duration unit)
     {

--- a/src/Sentry/MeasurementUnit.cs
+++ b/src/Sentry/MeasurementUnit.cs
@@ -19,11 +19,22 @@ public readonly partial struct MeasurementUnit : IEquatable<MeasurementUnit>
         Custom = 4
     }
 
-    private static readonly string[] DurationNames = Enum.GetNames<Duration>();
+    private static readonly string[] DurationNames = CreateLowercaseNames<Duration>();
 
-    private static readonly string[] InformationNames = Enum.GetNames<Information>();
+    private static readonly string[] InformationNames = CreateLowercaseNames<Information>();
 
-    private static readonly string[] FractionNames = Enum.GetNames<Fraction>();
+    private static readonly string[] FractionNames = CreateLowercaseNames<Fraction>();
+
+    private static string[] CreateLowercaseNames<T>() where T : struct, Enum
+    {
+        var names = Enum.GetNames<T>();
+        for (var i = 0; i < names.Length; i++)
+        {
+            names[i] = names[i].ToLowerInvariant();
+        }
+
+        return names;
+    }
 
     private MeasurementUnit(Duration unit)
     {

--- a/src/Sentry/MeasurementUnit.cs
+++ b/src/Sentry/MeasurementUnit.cs
@@ -6,18 +6,80 @@ namespace Sentry;
 /// <seealso href="https://getsentry.github.io/relay/relay_metrics/enum.MetricUnit.html"/>
 public readonly partial struct MeasurementUnit : IEquatable<MeasurementUnit>
 {
-    private readonly Enum? _unit;
+    private readonly UnitKind _kind;
+    private readonly int _value;
     private readonly string? _name;
 
-    private MeasurementUnit(Enum unit)
+    private enum UnitKind : byte
     {
-        _unit = unit;
+        None = 0,
+        Duration = 1,
+        Information = 2,
+        Fraction = 3,
+        Custom = 4
+    }
+
+    private static readonly string[] DurationNames =
+    [
+        "nanosecond",
+        "microsecond",
+        "millisecond",
+        "second",
+        "minute",
+        "hour",
+        "day",
+        "week"
+    ];
+
+    private static readonly string[] InformationNames =
+    [
+        "bit",
+        "byte",
+        "kilobyte",
+        "kibibyte",
+        "megabyte",
+        "mebibyte",
+        "gigabyte",
+        "gibibyte",
+        "terabyte",
+        "tebibyte",
+        "petabyte",
+        "pebibyte",
+        "exabyte",
+        "exbibyte"
+    ];
+
+    private static readonly string[] FractionNames =
+    [
+        "ratio",
+        "percent"
+    ];
+
+    private MeasurementUnit(Duration unit)
+    {
+        _kind = UnitKind.Duration;
+        _value = (int)unit;
+        _name = null;
+    }
+
+    private MeasurementUnit(Information unit)
+    {
+        _kind = UnitKind.Information;
+        _value = (int)unit;
+        _name = null;
+    }
+
+    private MeasurementUnit(Fraction unit)
+    {
+        _kind = UnitKind.Fraction;
+        _value = (int)unit;
         _name = null;
     }
 
     private MeasurementUnit(string name)
     {
-        _unit = null;
+        _kind = UnitKind.Custom;
+        _value = default;
         _name = name;
     }
 
@@ -70,21 +132,32 @@ public readonly partial struct MeasurementUnit : IEquatable<MeasurementUnit>
         return Custom(name);
     }
 
+    private string? GetPredefinedName()
+    {
+        return _kind switch
+        {
+            UnitKind.Duration when (uint)_value < (uint)DurationNames.Length => DurationNames[_value],
+            UnitKind.Information when (uint)_value < (uint)InformationNames.Length => InformationNames[_value],
+            UnitKind.Fraction when (uint)_value < (uint)FractionNames.Length => FractionNames[_value],
+            _ => null
+        };
+    }
+
     /// <summary>
     /// Returns the string representation of the measurement unit, as it will be sent to Sentry.
     /// </summary>
-    public override string ToString() => _unit?.ToString().ToLowerInvariant() ?? _name ?? "";
+    public override string ToString() => ToNullableString() ?? "";
 
-    internal string? ToNullableString() => _unit?.ToString().ToLowerInvariant() ?? _name;
+    internal string? ToNullableString() => _name ?? GetPredefinedName();
 
     /// <inheritdoc />
-    public bool Equals(MeasurementUnit other) => Equals(_unit, other._unit) && _name == other._name;
+    public bool Equals(MeasurementUnit other) => _kind == other._kind && _value == other._value && _name == other._name;
 
     /// <inheritdoc />
     public override bool Equals(object? obj) => obj is MeasurementUnit other && Equals(other);
 
     /// <inheritdoc />
-    public override int GetHashCode() => HashCode.Combine(_unit, _name, _unit?.GetType());
+    public override int GetHashCode() => HashCode.Combine(_kind, _value, _name);
 
     /// <summary>
     /// Returns true if the operands are equal.

--- a/test/Sentry.Tests/MeasurementUnitTests.cs
+++ b/test/Sentry.Tests/MeasurementUnitTests.cs
@@ -1,5 +1,7 @@
 namespace Sentry.Tests;
 
+using System.Globalization;
+
 public class MeasurementUnitTests
 {
     [Fact]
@@ -125,5 +127,38 @@ public class MeasurementUnitTests
         var m1 = MeasurementUnit.Custom("second");
         var m2 = MeasurementUnit.Duration.Second;
         Assert.NotEqual(m1, m2);
+    }
+
+    [Fact]
+    public void DurationUnits_ToNullableString_MatchesLowercaseEnumNames()
+    {
+        foreach (var value in Enum.GetValues<MeasurementUnit.Duration>())
+        {
+            MeasurementUnit unit = value;
+            var expected = value.ToString().ToLower(CultureInfo.InvariantCulture);
+            Assert.Equal(expected, unit.ToNullableString());
+        }
+    }
+
+    [Fact]
+    public void InformationUnits_ToNullableString_MatchesLowercaseEnumNames()
+    {
+        foreach (var value in Enum.GetValues<MeasurementUnit.Information>())
+        {
+            MeasurementUnit unit = value;
+            var expected = value.ToString().ToLower(CultureInfo.InvariantCulture);
+            Assert.Equal(expected, unit.ToNullableString());
+        }
+    }
+
+    [Fact]
+    public void FractionUnits_ToNullableString_MatchesLowercaseEnumNames()
+    {
+        foreach (var value in Enum.GetValues<MeasurementUnit.Fraction>())
+        {
+            MeasurementUnit unit = value;
+            var expected = value.ToString().ToLower(CultureInfo.InvariantCulture);
+            Assert.Equal(expected, unit.ToNullableString());
+        }
     }
 }

--- a/test/Sentry.Tests/MeasurementUnitTests.cs
+++ b/test/Sentry.Tests/MeasurementUnitTests.cs
@@ -132,9 +132,10 @@ public class MeasurementUnitTests
     [Fact]
     public void DurationUnits_ToNullableString_MatchesLowercaseEnumNames()
     {
-        foreach (MeasurementUnit.Duration value in Enum.GetValues(typeof(MeasurementUnit.Duration)))
+        foreach (var raw in Enum.GetValues(typeof(MeasurementUnit.Duration)))
         {
-            MeasurementUnit unit = value;
+            var value = (MeasurementUnit.Duration)raw;
+            MeasurementUnit unit = (MeasurementUnit.Duration)raw;
             var expected = value.ToString().ToLower(CultureInfo.InvariantCulture);
             Assert.Equal(expected, unit.ToNullableString());
         }
@@ -143,9 +144,10 @@ public class MeasurementUnitTests
     [Fact]
     public void InformationUnits_ToNullableString_MatchesLowercaseEnumNames()
     {
-        foreach (MeasurementUnit.Information value in Enum.GetValues(typeof(MeasurementUnit.Information)))
+        foreach (var raw in Enum.GetValues(typeof(MeasurementUnit.Information)))
         {
-            MeasurementUnit unit = value;
+            var value = (MeasurementUnit.Information)raw;
+            MeasurementUnit unit = (MeasurementUnit.Information)raw;
             var expected = value.ToString().ToLower(CultureInfo.InvariantCulture);
             Assert.Equal(expected, unit.ToNullableString());
         }
@@ -154,9 +156,10 @@ public class MeasurementUnitTests
     [Fact]
     public void FractionUnits_ToNullableString_MatchesLowercaseEnumNames()
     {
-        foreach (MeasurementUnit.Fraction value in Enum.GetValues(typeof(MeasurementUnit.Fraction)))
+        foreach (var raw in Enum.GetValues(typeof(MeasurementUnit.Fraction)))
         {
-            MeasurementUnit unit = value;
+            var value = (MeasurementUnit.Fraction)raw;
+            MeasurementUnit unit = (MeasurementUnit.Fraction)raw;
             var expected = value.ToString().ToLower(CultureInfo.InvariantCulture);
             Assert.Equal(expected, unit.ToNullableString());
         }

--- a/test/Sentry.Tests/MeasurementUnitTests.cs
+++ b/test/Sentry.Tests/MeasurementUnitTests.cs
@@ -132,7 +132,7 @@ public class MeasurementUnitTests
     [Fact]
     public void DurationUnits_ToNullableString_MatchesLowercaseEnumNames()
     {
-        foreach (var value in Enum.GetValues<MeasurementUnit.Duration>())
+        foreach (MeasurementUnit.Duration value in Enum.GetValues(typeof(MeasurementUnit.Duration)))
         {
             MeasurementUnit unit = value;
             var expected = value.ToString().ToLower(CultureInfo.InvariantCulture);
@@ -143,7 +143,7 @@ public class MeasurementUnitTests
     [Fact]
     public void InformationUnits_ToNullableString_MatchesLowercaseEnumNames()
     {
-        foreach (var value in Enum.GetValues<MeasurementUnit.Information>())
+        foreach (MeasurementUnit.Information value in Enum.GetValues(typeof(MeasurementUnit.Information)))
         {
             MeasurementUnit unit = value;
             var expected = value.ToString().ToLower(CultureInfo.InvariantCulture);
@@ -154,7 +154,7 @@ public class MeasurementUnitTests
     [Fact]
     public void FractionUnits_ToNullableString_MatchesLowercaseEnumNames()
     {
-        foreach (var value in Enum.GetValues<MeasurementUnit.Fraction>())
+        foreach (MeasurementUnit.Fraction value in Enum.GetValues(typeof(MeasurementUnit.Fraction)))
         {
             MeasurementUnit unit = value;
             var expected = value.ToString().ToLower(CultureInfo.InvariantCulture);


### PR DESCRIPTION
## Summary
Closes https://github.com/getsentry/sentry-dotnet/issues/4844 by removing avoidable allocations in `MeasurementUnit`:

- Replace boxed `Enum` storage with compact internal representation (`UnitKind` + `int value`)
- Keep custom units as string-backed values
- Replace `Enum.ToString().ToLowerInvariant()` with precomputed lowercase name lookups for built-in units
- Preserve existing behavior for parsing, equality, hashing, and string serialization

This removes both enum boxing and per-call lowercase string allocation on the enum-backed path.

## Testing
- Ran: `dotnet test SentryNoMobile.slnf`
  - Result: all relevant suites passed for this change
  - Known baseline failures: `test/Sentry.AspNet.Tests` (net48) has 2 failing tests due to `MissingMethodException` in `SentryAspNetOptionsExtensionsTests`, reproducible on `main` with no local changes.

- Reproduced baseline on main:
  - `dotnet test test/Sentry.AspNet.Tests/Sentry.AspNet.Tests.csproj -f net48`
  - Same 2 failures occur on `main`.

#skip-changelog
