### PR TITLE
fix(serilog): don't reinitialize SDK in AspNetCore.Serilog sample

### DIFF
--- a/samples/Sentry.Samples.AspNetCore.Serilog/Program.cs
+++ b/samples/Sentry.Samples.AspNetCore.Serilog/Program.cs
@@ -15,13 +15,16 @@ public class Program
                 .MinimumLevel.Debug()
                 .WriteTo.Console()
                 // Add Sentry integration with Serilog
-                // Two levels are used to configure it.
-                // One sets which log level is minimally required to keep a log message as breadcrumbs
-                // The other sets the minimum level for messages to be sent out as events to Sentry
                 .WriteTo.Sentry(s =>
                 {
+                    // Sets the minimum log level required to keep a log message as breadcrumbs
                     s.MinimumBreadcrumbLevel = LogEventLevel.Debug;
+                    // Set the minimum level for messages to be sent out as events to Sentry
                     s.MinimumEventLevel = LogEventLevel.Error;
+                    // When configuring Sentry's Serilog integration in combination with other integrations that
+                    // initialize the Sentry SDK (like ASP.NET Core or MAUI) we need to tell it not to reinitialize
+                    // Sentry... we just want it to set up the Serilog sink
+                    s.InitializeSdk = false;
                 }));
 
         // Add Sentry integration

--- a/samples/Sentry.Samples.AspNetCore.Serilog/Program.cs
+++ b/samples/Sentry.Samples.AspNetCore.Serilog/Program.cs
@@ -17,7 +17,7 @@ public class Program
                 // Add Sentry integration with Serilog
                 .WriteTo.Sentry(s =>
                 {
-                    // Sets the minimum log level required to keep a log message as breadcrumbs
+                    // Sets the minimum log level required to add a log message as breadcrumb
                     s.MinimumBreadcrumbLevel = LogEventLevel.Debug;
                     // Set the minimum level for messages to be sent out as events to Sentry
                     s.MinimumEventLevel = LogEventLevel.Error;


### PR DESCRIPTION
The `Sentry.Samples.AspNetCore.Serilog` sample throws on startup once a DSN is configured (either via `UseSentry(SamplesShared.Dsn)` or `appsettings.json`).

The cause is double initialization: the ASP.NET Core integration (`UseSentry`) initializes the Sentry SDK, and the Serilog sink — which defaults to `InitializeSdk = true` — tries to initialize it again.

This sets `s.InitializeSdk = false` on the Serilog sink so it only wires up the sink and leaves SDK initialization to the ASP.NET Core integration. The accompanying comments are updated to explain when and why you'd disable SDK initialization on the sink.

Closes #5268

#skip-changelog