### PR TITLE
perf: avoid activity id conversion allocations

### DIFF
--- a/src/Sentry.OpenTelemetry.Exporter/ActivityExtensions.cs
+++ b/src/Sentry.OpenTelemetry.Exporter/ActivityExtensions.cs
@@ -4,11 +4,31 @@ internal static class ActivityExtensions
 {
     public static SpanId AsSentrySpanId(this ActivitySpanId id) => SpanId.Parse(id.ToHexString());
 
-    public static ActivitySpanId AsActivitySpanId(this SpanId id) =>
-        ActivitySpanId.CreateFromString(id.ToString().AsSpan());
+    public static ActivitySpanId AsActivitySpanId(this SpanId id)
+    {
+#if NET8_0_OR_GREATER
+        Span<byte> buffer = stackalloc byte[8];
+        id.TryWriteBytes(buffer);
+        return ActivitySpanId.CreateFromBytes(buffer);
+#else
+        Span<char> buffer = stackalloc char[16];
+        id.TryFormat(buffer);
+        return ActivitySpanId.CreateFromString(buffer);
+#endif
+    }
 
     public static SentryId AsSentryId(this ActivityTraceId id) => SentryId.Parse(id.ToHexString());
 
-    public static ActivityTraceId AsActivityTraceId(this SentryId id) =>
-        ActivityTraceId.CreateFromString(id.ToString().AsSpan());
+    public static ActivityTraceId AsActivityTraceId(this SentryId id)
+    {
+#if NET8_0_OR_GREATER
+        Span<byte> buffer = stackalloc byte[16];
+        id.TryWriteBytes(buffer);
+        return ActivityTraceId.CreateFromBytes(buffer);
+#else
+        Span<char> buffer = stackalloc char[32];
+        id.TryFormat(buffer);
+        return ActivityTraceId.CreateFromString(buffer);
+#endif
+    }
 }

