### PR TITLE
fix: exclude SentrySqlListener from .NET Framework builds

### DIFF
--- a/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentryDiagnosticSubscriber.cs
+++ b/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentryDiagnosticSubscriber.cs
@@ -13,7 +13,9 @@ internal class SentryDiagnosticSubscriber : IObserver<DiagnosticListener>
     // Thus, we will create the instances lazily.
 
     private readonly Lazy<SentryEFCoreListener> _efListener;
+#if !NETFRAMEWORK
     private readonly Lazy<SentrySqlListener> _sqlListener;
+#endif
 
     public SentryDiagnosticSubscriber(IHub hub, SentryOptions options)
     {
@@ -23,11 +25,13 @@ internal class SentryDiagnosticSubscriber : IObserver<DiagnosticListener>
             return new SentryEFCoreListener(hub, options);
         });
 
+#if !NETFRAMEWORK
         _sqlListener = new Lazy<SentrySqlListener>(() =>
         {
             options.Log(SentryLevel.Debug, "Registering SQL Client integration.");
             return new SentrySqlListener(hub, options);
         });
+#endif
     }
 
     public void OnCompleted() { }
@@ -44,13 +48,16 @@ internal class SentryDiagnosticSubscriber : IObserver<DiagnosticListener>
                     break;
                 }
 
+#if !NETFRAMEWORK
             case "SqlClientDiagnosticListener":
                 {
                     listener.Subscribe(_sqlListener.Value);
                     break;
                 }
+#endif
         }
 
+#if !NETFRAMEWORK
         // By default, the EF listener will duplicate spans already given by the SQL Client listener.
         // Thus, we should disable those parts of the EF listener when they are both registered.
         if (_efListener.IsValueCreated && _sqlListener.IsValueCreated)
@@ -59,5 +66,6 @@ internal class SentryDiagnosticSubscriber : IObserver<DiagnosticListener>
             efListener.DisableConnectionSpan();
             efListener.DisableQuerySpan();
         }
+#endif
     }
 }

--- a/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentrySqlListener.cs
+++ b/src/Sentry.DiagnosticSource/Internal/DiagnosticSource/SentrySqlListener.cs
@@ -1,3 +1,7 @@
+// SqlClient's DiagnosticSource integration is not supported on .NET Framework.
+// See: https://github.com/dotnet/SqlClient/issues/1529#issuecomment-1063166442
+#if !NETFRAMEWORK
+
 using Sentry.Extensibility;
 using Sentry.Internal.Extensions;
 
@@ -274,3 +278,5 @@ internal class SentrySqlListener : IObserver<KeyValuePair<string, object?>>
         }
     }
 }
+
+#endif

--- a/test/Sentry.DiagnosticSource.Tests/SentrySqlListenerExtensions.cs
+++ b/test/Sentry.DiagnosticSource.Tests/SentrySqlListenerExtensions.cs
@@ -1,3 +1,4 @@
+#if !NETFRAMEWORK
 using Sentry.Internal.DiagnosticSource;
 
 namespace Sentry.DiagnosticSource.Tests;
@@ -34,3 +35,5 @@ internal static class SentrySqlListenerExtensions
             SentrySqlListener.SqlDataWriteCommandError,
             new { OperationId = operationId, ConnectionId = connectionId, Command = new { CommandText = query } }));
 }
+
+#endif

--- a/test/Sentry.DiagnosticSource.Tests/SentrySqlListenerTests.cs
+++ b/test/Sentry.DiagnosticSource.Tests/SentrySqlListenerTests.cs
@@ -1,3 +1,4 @@
+#if !NETFRAMEWORK
 using Sentry.Internal.DiagnosticSource;
 using static Sentry.Internal.DiagnosticSource.SentrySqlListener;
 
@@ -685,3 +686,5 @@ public class SentrySqlListenerTests
         Assert.False(exceptionReceived);
     }
 }
+
+#endif


### PR DESCRIPTION
## Summary

SqlClient's DiagnosticSource-based events are not delivered on .NET Framework (see [dotnet/SqlClient#1529](https://github.com/dotnet/SqlClient/issues/1529#issuecomment-1063166442)), so including `SentrySqlListener` in the `net462` package is misleading — it compiles and registers but silently does nothing.

- Wrapped `SentrySqlListener` entirely in `#if !NETFRAMEWORK`
- Guarded the SQL listener field, lazy initializer, and `SqlClientDiagnosticListener` subscription in `SentryDiagnosticSubscriber` with the same guard
- Excluded `SentrySqlListenerExtensions` and `SentrySqlListenerTests` from .NET Framework test builds

All existing tests pass unchanged on `net9.0`.

#skip-changelog

Closes #3173
