### PR TITLE
fix: Unsampled Transactions no longer propagate empty trace headers

### DIFF
--- a/src/Sentry.AspNet/HttpContextExtensions.cs
+++ b/src/Sentry.AspNet/HttpContextExtensions.cs
@@ -26,7 +26,14 @@ public static class HttpContextExtensions
 
         try
         {
-            return SentryTraceHeader.Parse(value);
+            var traceHeader = SentryTraceHeader.Parse(value);
+            if (traceHeader?.TraceId != SentryId.Empty)
+            {
+                return traceHeader;
+            }
+
+            options?.LogWarning("Sentry trace header '{0}' has an empty trace ID.", value);
+            return null;
         }
         catch (Exception ex)
         {

--- a/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
@@ -34,4 +34,30 @@ public static class HttpContextBuilder
         };
     }
 
+    public static HttpContext BuildWithHeaders(ReadOnlySpan<(string Key, string Value)> headers, int responseStatusCode = 200)
+    {
+        var httpRequest = new HttpRequest("test", "http://test/the/path", null);
+
+        var httpRequestType = httpRequest.GetType();
+        var setHeaderMethod = httpRequestType.GetMethod("SetHeader", BindingFlags.Instance | BindingFlags.NonPublic, null, [typeof(string), typeof(string)], null);
+        var setHeaderParameters = new object[2];
+        Assert.NotNull(setHeaderMethod);
+
+        foreach (var header in headers)
+        {
+            setHeaderParameters[0] = header.Key;
+            setHeaderParameters[1] = header.Value;
+            setHeaderMethod.Invoke(httpRequest, setHeaderParameters);
+        }
+
+        return new HttpContext(
+            httpRequest,
+            new HttpResponse(TextWriter.Null)
+            {
+                StatusCode = responseStatusCode
+            })
+        {
+            ApplicationInstance = new HttpApplication()
+        };
+    }
 }

--- a/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
@@ -40,11 +40,14 @@ public static class HttpContextBuilder
     {
         var httpRequest = new HttpRequest("test", "http://test/the/path", null);
 
-#if WINDOWS
-        SetHeaders(httpRequest, headers);
-#else
-        SetReadOnlyHeaders(httpRequest, headers);
-#endif
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            SetHeaders(httpRequest, headers);
+        }
+        else
+        {
+            SetReadOnlyHeaders(httpRequest, headers);
+        }
 
         return new HttpContext(
             httpRequest,

--- a/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
@@ -1,5 +1,3 @@
-using System.Runtime.Versioning;
-
 namespace Sentry.AspNet.Tests;
 
 public static class HttpContextBuilder
@@ -40,14 +38,12 @@ public static class HttpContextBuilder
     {
         var httpRequest = new HttpRequest("test", "http://test/the/path", null);
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        httpRequest.Headers.Unprotect();
+        foreach (var header in headers)
         {
-            SetHeaders(httpRequest, headers);
+            httpRequest.Headers.Add(header.Key, header.Value);
         }
-        else
-        {
-            SetReadOnlyHeaders(httpRequest, headers);
-        }
+        httpRequest.Headers.Protect();
 
         return new HttpContext(
             httpRequest,
@@ -59,29 +55,23 @@ public static class HttpContextBuilder
             ApplicationInstance = new HttpApplication()
         };
     }
+}
 
-    [SupportedOSPlatform("windows")]
-    private static void SetHeaders(HttpRequest httpRequest, ReadOnlySpan<(string Key, string Value)> headers)
+file static class NameValueCollectionExtensions
+{
+    private static readonly Type HeadersType = typeof(System.Collections.Specialized.NameValueCollection);
+    private static readonly PropertyInfo IsReadOnlyProperty = HeadersType.GetProperty("IsReadOnly", BindingFlags.Instance | BindingFlags.NonPublic);
+
+    extension(System.Collections.Specialized.NameValueCollection collection)
     {
-        foreach (var header in headers)
+        public void Protect()
         {
-            httpRequest.Headers.Add(header.Key, header.Value);
+            IsReadOnlyProperty.SetValue(collection, true);
         }
-    }
 
-    [UnsupportedOSPlatform("windows")]
-    private static void SetReadOnlyHeaders(HttpRequest httpRequest, ReadOnlySpan<(string Key, string Value)> headers)
-    {
-        var httpRequestType = httpRequest.GetType();
-        var setHeaderMethod = httpRequestType.GetMethod("SetHeader", BindingFlags.Instance | BindingFlags.NonPublic, null, [typeof(string), typeof(string)], null);
-        var setHeaderParameters = new object[2];
-        Assert.NotNull(setHeaderMethod);
-
-        foreach (var header in headers)
+        public void Unprotect()
         {
-            setHeaderParameters[0] = header.Key;
-            setHeaderParameters[1] = header.Value;
-            setHeaderMethod.Invoke(httpRequest, setHeaderParameters);
+            IsReadOnlyProperty.SetValue(collection, false);
         }
     }
 }