--- a/src/Sentry.OpenTelemetry.Exporter/ActivityExtensions.cs
+++ b/src/Sentry.OpenTelemetry.Exporter/ActivityExtensions.cs
@@ -2,16 +2,22 @@ namespace Sentry.Internal;
 
 internal static class ActivityExtensions
 {
+    private const int HexCharsPerByte = 2;
+    private const int SpanIdByteCount = sizeof(long);
+    private const int SpanIdHexCharCount = SpanIdByteCount * HexCharsPerByte;
+    private static readonly int TraceIdByteCount = Unsafe.SizeOf<Guid>();
+    internal static readonly int TraceIdHexCharCount = TraceIdByteCount * HexCharsPerByte;
+
     public static SpanId AsSentrySpanId(this ActivitySpanId id) => SpanId.Parse(id.ToHexString());
 
     public static ActivitySpanId AsActivitySpanId(this SpanId id)
     {
 #if NET8_0_OR_GREATER
-        Span<byte> buffer = stackalloc byte[8];
+        Span<byte> buffer = stackalloc byte[SpanIdByteCount];
         id.TryWriteBytes(buffer);
         return ActivitySpanId.CreateFromBytes(buffer);
 #else
-        Span<char> buffer = stackalloc char[16];
+        Span<char> buffer = stackalloc char[SpanIdHexCharCount];
         id.TryFormat(buffer);
         return ActivitySpanId.CreateFromString(buffer);
 #endif
@@ -22,11 +28,11 @@ internal static class ActivityExtensions
     public static ActivityTraceId AsActivityTraceId(this SentryId id)
     {
 #if NET8_0_OR_GREATER
-        Span<byte> buffer = stackalloc byte[16];
+        Span<byte> buffer = stackalloc byte[TraceIdByteCount];
         id.TryWriteBytes(buffer);
         return ActivityTraceId.CreateFromBytes(buffer);
 #else
-        Span<char> buffer = stackalloc char[32];
+        Span<char> buffer = stackalloc char[TraceIdHexCharCount];
         id.TryFormat(buffer);
         return ActivityTraceId.CreateFromString(buffer);
 #endif

--- a/src/Sentry/Internal/Polyfills.cs
+++ b/src/Sentry/Internal/Polyfills.cs
@@ -111,3 +111,55 @@ internal static class ArgumentNullExceptionExtensions
     }
 }
 #endif
+
+#if !NET8_0_OR_GREATER
+internal static partial class PolyfillExtensions
+{
+    /// <summary>
+    /// Polyfill for <see cref="Guid.TryWriteBytes"/> on older TFMs (.NET Framework, .NET Standard 2.0/2.1, .NET 5–7).
+    /// </summary>
+    /// <remarks>
+    /// On .NET 8+, this method exists natively on Guid.
+    /// On older TFMs, we provide a shim that handles byte-order conversion.
+    /// </remarks>
+    public static bool TryWriteBytes(this Guid guid, Span<byte> destination, bool bigEndian, out int bytesWritten)
+    {
+        const int GuidByteCount = 16;
+
+        if (destination.Length < GuidByteCount)
+        {
+            bytesWritten = 0;
+            return false;
+        }
+
+        var bytes = guid.ToByteArray();
+
+        if (bigEndian)
+        {
+            // Convert from Guid's mixed-endian byte layout to big-endian trace-id order:
+            // Data1 (4 bytes) and Data2/Data3 (2 bytes each) are little-endian in Guid.ToByteArray();
+            // Data4 (8 bytes) is stored in native byte order. We reverse the first 3 fields
+            // to get canonical big-endian trace-id byte order.
+            destination[0] = bytes[3];
+            destination[1] = bytes[2];
+            destination[2] = bytes[1];
+            destination[3] = bytes[0];
+            destination[4] = bytes[5];
+            destination[5] = bytes[4];
+            destination[6] = bytes[7];
+            destination[7] = bytes[6];
+            // Data4 bytes remain unchanged
+            bytes.AsSpan(8..).CopyTo(destination[8..]);
+        }
+        else
+        {
+            // Native byte order: copy as-is
+            bytes.CopyTo(destination);
+        }
+
+        bytesWritten = GuidByteCount;
+        return true;
+    }
+}
+#endif
+

--- a/src/Sentry/Internal/Polyfills.cs
+++ b/src/Sentry/Internal/Polyfills.cs
@@ -116,7 +116,7 @@ internal static class ArgumentNullExceptionExtensions
 internal static partial class PolyfillExtensions
 {
     /// <summary>
-    /// Polyfill for <see cref="Guid.TryWriteBytes"/> on older TFMs (.NET Framework, .NET Standard 2.0/2.1, .NET 5–7).
+    /// Polyfill for Guid.TryWriteBytes on older TFMs (.NET Framework, .NET Standard 2.0/2.1, .NET 5–7).
     /// </summary>
     /// <remarks>
     /// On .NET 8+, this method exists natively on Guid.
@@ -124,9 +124,9 @@ internal static partial class PolyfillExtensions
     /// </remarks>
     public static bool TryWriteBytes(this Guid guid, Span<byte> destination, bool bigEndian, out int bytesWritten)
     {
-        const int GuidByteCount = 16;
+        const int guidByteCount = 16;
 
-        if (destination.Length < GuidByteCount)
+        if (destination.Length < guidByteCount)
         {
             bytesWritten = 0;
             return false;
@@ -149,7 +149,7 @@ internal static partial class PolyfillExtensions
             destination[6] = bytes[7];
             destination[7] = bytes[6];
             // Data4 bytes remain unchanged
-            bytes.AsSpan(8..).CopyTo(destination[8..]);
+            bytes.AsSpan(8).CopyTo(destination[8..]);
         }
         else
         {
@@ -157,7 +157,7 @@ internal static partial class PolyfillExtensions
             bytes.CopyTo(destination);
         }
 
-        bytesWritten = GuidByteCount;
+        bytesWritten = guidByteCount;
         return true;
     }
 }

--- a/src/Sentry/SentryId.cs
+++ b/src/Sentry/SentryId.cs
@@ -41,7 +41,7 @@ public readonly struct SentryId : IEquatable<SentryId>, ISentryJsonSerializable
         value.AsSpan().CopyTo(destination);
         return true;
 #else
-        return _guid.TryFormat(destination, out var charsWritten, "N") && charsWritten == 32;
+        return _guid.TryFormat(destination, out var charsWritten, "n") && charsWritten == 32;
 #endif
     }
 

