### PR TITLE
fix: [.NET 10] PageNavigationExtensions updated for public Page properties

### DIFF
--- a/src/Sentry.Maui/Internal/PageNavigationExtensions.cs
+++ b/src/Sentry.Maui/Internal/PageNavigationExtensions.cs
@@ -16,9 +16,9 @@ internal static class PageNavigationExtensions
             return;
         }
         DestinationPageProperty = typeof(NavigatedFromEventArgs)
-            .GetProperty("DestinationPage", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            .GetProperty("DestinationPage", BindingFlags.Instance | BindingFlags.NonPublic);
         PreviousPageProperty = typeof(NavigatedToEventArgs)
-            .GetProperty("PreviousPage", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            .GetProperty("PreviousPage", BindingFlags.Instance | BindingFlags.NonPublic);
     }
 #endif
 

--- a/src/Sentry.Maui/Internal/PageNavigationExtensions.cs
+++ b/src/Sentry.Maui/Internal/PageNavigationExtensions.cs
@@ -4,6 +4,7 @@ namespace Sentry.Maui.Internal;
 
 internal static class PageNavigationExtensions
 {
+#if !NET10_0_OR_GREATER
     private static readonly PropertyInfo? DestinationPageProperty;
     private static readonly PropertyInfo? PreviousPageProperty;
 
@@ -15,22 +16,29 @@ internal static class PageNavigationExtensions
             return;
         }
         DestinationPageProperty = typeof(NavigatedFromEventArgs)
-            .GetProperty("DestinationPage", BindingFlags.Instance | BindingFlags.NonPublic);
+            .GetProperty("DestinationPage", BindingFlags.Instance | BindingFlags.Public);
         PreviousPageProperty = typeof(NavigatedToEventArgs)
-            .GetProperty("PreviousPage", BindingFlags.Instance | BindingFlags.NonPublic);
+            .GetProperty("PreviousPage", BindingFlags.Instance | BindingFlags.Public);
     }
+#endif
 
     /// <summary>
-    /// Reads the (internal) NavigatedFromEventArgs.DestinationPage property via reflection.
-    /// Note that this will return null if trimming is enabled.
+    /// Gets the destination page from navigation arguments.
     /// </summary>
     public static Page? GetDestinationPage(this NavigatedFromEventArgs eventArgs) =>
+#if NET10_0_OR_GREATER
+        eventArgs.DestinationPage;
+#else
         DestinationPageProperty?.GetValue(eventArgs) as Page;
+#endif
 
     /// <summary>
-    /// Reads the (internal) NavigatedFromEventArgs.PreviousPage property via reflection.
-    /// Note that this will return null if trimming is enabled.
+    /// Gets the previous page from navigation arguments.
     /// </summary>
     public static Page? GetPreviousPage(this NavigatedToEventArgs eventArgs) =>
+#if NET10_0_OR_GREATER
+        eventArgs.PreviousPage;
+#else
         PreviousPageProperty?.GetValue(eventArgs) as Page;
+#endif
 }

--- a/src/Sentry.Maui/Internal/PageNavigationExtensions.cs
+++ b/src/Sentry.Maui/Internal/PageNavigationExtensions.cs
@@ -16,9 +16,9 @@ internal static class PageNavigationExtensions
             return;
         }
         DestinationPageProperty = typeof(NavigatedFromEventArgs)
-            .GetProperty("DestinationPage", BindingFlags.Instance | BindingFlags.Public);
+            .GetProperty("DestinationPage", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         PreviousPageProperty = typeof(NavigatedToEventArgs)
-            .GetProperty("PreviousPage", BindingFlags.Instance | BindingFlags.Public);
+            .GetProperty("PreviousPage", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
     }
 #endif
 

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.Page.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.Page.cs
@@ -88,11 +88,9 @@ public partial class MauiEventsBinderTests
         Assert.Equal(MauiEventsBinder.NavigationType, crumb.Type);
         Assert.Equal(MauiEventsBinder.NavigationCategory, crumb.Category);
         crumb.Data.Should().Contain($"{nameof(Page)}.Name", "page");
-#if !NET10_0
         // TODO: Work out why these are missing in .NET 10
         crumb.Data.Should().Contain("PreviousPage", nameof(Page));
         crumb.Data.Should().Contain("PreviousPage.Name", "otherPage");
-#endif
     }
 
     [Fact]

--- a/test/Sentry.Maui.Tests/MauiEventsBinderTests.Page.cs
+++ b/test/Sentry.Maui.Tests/MauiEventsBinderTests.Page.cs
@@ -88,7 +88,6 @@ public partial class MauiEventsBinderTests
         Assert.Equal(MauiEventsBinder.NavigationType, crumb.Type);
         Assert.Equal(MauiEventsBinder.NavigationCategory, crumb.Category);
         crumb.Data.Should().Contain($"{nameof(Page)}.Name", "page");
-        // TODO: Work out why these are missing in .NET 10
         crumb.Data.Should().Contain("PreviousPage", nameof(Page));
         crumb.Data.Should().Contain("PreviousPage.Name", "otherPage");
     }


### PR DESCRIPTION
starting with .NET 10 `DestinationPage` and `PreviousPage` in `NavigatedFromEventArgs` and `NavigatedToEventArgs` are no longer internal so no need for getting them via reflection in `PageNavigationExtensions`.

PR in dotnet/maui: https://github.com/dotnet/maui/pull/28384
fixes: https://github.com/getsentry/sentry-dotnet/issues/4578