--- a/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
@@ -1,3 +1,5 @@
+using System.Runtime.Versioning;
+
 namespace Sentry.AspNet.Tests;
 
 public static class HttpContextBuilder
@@ -38,6 +40,35 @@ public static class HttpContextBuilder
     {
         var httpRequest = new HttpRequest("test", "http://test/the/path", null);
 
+#if WINDOWS
+        SetHeaders(httpRequest, headers);
+#else
+        SetReadOnlyHeaders(httpRequest, headers);
+#endif
+
+        return new HttpContext(
+            httpRequest,
+            new HttpResponse(TextWriter.Null)
+            {
+                StatusCode = responseStatusCode
+            })
+        {
+            ApplicationInstance = new HttpApplication()
+        };
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void SetHeaders(HttpRequest httpRequest, ReadOnlySpan<(string Key, string Value)> headers)
+    {
+        foreach (var header in headers)
+        {
+            httpRequest.Headers.Add(header.Key, header.Value);
+        }
+    }
+
+    [UnsupportedOSPlatform("windows")]
+    private static void SetReadOnlyHeaders(HttpRequest httpRequest, ReadOnlySpan<(string Key, string Value)> headers)
+    {
         var httpRequestType = httpRequest.GetType();
         var setHeaderMethod = httpRequestType.GetMethod("SetHeader", BindingFlags.Instance | BindingFlags.NonPublic, null, [typeof(string), typeof(string)], null);
         var setHeaderParameters = new object[2];
@@ -49,15 +80,5 @@ public static class HttpContextBuilder
             setHeaderParameters[1] = header.Value;
             setHeaderMethod.Invoke(httpRequest, setHeaderParameters);
         }
-
-        return new HttpContext(
-            httpRequest,
-            new HttpResponse(TextWriter.Null)
-            {
-                StatusCode = responseStatusCode
-            })
-        {
-            ApplicationInstance = new HttpApplication()
-        };
     }
 }

--- a/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextBuilder.cs
@@ -34,6 +34,9 @@ public static class HttpContextBuilder
         };
     }
 
+    internal static readonly bool IsHttpHeaderMutationSupported = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+    [System.Runtime.Versioning.UnsupportedOSPlatform("windows", "Works on Mono. But requires IIS7 on NetFx.")]
     public static HttpContext BuildWithHeaders(ReadOnlySpan<(string Key, string Value)> headers, int responseStatusCode = 200)
     {
         var httpRequest = new HttpRequest("test", "http://test/the/path", null);

--- a/test/Sentry.AspNet.Tests/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextExtensionsTests.cs
@@ -153,14 +153,40 @@ public class HttpContextExtensionsTests
     }
 
     [Fact]
