### PR TITLE
TransactionTracer concurrency for Maui Transactions

### DIFF
--- a/src/Sentry.Maui/Internal/MauiEventsBinder.cs
+++ b/src/Sentry.Maui/Internal/MauiEventsBinder.cs
@@ -420,9 +420,8 @@ internal class MauiEventsBinder : IMauiEventsBinder
         if (CurrentUiTx is not null)
         {
             // Idle timer will clean up any previous UI transaction, but we don't want any more child spans on it
-            _hub.ConfigureScope(scope => scope.ResetTransaction(CurrentUiTx));
+            _hub.ConfigureScope(static (scope, tx) => scope.ResetTransaction(tx), CurrentUiTx);
         }
-        CurrentUiTx = null;
 
         var context = new TransactionContext(name, UserInteractionClickOp)
         {
@@ -430,11 +429,10 @@ internal class MauiEventsBinder : IMauiEventsBinder
         };
         CurrentUiTx = _hub is IHubInternal internalHub
             ? internalHub.StartTransaction(context, _options.AutoTransactionIdleTimeout)
-            // never called in practice... all our hubs implement IHubInternal
             : _hub.StartTransaction(context);
 
-        // Only bind to scope if there is no other transaction already there (user-created or SDK-owned navigation).
-        _hub.ConfigureScope(scope => scope.Transaction ??= CurrentUiTx);
+        // Bind to scope only if no other transaction is already there (user-installed or SDK-owned navigation).
+        _hub.ConfigureScope(static (scope, tx) => scope.Transaction ??= tx, CurrentUiTx);
     }
 
     // Application Events
@@ -472,13 +470,13 @@ internal class MauiEventsBinder : IMauiEventsBinder
                 if (uiTx.Spans.Count > 0)
                 {
                     // Only finish UI transactions with child spans.
-                    // Childless transactions will be discarded by the idle timeout.
+                    // Childless transactions get discarded by the idle timeout.
                     uiTx.Finish(SpanStatus.Ok);
                 }
                 else
                 {
-                    // No child spans, so just detach from scope and let idle timeout handle it.
-                    _hub.ConfigureScope(scope => scope.ResetTransaction(CurrentUiTx));
+                    // No child spans, so just detach from scope and let idle timeout handle it
+                    _hub.ConfigureScope(static (scope, tx) => scope.ResetTransaction(tx), uiTx);
                 }
             }
             CurrentUiTx = null;

--- a/src/Sentry/SpanTracer.cs
+++ b/src/Sentry/SpanTracer.cs
@@ -34,11 +34,32 @@ public sealed class SpanTracer : IBaseTracer, ISpan
     /// <inheritdoc />
     public DateTimeOffset StartTimestamp { get; internal set; }
 
-    /// <inheritdoc />
-    public DateTimeOffset? EndTimestamp { get; internal set; }
+    private DateTimeOffset? _endTimestamp;
+    private bool _isFinished;
 
     /// <inheritdoc />
-    public bool IsFinished => EndTimestamp is not null;
+    public DateTimeOffset? EndTimestamp
+    {
+        get => Volatile.Read(ref _isFinished) ? _endTimestamp : null;
+        internal set
+        {
+            // Ordering is load-bearing: the gate-flip is release-ordered against the data write,
+            // so lock-free readers gating on `_isFinished` see a consistent (timestamp, finished) pair.
+            if (value is null)
+            {
+                Volatile.Write(ref _isFinished, false);
+                _endTimestamp = null;
+            }
+            else
+            {
+                _endTimestamp = value;
+                Volatile.Write(ref _isFinished, true);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public bool IsFinished => Volatile.Read(ref _isFinished);
 
     // Not readonly because of deserialization
     internal Dictionary<string, Measurement>? InternalMeasurements { get; private set; }

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -381,9 +381,6 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
         }
     }
 
-    // All callers (`AddChildSpan`, `ChildSpanFinished`, `TryBeginFinish`, `ReleaseSpans`,
-    // and the public `GetLastActiveSpan` below) acquire the enclosing `TransactionTracer._lock`
-    // before touching this tracker, so it does not need its own lock.
     private class LastActiveSpanTracker
     {
         private readonly Lazy<Stack<ISpan>> _trackedSpans = new();

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -381,51 +381,43 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
         }
     }
 
