### PR TITLE
docs: add XML comments for boolean return of ILogEntryFilter

### DIFF
--- a/src/Sentry.Extensions.Logging/DelegateLogEntryFilter.cs
+++ b/src/Sentry.Extensions.Logging/DelegateLogEntryFilter.cs
@@ -13,7 +13,7 @@ public class DelegateLogEntryFilter : ILogEntryFilter
     /// <summary>
     /// Creates a new instance of <see cref="DelegateLogEntryFilter"/>
     /// </summary>
-    /// <param name="filter"></param>
+    /// <param name="filter">The filter <see langword="delegate"/>.</param>
     public DelegateLogEntryFilter(Func<string, LogLevel, EventId, Exception?, bool> filter)
     {
         ArgumentNullException.ThrowIfNull(filter);

--- a/src/Sentry.Extensions.Logging/ILogEntryFilter.cs
+++ b/src/Sentry.Extensions.Logging/ILogEntryFilter.cs
@@ -18,6 +18,7 @@ public interface ILogEntryFilter
     /// <param name="logLevel">The event level.</param>
     /// <param name="eventId">The EventId.</param>
     /// <param name="exception">The Exception, if any.</param>
+    /// <returns><see langword="true"/> if the event should be filtered out; otherwise, <see langword="false"/>.</returns>
     public bool Filter(
         string categoryName,
         LogLevel logLevel,

--- a/src/Sentry.Extensions.Logging/SentryLoggingOptionsExtensions.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggingOptionsExtensions.cs
@@ -9,26 +9,28 @@ namespace Sentry.Extensions.Logging;
 public static class SentryLoggingOptionsExtensions
 {
     /// <summary>
-    /// Add an log event filter
+    /// Add a log event filter.
     /// </summary>
     /// <remarks>
     /// Filters are called before sending an event.
     /// This allows the filter to decide whether the log message should not be recorded at all.
+    /// The log entry is neither captured as <see cref="SentryEvent"/> nor added as <see cref="Breadcrumb"/> when any filter returns <see langword="true"/>.
     /// </remarks>
     /// <param name="options">The <see cref="SentryLoggingOptions"/> to hold the filter.</param>
-    /// <param name="filter">The filter.</param>
+    /// <param name="filter">The <see cref="ILogEntryFilter"/> filter.</param>
     public static void AddLogEntryFilter(this SentryLoggingOptions options, ILogEntryFilter filter)
         => options.Filters = options.Filters.Concat(new[] { filter }).ToArray();
 
     /// <summary>
-    /// Add an log event filter
+    /// Add a log event filter.
     /// </summary>
     /// <remarks>
     /// Filters are called before sending an event.
     /// This allows the filter to decide whether the log message should not be recorded at all.
+    /// The log entry is neither captured as <see cref="SentryEvent"/> nor added as <see cref="Breadcrumb"/> when any filter returns <see langword="true"/>.
     /// </remarks>
     /// <param name="options">The <see cref="SentryLoggingOptions"/> to hold the filter.</param>
-    /// <param name="filter">The filter.</param>
+    /// <param name="filter">The filter <see langword="delegate"/>. Return <see langword="true"/> if the log entry should be filtered.</param>
     public static void AddLogEntryFilter(
         this SentryLoggingOptions options,
         Func<string, LogLevel, EventId, Exception?, bool> filter)

--- a/src/Sentry.Extensions.Logging/SentryLoggingOptionsExtensions.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggingOptionsExtensions.cs
@@ -30,7 +30,7 @@ public static class SentryLoggingOptionsExtensions
     /// The log entry is neither captured as <see cref="SentryEvent"/> nor added as <see cref="Breadcrumb"/> when any filter returns <see langword="true"/>.
     /// </remarks>
     /// <param name="options">The <see cref="SentryLoggingOptions"/> to hold the filter.</param>
-    /// <param name="filter">The filter <see langword="delegate"/>. Return <see langword="true"/> if the log entry should be filtered.</param>
+    /// <param name="filter">The filter <see langword="delegate"/>. Return <see langword="true"/> if the log entry should be filtered out.</param>
     public static void AddLogEntryFilter(
         this SentryLoggingOptions options,
         Func<string, LogLevel, EventId, Exception?, bool> filter)

--- a/src/Sentry.Extensions.Logging/SentryLoggingOptionsExtensions.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggingOptionsExtensions.cs
@@ -14,7 +14,7 @@ public static class SentryLoggingOptionsExtensions
     /// <remarks>
     /// Filters are called before sending an event.
     /// This allows the filter to decide whether the log message should not be recorded at all.
-    /// The log entry is neither captured as <see cref="SentryEvent"/> nor added as <see cref="Breadcrumb"/> when any filter returns <see langword="true"/>.
+    /// The log entry is neither captured as a <see cref="SentryEvent"/> nor added as a <see cref="Breadcrumb"/> when any filter returns <see langword="true"/>.
     /// </remarks>
     /// <param name="options">The <see cref="SentryLoggingOptions"/> to hold the filter.</param>
     /// <param name="filter">The <see cref="ILogEntryFilter"/> filter.</param>


### PR DESCRIPTION
resolves #5296

### Summary

Add missing documentation comments for the `bool` return value of `Sentry.Extensions.Logging` Filter-Option.

### Remarks

Also fixes a typo.

### Changelog Entry

docs: add XML comments for boolean return of `Sentry.Extensions.Logging` Filters