-    public void StartSentryTransaction_WithEmptyTraceId_ReturnsNull()
+    public void StartSentryTransaction_WithTraceId_IsSampled()
     {
         // Arrange
         using var _ = SentrySdk.UseHub(new Hub(
             new SentryOptions
             {
                 Dsn = ValidDsn,
-                TracesSampleRate = 0.0
+                TracesSampleRate = 0.0,
+            },
+            Substitute.For<ISentryClient>()
+        ));
+
+        var context = HttpContextBuilder.BuildWithHeaders([(SentryTraceHeader.HttpHeaderName, "5bd5f6d346b442dd9177dce9302fd737-b0d83d6cfec87606-1")]);
+
+        // Act
+        var transaction = context.StartSentryTransaction();
+        var traceHeader = transaction.GetTraceHeader();
+
+        // Assert
+        transaction.Should().BeOfType<TransactionTracer>();
+        traceHeader.TraceId.Should().NotBe(SentryId.Empty).And.Be(transaction.TraceId);
+        traceHeader.SpanId.Should().NotBe(SpanId.Empty).And.Be(transaction.SpanId);
+        traceHeader.IsSampled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void StartSentryTransaction_WithEmptyTraceId_IsNotSampled()
+    {
+        // Arrange
+        using var _ = SentrySdk.UseHub(new Hub(
+            new SentryOptions
+            {
+                Dsn = ValidDsn,
+                TracesSampleRate = 0.0,
             },
             Substitute.For<ISentryClient>()
         ));

--- a/test/Sentry.AspNet.Tests/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextExtensionsTests.cs
@@ -152,9 +152,11 @@ public class HttpContextExtensionsTests
         transaction.Request.Cookies.Should().BeNull();
     }
 
-    [Fact]
+    [SkippableFact]
     public void StartSentryTransaction_WithTraceId_IsSampled()
     {
+        Skip.IfNot(HttpContextBuilder.IsHttpHeaderMutationSupported, nameof(HttpContextBuilder.IsHttpHeaderMutationSupported));
+
         // Arrange
         using var _ = SentrySdk.UseHub(new Hub(
             new SentryOptions
@@ -178,9 +180,11 @@ public class HttpContextExtensionsTests
         traceHeader.IsSampled.Should().BeTrue();
     }
 
-    [Fact]
+    [SkippableFact]
     public void StartSentryTransaction_WithEmptyTraceId_IsNotSampled()
     {
+        Skip.IfNot(HttpContextBuilder.IsHttpHeaderMutationSupported, nameof(HttpContextBuilder.IsHttpHeaderMutationSupported));
+
         // Arrange
         using var _ = SentrySdk.UseHub(new Hub(
             new SentryOptions

--- a/test/Sentry.AspNet.Tests/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNet.Tests/HttpContextExtensionsTests.cs
@@ -151,4 +151,30 @@ public class HttpContextExtensionsTests
         // Assert
         transaction.Request.Cookies.Should().BeNull();
     }
+
+    [Fact]
+    public void StartSentryTransaction_WithEmptyTraceId_ReturnsNull()
+    {
+        // Arrange
+        using var _ = SentrySdk.UseHub(new Hub(
+            new SentryOptions
+            {
+                Dsn = ValidDsn,
+                TracesSampleRate = 0.0
+            },
+            Substitute.For<ISentryClient>()
+        ));
+
+        var context = HttpContextBuilder.BuildWithHeaders([(SentryTraceHeader.HttpHeaderName, "00000000000000000000000000000000-1000000000000000-1")]);
+
+        // Act
+        var transaction = context.StartSentryTransaction();
+        var traceHeader = transaction.GetTraceHeader();
+
+        // Assert
+        transaction.Should().BeOfType<UnsampledTransaction>();
+        traceHeader.TraceId.Should().NotBe(SentryId.Empty).And.Be(transaction.TraceId);
+        traceHeader.SpanId.Should().NotBe(SpanId.Empty).And.Be(transaction.SpanId);
+        traceHeader.IsSampled.Should().BeFalse();
+    }
 }

--- a/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
+++ b/test/Sentry.AspNetCore.Tests/Extensions/HttpContextExtensionsTests.cs
@@ -80,6 +80,24 @@ public class HttpContextExtensionsTests
     }
 
     [Fact]
+    public void TryGetSentryTraceHeader_WithTraceId_ReturnsNotNull()
+    {
+        // Arrange
+        var httpContext = Fixture.GetSut();
+        var options = new SentryOptions();
+        httpContext.Request.Headers.Append(SentryTraceHeader.HttpHeaderName, "5bd5f6d346b442dd9177dce9302fd737-b0d83d6cfec87606-1");
+
+        // Act
+        var header = httpContext.TryGetSentryTraceHeader(options);
+
+        // Assert
+        Assert.NotNull(header);
+        header.TraceId.Should().Be(SentryId.Parse("5bd5f6d346b442dd9177dce9302fd737"));
+        header.SpanId.Should().Be(SpanId.Parse("b0d83d6cfec87606"));
+        header.IsSampled.Should().BeTrue();
+    }
+
+    [Fact]
     public void TryGetSentryTraceHeader_WithEmptyTraceId_ReturnsNull()
     {
         // Arrange

--- a/test/Sentry.OpenTelemetry.Exporter.Tests/SentryPropagatorTests.cs
+++ b/test/Sentry.OpenTelemetry.Exporter.Tests/SentryPropagatorTests.cs
@@ -169,4 +169,30 @@ public class SentryPropagatorTests
             outContext.Baggage.GetBaggage("sentry-sample_rate").Should().Be("1.0");
         }
     }
+
+    [Fact]
+    public void Extract_WithEmptyTraceId_From_SentryTraceHeader()
+    {
+        // Arrange
+        var carrier = new Dictionary<string, string>()
+        {
+            { "sentry-trace", "00000000000000000000000000000000-1000000000000000-1" }
+        };
+
+        var sut = new SentryPropagator();
+        var contextIn = new PropagationContext();
+
+        // Act
+        var outContext = sut.Extract(contextIn, carrier, _getter);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            $"{outContext.ActivityContext.TraceId}".Should().Be("00000000000000000000000000000000");
+            $"{outContext.ActivityContext.SpanId}".Should().Be("1000000000000000");
+            outContext.ActivityContext.TraceFlags.Should().Be(ActivityTraceFlags.Recorded);
+            outContext.ActivityContext.TraceState.Should().BeNull();
+            outContext.ActivityContext.IsRemote.Should().Be(true);
+        }
+    }
 }


### PR DESCRIPTION
This is a follow-up to
- #4302

#4302 applied the fix to `Sentry.AspNetCore` only.

### Changes
This changeset is
- porting the fix to `Sentry.AspNet` as well
- adding an additional Test-Case to `Sentry.OpenTelemetry`/`Sentry.OpenTelemetry.Exporter` for existing related behavior that is intentionally left unchanged