--- a/src/Sentry/SentryId.cs
+++ b/src/Sentry/SentryId.cs
@@ -29,6 +29,46 @@ public readonly struct SentryId : IEquatable<SentryId>, ISentryJsonSerializable
     /// <returns>String representation of the event id.</returns>
     public override string ToString() => _guid.ToString("n");
 
+    internal bool TryFormat(Span<char> destination)
+    {
+#if NETSTANDARD2_0 || NET462
+        var value = ToString();
+        if (destination.Length < value.Length)
+        {
+            return false;
+        }
+
+        value.AsSpan().CopyTo(destination);
+        return true;
+#else
+        return _guid.TryFormat(destination, out var charsWritten, "N") && charsWritten == 32;
+#endif
+    }
+
+    internal bool TryWriteBytes(Span<byte> destination)
+    {
+        if (destination.Length < 16)
+        {
+            return false;
+        }
+
+#if NET8_0_OR_GREATER
+        return _guid.TryWriteBytes(destination, bigEndian: true, out var bytesWritten) && bytesWritten == 16;
+#else
+        var bytes = _guid.ToByteArray();
+        destination[0] = bytes[3];
+        destination[1] = bytes[2];
+        destination[2] = bytes[1];
+        destination[3] = bytes[0];
+        destination[4] = bytes[5];
+        destination[5] = bytes[4];
+        destination[6] = bytes[7];
+        destination[7] = bytes[6];
+        bytes.AsSpan(8).CopyTo(destination[8..]);
+        return true;
+#endif
+    }
+
     /// <inheritdoc />
     public bool Equals(SentryId other) => _guid.Equals(other._guid);
 

--- a/src/Sentry/SentryId.cs
+++ b/src/Sentry/SentryId.cs
@@ -7,6 +7,10 @@ namespace Sentry;
 /// </summary>
 public readonly struct SentryId : IEquatable<SentryId>, ISentryJsonSerializable
 {
+    private const int HexCharsPerByte = 2;
+    private static readonly int ByteCount = Unsafe.SizeOf<Guid>();
+    private static readonly int HexCharCount = ByteCount * HexCharsPerByte;
+
     private readonly Guid _guid;
 
     /// <summary>
@@ -41,21 +45,22 @@ public readonly struct SentryId : IEquatable<SentryId>, ISentryJsonSerializable
         value.AsSpan().CopyTo(destination);
         return true;
 #else
-        return _guid.TryFormat(destination, out var charsWritten, "n") && charsWritten == 32;
+        return _guid.TryFormat(destination, out var charsWritten, "n") && charsWritten == HexCharCount;
 #endif
     }
 
     internal bool TryWriteBytes(Span<byte> destination)
     {
-        if (destination.Length < 16)
+        if (destination.Length < ByteCount)
         {
             return false;
         }
 
 #if NET8_0_OR_GREATER
-        return _guid.TryWriteBytes(destination, bigEndian: true, out var bytesWritten) && bytesWritten == 16;
+        return _guid.TryWriteBytes(destination, bigEndian: true, out var bytesWritten) && bytesWritten == ByteCount;
 #else
         var bytes = _guid.ToByteArray();
+        // Guid.ToByteArray() returns little-endian bytes; reverse the first two 4-byte groups for big-endian
         destination[0] = bytes[3];
         destination[1] = bytes[2];
         destination[2] = bytes[1];
@@ -64,7 +69,8 @@ public readonly struct SentryId : IEquatable<SentryId>, ISentryJsonSerializable
         destination[5] = bytes[4];
         destination[6] = bytes[7];
         destination[7] = bytes[6];
-        bytes.AsSpan(8).CopyTo(destination[8..]);
+        // Copy the last 8 bytes unchanged
+        bytes.AsSpan(8..).CopyTo(destination[8..]);
         return true;
 #endif
     }

