### PR TITLE
fix(otlp): don't configure an automatic OTel propagator

### DIFF
--- a/src/Sentry.OpenTelemetry.Exporter/SentryOptionsExtensions.cs
+++ b/src/Sentry.OpenTelemetry.Exporter/SentryOptionsExtensions.cs
@@ -1,4 +1,3 @@
-using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
 using Sentry.OpenTelemetry.Exporter;
 
@@ -21,24 +20,19 @@ public static class SentryOptionsExtensions
     /// <param name="tracerProviderBuilder"><see cref="TracerProviderBuilder"/></param>
     /// <param name="collectorUrl">A custom endpoint to export OLTP trace information to. If no url is provided, the
     /// endpoint will be inferred automatically from the DSN.</param>
-    /// <param name="defaultTextMapPropagator">
-    ///     <para>The default TextMapPropagator to be used by OpenTelemetry.</para>
-    ///     <para>
-    ///         If this parameter is not supplied, the <see cref="OpenTelemetry.SentryPropagator"/> will be used, which propagates the
-    ///         baggage header as well as Sentry trace headers.
-    ///     </para>
-    ///     <para>
-    ///         The <see cref="OpenTelemetry.SentryPropagator"/> is required for Sentry's OpenTelemetry integration to work, but you
-    ///         could wrap this in a <see cref="CompositeTextMapPropagator"/> if you needed other propagators as well.
-    ///     </para>
-    /// </param>
-    public static void UseOtlp(this SentryOptions options, TracerProviderBuilder tracerProviderBuilder, Uri? collectorUrl = null, TextMapPropagator? defaultTextMapPropagator = null)
+    /// <remarks>
+    /// In line with the OTLP integration specification, this method does not configure an OpenTelemetry propagator.
+    /// Cross-service trace propagation should be enabled either via the <see cref="SentryOptions.PropagateTraceparent"/>
+    /// option or by configuring OpenTelemetry propagators yourself (e.g. by calling
+    /// <c>Sdk.SetDefaultTextMapPropagator</c>).
+    /// </remarks>
+    public static void UseOtlp(this SentryOptions options, TracerProviderBuilder tracerProviderBuilder, Uri? collectorUrl = null)
     {
         if (string.IsNullOrWhiteSpace(options.Dsn))
         {
             throw new ArgumentException("Sentry DSN must be set before calling `SentryOptions.UseOtlp`", nameof(options.Dsn));
         }
-        tracerProviderBuilder.AddSentryOtlpExporter(options.Dsn, collectorUrl, defaultTextMapPropagator);
+        tracerProviderBuilder.AddSentryOtlpExporter(options.Dsn, collectorUrl);
         options.UseOtlp();
     }
 

--- a/src/Sentry.OpenTelemetry.Exporter/SentryOptionsExtensions.cs
+++ b/src/Sentry.OpenTelemetry.Exporter/SentryOptionsExtensions.cs
@@ -21,9 +21,8 @@ public static class SentryOptionsExtensions
     /// <param name="collectorUrl">A custom endpoint to export OLTP trace information to. If no url is provided, the
     /// endpoint will be inferred automatically from the DSN.</param>
     /// <remarks>
-    /// In line with the OTLP integration specification, this method does not configure an OpenTelemetry propagator.
-    /// Cross-service trace propagation should be enabled either via the <see cref="SentryOptions.PropagateTraceparent"/>
-    /// option or by configuring OpenTelemetry propagators yourself (e.g. by calling
+    /// This method does not configure an OpenTelemetry propagator.
+    /// Cross-service trace propagation should be enabled via the OpenTelemetry SDK (e.g. by calling
     /// <c>Sdk.SetDefaultTextMapPropagator</c>).
     /// </remarks>
     public static void UseOtlp(this SentryOptions options, TracerProviderBuilder tracerProviderBuilder, Uri? collectorUrl = null)

--- a/src/Sentry.OpenTelemetry.Exporter/SentryTracerProviderBuilderExtensions.cs
+++ b/src/Sentry.OpenTelemetry.Exporter/SentryTracerProviderBuilderExtensions.cs
@@ -27,9 +27,8 @@ public static class SentryTracerProviderBuilderExtensions
     /// endpoint will be inferred automatically from the DSN.</param>
     /// <returns>The supplied <see cref="TracerProviderBuilder"/> for chaining.</returns>
     /// <remarks>
