### PR TITLE
feat: add TagList overload to Metrics-Emit APIs as Attributes parameter

### DIFF
--- a/benchmarks/Sentry.Benchmarks/BenchmarkDotNet.Artifacts/results/Sentry.Benchmarks.SentryMetricEmitterBenchmarks-report-github.md
+++ b/benchmarks/Sentry.Benchmarks/BenchmarkDotNet.Artifacts/results/Sentry.Benchmarks.SentryMetricEmitterBenchmarks-report-github.md
@@ -1,0 +1,16 @@
+```
+
+BenchmarkDotNet v0.13.12, macOS 26.4.1 (25E253) [Darwin 25.4.0]
+Apple M3 Pro, 1 CPU, 12 logical and 12 physical cores
+.NET SDK 10.0.203
+  [Host]     : .NET 9.0.8 (9.0.825.36511), Arm64 RyuJIT AdvSIMD
+  DefaultJob : .NET 9.0.8 (9.0.825.36511), Arm64 RyuJIT AdvSIMD
+
+
+```
+| Method                        | Mean      | Error    | StdDev   | Gen0   | Gen1   | Allocated |
+|------------------------------ |----------:|---------:|---------:|-------:|-------:|----------:|
+| EmitWithoutAttributes         |  99.82 ns | 1.894 ns | 1.945 ns | 0.0640 | 0.0001 |     536 B |
+| EmitWithAttributes_Enumerable | 148.19 ns | 0.544 ns | 0.454 ns | 0.0851 |      - |     712 B |
+| EmitWithAttributes_Span       | 127.01 ns | 0.300 ns | 0.266 ns | 0.0706 | 0.0002 |     592 B |
+| EmitWithAttributes_TagList    | 134.64 ns | 1.935 ns | 1.715 ns | 0.0706 | 0.0002 |     592 B |

--- a/benchmarks/Sentry.Benchmarks/SentryMetricEmitterBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/SentryMetricEmitterBenchmarks.cs
@@ -1,0 +1,84 @@
+#nullable enable
+
+using BenchmarkDotNet.Attributes;
+using Sentry.Extensibility;
+using Sentry.Internal;
+using Sentry.Testing;
+
+namespace Sentry.Benchmarks;
+
+public class SentryMetricEmitterBenchmarks
+{
+    private Hub _hub = null!;
+    private SentryMetricEmitter _metrics = null!;
+
+    private SentryMetric? _lastMetric;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        SentryOptions options = new()
+        {
+            Dsn = DsnSamples.ValidDsn,
+            EnableMetrics = true,
+        };
+        options.SetBeforeSendMetric((SentryMetric metric) =>
+        {
+            _lastMetric = metric;
+            return null;
+        });
+
+        MockClock clock = new(new DateTimeOffset(2025, 04, 22, 14, 51, 00, 789, TimeSpan.FromHours(2)));
+
+        _hub = new Hub(options, DisabledHub.Instance);
+        _metrics = SentryMetricEmitter.Create(_hub, options, clock);
+    }
+
+    [Benchmark]
+    public void EmitWithoutAttributes()
+    {
+        _metrics.EmitGauge("sentry_benchmarks.sentry_trace_metrics_tests.gauge", 1);
+    }
+
+    [Benchmark]
+    public void EmitWithAttributes_Enumerable()
+    {
+        IEnumerable<KeyValuePair<string, object>> attributes = new List<KeyValuePair<string, object>>(1)
+        {
+            KeyValuePair.Create<string, object>("attribute.key", "attribute-value"),
+        };
+        _metrics.EmitGauge("sentry_benchmarks.sentry_trace_metrics_tests.gauge", 1, MeasurementUnit.Information.Bit, attributes);
+    }
+
+    [Benchmark]
+    public void EmitWithAttributes_Span()
+    {
+        ReadOnlySpan<KeyValuePair<string, object>> attributes =
+        [
+            KeyValuePair.Create<string, object>("attribute.key", "attribute-value"),
+        ];
+        _metrics.EmitGauge("sentry_benchmarks.sentry_trace_metrics_tests.gauge", 1, MeasurementUnit.Information.Bit, attributes);
+    }
+
+    [Benchmark]
+    public void EmitWithAttributes_TagList()
+    {
+        TagList attributes = new()
+        {
+            { "attribute.key", "attribute-value" },
+        };
+        _metrics.EmitGauge("sentry_benchmarks.sentry_trace_metrics_tests.gauge", 1, MeasurementUnit.Information.Bit, in attributes);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        (_metrics as IDisposable)?.Dispose();
+        _hub.Dispose();
+
+        if (_lastMetric is null)
+        {
+            throw new InvalidOperationException("Last Metric is null");
+        }
+    }
+}

