### PR TITLE
feat(android): expose tombstone options via SentryOptions.Native

### DIFF
--- a/src/Sentry/Platforms/Android/BindableNativeSentryOptions.cs
+++ b/src/Sentry/Platforms/Android/BindableNativeSentryOptions.cs
@@ -34,6 +34,8 @@ internal partial class BindableSentryOptions
         public bool? PrintUncaughtStackTrace { get; set; }
         public double? ProfilesSampleRate { get; set; }
         public TimeSpan? ReadTimeout { get; set; }
+        public bool? TombstoneEnabled { get; set; }
+        public bool? ReportHistoricalTombstones { get; set; }
         public bool? EnableTracing { get; set; }
         public bool? EnableBeforeSend { get; set; }
 
@@ -77,6 +79,8 @@ internal partial class BindableSentryOptions
             options.PrintUncaughtStackTrace = PrintUncaughtStackTrace ?? options.PrintUncaughtStackTrace;
             options.ProfilesSampleRate = ProfilesSampleRate ?? options.ProfilesSampleRate;
             options.ReadTimeout = ReadTimeout ?? options.ReadTimeout;
+            options.TombstoneEnabled = TombstoneEnabled ?? options.TombstoneEnabled;
+            options.ReportHistoricalTombstones = ReportHistoricalTombstones ?? options.ReportHistoricalTombstones;
             options.EnableTracing = EnableTracing ?? options.EnableTracing;
             options.EnableBeforeSend = EnableBeforeSend ?? options.EnableBeforeSend;
 

--- a/src/Sentry/Platforms/Android/BindableNativeSentryOptions.cs
+++ b/src/Sentry/Platforms/Android/BindableNativeSentryOptions.cs
@@ -36,8 +36,6 @@ internal partial class BindableSentryOptions
         public bool? PrintUncaughtStackTrace { get; set; }
         public double? ProfilesSampleRate { get; set; }
         public TimeSpan? ReadTimeout { get; set; }
-        public bool? TombstoneEnabled { get; set; }
-        public bool? ReportHistoricalTombstones { get; set; }
         public bool? EnableTracing { get; set; }
         public bool? EnableBeforeSend { get; set; }
 

--- a/src/Sentry/Platforms/Android/BindableNativeSentryOptions.cs
+++ b/src/Sentry/Platforms/Android/BindableNativeSentryOptions.cs
@@ -26,6 +26,8 @@ internal partial class BindableSentryOptions
         public bool? EnableAutoActivityLifecycleTracing { get; set; }
         public bool? EnableActivityLifecycleTracingAutoFinish { get; set; }
         public bool? EnableUserInteractionTracing { get; set; }
+        public bool? TombstoneEnabled { get; set; }
+        public bool? ReportHistoricalTombstones { get; set; }
         public bool? AttachThreads { get; set; }
         public TimeSpan? ConnectionTimeout { get; set; }
         public bool? EnableNdk { get; set; }
@@ -71,6 +73,8 @@ internal partial class BindableSentryOptions
             options.EnableAutoActivityLifecycleTracing = EnableAutoActivityLifecycleTracing ?? options.EnableAutoActivityLifecycleTracing;
             options.EnableActivityLifecycleTracingAutoFinish = EnableActivityLifecycleTracingAutoFinish ?? options.EnableActivityLifecycleTracingAutoFinish;
             options.EnableUserInteractionTracing = EnableUserInteractionTracing ?? options.EnableUserInteractionTracing;
+            options.TombstoneEnabled = TombstoneEnabled ?? options.TombstoneEnabled;
+            options.ReportHistoricalTombstones = ReportHistoricalTombstones ?? options.ReportHistoricalTombstones;
             options.AttachThreads = AttachThreads ?? options.AttachThreads;
             options.ConnectionTimeout = ConnectionTimeout ?? options.ConnectionTimeout;
             options.EnableNdk = EnableNdk ?? options.EnableNdk;