--- a/src/Sentry/SentryId.cs
+++ b/src/Sentry/SentryId.cs
@@ -56,23 +56,7 @@ public readonly struct SentryId : IEquatable<SentryId>, ISentryJsonSerializable
             return false;
         }
 
-#if NET8_0_OR_GREATER
         return _guid.TryWriteBytes(destination, bigEndian: true, out var bytesWritten) && bytesWritten == ByteCount;
-#else
-        var bytes = _guid.ToByteArray();
-        // Guid.ToByteArray() returns little-endian bytes; reverse the first two 4-byte groups for big-endian
-        destination[0] = bytes[3];
-        destination[1] = bytes[2];
-        destination[2] = bytes[1];
-        destination[3] = bytes[0];
-        destination[4] = bytes[5];
-        destination[5] = bytes[4];
-        destination[6] = bytes[7];
-        destination[7] = bytes[6];
-        // Copy the last 8 bytes unchanged
-        bytes.AsSpan(8..).CopyTo(destination[8..]);
-        return true;
-#endif
     }
 
     /// <inheritdoc />

--- a/src/Sentry/SpanId.cs
+++ b/src/Sentry/SpanId.cs
@@ -43,6 +43,42 @@ public readonly struct SpanId : IEquatable<SpanId>, ISentryJsonSerializable
     /// <inheritdoc />
     public override string ToString() => _value.ToString("x8").PadLeft(16, '0');
 
+    internal bool TryFormat(Span<char> destination)
+    {
+        if (destination.Length < 16)
+        {
+            return false;
+        }
+
+        Span<byte> convertedBytes = stackalloc byte[sizeof(long)];
+        Unsafe.As<byte, long>(ref convertedBytes[0]) = _value;
+
+        // Going backwards through the array to preserve the order of the output hex string (i.e. `4e76` -> `76e4`)
+        for (var i = convertedBytes.Length - 1; i >= 0; i--)
+        {
+            var value = convertedBytes[i];
+            destination[(convertedBytes.Length - 1 - i) * 2] = HexChars[value >> 4];
+            destination[(convertedBytes.Length - 1 - i) * 2 + 1] = HexChars[value & 0xF];
+        }
+
+        return true;
+    }
+
+    internal bool TryWriteBytes(Span<byte> destination)
+    {
+        if (destination.Length < sizeof(long))
+        {
+            return false;
+        }
+
+        for (var i = 0; i < sizeof(long); i++)
+        {
+            destination[i] = (byte)(_value >> ((sizeof(long) - 1 - i) * 8));
+        }
+
+        return true;
+    }
+
     /// <summary>
     /// Generates a new Sentry ID.
     /// </summary>
@@ -69,18 +105,8 @@ public readonly struct SpanId : IEquatable<SpanId>, ISentryJsonSerializable
     /// <inheritdoc />
     public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? _)
     {
-        Span<byte> convertedBytes = stackalloc byte[sizeof(long)];
-        Unsafe.As<byte, long>(ref convertedBytes[0]) = _value;
-
-        // Going backwards through the array to preserve the order of the output hex string (i.e. `4e76` -> `76e4`)
         Span<char> output = stackalloc char[16];
-        for (var i = convertedBytes.Length - 1; i >= 0; i--)
-        {
-            var value = convertedBytes[i];
-            output[(convertedBytes.Length - 1 - i) * 2] = HexChars[value >> 4];
-            output[(convertedBytes.Length - 1 - i) * 2 + 1] = HexChars[value & 0xF];
-        }
-
+        TryFormat(output);
         writer.WriteStringValue(output);
     }
 