--- a/samples/Sentry.Samples.AspNetCore.Basic/Program.cs
+++ b/samples/Sentry.Samples.AspNetCore.Basic/Program.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.WebHost.UseSentry(options =>
@@ -73,7 +75,33 @@ app.Use(async (context, next) =>
         span.Finish(e);
         throw;
     }
-    await next();
+
+    var timestamp = Stopwatch.GetTimestamp();
+    TagList attributes = new()
+    {
+        { "request.scheme", context.Request.Scheme },
+        { "request.method", context.Request.Method },
+    };
+    if (context.Request.Path.HasValue)
+    {
+        attributes.Add("request.route", context.Request.Path.Value);
+    }
+
+    try
+    {
+        await next();
+    }
+    catch (Exception exception)
+    {
+        attributes.Add("exception.message", exception.Message);
+        attributes.Add("exception.type", exception.GetType().FullName);
+        throw;
+    }
+    finally
+    {
+        var elapsed = Stopwatch.GetElapsedTime(timestamp);
+        SentrySdk.Metrics.EmitDistribution("http.server.request.duration", elapsed.TotalSeconds, MeasurementUnit.Duration.Second, attributes);
+    }
 });
 
 app.Run();

--- a/samples/Sentry.Samples.AspNetCore.Basic/Properties/launchSettings.json
+++ b/samples/Sentry.Samples.AspNetCore.Basic/Properties/launchSettings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
@@ -18,7 +19,8 @@
     },
     "Sentry.Samples.AspNetCore.Basic": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
       "launchUrl": "throw",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/samples/Sentry.Samples.AspNetCore.Basic/Sentry.Samples.AspNetCore.Basic.http
+++ b/samples/Sentry.Samples.AspNetCore.Basic/Sentry.Samples.AspNetCore.Basic.http
@@ -5,7 +5,7 @@ Accept: application/json
 
 ###
 
-GET {{HostAddress}}/throw/error-message/
+GET {{HostAddress}}/throw/sample error message/
 Accept: application/json
 
 ###

--- a/samples/Sentry.Samples.AspNetCore.Basic/Sentry.Samples.AspNetCore.Basic.http
+++ b/samples/Sentry.Samples.AspNetCore.Basic/Sentry.Samples.AspNetCore.Basic.http
@@ -1,0 +1,16 @@
+@HostAddress = http://localhost:59740
+
+GET {{HostAddress}}/throw/
+Accept: application/json
+
+###
+
+GET {{HostAddress}}/throw/error-message/
+Accept: application/json
+
+###
+
+GET {{HostAddress}}/not-found/
+Accept: application/json
+
+###

--- a/src/Sentry/Internal/DefaultSentryMetricEmitter.cs
+++ b/src/Sentry/Internal/DefaultSentryMetricEmitter.cs
@@ -61,6 +61,27 @@ internal sealed class DefaultSentryMetricEmitter : SentryMetricEmitter, IDisposa
         CaptureMetric(metric);
     }
 
+#if NET6_0_OR_GREATER
+    /// <inheritdoc />
+    private protected override void CaptureMetric<T>(SentryMetricType type, string name, T value, string? unit, in TagList attributes, Scope? scope) where T : struct
+    {
+        if (!SentryMetric.IsSupported(typeof(T)))
+        {
+            _options.DiagnosticLogger?.LogWarning("{0} is unsupported type for Sentry Metrics. The only supported types are byte, short, int, long, float, and double.", typeof(T));
+            return;
+        }
+
+        if (string.IsNullOrEmpty(name))
+        {
+            _options.DiagnosticLogger?.LogWarning("Name of metrics cannot be null or empty. Metric-Type: {0}; Value-Type: {1}", type.ToString(), typeof(T));
+            return;
+        }
+
+        var metric = SentryMetric.Create(_hub, _options, _clock, type, name, value, unit, in attributes, scope);
+        CaptureMetric(metric);
+    }
+#endif
+
     /// <inheritdoc />
     private protected override void CaptureMetric<T>(SentryMetric<T> metric) where T : struct
     {

--- a/src/Sentry/Internal/DisabledSentryMetricEmitter.cs
+++ b/src/Sentry/Internal/DisabledSentryMetricEmitter.cs
@@ -20,6 +20,14 @@ internal sealed class DisabledSentryMetricEmitter : SentryMetricEmitter
         // disabled
     }
 
+#if NET6_0_OR_GREATER
+    /// <inheritdoc />
+    private protected override void CaptureMetric<T>(SentryMetricType type, string name, T value, string? unit, in TagList attributes, Scope? scope) where T : struct
+    {
+        // disabled
+    }
+#endif
+
     /// <inheritdoc />
     private protected override void CaptureMetric<T>(SentryMetric<T> metric) where T : struct
     {

--- a/src/Sentry/Protocol/SentryAttributes.cs
+++ b/src/Sentry/Protocol/SentryAttributes.cs
@@ -155,6 +155,27 @@ internal class SentryAttributes : Dictionary<string, SentryAttribute>, ISentryJs
         }
     }
 
