### PR TITLE
LatestWindowsTfm added to Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,6 +34,7 @@
     <PreviousIosTfm>net9.0-ios18.0</PreviousIosTfm>
     <LatestMacCatalystTfm>net10.0-maccatalyst26</LatestMacCatalystTfm>
     <PreviousMacCatalystTfm>net9.0-maccatalyst18.0</PreviousMacCatalystTfm>
+    <LatestWindowsTfm>net10.0-windows10.0.19041.0</LatestWindowsTfm>
     <PreviousWindowsTfm>net9.0-windows10.0.19041.0</PreviousWindowsTfm>
   </PropertyGroup>
 

--- a/src/Sentry.Maui/Sentry.Maui.csproj
+++ b/src/Sentry.Maui/Sentry.Maui.csproj
@@ -10,7 +10,7 @@
     <TargetFrameworks Condition="'$(NO_ANDROID)' == ''">$(TargetFrameworks);$(LatestAndroidTfm);$(PreviousAndroidTfm)</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);$(LatestIosTfm);$(PreviousIosTfm)</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_MACCATALYST)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);$(LatestMacCatalystTfm);$(PreviousMacCatalystTfm)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(NO_WINDOWS)' == '' And !$([MSBuild]::IsOSPlatform('Linux'))">$(TargetFrameworks);$(PreviousWindowsTfm);$(LatestWindowsTfm)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(NO_WINDOWS)' == '' And !$([MSBuild]::IsOSPlatform('Linux'))">$(TargetFrameworks);$(LatestWindowsTfm);$(PreviousWindowsTfm)</TargetFrameworks>
 
     <!--
       This flag allows us to target Windows-specific code when building on OSX, so we can build and pack all platforms on a single machine.

--- a/src/Sentry.Maui/Sentry.Maui.csproj
+++ b/src/Sentry.Maui/Sentry.Maui.csproj
@@ -10,7 +10,7 @@
     <TargetFrameworks Condition="'$(NO_ANDROID)' == ''">$(TargetFrameworks);$(LatestAndroidTfm);$(PreviousAndroidTfm)</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_IOS)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);$(LatestIosTfm);$(PreviousIosTfm)</TargetFrameworks>
     <TargetFrameworks Condition="'$(NO_MACCATALYST)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);$(LatestMacCatalystTfm);$(PreviousMacCatalystTfm)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(NO_WINDOWS)' == '' And !$([MSBuild]::IsOSPlatform('Linux'))">$(TargetFrameworks);$(PreviousWindowsTfm)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(NO_WINDOWS)' == '' And !$([MSBuild]::IsOSPlatform('Linux'))">$(TargetFrameworks);$(PreviousWindowsTfm);$(LatestWindowsTfm)</TargetFrameworks>
 
     <!--
       This flag allows us to target Windows-specific code when building on OSX, so we can build and pack all platforms on a single machine.


### PR DESCRIPTION
Adds `LatestWindowsTfm` to `Directory.Build.props` and include it in the `TargetFrameworks` of `Sentry.Maui.csproj`. This update ensures that the project targets the latest Windows TFM. This fixes #5037 for me

## Root cause
Sentry.Maui's TFM list ([Directory.Build.props](https://github.com/getsentry/sentry-dotnet) + [Sentry.Maui.csproj](https://github.com/getsentry/sentry-dotnet)) ships these Windows-relevant assets before the PR:

- `net10.0` — generic, no WinUI lifecycle/event binders
- `net9.0-windows10.0.19041.0` — the only asset that contains the Windows breadcrumb binders

A .NET 10 MAUI app targets `net10.0-windows10.0.19041.0`. NuGet's nearest-framework algorithm prioritizes the highest .NET major version first, so it picks the generic `net10.0` asset over the platform-specific `net9.0-windows` one. The app therefore binds against the Windows-blind generic assembly → no automatic breadcrumbs on Windows. 