### PR TITLE
docs: fix XML comments for boolean return of ILogEntryFilter

### DIFF
--- a/src/Sentry.Extensions.Logging/SentryLoggingOptionsExtensions.cs
+++ b/src/Sentry.Extensions.Logging/SentryLoggingOptionsExtensions.cs
@@ -27,7 +27,7 @@ public static class SentryLoggingOptionsExtensions
     /// <remarks>
     /// Filters are called before sending an event.
     /// This allows the filter to decide whether the log message should not be recorded at all.
-    /// The log entry is neither captured as <see cref="SentryEvent"/> nor added as <see cref="Breadcrumb"/> when any filter returns <see langword="true"/>.
+    /// The log entry is neither captured as a <see cref="SentryEvent"/> nor added as a <see cref="Breadcrumb"/> when any filter returns <see langword="true"/>.
     /// </remarks>
     /// <param name="options">The <see cref="SentryLoggingOptions"/> to hold the filter.</param>
     /// <param name="filter">The filter <see langword="delegate"/>. Return <see langword="true"/> if the log entry should be filtered out.</param>


### PR DESCRIPTION
### Summary

Fix XML comments for `bool` return of `ILogEntryFilter`.

### Remarks

Follow-up to #5297, where we did fix the grammar of one comment during review, but missed the 2nd comment.
See suggestion applied via https://github.com/getsentry/sentry-dotnet/pull/5297#discussion_r3463205081.

---

#skip-changelog, due to follow-up to still `Unreleased` changes of #5297