+    // All callers (`AddChildSpan`, `ChildSpanFinished`, `TryBeginFinish`, `ReleaseSpans`,
+    // and the public `GetLastActiveSpan` below) acquire the enclosing `TransactionTracer._lock`
+    // before touching this tracker, so it does not need its own lock.
     private class LastActiveSpanTracker
     {
-        private readonly Lock _lock = new();
-
         private readonly Lazy<Stack<ISpan>> _trackedSpans = new();
         private Stack<ISpan> TrackedSpans => _trackedSpans.Value;
 
-        public void Push(ISpan span)
-        {
-            lock (_lock)
-            {
-                TrackedSpans.Push(span);
-            }
-        }
+        public void Push(ISpan span) => TrackedSpans.Push(span);
 
         public ISpan? PeekActive()
         {
-            lock (_lock)
+            while (TrackedSpans.Count > 0)
             {
-                while (TrackedSpans.Count > 0)
+                // Stop tracking inactive spans
+                var span = TrackedSpans.Peek();
+                if (!span.IsFinished)
                 {
-                    // Stop tracking inactive spans
-                    var span = TrackedSpans.Peek();
-                    if (!span.IsFinished)
-                    {
-                        return span;
-                    }
-                    TrackedSpans.Pop();
+                    return span;
                 }
-                return null;
+                TrackedSpans.Pop();
             }
+            return null;
         }
 
-        public void Clear()
-        {
-            lock (_lock)
-            {
-                TrackedSpans.Clear();
-            }
-        }
+        public void Clear() => TrackedSpans.Clear();
     }
     private readonly LastActiveSpanTracker _activeSpanTracker = new LastActiveSpanTracker();
 
     /// <inheritdoc />
-    public ISpan? GetLastActiveSpan() => _activeSpanTracker.PeekActive();
+    public ISpan? GetLastActiveSpan()
+    {
+        lock (_lock)
+        {
+            return _activeSpanTracker.PeekActive();
+        }
+    }
 
     void IAutoTimeoutTracer.ResetIdleTimeout()
     {

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -18,17 +18,13 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
     private readonly TimeSpan? _idleTimeout;
     private readonly SentryStopwatch _stopwatch = SentryStopwatch.StartNew();
 
-    // The Running -> Finished transition happens exactly once, inside `_lock`, atomically
-    // with assigning `_endTimestamp` and disposing the idle timer. After the transition, no
-    // further spans are accepted and observers see a consistent view: `IsFinished == true`
-    // AND `EndTimestamp != null` AND `_spans` is frozen.
-    //
-    // `IsFinished` reads `_hasFinished` (not `EndTimestamp`) so the two observables can
-    // never diverge. The public `EndTimestamp` setter exists for back-compat with the
-    // existing API surface (tests, serialization round-trip); it routes writes through
-    // `_lock` so external use cannot create a torn view.
+    /// <summary>
+    /// Set exactly once inside the `_lock` at the same time as setting `_endTimestamp` and disposing the idle timer.
+    /// `IsFinished` makes a volatile read of `_hasFinished` (no lock required as would be necessary for the more
+    /// complex `_endTimestamp` struct), which is essentially why we need this separate flag.
+    /// </summary>
     private bool _hasFinished;
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
 
     private readonly Instrumenter _instrumenter = Instrumenter.Sentry;
 
@@ -79,15 +75,16 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
     /// <inheritdoc />
     public DateTimeOffset StartTimestamp { get; internal set; }
 
-    // Written exactly once during the Running -> Finished transition, inside `_lock`.
-    // External writes via the setter also go through `_lock`. Reads are lock-free because
-    // the field becomes monotonically stable (non-null) the moment `_hasFinished` flips.
+    /// <summary>
+    /// Guard writes with `_lock`
+    /// </summary>
     private DateTimeOffset? _endTimestamp;
 
     /// <inheritdoc />
     public DateTimeOffset? EndTimestamp
     {
-        get => _endTimestamp;
+        // get => _endTimestamp;
+        get => Volatile.Read(ref _hasFinished) ? _endTimestamp : null;
         internal set
         {
             lock (_lock)
@@ -208,10 +205,6 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
     internal bool HasMetrics => _metricsSummary.IsValueCreated;
 
     /// <inheritdoc />
-    // Derived from the lifecycle flag, not from `EndTimestamp`. This is the key invariant:
-    // anyone who observes `IsFinished == true` is guaranteed that the transition flip
-    // already happened, which means `_endTimestamp` was set inside the same critical
-    // section and `_spans` will no longer mutate.
     public bool IsFinished => Volatile.Read(ref _hasFinished);
 
     internal DynamicSamplingContext? DynamicSamplingContext { get; set; }
@@ -281,15 +274,6 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
         }
     }
 
-    // The idle-timer callback. Runs on the ThreadPool. The whole "should we finish?"
-    // decision happens inside one critical section so that a concurrent AddChildSpan
-    // cannot slip a new span in between deciding-to-finish and actually-finishing.
-    //
-    // `Timer.Change(Infinite, ...)` (i.e. `_idleTimer.Cancel()`) cannot stop a callback
-    // that has already begun executing — so cancellation is advisory. The defense against
-    // a stale firing is the `PeekActive() != null` re-check inside the lock: if a span
-    // arrived after the timer fired but before we acquired the lock, we silently bail
-    // and let AddChildSpan's `Cancel()` (which already ran) keep the timer paused.
     private void OnIdleTimeout()
     {
         if (IsSentryRequest)
@@ -349,10 +333,6 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
         return span;
     }
 
-    // All decisions about whether to accept the span happen inside the same critical
-    // section as the actual mutation of `_spans`/`_activeSpanTracker`/`_idleTimer`. This
-    // closes both the span-limit TOCTOU and the "transaction finished between the check
-    // and the add" race.
     private void AddChildSpan(SpanTracer span)
     {
         lock (_lock)
@@ -372,7 +352,7 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
             }
 
             span.IsSampled = IsSampled;
-            _idleTimer?.Cancel(); // Pause the idle timer while a child span is in flight (advisory)
+            _idleTimer?.Cancel();
             _spans.Add(span);
             _activeSpanTracker.Push(span);
         }
