### PR TITLE
feat: propagate trace to `sentry-android` and `sentry-cocoa`

### DIFF
--- a/src/Sentry/Platforms/Android/AndroidScopeObserver.cs
+++ b/src/Sentry/Platforms/Android/AndroidScopeObserver.cs
@@ -102,7 +102,14 @@ internal sealed class AndroidScopeObserver : IScopeObserver
 
     public void SetTrace(SentryId traceId, SpanId parentSpanId)
     {
-        // TODO: This requires sentry-java 8.4.0
+        try
+        {
+            JavaSdk.Android.Core.InternalSentrySdk.SetTrace(traceId.ToString(), parentSpanId.ToString(), null, null);
+        }
+        finally
+        {
+            _innerObserver?.SetTrace(traceId, parentSpanId);
+        }
     }
 
     public void AddAttachment(SentryAttachment attachment)

--- a/src/Sentry/Platforms/Cocoa/CocoaScopeObserver.cs
+++ b/src/Sentry/Platforms/Cocoa/CocoaScopeObserver.cs
@@ -110,7 +110,14 @@ internal sealed class CocoaScopeObserver : IScopeObserver
 
     public void SetTrace(SentryId traceId, SpanId parentSpanId)
     {
-        // TODO: Missing corresponding functionality on the Cocoa SDK
+        try
+        {
+            SentryCocoaHybridSdk.SetTrace(traceId.ToCocoaSentryId(), parentSpanId.ToCocoaSpanId());
+        }
+        finally
+        {
+            _innerObserver?.SetTrace(traceId, parentSpanId);
+        }
     }
 
     public void AddAttachment(SentryAttachment attachment)


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-dotnet/issues/4074

The native SDKs provide API to `SetTrace` so we can finalize the `ScopeObserver`.