+#if NET6_0_OR_GREATER
+    [SuppressMessage("Roslynator", "RCS1242:Do not pass non-read-only struct by read-only reference", Justification = $"Ensure that only readonly instance members of {nameof(TagList)} are invoked, to avoid a defensive copy created by the compiler.")]
+    internal void SetAttributes(in TagList attributes)
+    {
+        if (attributes.Count == 0)
+        {
+            return;
+        }
+
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        _ = EnsureCapacity(Count + attributes.Count);
+#endif
+
+        for (var index = 0; index < attributes.Count; index++)
+        {
+            var attribute = attributes[index];
+            this[attribute.Key] = new SentryAttribute(attribute.Value!);
+        }
+    }
+#endif
+
     /// <inheritdoc cref="ISentryJsonSerializable.WriteTo(Utf8JsonWriter, IDiagnosticLogger)" />
     public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? logger)
     {

--- a/src/Sentry/SentryMetric.Factory.cs
+++ b/src/Sentry/SentryMetric.Factory.cs
@@ -39,6 +39,16 @@ public abstract partial class SentryMetric
         return metric;
     }
 
+#if NET6_0_OR_GREATER
+    [SuppressMessage("Roslynator", "RCS1242:Do not pass non-read-only struct by read-only reference", Justification = $"Ensure that only readonly instance members of {nameof(TagList)} are invoked, to avoid a defensive copy created by the compiler.")]
+    internal static SentryMetric<T> Create<T>(IHub hub, SentryOptions options, ISystemClock clock, SentryMetricType type, string name, T value, string? unit, in TagList attributes, Scope? scope) where T : struct
+    {
+        var metric = CreateCore<T>(hub, options, clock, type, name, value, unit, scope);
+        metric.Attributes.SetAttributes(in attributes);
+        return metric;
+    }
+#endif
+
     private static bool IsSupported<T>() where T : struct
     {
         var valueType = typeof(T);

--- a/src/Sentry/SentryMetricEmitter.Counter.cs
+++ b/src/Sentry/SentryMetricEmitter.Counter.cs
@@ -54,4 +54,21 @@ public abstract partial class SentryMetricEmitter
     {
         CaptureMetric(SentryMetricType.Counter, name, value, null, attributes, scope);
     }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Increment a counter.
+    /// </summary>
+    /// <param name="name">The name of the metric.</param>
+    /// <param name="value">The value of the metric.</param>
+    /// <param name="attributes">A dictionary of attributes (key-value pairs with type information).</param>
+    /// <param name="scope">The scope to capture the metric with.</param>
+    /// <typeparam name="T">The numeric type of the metric.</typeparam>
+    /// <remarks>Supported numeric value types for <typeparamref name="T"/> are <see langword="byte"/>, <see langword="short"/>, <see langword="int"/>, <see langword="long"/>, <see langword="float"/>, and <see langword="double"/>.</remarks>
+    [SuppressMessage("Roslynator", "RCS1242:Do not pass non-read-only struct by read-only reference", Justification = $"Ensure that only readonly instance members of {nameof(TagList)} are invoked, to avoid a defensive copy created by the compiler.")]
+    public void EmitCounter<T>(string name, T value, in TagList attributes, Scope? scope = null) where T : struct
+    {
+        CaptureMetric(SentryMetricType.Counter, name, value, null, in attributes, scope);
+    }
+#endif
 }

