### PR TITLE
build: enable CA2007 enforcement via nested src/.editorconfig

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,9 @@
+# Settings that apply only to library code under /src
+# (so tests, samples, benchmarks, and integration-tests are not affected).
+
+[*.cs]
+
+# CA2007: Consider calling ConfigureAwait on the awaited task.
+# Library code must always ConfigureAwait(false) to avoid deadlocks in
+# callers that have a SynchronizationContext.
+dotnet_diagnostic.CA2007.severity = error

--- a/src/CodeAnalysis.ruleset
+++ b/src/CodeAnalysis.ruleset
@@ -1,5 +1,0 @@
-﻿<RuleSet Name="Microsoft.Analyzers.ManagedCodeAnalysis" Description="Microsoft.Analyzers.ManagedCodeAnalysis" ToolsVersion="14.0">
-  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
-      <Rule Id="CA2007" Action="Error" />          <!-- Consider calling ConfigureAwait on the awaited task -->
-  </Rules>
-</RuleSet>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,7 +32,6 @@
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 
     <Nullable>annotations</Nullable>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <!-- Centralise logic for enabling `IsAotCompatible`. We use this to disable Aot for the device tests, for example -->


### PR DESCRIPTION
## Summary

Move `ConfigureAwait(false)` enforcement (CA2007) from the legacy `src/CodeAnalysis.ruleset` to a nested `src/.editorconfig`.

The ruleset file no longer reliably enables CA2007 with current .NET SDKs (CA2007 is **disabled by default** in modern .NET analyzers, and `<CodeAnalysisRuleSet>` only overrides severity for rules that are already active). As a result, the rule only fired in CI Release builds and was silently ignored locally — both in Rider and with `dotnet build` — the regression reported in #2308.

Using `dotnet_diagnostic.CA2007.severity = error` inside a nested editorconfig under `/src` has two advantages over the previous setup:

- It correctly activates analyzer rules that are disabled by default, so violations fail locally and in CI
- It scopes the rule to library code only. Tests, samples, benchmarks and integration-test projects are unaffected, where calling `ConfigureAwait(false)` is unnecessary noise.

## Verification

Tested locally on macOS:

- Clean build of `src/Sentry/Sentry.csproj` in **Debug** → 0 errors.
- Temporarily replaced `await sentryTask.ConfigureAwait(false);` with `await sentryTask;` in `SpotlightHttpTransport.cs` → build fails with:
  ```
  error CA2007: Consider calling ConfigureAwait on the awaited task
  ```
  ...across all target frameworks (`net8.0`, `net9.0`, `net10.0`). Reverted before commit.
- Built `test/Sentry.Tests/Sentry.Tests.csproj` with its existing `await client.GetAsync(...);` calls (no `ConfigureAwait`) → 0 CA2007 errors, confirming the rule is correctly scoped to `/src` only.

Closes #2308

#skip-changelog