--- a/src/Sentry/SpanId.cs
+++ b/src/Sentry/SpanId.cs
@@ -8,6 +8,10 @@ namespace Sentry;
 /// </summary>
 public readonly struct SpanId : IEquatable<SpanId>, ISentryJsonSerializable
 {
+    private const int ByteCount = sizeof(long);
+    private const int HexCharsPerByte = 2;
+    private const int HexCharCount = ByteCount * HexCharsPerByte;
+
     private static readonly char[] HexChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
     private static readonly RandomValuesFactory Random = new SynchronizedRandomValuesFactory();
 
@@ -41,16 +45,16 @@ public readonly struct SpanId : IEquatable<SpanId>, ISentryJsonSerializable
     public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(_value);
 
     /// <inheritdoc />
-    public override string ToString() => _value.ToString("x8").PadLeft(16, '0');
+    public override string ToString() => _value.ToString("x8").PadLeft(HexCharCount, '0');
 
     internal bool TryFormat(Span<char> destination)
     {
-        if (destination.Length < 16)
+        if (destination.Length < HexCharCount)
         {
             return false;
         }
 
-        Span<byte> convertedBytes = stackalloc byte[sizeof(long)];
+        Span<byte> convertedBytes = stackalloc byte[ByteCount];
         Unsafe.As<byte, long>(ref convertedBytes[0]) = _value;
 
         // Going backwards through the array to preserve the order of the output hex string (i.e. `4e76` -> `76e4`)
@@ -66,14 +70,14 @@ public readonly struct SpanId : IEquatable<SpanId>, ISentryJsonSerializable
 
     internal bool TryWriteBytes(Span<byte> destination)
     {
-        if (destination.Length < sizeof(long))
+        if (destination.Length < ByteCount)
         {
             return false;
         }
 
-        for (var i = 0; i < sizeof(long); i++)
+        for (var i = 0; i < ByteCount; i++)
         {
-            destination[i] = (byte)(_value >> ((sizeof(long) - 1 - i) * 8));
+            destination[i] = (byte)(_value >> ((ByteCount - 1 - i) * 8));
         }
 
         return true;
@@ -85,9 +89,9 @@ public readonly struct SpanId : IEquatable<SpanId>, ISentryJsonSerializable
     public static SpanId Create()
     {
 #if NETSTANDARD2_0 || NET462
-        byte[] buf = new byte[8];
+        byte[] buf = new byte[ByteCount];
 #else
-        Span<byte> buf = stackalloc byte[8];
+        Span<byte> buf = stackalloc byte[ByteCount];
 #endif
 
         Random.NextBytes(buf);
@@ -105,7 +109,7 @@ public readonly struct SpanId : IEquatable<SpanId>, ISentryJsonSerializable
     /// <inheritdoc />
     public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? _)
     {
-        Span<char> output = stackalloc char[16];
+        Span<char> output = stackalloc char[HexCharCount];
         TryFormat(output);
         writer.WriteStringValue(output);
     }

--- a/test/Sentry.OpenTelemetry.Exporter.Tests/ActivityExtensionsTests.cs
+++ b/test/Sentry.OpenTelemetry.Exporter.Tests/ActivityExtensionsTests.cs
@@ -55,6 +55,19 @@ public class ActivityExtensionsTests
     }
 
     [Fact]
+    public void AsActivitySpanId_WithHighBitValue_ConvertsCorrectly()
+    {
+        // Arrange
+        var sentrySpanId = SpanId.Parse("a1b2c3d4e5f6a7b8");
+
+        // Act
+        var activitySpanId = sentrySpanId.AsActivitySpanId();
+
+        // Assert
+        activitySpanId.ToHexString().Should().Be("a1b2c3d4e5f6a7b8");
+    }
+
+    [Fact]
     public void AsSentryId_WithActivityTraceId_ConvertsCorrectly()
     {
         // Arrange
@@ -91,5 +104,18 @@ public class ActivityExtensionsTests
 
         // Assert
         roundTripped.Should().Be(original);
+    }
+
+    [Fact]
+    public void AsActivityTraceId_WithFixedValue_ConvertsCorrectly()
+    {
+        // Arrange
+        var sentryId = SentryId.Parse("5bd5f6d346b442dd9177dce9302fd737");
+
+        // Act
+        var activityTraceId = sentryId.AsActivityTraceId();
+
+        // Assert
+        activityTraceId.ToHexString().Should().Be("5bd5f6d346b442dd9177dce9302fd737");
     }
 }

--- a/test/Sentry.OpenTelemetry.Exporter.Tests/ActivityExtensionsTests.cs
+++ b/test/Sentry.OpenTelemetry.Exporter.Tests/ActivityExtensionsTests.cs
@@ -118,4 +118,21 @@ public class ActivityExtensionsTests
         // Assert
         activityTraceId.ToHexString().Should().Be("5bd5f6d346b442dd9177dce9302fd737");
     }