@@ -79,8 +83,6 @@ internal partial class BindableSentryOptions
             options.PrintUncaughtStackTrace = PrintUncaughtStackTrace ?? options.PrintUncaughtStackTrace;
             options.ProfilesSampleRate = ProfilesSampleRate ?? options.ProfilesSampleRate;
             options.ReadTimeout = ReadTimeout ?? options.ReadTimeout;
-            options.TombstoneEnabled = TombstoneEnabled ?? options.TombstoneEnabled;
-            options.ReportHistoricalTombstones = ReportHistoricalTombstones ?? options.ReportHistoricalTombstones;
             options.EnableTracing = EnableTracing ?? options.EnableTracing;
             options.EnableBeforeSend = EnableBeforeSend ?? options.EnableBeforeSend;
 

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -209,15 +209,15 @@ public partial class SentryOptions
 
         /// <summary>
         /// Gets or sets a value that indicates if native crash reporting via tombstones is enabled.
-        /// The default value is <c>true</c> (enabled).
+        /// The default value is <c>false</c> (disabled).
         /// </summary>
-        public bool TombstoneEnabled { get; set; } = true;
+        public bool TombstoneEnabled { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value that indicates if historical tombstones should be reported.
-        /// The default value is <c>true</c> (enabled).
+        /// The default value is <c>false</c> (disabled).
         /// </summary>
-        public bool ReportHistoricalTombstones { get; set; } = true;
+        public bool ReportHistoricalTombstones { get; set; } = false;
 
         // ---------- Other ----------
 

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -207,6 +207,18 @@ public partial class SentryOptions
         /// </summary>
         public TimeSpan ReadTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
+        /// <summary>
+        /// Gets or sets a value that indicates if native crash reporting via tombstones is enabled.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        public bool TombstoneEnabled { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value that indicates if historical tombstones should be reported.
+        /// The default value is <c>true</c> (enabled).
+        /// </summary>
+        public bool ReportHistoricalTombstones { get; set; } = true;
+
         // ---------- Other ----------
 
         internal List<string>? InAppExcludes { get; private set; }

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -211,12 +211,18 @@ public partial class SentryOptions
         /// Gets or sets a value that indicates if native crash reporting via tombstones is enabled.
         /// The default value is <c>false</c> (disabled).
         /// </summary>
+        /// <remarks>
+        /// See https://docs.sentry.io/platforms/android/configuration/tombstones/
+        /// </remarks>
         public bool TombstoneEnabled { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value that indicates if historical tombstones should be reported.
         /// The default value is <c>false</c> (disabled).
         /// </summary>
+        /// <remarks>
+        /// See https://docs.sentry.io/platforms/android/configuration/tombstones/
+        /// </remarks>
         public bool ReportHistoricalTombstones { get; set; } = false;
 
         // ---------- Other ----------

--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -154,6 +154,18 @@ public partial class SentryOptions
         /// </remarks>
         public bool EnableUserInteractionTracing { get; set; } = false;
 
+        /// <summary>
+        /// Gets or sets a value that indicates if native crash reporting via tombstones is enabled.
+        /// The default value is <c>false</c> (disabled).
+        /// </summary>
+        public bool TombstoneEnabled { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value that indicates if historical tombstones should be reported.
+        /// The default value is <c>false</c> (disabled).
+        /// </summary>
+        public bool ReportHistoricalTombstones { get; set; } = false;
+
         // ---------- From SentryOptions.java ----------
 
         /// <summary>
@@ -206,18 +218,6 @@ public partial class SentryOptions
         /// The default value is 5 seconds.
         /// </summary>
         public TimeSpan ReadTimeout { get; set; } = TimeSpan.FromSeconds(5);
-
-        /// <summary>
-        /// Gets or sets a value that indicates if native crash reporting via tombstones is enabled.
-        /// The default value is <c>false</c> (disabled).
-        /// </summary>
-        public bool TombstoneEnabled { get; set; } = false;
-
-        /// <summary>
-        /// Gets or sets a value that indicates if historical tombstones should be reported.
-        /// The default value is <c>false</c> (disabled).
-        /// </summary>
-        public bool ReportHistoricalTombstones { get; set; } = false;
 
         // ---------- Other ----------
 

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -157,7 +157,7 @@ public static partial class SentrySdk
             o.PrintUncaughtStackTrace = options.Native.PrintUncaughtStackTrace;
             o.ReadTimeoutMillis = (int)options.Native.ReadTimeout.TotalMilliseconds;
             o.TombstoneEnabled = options.Native.TombstoneEnabled;
-            o.ReportHistoricalAnrs = options.Native.ReportHistoricalTombstones;
+            o.ReportHistoricalTombstones = options.Native.ReportHistoricalTombstones;
 
             // In-App Excludes and Includes to be passed to the Android SDK
             options.Native.InAppExcludes?.ForEach(o.AddInAppExclude);

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -156,6 +156,8 @@ public static partial class SentrySdk
             o.ProfilesSampleRate = (JavaDouble?)options.Native.ProfilesSampleRate;
             o.PrintUncaughtStackTrace = options.Native.PrintUncaughtStackTrace;
             o.ReadTimeoutMillis = (int)options.Native.ReadTimeout.TotalMilliseconds;
+            o.TombstoneEnabled = options.Native.TombstoneEnabled;
+            o.ReportHistoricalAnrs = options.Native.ReportHistoricalTombstones;
 
             // In-App Excludes and Includes to be passed to the Android SDK
             options.Native.InAppExcludes?.ForEach(o.AddInAppExclude);

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -146,6 +146,8 @@ public static partial class SentrySdk
             o.EnableNetworkEventBreadcrumbs = options.Native.EnableNetworkEventBreadcrumbs;
             o.EnableUserInteractionBreadcrumbs = options.Native.EnableUserInteractionBreadcrumbs;
             o.EnableUserInteractionTracing = options.Native.EnableUserInteractionTracing;
+            o.TombstoneEnabled = options.Native.TombstoneEnabled;
+            o.ReportHistoricalTombstones = options.Native.ReportHistoricalTombstones;
 
             // These options are in Java.SentryOptions but not ours
             o.AttachThreads = options.Native.AttachThreads;
@@ -156,8 +158,6 @@ public static partial class SentrySdk
             o.ProfilesSampleRate = (JavaDouble?)options.Native.ProfilesSampleRate;
             o.PrintUncaughtStackTrace = options.Native.PrintUncaughtStackTrace;
             o.ReadTimeoutMillis = (int)options.Native.ReadTimeout.TotalMilliseconds;
-            o.TombstoneEnabled = options.Native.TombstoneEnabled;
-            o.ReportHistoricalTombstones = options.Native.ReportHistoricalTombstones;
 
             // In-App Excludes and Includes to be passed to the Android SDK
             options.Native.InAppExcludes?.ForEach(o.AddInAppExclude);


### PR DESCRIPTION
## Summary
- Adds `TombstoneEnabled` and `ReportHistoricalTombstones` to `SentryOptions.NativeOptions` (Android)
- Adds corresponding nullable bindable options in `BindableSentryOptions.NativeOptions`
- Applies bindable config values in `ApplyTo`
- Maps both options into Java `SentryAndroidOptions` during Android SDK init

## Why
Implements #5027 by exposing Android Java SDK tombstone controls through .NET native options.

## Testing
- `dotnet build src/Sentry/Sentry.csproj -f net9.0-android35.0 -v minimal`
- `dotnet test test/Sentry.Tests/Sentry.Tests.csproj -f net9.0-android35.0 --no-restore --filter "FullyQualifiedName~Platforms.Android.BindableNativeOptionsTests" -v normal`

Closes #5027
