### PR TITLE
fix: return early from AddSentryOtlpExporter when DSN is the disable-SDK sentinel

### DIFF
--- a/src/Sentry.OpenTelemetry.Exporter/SentryTracerProviderBuilderExtensions.cs
+++ b/src/Sentry.OpenTelemetry.Exporter/SentryTracerProviderBuilderExtensions.cs
@@ -42,6 +42,11 @@ public static class SentryTracerProviderBuilderExtensions
     public static TracerProviderBuilder AddSentryOtlpExporter(this TracerProviderBuilder tracerProviderBuilder,
         string dsnString, Uri? collectorUrl = null, TextMapPropagator? defaultTextMapPropagator = null)
     {
+        if (Dsn.IsDisabled(dsnString))
+        {
+            return tracerProviderBuilder;
+        }
+
         if (Dsn.TryParse(dsnString) is not { } dsn)
         {
             throw new ArgumentException(MissingDsnWarning, nameof(dsnString));

--- a/test/Sentry.OpenTelemetry.Exporter.Tests/SentryTracerProviderBuilderExtensionsTests.cs
+++ b/test/Sentry.OpenTelemetry.Exporter.Tests/SentryTracerProviderBuilderExtensionsTests.cs
@@ -7,7 +7,6 @@ public class SentryTracerProviderBuilderExtensionsTests
 {
     [Theory]
     [InlineData(null)]
-    [InlineData("")]
     [InlineData("foo")]
     public void AddSentryOtlpExporter_InvalidDsn_ThrowsArgumentException(string dsn)
     {
@@ -20,6 +19,20 @@ public class SentryTracerProviderBuilderExtensionsTests
         // Assert
         act.Should().Throw<ArgumentException>()
             .WithMessage($"{SentryTracerProviderBuilderExtensions.MissingDsnWarning}*");
+    }
+
+    [Fact]
+    public void AddSentryOtlpExporter_DisabledSdkDsn_ReturnsWithoutConfiguringExporter()
+    {
+        // Arrange
+        var tracerProviderBuilder = Substitute.For<TracerProviderBuilder>();
+
+        // Act
+        var result = tracerProviderBuilder.AddSentryOtlpExporter(SentryConstants.DisableSdkDsnValue);
+
+        // Assert
+        result.Should().BeSameAs(tracerProviderBuilder);
+        tracerProviderBuilder.DidNotReceive().AddInstrumentation(Arg.Any<Func<object>>());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

When a caller passes `SentryConstants.DisableSdkDsnValue` (empty string `""`) to `AddSentryOtlpExporter`, the method previously threw an exception rather than disabling the integration. `SentryConstants.DisableSdkDsnValue` is a valid DSN value and should be handled gracefully.

- Added an early-return check using `Dsn.IsDisabled(dsnString)` before the existing DSN validation, so disabled-SDK callers get back the builder unchanged.

Fixes #5246