+
+    [Fact]
+    public void SentryIdTryFormat_OutputIsAcceptedByActivityTraceId()
+    {
+        // Arrange
+        var sentryId = SentryId.Parse("5bd5f6d346b442dd9177dce9302fd737");
+        Span<char> buffer = stackalloc char[32];
+
+        // Act
+        var formatted = sentryId.TryFormat(buffer);
+        var activityTraceId = ActivityTraceId.CreateFromString(buffer);
+
+        // Assert
+        formatted.Should().BeTrue();
+        buffer.ToString().Should().Be("5bd5f6d346b442dd9177dce9302fd737");
+        activityTraceId.ToHexString().Should().Be("5bd5f6d346b442dd9177dce9302fd737");
+    }
 }

--- a/test/Sentry.OpenTelemetry.Exporter.Tests/ActivityExtensionsTests.cs
+++ b/test/Sentry.OpenTelemetry.Exporter.Tests/ActivityExtensionsTests.cs
@@ -124,7 +124,7 @@ public class ActivityExtensionsTests
     {
         // Arrange
         var sentryId = SentryId.Parse("5bd5f6d346b442dd9177dce9302fd737");
-        Span<char> buffer = stackalloc char[32];
+        Span<char> buffer = stackalloc char[ActivityExtensions.TraceIdHexCharCount];
 
         // Act
         var formatted = sentryId.TryFormat(buffer);


### PR DESCRIPTION
Fixes #4289.

#skip-changelog

## Summary

- Add internal span/byte formatting helpers for `SpanId` and `SentryId`.
- Convert Sentry IDs to OpenTelemetry `Activity*Id` values with stackallocated byte buffers on `net8.0+`, avoiding the intermediate `ToString()` allocation.
- Keep stackallocated char-buffer fallbacks for legacy target frameworks.
- Add explicit fixed-value conversion coverage for high-bit span IDs and trace IDs.

## Verification

- `dotnet test /home/sean/.cache/codex/oss-contrib/sentry-dotnet-otel-alloc/test/Sentry.OpenTelemetry.Exporter.Tests/Sentry.OpenTelemetry.Exporter.Tests.csproj --framework net10.0 --no-restore /p:MSBuildEnableWorkloadResolver=false /p:WorkloadList=none /p:NO_MOBILE=true`
- `dotnet build /home/sean/.cache/codex/oss-contrib/sentry-dotnet-otel-alloc/src/Sentry.OpenTelemetry.Exporter/Sentry.OpenTelemetry.Exporter.csproj --framework netstandard2.0 --no-restore /p:MSBuildEnableWorkloadResolver=false /p:WorkloadList=none /p:NO_MOBILE=true`
- `dotnet build /home/sean/.cache/codex/oss-contrib/sentry-dotnet-otel-alloc/src/Sentry.OpenTelemetry.Exporter/Sentry.OpenTelemetry.Exporter.csproj --framework net462 --no-restore /p:MSBuildEnableWorkloadResolver=false /p:WorkloadList=none /p:NO_MOBILE=true`
- `git diff --check`

AI assistance: This PR was prepared with OpenAI Codex.
