### PR TITLE
revert: roll back the broken 6.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,5 @@
 # Changelog
 
-## 6.6.0
-
-### Features ✨
-
-- feat: propagate trace to `sentry-android` and `sentry-cocoa` by @bitsandfoxes in [#5244](https://github.com/getsentry/sentry-dotnet/pull/5244)
-- feat: User.Id can now be overriden (set to null) in Global mode by @jamescrosswell in [#5039](https://github.com/getsentry/sentry-dotnet/pull/5039)
-- feat: Implement strict trace continuation by @giortzisg in [#4981](https://github.com/getsentry/sentry-dotnet/pull/4981)
-
-### Fixes 🐛
-
-- fix: return early from AddSentryOtlpExporter when DSN is the disable-SDK sentinel by @jamescrosswell in [#5247](https://github.com/getsentry/sentry-dotnet/pull/5247)
-- fix: sync default tags to native layer by @bitsandfoxes in [#5214](https://github.com/getsentry/sentry-dotnet/pull/5214)
-
-### Dependencies ⬆️
-
-#### Deps
-
-- chore(deps): update Cocoa SDK to v9.14.0 by @github-actions[bot] in [#5252](https://github.com/getsentry/sentry-dotnet/pull/5252)
-- chore(deps): update Java SDK to v8.42.0 by @github-actions[bot] in [#5208](https://github.com/getsentry/sentry-dotnet/pull/5208)
-
-### Other
-
-- chore: update scripts/update-cli.ps1 to 3.4.3 by @github-actions[bot] in [#5251](https://github.com/getsentry/sentry-dotnet/pull/5251)
-- ci: update the Update Dependencies workflow by @Flash0ver in [#5175](https://github.com/getsentry/sentry-dotnet/pull/5175)
-- chore: update modules/sentry-native to 0.14.2 by @github-actions[bot] in [#5229](https://github.com/getsentry/sentry-dotnet/pull/5229)
-- chore: update modules/sentry-cocoa to 9.13.0 by @github-actions[bot] in [#5221](https://github.com/getsentry/sentry-dotnet/pull/5221)
-- chore: update scripts/update-cli.ps1 to 3.4.2 by @github-actions[bot] in [#5220](https://github.com/getsentry/sentry-dotnet/pull/5220)
-- chore: update modules/sentry-cocoa to 9.12.1 by @github-actions[bot] in [#5207](https://github.com/getsentry/sentry-dotnet/pull/5207)
-
 ## 6.5.0
 
 ### Features ✨


### PR DESCRIPTION
Part of the 6.6.0 release rewind. Refs #5260.

## What this does

Reverts the `release/6.6.0` merge ([4a85500](https://github.com/getsentry/sentry-dotnet/commit/4a85500a59f60c42b3f6b008a27b12a65d55b914)), which removes the 6.6.0 section from `CHANGELOG.md`. That's the only file that was modified by the original release commit — `Directory.Build.props` was never bumped, which is what caused the broken release in the first place (see #5261 for the underlying CI fix).

## Why

The 6.6.0 release published GitHub assets named `*.6.5.0.nupkg` (root cause analysed in #5260 / #5261). NuGet rejected the upload as duplicates of the existing 6.5.0 packages, so nothing landed on nuget.org. We want to fully roll back and re-cut 6.6.0 cleanly once #5261 is merged.

## Coordination

This PR is one of several steps. Recommended order:

1. Merge #5261 (`.craft.yml` `preReleaseCommand` fix).
2. Merge this PR.
3. Delete on GitHub: the `6.6.0` release, the `6.6.0` git tag, and the `release/6.6.0` branch.
4. Re-run the Release workflow with version `6.6.0` (or `auto`).

#skip-changelog