--- a/src/Sentry/SentryMetricEmitter.Distribution.cs
+++ b/src/Sentry/SentryMetricEmitter.Distribution.cs
@@ -23,6 +23,7 @@ public abstract partial class SentryMetricEmitter
     /// <typeparam name="T">The numeric type of the metric.</typeparam>
     /// <remarks>Supported numeric value types for <typeparamref name="T"/> are <see langword="byte"/>, <see langword="short"/>, <see langword="int"/>, <see langword="long"/>, <see langword="float"/>, and <see langword="double"/>.</remarks>
     [Obsolete(ObsoleteStringUnitForwardCompatibility)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void EmitDistribution<T>(string name, T value, string? unit) where T : struct
     {
         CaptureMetric(SentryMetricType.Distribution, name, value, unit, [], null);
@@ -64,11 +65,11 @@ public abstract partial class SentryMetricEmitter
     /// <typeparam name="T">The numeric type of the metric.</typeparam>
     /// <remarks>Supported numeric value types for <typeparamref name="T"/> are <see langword="byte"/>, <see langword="short"/>, <see langword="int"/>, <see langword="long"/>, <see langword="float"/>, and <see langword="double"/>.</remarks>
     [Obsolete(ObsoleteStringUnitForwardCompatibility)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void EmitDistribution<T>(string name, T value, string? unit, Scope? scope) where T : struct
     {
         CaptureMetric(SentryMetricType.Distribution, name, value, unit, [], scope);
     }
-
 
     /// <summary>
     /// Add a distribution value.
@@ -84,8 +85,6 @@ public abstract partial class SentryMetricEmitter
         CaptureMetric(SentryMetricType.Distribution, name, value, unit.ToNullableString(), [], scope);
     }
 
-
-
     /// <summary>
     /// Add a distribution value.
     /// </summary>
@@ -97,6 +96,7 @@ public abstract partial class SentryMetricEmitter
     /// <typeparam name="T">The numeric type of the metric.</typeparam>
     /// <remarks>Supported numeric value types for <typeparamref name="T"/> are <see langword="byte"/>, <see langword="short"/>, <see langword="int"/>, <see langword="long"/>, <see langword="float"/>, and <see langword="double"/>.</remarks>
     [Obsolete(ObsoleteStringUnitForwardCompatibility)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void EmitDistribution<T>(string name, T value, string? unit, IEnumerable<KeyValuePair<string, object>>? attributes, Scope? scope = null) where T : struct
     {
         CaptureMetric(SentryMetricType.Distribution, name, value, unit, attributes, scope);
@@ -128,6 +128,7 @@ public abstract partial class SentryMetricEmitter
     /// <typeparam name="T">The numeric type of the metric.</typeparam>
     /// <remarks>Supported numeric value types for <typeparamref name="T"/> are <see langword="byte"/>, <see langword="short"/>, <see langword="int"/>, <see langword="long"/>, <see langword="float"/>, and <see langword="double"/>.</remarks>
     [Obsolete(ObsoleteStringUnitForwardCompatibility)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void EmitDistribution<T>(string name, T value, string? unit, ReadOnlySpan<KeyValuePair<string, object>> attributes, Scope? scope = null) where T : struct
     {
         CaptureMetric(SentryMetricType.Distribution, name, value, unit, attributes, scope);
@@ -147,4 +148,42 @@ public abstract partial class SentryMetricEmitter
     {
         CaptureMetric(SentryMetricType.Distribution, name, value, unit.ToNullableString(), attributes, scope);
     }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Add a distribution value.
+    /// </summary>
+    /// <param name="name">The name of the metric.</param>
+    /// <param name="value">The value of the metric.</param>
+    /// <param name="unit">The unit of measurement.</param>
+    /// <param name="attributes">A dictionary of attributes (key-value pairs with type information).</param>
+    /// <param name="scope">The scope to capture the metric with.</param>
+    /// <typeparam name="T">The numeric type of the metric.</typeparam>
+    /// <remarks>Supported numeric value types for <typeparamref name="T"/> are <see langword="byte"/>, <see langword="short"/>, <see langword="int"/>, <see langword="long"/>, <see langword="float"/>, and <see langword="double"/>.</remarks>
+    [Obsolete(ObsoleteStringUnitForwardCompatibility)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [SuppressMessage("Roslynator", "RCS1242:Do not pass non-read-only struct by read-only reference", Justification = $"Ensure that only readonly instance members of {nameof(TagList)} are invoked, to avoid a defensive copy created by the compiler.")]
+    public void EmitDistribution<T>(string name, T value, string? unit, in TagList attributes, Scope? scope = null) where T : struct
+    {
+        CaptureMetric(SentryMetricType.Distribution, name, value, unit, in attributes, scope);
+    }
+#endif
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Add a distribution value.
+    /// </summary>
+    /// <param name="name">The name of the metric.</param>
+    /// <param name="value">The value of the metric.</param>
+    /// <param name="unit">The unit of measurement.</param>
+    /// <param name="attributes">A dictionary of attributes (key-value pairs with type information).</param>
+    /// <param name="scope">The scope to capture the metric with.</param>
+    /// <typeparam name="T">The numeric type of the metric.</typeparam>
+    /// <remarks>Supported numeric value types for <typeparamref name="T"/> are <see langword="byte"/>, <see langword="short"/>, <see langword="int"/>, <see langword="long"/>, <see langword="float"/>, and <see langword="double"/>.</remarks>
+    [SuppressMessage("Roslynator", "RCS1242:Do not pass non-read-only struct by read-only reference", Justification = $"Ensure that only readonly instance members of {nameof(TagList)} are invoked, to avoid a defensive copy created by the compiler.")]
+    public void EmitDistribution<T>(string name, T value, MeasurementUnit unit, in TagList attributes, Scope? scope = null) where T : struct
+    {
+        CaptureMetric(SentryMetricType.Distribution, name, value, unit.ToNullableString(), in attributes, scope);
+    }
+#endif
 }

--- a/src/Sentry/SentryMetricEmitter.Gauge.cs
+++ b/src/Sentry/SentryMetricEmitter.Gauge.cs
@@ -23,6 +23,7 @@ public abstract partial class SentryMetricEmitter
     /// <typeparam name="T">The numeric type of the metric.</typeparam>
     /// <remarks>Supported numeric value types for <typeparamref name="T"/> are <see langword="byte"/>, <see langword="short"/>, <see langword="int"/>, <see langword="long"/>, <see langword="float"/>, and <see langword="double"/>.</remarks>
     [Obsolete(ObsoleteStringUnitForwardCompatibility)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void EmitGauge<T>(string name, T value, string? unit) where T : struct
     {
         CaptureMetric(SentryMetricType.Gauge, name, value, unit, [], null);
@@ -64,6 +65,7 @@ public abstract partial class SentryMetricEmitter
     /// <typeparam name="T">The numeric type of the metric.</typeparam>
     /// <remarks>Supported numeric value types for <typeparamref name="T"/> are <see langword="byte"/>, <see langword="short"/>, <see langword="int"/>, <see langword="long"/>, <see langword="float"/>, and <see langword="double"/>.</remarks>
     [Obsolete(ObsoleteStringUnitForwardCompatibility)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void EmitGauge<T>(string name, T value, string? unit, Scope? scope) where T : struct
     {
         CaptureMetric(SentryMetricType.Gauge, name, value, unit, [], scope);
@@ -94,6 +96,7 @@ public abstract partial class SentryMetricEmitter
     /// <typeparam name="T">The numeric type of the metric.</typeparam>
     /// <remarks>Supported numeric value types for <typeparamref name="T"/> are <see langword="byte"/>, <see langword="short"/>, <see langword="int"/>, <see langword="long"/>, <see langword="float"/>, and <see langword="double"/>.</remarks>
     [Obsolete(ObsoleteStringUnitForwardCompatibility)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void EmitGauge<T>(string name, T value, string? unit, IEnumerable<KeyValuePair<string, object>>? attributes, Scope? scope = null) where T : struct
     {
         CaptureMetric(SentryMetricType.Gauge, name, value, unit, attributes, scope);
@@ -125,6 +128,7 @@ public abstract partial class SentryMetricEmitter
     /// <typeparam name="T">The numeric type of the metric.</typeparam>
     /// <remarks>Supported numeric value types for <typeparamref name="T"/> are <see langword="byte"/>, <see langword="short"/>, <see langword="int"/>, <see langword="long"/>, <see langword="float"/>, and <see langword="double"/>.</remarks>
     [Obsolete(ObsoleteStringUnitForwardCompatibility)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void EmitGauge<T>(string name, T value, string? unit, ReadOnlySpan<KeyValuePair<string, object>> attributes, Scope? scope = null) where T : struct
     {
         CaptureMetric(SentryMetricType.Gauge, name, value, unit, attributes, scope);
@@ -144,4 +148,42 @@ public abstract partial class SentryMetricEmitter
     {
         CaptureMetric(SentryMetricType.Gauge, name, value, unit.ToNullableString(), attributes, scope);
     }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Set a gauge value.
+    /// </summary>
+    /// <param name="name">The name of the metric.</param>
+    /// <param name="value">The value of the metric.</param>
+    /// <param name="unit">The unit of measurement.</param>
+    /// <param name="attributes">A dictionary of attributes (key-value pairs with type information).</param>
+    /// <param name="scope">The scope to capture the metric with.</param>
+    /// <typeparam name="T">The numeric type of the metric.</typeparam>
+    /// <remarks>Supported numeric value types for <typeparamref name="T"/> are <see langword="byte"/>, <see langword="short"/>, <see langword="int"/>, <see langword="long"/>, <see langword="float"/>, and <see langword="double"/>.</remarks>
+    [Obsolete(ObsoleteStringUnitForwardCompatibility)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [SuppressMessage("Roslynator", "RCS1242:Do not pass non-read-only struct by read-only reference", Justification = $"Ensure that only readonly instance members of {nameof(TagList)} are invoked, to avoid a defensive copy created by the compiler.")]
+    public void EmitGauge<T>(string name, T value, string? unit, in TagList attributes, Scope? scope = null) where T : struct
+    {
+        CaptureMetric(SentryMetricType.Gauge, name, value, unit, in attributes, scope);
+    }
+#endif
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Set a gauge value.
+    /// </summary>
+    /// <param name="name">The name of the metric.</param>
+    /// <param name="value">The value of the metric.</param>
+    /// <param name="unit">The unit of measurement.</param>
+    /// <param name="attributes">A dictionary of attributes (key-value pairs with type information).</param>
+    /// <param name="scope">The scope to capture the metric with.</param>
+    /// <typeparam name="T">The numeric type of the metric.</typeparam>
+    /// <remarks>Supported numeric value types for <typeparamref name="T"/> are <see langword="byte"/>, <see langword="short"/>, <see langword="int"/>, <see langword="long"/>, <see langword="float"/>, and <see langword="double"/>.</remarks>
+    [SuppressMessage("Roslynator", "RCS1242:Do not pass non-read-only struct by read-only reference", Justification = $"Ensure that only readonly instance members of {nameof(TagList)} are invoked, to avoid a defensive copy created by the compiler.")]
+    public void EmitGauge<T>(string name, T value, MeasurementUnit unit, in TagList attributes, Scope? scope = null) where T : struct
+    {
+        CaptureMetric(SentryMetricType.Gauge, name, value, unit.ToNullableString(), in attributes, scope);
+    }
+#endif
 }

--- a/src/Sentry/SentryMetricEmitter.cs
+++ b/src/Sentry/SentryMetricEmitter.cs
@@ -48,6 +48,21 @@ public abstract partial class SentryMetricEmitter
     /// <typeparam name="T">The numeric type of the metric.</typeparam>
     private protected abstract void CaptureMetric<T>(SentryMetricType type, string name, T value, string? unit, ReadOnlySpan<KeyValuePair<string, object>> attributes, Scope? scope) where T : struct;
 
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Buffers a <see href="https://develop.sentry.dev/sdk/telemetry/metrics/">Sentry Metric</see> item
+    /// via the associated <see href="https://develop.sentry.dev/sdk/telemetry/telemetry-processor/batch-processor/">Batch Processor</see>.
+    /// </summary>
+    /// <param name="type">The type of metric.</param>
+    /// <param name="name">The name of the metric.</param>
+    /// <param name="value">The numeric value of the metric.</param>
+    /// <param name="unit">The unit of measurement for the metric value.</param>
+    /// <param name="attributes">A dictionary of key-value pairs of arbitrary data attached to the metric.</param>
+    /// <param name="scope">The optional scope to capture the metric with.</param>
+    /// <typeparam name="T">The numeric type of the metric.</typeparam>
+    private protected abstract void CaptureMetric<T>(SentryMetricType type, string name, T value, string? unit, in TagList attributes, Scope? scope) where T : struct;
+#endif
+
     /// <summary>
     /// Buffers a <see href="https://develop.sentry.dev/sdk/telemetry/metrics/">Sentry Metric</see> item
     /// via the associated <see href="https://develop.sentry.dev/sdk/telemetry/telemetry-processor/batch-processor/">Batch Processor</see>.

--- a/test/Sentry.Testing/InMemorySentryMetricEmitter.cs
+++ b/test/Sentry.Testing/InMemorySentryMetricEmitter.cs
@@ -19,6 +19,14 @@ public sealed class InMemorySentryMetricEmitter : SentryMetricEmitter
         Entries.Add(MetricEntry.Create(type, name, value, unit, attributes.ToArray(), scope));
     }
 
+#if NET6_0_OR_GREATER
+    /// <inheritdoc />
+    private protected override void CaptureMetric<T>(SentryMetricType type, string name, T value, string? unit, in TagList attributes, Scope? scope) where T : struct
+    {
+        Entries.Add(MetricEntry.Create(type, name, value, unit, attributes, scope));
+    }
+#endif
+
     /// <inheritdoc />
     private protected override void CaptureMetric<T>(SentryMetric<T> metric) where T : struct
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -688,6 +688,8 @@ namespace Sentry
             where T :  struct { }
         public void EmitCounter<T>(string name, T value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
             where T :  struct { }
+        public void EmitCounter<T>(string name, T value, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
         public void EmitDistribution<T>(string name, T value)
             where T :  struct { }
         public void EmitDistribution<T>(string name, T value, Sentry.MeasurementUnit unit)
@@ -710,6 +712,8 @@ namespace Sentry
             where T :  struct { }
         public void EmitDistribution<T>(string name, T value, Sentry.MeasurementUnit unit, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
             where T :  struct { }
+        public void EmitDistribution<T>(string name, T value, Sentry.MeasurementUnit unit, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
         [System.Obsolete("Custom units may be supported in the future. The String-based overloads are for f" +
             "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
             "d.")]
@@ -719,6 +723,11 @@ namespace Sentry
             "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
             "d.")]
         public void EmitDistribution<T>(string name, T value, string? unit, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
+        [System.Obsolete("Custom units may be supported in the future. The String-based overloads are for f" +
+            "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
+            "d.")]
+        public void EmitDistribution<T>(string name, T value, string? unit, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
             where T :  struct { }
         public void EmitGauge<T>(string name, T value)
             where T :  struct { }
@@ -742,6 +751,8 @@ namespace Sentry
             where T :  struct { }
         public void EmitGauge<T>(string name, T value, Sentry.MeasurementUnit unit, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
             where T :  struct { }
+        public void EmitGauge<T>(string name, T value, Sentry.MeasurementUnit unit, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
         [System.Obsolete("Custom units may be supported in the future. The String-based overloads are for f" +
             "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
             "d.")]
@@ -751,6 +762,11 @@ namespace Sentry
             "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
             "d.")]
         public void EmitGauge<T>(string name, T value, string? unit, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
+        [System.Obsolete("Custom units may be supported in the future. The String-based overloads are for f" +
+            "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
+            "d.")]
+        public void EmitGauge<T>(string name, T value, string? unit, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
             where T :  struct { }
         protected abstract void Flush();
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -688,6 +688,8 @@ namespace Sentry
             where T :  struct { }
         public void EmitCounter<T>(string name, T value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
             where T :  struct { }
+        public void EmitCounter<T>(string name, T value, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
         public void EmitDistribution<T>(string name, T value)
             where T :  struct { }
         public void EmitDistribution<T>(string name, T value, Sentry.MeasurementUnit unit)
@@ -710,6 +712,8 @@ namespace Sentry
             where T :  struct { }
         public void EmitDistribution<T>(string name, T value, Sentry.MeasurementUnit unit, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
             where T :  struct { }
+        public void EmitDistribution<T>(string name, T value, Sentry.MeasurementUnit unit, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
         [System.Obsolete("Custom units may be supported in the future. The String-based overloads are for f" +
             "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
             "d.")]
@@ -719,6 +723,11 @@ namespace Sentry
             "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
             "d.")]
         public void EmitDistribution<T>(string name, T value, string? unit, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
+        [System.Obsolete("Custom units may be supported in the future. The String-based overloads are for f" +
+            "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
+            "d.")]
+        public void EmitDistribution<T>(string name, T value, string? unit, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
             where T :  struct { }
         public void EmitGauge<T>(string name, T value)
             where T :  struct { }
@@ -742,6 +751,8 @@ namespace Sentry
             where T :  struct { }
         public void EmitGauge<T>(string name, T value, Sentry.MeasurementUnit unit, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
             where T :  struct { }
+        public void EmitGauge<T>(string name, T value, Sentry.MeasurementUnit unit, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
         [System.Obsolete("Custom units may be supported in the future. The String-based overloads are for f" +
             "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
             "d.")]
@@ -751,6 +762,11 @@ namespace Sentry
             "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
             "d.")]
         public void EmitGauge<T>(string name, T value, string? unit, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
+        [System.Obsolete("Custom units may be supported in the future. The String-based overloads are for f" +
+            "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
+            "d.")]
+        public void EmitGauge<T>(string name, T value, string? unit, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
             where T :  struct { }
         protected abstract void Flush();
     }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -688,6 +688,8 @@ namespace Sentry
             where T :  struct { }
         public void EmitCounter<T>(string name, T value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
             where T :  struct { }
+        public void EmitCounter<T>(string name, T value, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
         public void EmitDistribution<T>(string name, T value)
             where T :  struct { }
         public void EmitDistribution<T>(string name, T value, Sentry.MeasurementUnit unit)
@@ -710,6 +712,8 @@ namespace Sentry
             where T :  struct { }
         public void EmitDistribution<T>(string name, T value, Sentry.MeasurementUnit unit, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
             where T :  struct { }
+        public void EmitDistribution<T>(string name, T value, Sentry.MeasurementUnit unit, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
         [System.Obsolete("Custom units may be supported in the future. The String-based overloads are for f" +
             "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
             "d.")]
@@ -719,6 +723,11 @@ namespace Sentry
             "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
             "d.")]
         public void EmitDistribution<T>(string name, T value, string? unit, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
+        [System.Obsolete("Custom units may be supported in the future. The String-based overloads are for f" +
+            "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
+            "d.")]
+        public void EmitDistribution<T>(string name, T value, string? unit, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
             where T :  struct { }
         public void EmitGauge<T>(string name, T value)
             where T :  struct { }
@@ -742,6 +751,8 @@ namespace Sentry
             where T :  struct { }
         public void EmitGauge<T>(string name, T value, Sentry.MeasurementUnit unit, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
             where T :  struct { }
+        public void EmitGauge<T>(string name, T value, Sentry.MeasurementUnit unit, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
         [System.Obsolete("Custom units may be supported in the future. The String-based overloads are for f" +
             "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
             "d.")]
@@ -751,6 +762,11 @@ namespace Sentry
             "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
             "d.")]
         public void EmitGauge<T>(string name, T value, string? unit, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> attributes, Sentry.Scope? scope = null)
+            where T :  struct { }
+        [System.Obsolete("Custom units may be supported in the future. The String-based overloads are for f" +
+            "orward compatibility. The MeasurementUnit-based overloads are currently preferre" +
+            "d.")]
+        public void EmitGauge<T>(string name, T value, string? unit, in System.Diagnostics.TagList attributes, Sentry.Scope? scope = null)
             where T :  struct { }
         protected abstract void Flush();
     }

--- a/test/Sentry.Tests/Sentry.Tests.csproj
+++ b/test/Sentry.Tests/Sentry.Tests.csproj
@@ -39,7 +39,7 @@
       <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
       <DependentUpon>HintTests.cs</DependentUpon>
     </None>
-    <Compile Update="SentryMetricEmitterTests.Options.cs;SentryMetricEmitterTests.Types.cs;SentryMetricEmitterTests.Values.cs">
+    <Compile Update="SentryMetricEmitterTests.Attributes.cs;SentryMetricEmitterTests.Options.cs;SentryMetricEmitterTests.Types.cs;SentryMetricEmitterTests.Values.cs">
       <DependentUpon>SentryMetricEmitterTests.cs</DependentUpon>
     </Compile>
     <Compile Update="SentryStructuredLoggerTests.Format.cs">

--- a/test/Sentry.Tests/SentryMetricEmitterTests.Attributes.cs
+++ b/test/Sentry.Tests/SentryMetricEmitterTests.Attributes.cs
@@ -1,0 +1,132 @@
+#nullable enable
+
+namespace Sentry.Tests;
+
+public partial class SentryMetricEmitterTests
+{
+    [Theory]
+    [InlineData(SentryMetricType.Counter)]
+    [InlineData(SentryMetricType.Gauge)]
+    [InlineData(SentryMetricType.Distribution)]
+    public void Emit_WithAttributes_Enumerable(SentryMetricType type)
+    {
+        SentryMetric? captured = null;
+        _fixture.Options.SetBeforeSendMetric(SentryMetric? (SentryMetric metric) =>
+        {
+            captured = metric;
+            return null;
+        });
+        var metrics = _fixture.GetSut();
+
+        IEnumerable<KeyValuePair<string, object>>? attributes = [new KeyValuePair<string, object>("attribute.key", "attribute-value")];
+        metrics.Emit<int>(type, 1, attributes);
+
+        captured.Should().NotBeNull();
+        captured.Attributes.ShouldContain("attribute.key", "attribute-value");
+    }
+
+    [Theory]
+    [InlineData(SentryMetricType.Counter)]
+    [InlineData(SentryMetricType.Gauge)]
+    [InlineData(SentryMetricType.Distribution)]
+    public void Emit_WithAttributes_Span(SentryMetricType type)
+    {
+        SentryMetric? captured = null;
+        _fixture.Options.SetBeforeSendMetric(SentryMetric? (SentryMetric metric) =>
+        {
+            captured = metric;
+            return null;
+        });
+        var metrics = _fixture.GetSut();
+
+        ReadOnlySpan<KeyValuePair<string, object>> attributes = [new KeyValuePair<string, object>("attribute.key", "attribute-value")];
+        metrics.Emit<int>(type, 1, attributes);
+
+        captured.Should().NotBeNull();
+        captured.Attributes.ShouldContain("attribute.key", "attribute-value");
+    }
+
+#if NET6_0_OR_GREATER
+    [Theory]
+    [InlineData(SentryMetricType.Counter)]
+    [InlineData(SentryMetricType.Gauge)]
+    [InlineData(SentryMetricType.Distribution)]
+    public void Emit_WithAttributes_TagList(SentryMetricType type)
+    {
+        SentryMetric? captured = null;
+        _fixture.Options.SetBeforeSendMetric(SentryMetric? (SentryMetric metric) =>
+        {
+            captured = metric;
+            return null;
+        });
+        var metrics = _fixture.GetSut();
+
+        TagList attributes = new() { { "attribute.key", "attribute-value" } };
+        metrics.Emit<int>(type, 1, in attributes);
+
+        captured.Should().NotBeNull();
+        captured.Attributes.ShouldContain("attribute.key", "attribute-value");
+    }
+#endif
+}
+
+[Obsolete(SentryMetricEmitter.ObsoleteStringUnitForwardCompatibility)]
+file static class SentryMetricEmitterExtensions
+{
+    public static void Emit<T>(this SentryMetricEmitter metrics, SentryMetricType type, T value, IEnumerable<KeyValuePair<string, object>>? attributes) where T : struct
+    {
+        switch (type)
+        {
+            case SentryMetricType.Counter:
+                metrics.EmitCounter<T>("sentry_tests.sentry_trace_metrics_tests.counter", value, attributes);
+                break;
+            case SentryMetricType.Gauge:
+                metrics.EmitGauge<T>("sentry_tests.sentry_trace_metrics_tests.counter", value, "measurement_unit", attributes);
+                break;
+            case SentryMetricType.Distribution:
+                metrics.EmitDistribution<T>("sentry_tests.sentry_trace_metrics_tests.counter", value, "measurement_unit", attributes);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), type, null);
+        }
+    }
+
+    public static void Emit<T>(this SentryMetricEmitter metrics, SentryMetricType type, T value, ReadOnlySpan<KeyValuePair<string, object>> attributes) where T : struct
+    {
+        switch (type)
+        {
+            case SentryMetricType.Counter:
+                metrics.EmitCounter<T>("sentry_tests.sentry_trace_metrics_tests.counter", value, attributes);
+                break;
+            case SentryMetricType.Gauge:
+                metrics.EmitGauge<T>("sentry_tests.sentry_trace_metrics_tests.counter", value, "measurement_unit", attributes);
+                break;
+            case SentryMetricType.Distribution:
+                metrics.EmitDistribution<T>("sentry_tests.sentry_trace_metrics_tests.counter", value, "measurement_unit", attributes);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), type, null);
+        }
+    }
+
+#if NET6_0_OR_GREATER
+    [SuppressMessage("Roslynator", "RCS1242:Do not pass non-read-only struct by read-only reference", Justification = $"Ensure that only readonly instance members of {nameof(TagList)} are invoked, to avoid a defensive copy created by the compiler.")]
+    public static void Emit<T>(this SentryMetricEmitter metrics, SentryMetricType type, T value, in TagList attributes) where T : struct
+    {
+        switch (type)
+        {
+            case SentryMetricType.Counter:
+                metrics.EmitCounter<T>("sentry_tests.sentry_trace_metrics_tests.counter", value, in attributes);
+                break;
+            case SentryMetricType.Gauge:
+                metrics.EmitGauge<T>("sentry_tests.sentry_trace_metrics_tests.counter", value, "measurement_unit", in attributes);
+                break;
+            case SentryMetricType.Distribution:
+                metrics.EmitDistribution<T>("sentry_tests.sentry_trace_metrics_tests.counter", value, "measurement_unit", in attributes);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), type, null);
+        }
+    }
+#endif
+}


### PR DESCRIPTION
fixes #5259

### Summary

Add an overload to all Metrics method groups (`EmitCounter`, `EmitGauge`, `EmitDistribution`) that accept _Attributes_, alongside the existing `ReadOnlySpan<>` and `IEnumerable<>` overloads.

### Remarks

TODOs
- [ ] Move "EditorBrowsable Never" Attributes to separate PR
- [ ] Verify that we don't run into problems when adding conditionally-compiled non-public `abstract` methods to a type that is non-constructible by user code, e.g. when having a `netstandard2.0` library with a `PackageReference` to `Sentry` that is referenced by a `net8.0` application that also has a `PackageReference` to `Sentry`
- [ ] Explain why `for` over `foreach` (only .NET 10+ can devirtualize to `TagList.Enumerator`
