### PR TITLE
chore: add semver field to release.yml categories for craft auto-versioning

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,21 +7,25 @@ changelog:
       - dependabot
   categories:
     - title: Breaking Changes 🛠
+      semver: major
       labels:
         - "Changelog: Breaking Change"
       commit_patterns:
         - "^(?<type>\\w+(?:\\((?<scope>[^)]+)\\))?!:\\s*)"
     - title: Features ✨
+      semver: minor
       labels:
         - "Changelog: Feature"
       commit_patterns:
         - "^feat(?:\\([^\\)]+\\))?:\\s+"
     - title: Fixes 🐛
+      semver: patch
       labels:
         - "Changelog: Bugfix"
       commit_patterns:
         - "^(?:fix|bugfix)(?:\\([^\\)]+\\))?:\\s+"
     - title: Dependencies ⬆️
+      semver: patch
       labels:
         - "Changelog: Dependency Update"
       commit_patterns:


### PR DESCRIPTION
Craft's `auto` versioning policy needs each changelog category in `.github/release.yml` to declare a `semver` field (`major` / `minor` / `patch` / `none`). It uses that field to map commits since the last tag to a bump type and pick the next version.

The current categories have no `semver` field, so `craft prepare auto` fails with:

> Cannot determine version automatically: 60 commit(s) found, but none matched a category with a "semver" field in the release configuration.

See the recent failure: https://github.com/getsentry/sentry-dotnet/actions/runs/26375155007/job/77634036157

## References
- https://getsentry.github.io/craft/configuration/#auto-mode

#skip-changelog