### PR TITLE
fix: Log4Net integration filters SDK-internal log events to prevent infinite loops

### DIFF
--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -58,6 +58,8 @@ public class SentryAppender : AppenderSkeleton
         _hub = hubGetter;
     }
 
+    private static readonly AsyncLocal<bool> IsReentrant = new();
+
     /// <summary>
     /// Append log.
     /// </summary>
@@ -70,6 +72,24 @@ public class SentryAppender : AppenderSkeleton
             return;
         }
 
+        if (IsReentrant.Value)
+        {
+            return;
+        }
+
+        IsReentrant.Value = true;
+        try
+        {
+            AppendCore(loggingEvent);
+        }
+        finally
+        {
+            IsReentrant.Value = false;
+        }
+    }
+
+    private void AppendCore(LoggingEvent loggingEvent)
+    {
         if (!_hub.IsEnabled && _sdkHandle == null)
         {
             if (Dsn == null)
@@ -82,6 +102,11 @@ public class SentryAppender : AppenderSkeleton
                 // ReSharper disable once NonAtomicCompoundOperator Double init guarded by the lock
                 _sdkHandle ??= _initAction(Dsn);
             }
+        }
+
+        if (IsSentryLogger(loggingEvent.LoggerName))
+        {
+            return;
         }
 
         var exception = loggingEvent.ExceptionObject ?? loggingEvent.MessageObject as Exception;
@@ -138,6 +163,11 @@ public class SentryAppender : AppenderSkeleton
 
         _hub.CaptureEvent(evt);
     }
+
+    internal static bool IsSentryLogger(string? loggerName) =>
+        loggerName != null &&
+        (string.Equals(loggerName, "Sentry", StringComparison.Ordinal) ||
+         loggerName.StartsWith("Sentry.", StringComparison.Ordinal));
 
     private static IEnumerable<KeyValuePair<string, object?>> GetLoggingEventProperties(LoggingEvent loggingEvent)
     {

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -104,11 +104,6 @@ public class SentryAppender : AppenderSkeleton
             }
         }
 
-        if (IsSentryLogger(loggingEvent.LoggerName))
-        {
-            return;
-        }
-
         var exception = loggingEvent.ExceptionObject ?? loggingEvent.MessageObject as Exception;
 
         if (MinimumEventLevel is not null && loggingEvent.Level < MinimumEventLevel)
@@ -163,11 +158,6 @@ public class SentryAppender : AppenderSkeleton
 
         _hub.CaptureEvent(evt);
     }
-
-    internal static bool IsSentryLogger(string? loggerName) =>
-        loggerName != null &&
-        (string.Equals(loggerName, "Sentry", StringComparison.Ordinal) ||
-         loggerName.StartsWith("Sentry.", StringComparison.Ordinal));
 
     private static IEnumerable<KeyValuePair<string, object?>> GetLoggingEventProperties(LoggingEvent loggingEvent)
     {

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -78,7 +78,7 @@ public class SentryAppender : AppenderSkeleton
             return;
         }
 
-        if (IsReentrant.Value || HttpTransportBase.IsLoggingRateLimited.Value)
+        if (IsReentrant.Value || _isLoggingRateLimited())
         {
             return;
         }

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -45,6 +45,8 @@ public class SentryAppender : AppenderSkeleton
     /// <see href="https://github.com/getsentry/sentry-release-registry" />
     internal const string SdkName = "sentry.dotnet.log4net";
 
+    internal Func<bool> _isLoggingRateLimited;
+
     /// <summary>
     /// Creates a new instance of the <see cref="SentryAppender"/>.
     /// </summary>
@@ -53,10 +55,13 @@ public class SentryAppender : AppenderSkeleton
 
     internal SentryAppender(
         Func<string, IDisposable> initAction,
-        IHub hubGetter)
+        IHub hubGetter,
+        Func<bool>? isLoggingRateLimitedResolver = null)
     {
         _initAction = initAction;
         _hub = hubGetter;
+        isLoggingRateLimitedResolver ??= () => HttpTransportBase.IsLoggingRateLimited.Value;
+        _isLoggingRateLimited = isLoggingRateLimitedResolver;
     }
 
     private static readonly AsyncLocal<bool> IsReentrant = new();
@@ -73,7 +78,7 @@ public class SentryAppender : AppenderSkeleton
             return;
         }
 