@@ -381,9 +361,7 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
     internal void ChildSpanFinished()
     {
         // Fast path: only idle-timeout transactions need to react to child finishes.
-        // `_idleTimeout` is readonly, so this check is safe outside the lock and avoids
-        // lock-acquisition overhead for the (overwhelming) majority of transactions that
-        // do not use an idle timer.
+        // `_idleTimeout` is readonly, so this check is safe outside the lock
         if (!_idleTimeout.HasValue)
         {
             return;
@@ -464,13 +442,13 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
     /// <summary>
     /// The single atomic primitive for transitioning Running -> Finished. Returns true to
     /// exactly one caller; all subsequent calls return false. The Running -> Finished flip,
-    /// the `EndTimestamp` write, and the timer disposal happen inside the same critical
+    /// the `EndTimestamp` write, and the timer disposal all happen inside the same critical
     /// section, so no observer can ever see an inconsistent intermediate state.
     /// </summary>
     /// <param name="fromIdleTimer">
     /// True when called from the idle-timer callback. In that case we also re-check whether
     /// a child span is still active (it might have been added after the timer fired but
-    /// before we acquired the lock); if so, the firing is stale and we refuse to finish.
+    /// before we acquired the lock); if so, the firing is stale, and we refuse to finish.
     /// </param>
     /// <param name="shouldDiscard">
     /// True if the transaction had no child spans and the caller (idle timer) should
@@ -528,9 +506,7 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
             _idleTimer?.Cancel();
             _idleTimer?.Dispose();
 
-            // The flip is the LAST write inside the lock. Use Volatile to publish the
-            // store; readers using `IsFinished` will, on observing `true`, also see the
-            // prior `_endTimestamp` write (release-store / acquire-load semantics).
+            // MUST be the last write inside the lock for all logic that depends on volatile reads to work
             Volatile.Write(ref _hasFinished, true);
             return true;
         }
@@ -558,10 +534,9 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
         CompleteCapture();
     }
 
