### PR TITLE
chore: Enable Dependabot for development dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 2
+  allow:
+    - dependency-name: "BenchmarkDotNet*"
   groups:
     benchmarkdotnet:
       patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,37 @@ updates:
   open-pull-requests-limit: 1
 
 - package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 2
+  allow:
+    - dependency-name: "UnoptimizedAssemblyDetector"
+    - dependency-name: "Roslynator.Analyzers"
+
+- package-ecosystem: nuget
+  directory: "/benchmarks"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 2
+  groups:
+    benchmarkdotnet:
+      patterns:
+        - "BenchmarkDotNet*"
+
+- package-ecosystem: nuget
   directory: "/samples"
   schedule:
     interval: monthly
   open-pull-requests-limit: 2
+
+- package-ecosystem: nuget
+  directory: "/src"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 1
+  allow:
+    - dependency-name: "SIL.ReleaseTasks"
 
 - package-ecosystem: nuget
   directory: "/test"


### PR DESCRIPTION
fixes #5280

Enable Dependabot for development dependencies:
- add _root_, but only explicitly allow `PackageReference` from the root `./Directory.Build.props` file ... all sub-directories (benchmarks, samples, src, test) have their dedicated rule set
- add _benchmarks_, and group `"BenchmarkDotNet*"` packages into a single PR
- add _src_, but only for development dependencies ... does not include any other NuGet package, that would result in changing a transitive dependency for the consumer of the published package, which could be a breaking change in some scenarios ... we update these manually with the next major release of our Sentry SDK packages

See also https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference