### PR TITLE
fix: don't attach `sentry-trace` header with empty Trace ID

### DIFF
--- a/src/Sentry/SentryMessageHandler.cs
+++ b/src/Sentry/SentryMessageHandler.cs
@@ -151,7 +151,10 @@ public abstract class SentryMessageHandler : DelegatingHandler
             // Use the span created by this integration as parent, instead of its own parent
             (parentSpan?.GetTraceHeader() ?? _hub.GetTraceHeader()) is { } traceHeader)
         {
-            request.Headers.Add(SentryTraceHeader.HttpHeaderName, traceHeader.ToString());
+            if (traceHeader.TraceId != SentryId.Empty)
+            {
+                request.Headers.Add(SentryTraceHeader.HttpHeaderName, traceHeader.ToString());
+            }
         }
     }
 

--- a/test/Sentry.Tests/SentryHttpMessageHandlerTests.cs
+++ b/test/Sentry.Tests/SentryHttpMessageHandlerTests.cs
@@ -130,6 +130,28 @@ public class SentryHttpMessageHandlerTests
     }
 
     [Fact]
+    public async Task SendAsync_SentryTraceHeaderNotSet_DoesntSetHeader_WhenPropagationContextHasEmptyTraceId()
+    {
+        // Arrange
+        var hub = Substitute.For<IHub>();
+
+        hub.GetTraceHeader().ReturnsForAnyArgs(
+            SentryTraceHeader.Parse("00000000000000000000000000000000-1000000000000000-1"));
+
+        using var innerHandler = new RecordingHttpMessageHandler(new FakeHttpMessageHandler());
+        using var sentryHandler = new SentryHttpMessageHandler(innerHandler, hub);
+        using var client = new HttpClient(sentryHandler);
+
+        // Act
+        await client.GetAsync("https://localhost/");
+
+        using var request = innerHandler.GetRequests().Single();
+
+        // Assert
+        request.Headers.Should().NotContain(h => h.Key == "sentry-trace");
+    }
+
+    [Fact]
     public async Task SendAsync_SentryTraceHeaderAlreadySet_NotOverwritten()
     {
         // Arrange
@@ -478,6 +500,28 @@ public class SentryHttpMessageHandlerTests
 
         using var innerHandler = new RecordingHttpMessageHandler(new FakeHttpMessageHandler());
         using var sentryHandler = new SentryHttpMessageHandler(hub, options, innerHandler, failedRequestHandler);
+        using var client = new HttpClient(sentryHandler);
+
+        // Act
+        client.Get("https://localhost/");
+
+        using var request = innerHandler.GetRequests().Single();
+
+        // Assert
+        request.Headers.Should().NotContain(h => h.Key == "sentry-trace");
+    }
+
+    [Fact]
+    public void Send_SentryTraceHeaderNotSet_DoesntSetHeader_WhenPropagationContextHasEmptyTraceId()
+    {
+        // Arrange
+        var hub = Substitute.For<IHub>();
+
+        hub.GetTraceHeader().ReturnsForAnyArgs(
+            SentryTraceHeader.Parse("00000000000000000000000000000000-1000000000000000-1"));
+
+        using var innerHandler = new RecordingHttpMessageHandler(new FakeHttpMessageHandler());
+        using var sentryHandler = new SentryHttpMessageHandler(innerHandler, hub);
         using var client = new HttpClient(sentryHandler);
 
         // Act


### PR DESCRIPTION
### Summary

Don't attach a new `sentry-trace` header when the "trace-id" is empty (all `0`).

### Remarks

A user is having an issue in a distributed setup instrumented with multiple Sentry-SDKs where a tail-SDK is emitting Metrics with an empty Trace ID (`SentryId.Empty` / `00000000000000000000000000000000`), propagated via the `sentry-trace` header from a head-SDK.

### Update

This less-of-a-fix and more-of-a-workaround/hack might have become obsolete since we found the root cause:
- getsentry/sentry-electron#1389
