### PR TITLE
build: download ACKNOWLEDGEMENTS.md for sentry-cli when packing

### DIFF
--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -116,13 +116,27 @@
       <SentryCLIDownload Condition="'$(CI_PUBLISHING_BUILD)' == 'true' Or ($([MSBuild]::IsOSPlatform('Windows')) And $(_OSArchitecture) != 'X86')" Include="sentry-cli-Windows-x86_64.exe" FileHash="572b4a6c04504302a46e2e1c196ec31cda266b574b1444605426aa8e41d46b8c" />
     </ItemGroup>
 
-    <!-- Download the files -->
+    <!-- Download the platform-specific CLI binaries. -->
     <DownloadFile SourceUrl="https://downloads.sentry-cdn.com/sentry-cli/$(SentryCLIVersion)/%(SentryCLIDownload.Identity)" DestinationFolder="$(SentryCLIDirectory)" Condition="!Exists('$(SentryCLIDirectory)%(Identity)')" Retries="3">
       <Output TaskParameter="DownloadedFile" ItemName="SentryCLIDownloadedFile" />
     </DownloadFile>
 
     <!-- Build will fail if any downloaded files don't match the expected hash. -->
     <VerifyFileHash File="$(SentryCLIDirectory)%(SentryCLIDownload.Identity)" Hash="%(FileHash)" />
+
+    <!--
+      Download the platform-independent ACKNOWLEDGEMENTS.md that lists third-party OSS
+      attributions compiled into the sentry-cli binary. Required for license compliance
+      when redistributing the CLI executables in the Sentry NuGet package.
+      ContinueOnError is temporary while getsentry/sentry-cli#2823 is in progress —
+      remove it once sentry-cli starts publishing this file in releases.
+    -->
+    <DownloadFile
+      SourceUrl="https://downloads.sentry-cdn.com/sentry-cli/$(SentryCLIVersion)/ACKNOWLEDGEMENTS.md"
+      DestinationFolder="$(SentryCLIDirectory)"
+      Condition="!Exists('$(SentryCLIDirectory)ACKNOWLEDGEMENTS.md')"
+      ContinueOnError="WarnAndContinue"
+      Retries="3" />
 
     <!-- Set executable permissions for local usage. -->
     <Exec Command="chmod +x $(SentryCLIDirectory)*" Condition="!$([MSBuild]::IsOSPlatform('Windows'))" />


### PR DESCRIPTION
## Summary

The `Sentry` NuGet package bundles `sentry-cli` executables under `tools/`. Those binaries statically compile dozens of third-party Rust crates whose OSS licenses (Apache 2.0, MIT, etc.) require attribution when the software is redistributed. This PR adds the infrastructure to download and pack the `ACKNOWLEDGEMENTS.md` that sentry-cli will publish alongside its binaries.

### What changed

- Inside `DownloadSentryCLI`, added a `DownloadFile` step for the platform-independent `ACKNOWLEDGEMENTS.md` from `https://downloads.sentry-cdn.com/sentry-cli/<version>/ACKNOWLEDGEMENTS.md`.
- The existing `<None Include="$(SentryCLIDirectory)**" Pack="true" PackagePath="tools\">` wildcard already covers this file, so no extra pack entry is needed.
- `ContinueOnError="WarnAndContinue"` is used while [getsentry/sentry-cli#2823](https://github.com/getsentry/sentry-cli/issues/2823) is still in progress (the file is not yet published in sentry-cli releases). Once that ships:
  - Remove `ContinueOnError`.
  - Add the file hash to the release registry spec and extend `update-cli.ps1` to update it.

### Testing

- Local build emits a single MSBuild warning (`MSB3923: Failed to download`) for the missing file — not an error — confirming graceful degradation.
- Once sentry-cli#2823 ships, a version-bump via `update-cli.ps1 set-version <new>` + publish build will pull the file and pack it automatically.

Closes #4588

#skip-changelog