-        if (IsReentrant.Value || HttpTransportBase.IsLoggingRateLimited)
+        if (IsReentrant.Value || HttpTransportBase.IsLoggingRateLimited.Value)
         {
             return;
         }

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -1,3 +1,4 @@
+using Sentry.Http;
 using Sentry.Internal.Extensions;
 
 namespace Sentry.Log4Net;
@@ -72,7 +73,7 @@ public class SentryAppender : AppenderSkeleton
             return;
         }
 
-        if (IsReentrant.Value)
+        if (IsReentrant.Value || HttpTransportBase.IsLoggingRateLimited)
         {
             return;
         }

--- a/src/Sentry/Http/HttpTransportBase.cs
+++ b/src/Sentry/Http/HttpTransportBase.cs
@@ -587,16 +587,30 @@ public abstract class HttpTransportBase
             responseDetail);
     }
 
+    /// <summary>
+    /// See https://github.com/getsentry/sentry-dotnet/pull/5238
+    /// </summary>
+    [ThreadStatic]
+    internal static bool IsLoggingRateLimited;
+
     private void LogRateLimited(SentryId? eventId, string responseDetail)
     {
-        _options.LogWarning(
-            "{0}: Sentry rejected the envelope '{1}' due to rate limiting. " +
-            "This may indicate that you are sending too much data or have exceeded your quota. " +
-            "See https://docs.sentry.io/product/accounts/quotas/ for more information. " +
-            "Server response: {2}",
-            _typeName,
-            eventId,
-            responseDetail);
+        IsLoggingRateLimited = true;
+        try
+        {
+            _options.LogWarning(
+                "{0}: Sentry rejected the envelope '{1}' due to rate limiting. " +
+                "This may indicate that you are sending too much data or have exceeded your quota. " +
+                "See https://docs.sentry.io/product/accounts/quotas/ for more information. " +
+                "Server response: {2}",
+                _typeName,
+                eventId,
+                responseDetail);
+        }
+        finally
+        {
+            IsLoggingRateLimited = false;
+        }
     }
 
     private static bool HasJsonContent(HttpContent content) =>

--- a/src/Sentry/Http/HttpTransportBase.cs
+++ b/src/Sentry/Http/HttpTransportBase.cs
@@ -18,7 +18,7 @@ public abstract class HttpTransportBase
     /// <summary>
     /// See https://github.com/getsentry/sentry-dotnet/pull/5238
     /// </summary>
-    internal static AsyncLocal<bool> IsLoggingRateLimited = new ();
+    internal static AsyncLocal<bool> IsLoggingRateLimited = new();
 
     private readonly SentryOptions _options;
     private readonly BackpressureMonitor? _backpressureMonitor;

--- a/src/Sentry/Http/HttpTransportBase.cs
+++ b/src/Sentry/Http/HttpTransportBase.cs
@@ -15,6 +15,11 @@ public abstract class HttpTransportBase
 {
     internal const string DefaultErrorMessage = "No message";
 
+    /// <summary>
+    /// See https://github.com/getsentry/sentry-dotnet/pull/5238
+    /// </summary>
+    internal static AsyncLocal<bool> IsLoggingRateLimited = new ();
+
     private readonly SentryOptions _options;
     private readonly BackpressureMonitor? _backpressureMonitor;
     private readonly ISystemClock _clock;
@@ -587,15 +592,9 @@ public abstract class HttpTransportBase
             responseDetail);
     }
 
-    /// <summary>
-    /// See https://github.com/getsentry/sentry-dotnet/pull/5238
-    /// </summary>
-    [ThreadStatic]
-    internal static bool IsLoggingRateLimited;
-
     private void LogRateLimited(SentryId? eventId, string responseDetail)
     {
-        IsLoggingRateLimited = true;
+        IsLoggingRateLimited.Value = true;
         try
         {
             _options.LogWarning(
@@ -609,7 +608,7 @@ public abstract class HttpTransportBase
         }
         finally
         {
-            IsLoggingRateLimited = false;
+            IsLoggingRateLimited.Value = false;
         }
     }
 

--- a/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
+++ b/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
@@ -395,4 +395,64 @@ public class SentryAppenderTests
 
         _fixture.SdkDisposeHandle.Received(1).Dispose();
     }