-    // The non-locked work that follows a successful Running -> Finished transition: stop
-    // the profiler, reset scope, capture the transaction, and release tracked spans. By
-    // the time we get here, `_hasFinished == true` and `_endTimestamp` is set, so any
-    // concurrent reader sees a coherent finished transaction.
+    /// <summary>
+    /// Performs non-locked work that follows a successful Running -> Finished transition
+    /// </summary>
     private void CompleteCapture()
     {
         TransactionProfiler?.Finish();
@@ -569,7 +544,7 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
         _options?.LogDebug("Finished Transaction '{0}'.", SpanId);
 
         // Clear the transaction from the scope and regenerate the Propagation Context
-        // so new events don't have a trace context that is "older" than the transaction that just finished
+        // We do this so new events don't have a trace context that is "older" than the transaction that just finished
         _hub.ConfigureScope(static (scope, transactionTracer) => scope.ResetTransaction(transactionTracer), this);
 
         // Client decides whether to discard this transaction based on sampling

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -390,15 +390,13 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
 
         public ISpan? PeekActive()
         {
-            while (TrackedSpans.Count > 0)
+            // Non-destructive: leave finished spans in place so SpanTracer.Unfinish() can resurrect them.
+            foreach (var span in TrackedSpans)
             {
-                // Stop tracking inactive spans
-                var span = TrackedSpans.Peek();
                 if (!span.IsFinished)
                 {
                     return span;
                 }
-                TrackedSpans.Pop();
             }
             return null;
         }

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -18,21 +18,16 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
     private readonly TimeSpan? _idleTimeout;
     private readonly SentryStopwatch _stopwatch = SentryStopwatch.StartNew();
 
-    // Lifecycle state machine.
+    // The Running -> Finished transition happens exactly once, inside `_lock`, atomically
+    // with assigning `_endTimestamp` and disposing the idle timer. After the transition, no
+    // further spans are accepted and observers see a consistent view: `IsFinished == true`
+    // AND `EndTimestamp != null` AND `_spans` is frozen.
     //
-    // The transaction is either Running or Finished. The Running -> Finished transition
-    // happens exactly once, inside `_lock`, atomically with assigning `_endTimestamp` and
-    // disposing the idle timer. After the transition, no further spans are accepted and
-    // observers see a consistent view: `IsFinished == true` AND `EndTimestamp != null` AND
-    // `_spans` is frozen.
-    //
-    // `IsFinished` reads `_state` (not `EndTimestamp`) so the two observables can never
-    // diverge. The public `EndTimestamp` setter exists for back-compat with the existing
-    // API surface (tests, serialization round-trip); it routes writes through `_lock` so
-    // external use cannot create a torn view.
-    private const int StateRunning = 0;
-    private const int StateFinished = 1;
-    private int _state = StateRunning;
+    // `IsFinished` reads `_hasFinished` (not `EndTimestamp`) so the two observables can
+    // never diverge. The public `EndTimestamp` setter exists for back-compat with the
+    // existing API surface (tests, serialization round-trip); it routes writes through
+    // `_lock` so external use cannot create a torn view.
+    private bool _hasFinished;
     private readonly object _lock = new();
 
     private readonly Instrumenter _instrumenter = Instrumenter.Sentry;
@@ -86,7 +81,7 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
 
     // Written exactly once during the Running -> Finished transition, inside `_lock`.
     // External writes via the setter also go through `_lock`. Reads are lock-free because
-    // the field becomes monotonically stable (non-null) the moment `_state == Finished`.
+    // the field becomes monotonically stable (non-null) the moment `_hasFinished` flips.
     private DateTimeOffset? _endTimestamp;
 
     /// <inheritdoc />
@@ -213,11 +208,11 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
     internal bool HasMetrics => _metricsSummary.IsValueCreated;
 
     /// <inheritdoc />
-    // Derived from the lifecycle state field, not from `EndTimestamp`. This is the key
-    // invariant: anyone who observes `IsFinished == true` is guaranteed that `_state` has
-    // already transitioned, which means `_endTimestamp` was set inside the same critical
+    // Derived from the lifecycle flag, not from `EndTimestamp`. This is the key invariant:
+    // anyone who observes `IsFinished == true` is guaranteed that the transition flip
+    // already happened, which means `_endTimestamp` was set inside the same critical
     // section and `_spans` will no longer mutate.
-    public bool IsFinished => Volatile.Read(ref _state) != StateRunning;
+    public bool IsFinished => Volatile.Read(ref _hasFinished);
 
     internal DynamicSamplingContext? DynamicSamplingContext { get; set; }
 
@@ -362,7 +357,7 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
     {
         lock (_lock)
         {
-            if (_state != StateRunning)
+            if (_hasFinished)
             {
                 _options?.LogDebug("Discarding child span '{0}' as the trace has already finished", SpanId);
                 span.IsSampled = false;
@@ -395,7 +390,7 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
         }
         lock (_lock)
         {
-            if (_state != StateRunning)
+            if (_hasFinished)
             {
                 return;
             }
@@ -458,7 +453,7 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
     {
         lock (_lock)
         {
-            if (!_idleTimeout.HasValue || _state != StateRunning)
+            if (!_idleTimeout.HasValue || _hasFinished)
             {
                 return;
             }
@@ -486,7 +481,7 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
         shouldDiscard = false;
         lock (_lock)
         {
-            if (_state != StateRunning)
+            if (_hasFinished)
             {
                 return false;
             }
@@ -533,10 +528,10 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
             _idleTimer?.Cancel();
             _idleTimer?.Dispose();
 
-            // State flip is the LAST write inside the lock. Use Volatile to publish the
-            // store; readers using `IsFinished` will, on observing `Finished`, also see
-            // the prior `_endTimestamp` write (release-store / acquire-load semantics).
-            Volatile.Write(ref _state, StateFinished);
+            // The flip is the LAST write inside the lock. Use Volatile to publish the
+            // store; readers using `IsFinished` will, on observing `true`, also see the
+            // prior `_endTimestamp` write (release-store / acquire-load semantics).
+            Volatile.Write(ref _hasFinished, true);
             return true;
         }
     }
@@ -565,7 +560,7 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
 
     // The non-locked work that follows a successful Running -> Finished transition: stop
     // the profiler, reset scope, capture the transaction, and release tracked spans. By
-    // the time we get here, `_state == Finished` and `_endTimestamp` is set, so any
+    // the time we get here, `_hasFinished == true` and `_endTimestamp` is set, so any
     // concurrent reader sees a coherent finished transaction.
     private void CompleteCapture()
     {

--- a/src/Sentry/TransactionTracer.cs
+++ b/src/Sentry/TransactionTracer.cs
@@ -17,8 +17,23 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
     private readonly ISentryTimer? _idleTimer;
     private readonly TimeSpan? _idleTimeout;
     private readonly SentryStopwatch _stopwatch = SentryStopwatch.StartNew();
-    private bool _hasFinished;
-    private readonly object _finishLock = new();
+
+    // Lifecycle state machine.
+    //
+    // The transaction is either Running or Finished. The Running -> Finished transition
+    // happens exactly once, inside `_lock`, atomically with assigning `_endTimestamp` and
+    // disposing the idle timer. After the transition, no further spans are accepted and
+    // observers see a consistent view: `IsFinished == true` AND `EndTimestamp != null` AND
+    // `_spans` is frozen.
+    //
+    // `IsFinished` reads `_state` (not `EndTimestamp`) so the two observables can never
+    // diverge. The public `EndTimestamp` setter exists for back-compat with the existing
+    // API surface (tests, serialization round-trip); it routes writes through `_lock` so
+    // external use cannot create a torn view.
+    private const int StateRunning = 0;
+    private const int StateFinished = 1;
+    private int _state = StateRunning;
+    private readonly object _lock = new();
 
     private readonly Instrumenter _instrumenter = Instrumenter.Sentry;
 
@@ -69,8 +84,23 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
     /// <inheritdoc />
     public DateTimeOffset StartTimestamp { get; internal set; }
 
+    // Written exactly once during the Running -> Finished transition, inside `_lock`.
+    // External writes via the setter also go through `_lock`. Reads are lock-free because
+    // the field becomes monotonically stable (non-null) the moment `_state == Finished`.
+    private DateTimeOffset? _endTimestamp;
+
     /// <inheritdoc />
-    public DateTimeOffset? EndTimestamp { get; internal set; }
+    public DateTimeOffset? EndTimestamp
+    {
+        get => _endTimestamp;
+        internal set
+        {
+            lock (_lock)
+            {
+                _endTimestamp = value;
+            }
+        }
+    }
 
     /// <inheritdoc cref="ISpan.Operation" />
     public string Operation
@@ -183,7 +213,11 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
     internal bool HasMetrics => _metricsSummary.IsValueCreated;
 
     /// <inheritdoc />
-    public bool IsFinished => EndTimestamp is not null;
+    // Derived from the lifecycle state field, not from `EndTimestamp`. This is the key
+    // invariant: anyone who observes `IsFinished == true` is guaranteed that `_state` has
+    // already transitioned, which means `_endTimestamp` was set inside the same critical
+    // section and `_spans` will no longer mutate.
+    public bool IsFinished => Volatile.Read(ref _state) != StateRunning;
 
     internal DynamicSamplingContext? DynamicSamplingContext { get; set; }
 
@@ -252,6 +286,15 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
         }
     }
 
+    // The idle-timer callback. Runs on the ThreadPool. The whole "should we finish?"
+    // decision happens inside one critical section so that a concurrent AddChildSpan
+    // cannot slip a new span in between deciding-to-finish and actually-finishing.
+    //
+    // `Timer.Change(Infinite, ...)` (i.e. `_idleTimer.Cancel()`) cannot stop a callback
+    // that has already begun executing — so cancellation is advisory. The defense against
+    // a stale firing is the `PeekActive() != null` re-check inside the lock: if a span
+    // arrived after the timer fired but before we acquired the lock, we silently bail
+    // and let AddChildSpan's `Cancel()` (which already ran) keep the timer paused.
     private void OnIdleTimeout()
     {
         if (IsSentryRequest)
@@ -260,21 +303,9 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
             return;
         }
 
-        // Discard if no child spans were ever started
-        bool shouldDiscard;
-        lock (_finishLock)
+        if (!TryBeginFinish(fromIdleTimer: true, out var shouldDiscard))
         {
-            if (_spans.IsEmpty && !_hasFinished)
-            {
-                _hasFinished = true;
-                _idleTimer?.Dispose();
-                EndTimestamp = _stopwatch.CurrentDateTimeOffset;
-                shouldDiscard = true;
-            }
-            else
-            {
-                shouldDiscard = false;
-            }
+            return;
         }
 
         if (shouldDiscard)
@@ -284,7 +315,8 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
             return;
         }
 
-        Finish(Status ?? SpanStatus.Ok);
+        Status ??= SpanStatus.Ok;
+        CompleteCapture();
     }
 
     /// <inheritdoc />
@@ -322,10 +354,21 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
         return span;
     }
 
+    // All decisions about whether to accept the span happen inside the same critical
+    // section as the actual mutation of `_spans`/`_activeSpanTracker`/`_idleTimer`. This
+    // closes both the span-limit TOCTOU and the "transaction finished between the check
+    // and the add" race.
     private void AddChildSpan(SpanTracer span)
     {
-        lock (_finishLock)
+        lock (_lock)
         {
+            if (_state != StateRunning)
+            {
+                _options?.LogDebug("Discarding child span '{0}' as the trace has already finished", SpanId);
+                span.IsSampled = false;
+                return;
+            }
+
             if (_spans.Count >= SpanLimit)
             {
                 _options?.LogDebug("Discarding child span '{0}' due to {1} span limit", SpanId, SpanLimit);
@@ -333,15 +376,8 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
                 return;
             }
 
-            if (_hasFinished)
-            {
-                _options?.LogDebug("Discarding child span '{0}' as the trace has already finished", SpanId);
-                span.IsSampled = false;
-                return;
-            }
-
             span.IsSampled = IsSampled;
-            _idleTimer?.Cancel(); // Pause the idle timer while a child span is in flight
+            _idleTimer?.Cancel(); // Pause the idle timer while a child span is in flight (advisory)
             _spans.Add(span);
             _activeSpanTracker.Push(span);
         }
@@ -350,14 +386,16 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
     internal void ChildSpanFinished()
     {
         // Fast path: only idle-timeout transactions need to react to child finishes.
-        // _idleTimeout is readonly, so this check is safe outside the lock.
+        // `_idleTimeout` is readonly, so this check is safe outside the lock and avoids
+        // lock-acquisition overhead for the (overwhelming) majority of transactions that
+        // do not use an idle timer.
         if (!_idleTimeout.HasValue)
         {
             return;
         }
-        lock (_finishLock)
+        lock (_lock)
         {
-            if (_hasFinished)
+            if (_state != StateRunning)
             {
                 return;
             }
@@ -418,9 +456,9 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
 
     void IAutoTimeoutTracer.ResetIdleTimeout()
     {
-        lock (_finishLock)
+        lock (_lock)
         {
-            if (!_idleTimeout.HasValue || _hasFinished)
+            if (!_idleTimeout.HasValue || _state != StateRunning)
             {
                 return;
             }
@@ -428,17 +466,77 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
         }
     }
 
-    private bool TryFinishOnce()
+    /// <summary>
+    /// The single atomic primitive for transitioning Running -> Finished. Returns true to
+    /// exactly one caller; all subsequent calls return false. The Running -> Finished flip,
+    /// the `EndTimestamp` write, and the timer disposal happen inside the same critical
+    /// section, so no observer can ever see an inconsistent intermediate state.
+    /// </summary>
+    /// <param name="fromIdleTimer">
+    /// True when called from the idle-timer callback. In that case we also re-check whether
+    /// a child span is still active (it might have been added after the timer fired but
+    /// before we acquired the lock); if so, the firing is stale and we refuse to finish.
+    /// </param>
+    /// <param name="shouldDiscard">
+    /// True if the transaction had no child spans and the caller (idle timer) should
+    /// discard rather than capture.
+    /// </param>
+    private bool TryBeginFinish(bool fromIdleTimer, out bool shouldDiscard)
     {
-        lock (_finishLock)
+        shouldDiscard = false;
+        lock (_lock)
         {
-            if (_hasFinished)
+            if (_state != StateRunning)
             {
                 return false;
             }
-            _hasFinished = true;
+
+            if (fromIdleTimer)
+            {
+                // Defensive re-check: if a child span arrived between the timer firing and
+                // us acquiring the lock, AddChildSpan's `Cancel()` may have failed to stop
+                // the in-flight callback. The active-span check inside the lock is the
+                // authoritative answer.
+                if (_activeSpanTracker.PeekActive() != null)
+                {
+                    return false;
+                }
+
+                if (_spans.IsEmpty)
+                {
+                    shouldDiscard = true;
+                }
+            }
+
+            // Compute the end timestamp inside the lock. For idle transactions, trim to
+            // the latest finished child span when available. (Scanning `_spans` here is
+            // bounded by SpanLimit and only runs once per transaction.)
+            DateTimeOffset endTimestamp;
+            if (_idleTimeout.HasValue && !shouldDiscard)
+            {
+                DateTimeOffset latest = default;
+                foreach (var s in _spans)
+                {
+                    if (s.IsFinished && s.EndTimestamp is { } et && et > latest)
+                    {
+                        latest = et;
+                    }
+                }
+                endTimestamp = latest == default ? _stopwatch.CurrentDateTimeOffset : latest;
+            }
+            else
+            {
+                endTimestamp = _endTimestamp ?? _stopwatch.CurrentDateTimeOffset;
+            }
+
+            _endTimestamp = endTimestamp;
             _idleTimer?.Cancel();
             _idleTimer?.Dispose();
+
+            // State flip is the LAST write inside the lock. Use Volatile to publish the
+            // store; readers using `IsFinished` will, on observing `Finished`, also see
+            // the prior `_endTimestamp` write (release-store / acquire-load semantics).
+            Volatile.Write(ref _state, StateFinished);
             return true;
         }
     }
@@ -446,7 +544,7 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
     /// <inheritdoc />
     public void Finish()
     {
-        if (!TryFinishOnce())
+        if (!TryBeginFinish(fromIdleTimer: false, out _))
         {
             return;
         }
@@ -456,33 +554,27 @@ public sealed class TransactionTracer : IBaseTracer, IAutoTimeoutTracer, ITransa
         {
             // Normally we wouldn't start transactions for Sentry requests but when instrumenting with OpenTelemetry
             // we are only able to determine whether it's a sentry request or not when closing a span... we leave these
-            // to be garbage collected and we don't want idle timers triggering on them
+            // to be garbage collected. The idle timer has already been disposed inside TryBeginFinish.
             _options?.LogDebug("Transaction '{0}' is a Sentry Request. Don't complete.", SpanId);
             return;
         }
 
-        TransactionProfiler?.Finish();
         Status ??= SpanStatus.Ok;
+        CompleteCapture();
+    }
 
-        // For idle transactions, trim end time to the last finished child span
-        if (_idleTimeout.HasValue)
-        {
-            var latestSpanEnd = _spans
-                .Where(s => s.IsFinished)
-                .Select(s => s.EndTimestamp)
-                .DefaultIfEmpty()
-                .Max();
-            EndTimestamp = latestSpanEnd ?? _stopwatch.CurrentDateTimeOffset;
-        }
-        else
-        {
-            EndTimestamp ??= _stopwatch.CurrentDateTimeOffset;
-        }
+    // The non-locked work that follows a successful Running -> Finished transition: stop
+    // the profiler, reset scope, capture the transaction, and release tracked spans. By
+    // the time we get here, `_state == Finished` and `_endTimestamp` is set, so any
+    // concurrent reader sees a coherent finished transaction.
+    private void CompleteCapture()
+    {
+        TransactionProfiler?.Finish();
 
         _options?.LogDebug("Finished Transaction '{0}'.", SpanId);
 
         // Clear the transaction from the scope and regenerate the Propagation Context
-        // We do this so new events don't have a trace context that is "older" than the transaction that just finished
+        // so new events don't have a trace context that is "older" than the transaction that just finished
         _hub.ConfigureScope(static (scope, transactionTracer) => scope.ResetTransaction(transactionTracer), this);
 
         // Client decides whether to discard this transaction based on sampling

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -812,7 +812,6 @@ namespace Sentry
         public int MaxCacheItems { get; set; }
         public int MaxQueueItems { get; set; }
         public Sentry.Extensibility.INetworkStatusListener? NetworkStatusListener { get; set; }
-        public string? OrgId { get; set; }
         public double? ProfilesSampleRate { get; set; }
         public bool PropagateTraceparent { get; set; }
         public string? Release { get; set; }
@@ -828,7 +827,6 @@ namespace Sentry
         public System.TimeSpan ShutdownTimeout { get; set; }
         public string SpotlightUrl { get; set; }
         public Sentry.StackTraceMode StackTraceMode { get; set; }
-        public bool StrictTraceContinuation { get; set; }
         public System.Collections.Generic.IList<Sentry.StringOrRegex> TagFilters { get; set; }
         public System.Collections.Generic.IList<Sentry.HttpStatusCodeRange> TraceIgnoreStatusCodes { get; set; }
         public System.Collections.Generic.IList<Sentry.StringOrRegex> TracePropagationTargets { get; set; }

--- a/test/Sentry.Tests/TransactionTracerTests.cs
+++ b/test/Sentry.Tests/TransactionTracerTests.cs
@@ -216,4 +216,37 @@ public class TransactionTracerTests
         // Then the transaction is captured
         hub.Received(1).CaptureTransaction(Arg.Any<SentryTransaction>());
     }
+
+    [Fact]
+    public void IdleTimeout_AfterUnfinishedChildSpan_DoesNotCaptureTransaction()
+    {
+        // Regression: prior to the fix, LastActiveSpanTracker.PeekActive() destructively popped
+        // finished spans off the stack. That created a hole when combined with SpanTracer.Unfinish()
+        // (used by EF for connection-pool reuse):
+        //
+        //   1. SpanTracer.Finish() sets EndTimestamp and calls Transaction.ChildSpanFinished().
+        //   2. ChildSpanFinished -> PeekActive() destructively pops the now-finished span.
+        //   3. Stack empty -> idle timer (re)starts.
+        //   4. SpanTracer.Unfinish() resets EndTimestamp = null on the span -- it is logically alive
+        //      again, but no longer in _activeSpanTracker.
+        //   5. PeekActive() returns null -- the idle timer fires unopposed.
+        //   6. TryBeginFinish sees PeekActive() == null and _spans.Count > 0, captures the transaction
+        //      while the unfinished span is still in-flight.
+        //
+        // Fix: PeekActive is non-destructive; an unfinished span stays in the tracker and is
+        // re-discoverable after Unfinish().
+
+        // Given an auto-generated UI event transaction with a child span that is finished then unfinished
+        var hub = Substitute.For<IHub>();
+        var (transaction, timer) = CreateIdleTransaction(hub);
+        var span = (SpanTracer)transaction.StartChild("child");
+        span.Finish();
+        span.Unfinish();
+
+        // When the idle timer fires
+        timer.Fire();
+
+        // Then the transaction is NOT captured because the unfinished span is still tracked as active
+        hub.DidNotReceive().CaptureTransaction(Arg.Any<SentryTransaction>());
+    }
 }


### PR DESCRIPTION
Playing around with a concurrency solution for the three concurrency threads that keep getting re-flagged on #5138:

| Thread | Status on #5138 head | Resolved here by |
|---|---|---|
| `IsFinished` / `EndTimestamp` torn view (sentry-bot, deferred to #5174) | Open | `IsFinished` reads a Volatile bool, not the nullable struct |
| `OnIdleTimeout` TOCTOU — Warden flagged 3× across 3 commits (`b74a6c3`, `f5d222e`, `e13985b`) | Open | Single `TryBeginFinish` critical section; `PeekActive` re-check inside the lock |
| `_idleTimer.Cancel()` treated as authoritative | Open | Cancellation is explicitly advisory; correctness comes from the in-lock re-check |

## Solution

Treat `TransactionTracer` as a one-shot state machine (`Running → Finished`). The transition, the `EndTimestamp` write, and the idle-timer disposal happen in one critical section, and `IsFinished` reads a separate `bool` flag so observers can never see an inconsistent intermediate view.

## What changed

**`TransactionTracer`**
- `IsFinished` reads `bool _hasFinished` via `Volatile.Read`, not the `Nullable<DateTimeOffset>` `EndTimestamp`. `EndTimestamp` is gated on the same flag so lock-free readers see either `null` or the final stable value, never an in-progress write.
- `TryBeginFinish(fromIdleTimer, out shouldDiscard)` is the only path from Running → Finished. Inside one lock acquisition it: checks the one-shot guard, re-checks `PeekActive() == null` for idle-timer callers (the authoritative defense against a stale firing — `Timer.Change(Infinite)` cannot stop an in-flight callback), computes the trimmed `EndTimestamp`, disposes the timer, and flips `_hasFinished` last via `Volatile.Write`.
- `Finish()` and `OnIdleTimeout()` are thin wrappers around `TryBeginFinish` + `CompleteCapture`. Capture work (profiler stop, scope reset, `CaptureTransaction`, `ReleaseSpans`) runs outside the lock but only after the flag flip; concurrent `AddChildSpan` / `ChildSpanFinished` see `_hasFinished` and bail.
- `ChildSpanFinished` keeps its fast-path no-op for non-idle transactions — no lock acquisition in the common non-MAUI case.
- `LastActiveSpanTracker`: inner lock removed (all callers hold `_lock`); `PeekActive` is now non-destructive so `SpanTracer.Unfinish()` can resurrect a finished span without it falling out of the tracker.

**`SpanTracer`**
- Same Volatile-gated `EndTimestamp` / `IsFinished` pattern. The setter sequences writes in opposite orders for `null` vs non-`null` so the gate stays consistent through both `Finish` and `Unfinish`.

**`MauiEventsBinder`**
- `StartUiTransaction` and `OnWindowOnStopped` use the `(scope, state)` `ConfigureScope` overload with `static` lambdas — no closure allocations, no risk of the lambda reading a different `CurrentUiTx` than the caller intended.

> [!NOTE]
> Although every internal access to `_spans` is now protected by the lock, we still need a `ConcurrentBagLite` for this since external consumers can fetch a read-only reference to the collection, perform some operations on the transaction that would mutate the underlying collection, and then check/expect those changes to be reflected on the reference that they obtained earlier. This behaviour needs to be preserved.