### PR TITLE
chore: update Warden Configuration

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -2,14 +2,17 @@
 # https://github.com/getsentry/warden
 #
 # Warden reviews code using AI-powered skills triggered by GitHub events.
-# Skills live in .agents/skills/ or .claude/skills/
+# Built-in skills are available by name. Add more skills as needed.
 #
-# Add skills with: warden add <skill-name>
+# Add built-in reviews with:
+#   warden add security-review
+#   warden add code-review
 
 version = 1
 
 # Default settings inherited by all skills
 [defaults]
+runtime = "pi"
 # Severity levels: critical, high, medium, low, info
 # failOn: minimum severity that fails the check
 failOn = "high"
@@ -17,7 +20,9 @@ failOn = "high"
 reportOn = "medium"
 
 # Skills define what to analyze and when to run
-# Add skills with: warden add <skill-name>
+# Add built-in reviews with:
+#   warden add security-review
+#   warden add code-review
 #
 # Example skill with path filters and triggers:
 #
@@ -28,7 +33,9 @@ reportOn = "medium"
 #
 # [[skills.triggers]]
 # type = "pull_request"
-# actions = ["opened", "synchronize", "reopened"]
+# actions = ["opened", "synchronize", "reopened", "labeled"]
+# draft = false
+# labels = ["Warden"]
 
 [[skills]]
 name = "code-review"
@@ -36,7 +43,9 @@ remote = "getsentry/skills"
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]
 
 [[skills]]
 name = "find-bugs"
@@ -44,7 +53,9 @@ remote = "getsentry/skills"
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]
 
 [[skills]]
 name = "gha-security-review"
@@ -52,7 +63,9 @@ remote = "getsentry/skills"
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]
 
 [[skills]]
 name = "security-review"
@@ -60,4 +73,6 @@ remote = "getsentry/skills"
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]

--- a/warden.toml
+++ b/warden.toml
@@ -13,6 +13,7 @@ version = 1
 # Default settings inherited by all skills
 [defaults]
 runtime = "pi"
+model = "anthropic/claude-opus-4-5"
 # Severity levels: critical, high, medium, low, info
 # failOn: minimum severity that fails the check
 failOn = "high"


### PR DESCRIPTION
fixes #5292

### Summary

Update Warden Configuration to the latest version (currently `warden 0.38.1`).

### Remarks

What I did locally to create this PR is:
1. delete file `warden.toml`
1. update global `@sentry/warden` tool
   - > @sentry/warden@0.38.1
1. re-initialize Warden via `warden init`
   - created a new `warden.toml` from the latest template
1. restore previous actions and update previous configuration to the new template
1. add `model = "anthropic/claude-opus-4-5"`
   - the actual fix
   - commit: https://github.com/getsentry/sentry-dotnet/pull/5290/changes/8f0188b3b982066c4776286b6a1c597e2ecb2fc4

This fixes the current issue in CI, see
- https://github.com/getsentry/sentry-dotnet/pull/5288/checks?check_run_id=80987232263