+
+    [Theory]
+    [InlineData("Sentry", true)]
+    [InlineData("Sentry.Internal.Http", true)]
+    [InlineData("Sentry.Extensions.Logging", true)]
+    [InlineData("sentry", false)]
+    [InlineData("MySentry.App", false)]
+    [InlineData("MyApp.Logger", false)]
+    [InlineData(null, false)]
+    public void IsSentryLogger_VariousLoggerNames_ReturnsExpected(string loggerName, bool expected)
+    {
+        Assert.Equal(expected, SentryAppender.IsSentryLogger(loggerName));
+    }
+
+    [Fact]
+    public void Append_SentryLoggerName_DoesNotCaptureEvent()
+    {
+        _ = _fixture.Hub.IsEnabled.Returns(true);
+        var sut = _fixture.GetSut();
+
+        var evt = new LoggingEvent(null, null, "Sentry.Internal.Http", Level.Error, "rate limited", null);
+        sut.DoAppend(evt);
+
+        _ = _fixture.Hub.DidNotReceiveWithAnyArgs().CaptureEvent(Arg.Any<SentryEvent>());
+    }
+
+    [Fact]
+    public void Append_SentryLoggerName_DoesNotAddBreadcrumb()
+    {
+        _ = _fixture.Hub.IsEnabled.Returns(true);
+        var sut = _fixture.GetSut();
+        sut.MinimumEventLevel = Level.Error;
+
+        var evt = new LoggingEvent(null, null, "Sentry.Internal.Http", Level.Warn, "rate limited", null);
+        sut.DoAppend(evt);
+
+        Assert.Empty(_fixture.Scope.Breadcrumbs);
+    }
+
+    [Fact]
+    public void Append_ReentrantCall_DoesNotCaptureEvent()
+    {
+        _ = _fixture.Hub.IsEnabled.Returns(true);
+        var capturedEvents = 0;
+        _fixture.Hub.When(h => h.CaptureEvent(Arg.Any<SentryEvent>()))
+            .Do(_ =>
+            {
+                capturedEvents++;
+                // Simulate re-entry: SDK logs an error that arrives back at the appender
+                var sut = _fixture.GetSut();
+                var reentrantEvt = new LoggingEvent(null, null, "app-logger", Level.Error, "reentrant", null);
+                sut.DoAppend(reentrantEvt);
+            });
+
+        var sut = _fixture.GetSut();
+        var evt = new LoggingEvent(null, null, "app-logger", Level.Error, "original", null);
+        sut.DoAppend(evt);
+
+        Assert.Equal(1, capturedEvents);
+    }
 }

--- a/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
+++ b/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
@@ -4,6 +4,7 @@ public class SentryAppenderTests
 {
     private class Fixture
     {
+        public bool IsLoggingRateLimited { get; set; }
         public bool InitInvoked { get; set; }
         public string DsnReceivedOnInit { get; set; }
         public IDisposable SdkDisposeHandle { get; set; } = Substitute.For<IDisposable>();
@@ -27,7 +28,7 @@ public class SentryAppenderTests
 
         public SentryAppender GetSut()
         {
-            var sut = new SentryAppender(InitAction, Hub)
+            var sut = new SentryAppender(InitAction, Hub, () => IsLoggingRateLimited)
             {
                 Dsn = Dsn
             };
@@ -409,6 +410,36 @@ public class SentryAppenderTests
                 var sut = _fixture.GetSut();
                 var reentrantEvt = new LoggingEvent(null, null, "app-logger", Level.Error, "reentrant", null);
                 sut.DoAppend(reentrantEvt);
+            });
+
+        var sut = _fixture.GetSut();
+        var evt = new LoggingEvent(null, null, "app-logger", Level.Error, "original", null);
+        sut.DoAppend(evt);
+
+        Assert.Equal(1, capturedEvents);
+    }
+
+    [Fact]
+    public void Append_IsLoggingRateLimited_DoesNotCaptureEvent()
+    {
+        _ = _fixture.Hub.IsEnabled.Returns(true);
+        var capturedEvents = 0;
+        _fixture.Hub.When(h => h.CaptureEvent(Arg.Any<SentryEvent>()))
+            .Do(_ =>
+            {
+                capturedEvents++;
+                // Simulate 429 - the transport will set IsLoggingRateLimited before logging the 429
+                _fixture.IsLoggingRateLimited = true;
+                try
+                {
+                    var sut = _fixture.GetSut();
+                    var reentrantEvt = new LoggingEvent(null, null, "app-logger", Level.Error, "429", null);
+                    sut.DoAppend(reentrantEvt);
+                }
+                finally
+                {
+                    _fixture.IsLoggingRateLimited = false;
+                }
             });
 
         var sut = _fixture.GetSut();

--- a/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
+++ b/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
@@ -396,44 +396,6 @@ public class SentryAppenderTests
         _fixture.SdkDisposeHandle.Received(1).Dispose();
     }
 
-    [Theory]
-    [InlineData("Sentry", true)]
-    [InlineData("Sentry.Internal.Http", true)]
-    [InlineData("Sentry.Extensions.Logging", true)]
-    [InlineData("sentry", false)]
-    [InlineData("MySentry.App", false)]
-    [InlineData("MyApp.Logger", false)]
-    [InlineData(null, false)]
-    public void IsSentryLogger_VariousLoggerNames_ReturnsExpected(string loggerName, bool expected)
-    {
-        Assert.Equal(expected, SentryAppender.IsSentryLogger(loggerName));
-    }
-
-    [Fact]
-    public void Append_SentryLoggerName_DoesNotCaptureEvent()
-    {
-        _ = _fixture.Hub.IsEnabled.Returns(true);
-        var sut = _fixture.GetSut();
-
-        var evt = new LoggingEvent(null, null, "Sentry.Internal.Http", Level.Error, "rate limited", null);
-        sut.DoAppend(evt);
-
-        _ = _fixture.Hub.DidNotReceiveWithAnyArgs().CaptureEvent(Arg.Any<SentryEvent>());
-    }
-
-    [Fact]
-    public void Append_SentryLoggerName_DoesNotAddBreadcrumb()
-    {
-        _ = _fixture.Hub.IsEnabled.Returns(true);
-        var sut = _fixture.GetSut();
-        sut.MinimumEventLevel = Level.Error;
-
-        var evt = new LoggingEvent(null, null, "Sentry.Internal.Http", Level.Warn, "rate limited", null);
-        sut.DoAppend(evt);
-
-        Assert.Empty(_fixture.Scope.Breadcrumbs);
-    }
-
     [Fact]
     public void Append_ReentrantCall_DoesNotCaptureEvent()
     {


### PR DESCRIPTION
By default, `SentryOptions.DiagnosticLogger` is either `null` (when `Debug` is off) or a `ConsoleDiagnosticLogger`/`DebugDiagnosticLogger` that writes to `Console.Error` or `Debug.WriteLine`. Neither of those has anything to do with log4net, so `_options.LogWarning(...)` in `LogRateLimited` never touches `SentryAppender` at all. No loop possible.

The problem occurs when the user does something like:

```csharp
options.Debug = true;
options.DiagnosticLogger = new Log4NetDiagnosticLogger(LogManager.GetLogger("Sentry"));
```

At that point `_options.LogWarning(...)` → `Log4NetDiagnosticLogger.Log` → log4net → `SentryAppender.Append` → `CaptureEvent` → background worker → 429 → repeat. The user has literally wired the SDK's own error output back into the SDK's event pipeline.

# Solution

I've tried to add this:
https://github.com/getsentry/sentry-dotnet/blob/a62bd4b8070ea442f76fb6d6b8c663d53e010fa7/src/Sentry/Http/HttpTransportBase.cs#L595-L613

And then this:
https://github.com/getsentry/sentry-dotnet/blob/99d26478bbcde9c7467ee94cd2a223fed9459c13/src/Sentry.Log4Net/SentryAppender.cs#L81-L94

But ultimately I don't think there's any good solution to this problem. See [this comment](https://github.com/getsentry/sentry-dotnet/pull/5238#discussion_r3270928682) in my discussion with the AI overlords. 

# Aside (consistency)

Added an `AsyncLocal<bool>` re-entrance guard to `SentryAppender.Append` (matching the Serilog and NLog pattern) so that synchronous re-entrant log calls are dropped.

This doesn't address the original issue which stems from the Background Worker. The background worker is started with `Task.Run(DoWorkAsync)` long before any appender call sets `IsReentrant = true`. So when LogRateLimited → _options.LogWarning fires on the background worker thread, `IsReentrant.Value` is always false there.

Closes #2953

#skip-changelog