-    /// In line with the OTLP integration specification, this method does not configure an OpenTelemetry propagator.
-    /// Cross-service trace propagation should be enabled either via the <see cref="SentryOptions.PropagateTraceparent"/>
-    /// option or by configuring OpenTelemetry propagators yourself (e.g. by calling
+    /// This method does not configure an OpenTelemetry propagator.
+    /// Cross-service trace propagation should be enabled via the OpenTelemetry SDK (e.g. by calling
     /// <c>Sdk.SetDefaultTextMapPropagator</c>).
     /// </remarks>
     public static TracerProviderBuilder AddSentryOtlpExporter(this TracerProviderBuilder tracerProviderBuilder,

--- a/src/Sentry.OpenTelemetry.Exporter/SentryTracerProviderBuilderExtensions.cs
+++ b/src/Sentry.OpenTelemetry.Exporter/SentryTracerProviderBuilderExtensions.cs
@@ -1,7 +1,5 @@
-using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Exporter;
 using Sentry;
-using Sentry.OpenTelemetry;
 
 // ReSharper disable once CheckNamespace -- Discoverability
 namespace OpenTelemetry.Trace;
@@ -27,20 +25,15 @@ public static class SentryTracerProviderBuilderExtensions
     /// <param name="dsnString">The DSN for your Sentry project</param>
     /// <param name="collectorUrl">A custom endpoint to export OLTP trace information to. If no url is provided, the
     /// endpoint will be inferred automatically from the DSN.</param>
-    /// <param name="defaultTextMapPropagator">
-    ///     <para>The default TextMapPropagator to be used by OpenTelemetry.</para>
-    ///     <para>
-    ///         If this parameter is not supplied, the <see cref="SentryPropagator"/> will be used, which propagates the
-    ///         baggage header as well as Sentry trace headers.
-    ///     </para>
-    ///     <para>
-    ///         The <see cref="SentryPropagator"/> is required for Sentry's OpenTelemetry integration to work, but you
-    ///         could wrap this in a <see cref="CompositeTextMapPropagator"/> if you needed other propagators as well.
-    ///     </para>
-    /// </param>
     /// <returns>The supplied <see cref="TracerProviderBuilder"/> for chaining.</returns>
+    /// <remarks>
+    /// In line with the OTLP integration specification, this method does not configure an OpenTelemetry propagator.
+    /// Cross-service trace propagation should be enabled either via the <see cref="SentryOptions.PropagateTraceparent"/>
+    /// option or by configuring OpenTelemetry propagators yourself (e.g. by calling
+    /// <c>Sdk.SetDefaultTextMapPropagator</c>).
+    /// </remarks>
     public static TracerProviderBuilder AddSentryOtlpExporter(this TracerProviderBuilder tracerProviderBuilder,
-        string dsnString, Uri? collectorUrl = null, TextMapPropagator? defaultTextMapPropagator = null)
+        string dsnString, Uri? collectorUrl = null)
     {
         if (Dsn.IsDisabled(dsnString))
         {
@@ -51,9 +44,6 @@ public static class SentryTracerProviderBuilderExtensions
         {
             throw new ArgumentException(MissingDsnWarning, nameof(dsnString));
         }
-
-        defaultTextMapPropagator ??= new SentryPropagator();
-        Sdk.SetDefaultTextMapPropagator(defaultTextMapPropagator);
 
         collectorUrl ??= dsn.GetOtlpTracesEndpointUri();
         tracerProviderBuilder.AddOtlpExporter(options => OtlpConfigurationCallback(options, collectorUrl, dsn.PublicKey));

--- a/test/Sentry.OpenTelemetry.Exporter.Tests/SentryOptionsExtensionsTests.cs
+++ b/test/Sentry.OpenTelemetry.Exporter.Tests/SentryOptionsExtensionsTests.cs
@@ -1,4 +1,3 @@
-using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
 
 namespace Sentry.OpenTelemetry.Exporter.Tests;
@@ -115,21 +114,6 @@ public class SentryOptionsExtensionsTests
 
         // Act
         var act = () => options.UseOtlp(tracerProviderBuilder, collectorUrl);
-
-        // Assert
-        act.Should().NotThrow();
-    }
-
-    [Fact]
-    public void UseOtlp_WithCustomPropagator_DoesNotThrow()
-    {
-        // Arrange
-        var options = new SentryOptions { Dsn = DsnSamples.ValidDsn };
-        var tracerProviderBuilder = Substitute.For<TracerProviderBuilder>();
-        var customPropagator = Substitute.For<TextMapPropagator>();
-
-        // Act
-        var act = () => options.UseOtlp(tracerProviderBuilder, defaultTextMapPropagator: customPropagator);
 
         // Assert
         act.Should().NotThrow();

--- a/test/Sentry.OpenTelemetry.Exporter.Tests/SentryTracerProviderBuilderExtensionsTests.cs
+++ b/test/Sentry.OpenTelemetry.Exporter.Tests/SentryTracerProviderBuilderExtensionsTests.cs
@@ -1,3 +1,5 @@
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Trace;
 
@@ -33,6 +35,24 @@ public class SentryTracerProviderBuilderExtensionsTests
         // Assert
         result.Should().BeSameAs(tracerProviderBuilder);
         tracerProviderBuilder.DidNotReceive().AddInstrumentation(Arg.Any<Func<object>>());
+    }
+
+    [Fact]
+    public void AddSentryOtlpExporter_DoesNotConfigureDefaultPropagator()
+    {
+        // Arrange
+        // The OTLP integration spec requires that we MUST NOT set up an automatic propagator. Cross-service trace
+        // propagation is left to the propagateTraceparent option or to user-configured OTel propagators.
+        // See https://develop.sentry.dev/sdk/telemetry/traces/otlp/#integration-spec
+        var sentinel = new TraceContextPropagator();
+        Sdk.SetDefaultTextMapPropagator(sentinel);
+        var tracerProviderBuilder = Substitute.For<TracerProviderBuilder>();
+
+        // Act
+        tracerProviderBuilder.AddSentryOtlpExporter("https://examplePublicKey@o0.ingest.sentry.io/123456");
+
+        // Assert
+        Propagators.DefaultTextMapPropagator.Should().BeSameAs(sentinel);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #5299

## Summary

[The OTLP integration spec](https://develop.sentry.dev/sdk/telemetry/traces/otlp/#integration-spec) states:

> The integration MUST NOT set up an automatic propagator. Cross-service trace propagation is handled by the `propagateTraceparent` setting or by user-configured OTel propagators.

Our OTLP exporter was inconsistent with this: `AddSentryOtlpExporter` (and `UseOtlp`) called `Sdk.SetDefaultTextMapPropagator(new SentryPropagator())`, automatically configuring a global propagator. This brings us in line with the spec and with our other OTLP integrations.

## Changes

- Remove the `Sdk.SetDefaultTextMapPropagator(...)` call from `AddSentryOtlpExporter`.
- Remove the now-purposeless `defaultTextMapPropagator` parameter from both `AddSentryOtlpExporter` and `SentryOptionsExtensions.UseOtlp`.
- Update XML docs to point users at `PropagateTraceparent` / their own OTel propagator config.
- Drop the obsolete custom-propagator test; add a regression test asserting `AddSentryOtlpExporter` leaves `Propagators.DefaultTextMapPropagator` untouched.

> ⚠️ **Breaking API change.** The `defaultTextMapPropagator` parameter shipped in 6.5.0/6.6.0 and is removed here (source + binary breaking for anyone who passed it). This PR therefore targets `version7` rather than `main`. Note the classic (non-OTLP) `Sentry.OpenTelemetry` package is intentionally left unchanged — it still requires `SentryPropagator`.

Users who want cross-service propagation should now either set `SentryOptions.PropagateTraceparent` or configure OpenTelemetry propagators themselves (e.g. `Sdk.SetDefaultTextMapPropagator(...)`).

## Follow-up

- Docs need a matching update so the OTLP integration page explains propagator configuration — see getsentry/sentry-docs#18441 (discussion [r3463279950](https://github.com/getsentry/sentry-docs/pull/18441#discussion_r3463279950)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
