### PR TITLE
ci: restore version bumping via craft preReleaseCommand

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,5 +1,6 @@
 minVersion: 2.26.3
 changelogPolicy: auto
+preReleaseCommand: bash scripts/bump-version.sh
 targets:
   - name: nuget
   - name: github

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -3,5 +3,5 @@
 set -eux
 
 # Requires powershell: `brew install powershell`
-# craft executes this file by convension, passing the new version as the second argument:
+# craft executes this file by convention, passing the new version as the second argument:
 pwsh ./scripts/bump-version.ps1 $2


### PR DESCRIPTION
Closes #5260

## What happened

The `release: 6.6.0` commit ([0140be0](https://github.com/getsentry/sentry-dotnet/commit/0140be0a3b98ee01ff53097a5289bc6e7b703957)) only modified `CHANGELOG.md` — `<VersionPrefix>` in `Directory.Build.props` was left at `6.5.0`. Every nupkg built in the publish step was therefore named `*.6.5.0.nupkg`, and that's what got attached to the `6.6.0` GitHub release (and pushed to NuGet).

For comparison, the [6.5.0 release commit](https://github.com/getsentry/sentry-dotnet/commit/b0274763bab7530273d9d115b9e07b11b8895581) correctly bumped both `CHANGELOG.md` *and* `Directory.Build.props` (6.4.1 → 6.5.0).

## Root cause

From the craft prepare log in [run 26499066767](https://github.com/getsentry/sentry-dotnet/actions/runs/26499066767/job/78034487237):

```
[info] Running automatic version bumping from targets...
[debug] Running version bump for target "nuget"...
[debug] dotnet-setversion not available, falling back to manual edit
[debug] Target "nuget" did not apply (detection failed)
[warn] Targets [nuget] support version bumping but did not find applicable
       files in your project. Consider adding a preReleaseCommand if you
       need custom version bumping.
```

Craft 2.26.6's built-in nuget auto-bumper looks for the `dotnet-setversion` CLI, doesn't find it on the runner image, falls back to a "manual edit" heuristic that doesn't recognize `Directory.Build.props`, and downgrades the failure to a warning — so prepare carries on and commits/tags with the stale version.

This regressed when #5206 bumped craft `minVersion` to opt into the `auto` versioning strategy. Before that, the repo's own `scripts/bump-version.ps1` was rewriting `<VersionPrefix>` via the older pre-release hook convention; the switch to craft-native auto-bump dropped that wiring.

#skip-changelog