### PR TITLE
fix: OpenTelemetry transactions for failed requests keep their route name and otel context

### DIFF
--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -667,8 +667,22 @@ internal class Hub : IHub, IDisposable
             {
                 // Event contains a terminal exception -> finish any current transaction as aborted
                 // Do this *after* the event was captured, so that the event is still linked to the transaction.
-                _options.LogDebug("Ending transaction as Aborted, due to unhandled exception.");
-                transaction.Finish(SpanStatus.Aborted);
+                // Exception: OpenTelemetry-instrumented transactions are owned and finished by the
+                // SentrySpanProcessor when the underlying Activity ends. That's also where the transaction
+                // name, operation and otel/response contexts get populated (from the http.route etc.
+                // attributes, which aren't available yet at this point). Finishing it early here would
+                // capture it before that enrichment, sending it with the raw activity name (e.g.
+                // "Microsoft.AspNetCore.Hosting.HttpRequestIn") and no otel context. See issue #5091.
+                if (transaction is IBaseTracer { IsOtelInstrumenter: true })
+                {
+                    _options.LogDebug(
+                        "Not ending OpenTelemetry transaction as Aborted; it is finished by the SentrySpanProcessor.");
+                }
+                else
+                {
+                    _options.LogDebug("Ending transaction as Aborted, due to unhandled exception.");
+                    transaction.Finish(SpanStatus.Aborted);
+                }
             }
 
             return id;

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -667,12 +667,7 @@ internal class Hub : IHub, IDisposable
             {
                 // Event contains a terminal exception -> finish any current transaction as aborted
                 // Do this *after* the event was captured, so that the event is still linked to the transaction.
-                // Exception: OpenTelemetry-instrumented transactions are owned and finished by the
-                // SentrySpanProcessor when the underlying Activity ends. That's also where the transaction
-                // name, operation and otel/response contexts get populated (from the http.route etc.
-                // attributes, which aren't available yet at this point). Finishing it early here would
-                // capture it before that enrichment, sending it with the raw activity name (e.g.
-                // "Microsoft.AspNetCore.Hosting.HttpRequestIn") and no otel context. See issue #5091.
+                // Skip for OpenTelemetry transactions - these get handled by the SpanProcessor instead. See https://github.com/getsentry/sentry-dotnet/pull/5310
                 if (transaction is IBaseTracer { IsOtelInstrumenter: true })
                 {
                     _options.LogDebug(

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -546,6 +546,36 @@ public partial class HubTests : IDisposable
     }
 
     [Fact]
+    public void CaptureEvent_TerminalUnhandledException_DoesNotAbortOpenTelemetryTransaction()
+    {
+        // OpenTelemetry-instrumented transactions are owned and finished by the SentrySpanProcessor
+        // when the underlying Activity ends (which is also where the transaction name, operation and
+        // otel/response contexts get populated). Finishing them early here would capture them with the
+        // raw activity name and no otel context. See https://github.com/getsentry/sentry-dotnet/issues/5091
+
+        // Arrange
+        _fixture.Options.TracesSampleRate = 1.0;
+        _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
+        var hub = _fixture.GetSut();
+
+        var transactionContext = new TransactionContext("test", "operation")
+        {
+            Instrumenter = Instrumenter.OpenTelemetry
+        };
+        var transaction = hub.StartTransaction(transactionContext);
+        hub.ConfigureScope(scope => scope.Transaction = transaction);
+
+        var exception = new Exception("test");
+        exception.SetSentryMechanism("test", handled: false, terminal: true);
+
+        // Act
+        hub.CaptureEvent(new SentryEvent(exception));
+
+        // Assert
+        transaction.IsFinished.Should().BeFalse();
+    }
+
+    [Fact]
     public void CaptureEvent_NonTerminalUnhandledException_DoesNotAbortActiveTransaction()
     {
         // Arrange


### PR DESCRIPTION
Closes #5091

## Summary

Fixes the issue where, with the OpenTelemetry integration, transactions for **failed** requests were reported under the raw activity name (e.g. `Microsoft.AspNetCore.Hosting.HttpRequestIn`) instead of the route (e.g. `GET /Test/BadEndpoint`).

## Problem

With OTel instrumentation, `SentrySpanProcessor` creates the transaction on Activity **start** and only applies the final name, operation and `otel`/`response` contexts on Activity **end** (parsed from `http.route` etc., which aren't available at start).

When a request threw an unhandled exception, `Hub.CaptureEvent` finished the scope's transaction as `Aborted` immediately after capturing the exception event — *before* the Activity ended — synchronously capturing/sending it. By the time `SentrySpanProcessor.OnEnd` ran, the transaction was already finished, so all the OTel enrichment (route-based name, `http.server` operation, `otel`/`response` contexts) was discarded.

This early-abort is correct for the native Sentry.AspNetCore tracing path (where the name is set up-front), but wrong when OTel owns the transaction lifecycle.

## Fix

Skip the early `Aborted` finish for OTel-instrumented transactions. The `SentrySpanProcessor` owns their lifecycle and finishes them with the correct name/operation/status when the Activity ends.

## Verification

Reproduced with the customer's [minimal repro](https://github.com/tvardero/sentry-bug-repro) on .NET 10.

`POST/GET BadEndpoint` (throws → 500):

| | Before | After |
|---|---|---|
| name | `Microsoft.AspNetCore.Hosting.HttpRequestIn` | `GET Test/BadEndpoint` |
| source | Custom | Route |
| operation | `Microsoft.AspNetCore.Hosting.HttpRequestIn` | `http.server` |
| status | Aborted | UnknownError (registers as a failure) |
| `otel`/`response` context | missing | present |

Added a regression test: `CaptureEvent_TerminalUnhandledException_DoesNotAbortOpenTelemetryTransaction`.