### PR TITLE
fix: BackpressureMonitor.Dispose() no longer deadlocks on single-threaded targets

### DIFF
--- a/src/Sentry/Internal/BackpressureMonitor.cs
+++ b/src/Sentry/Internal/BackpressureMonitor.cs
@@ -40,7 +40,8 @@ internal class BackpressureMonitor : IDisposable
     internal long LastQueueOverflowTicks => Interlocked.Read(ref _lastQueueOverflow);
     internal long LastRateLimitEventTicks => Interlocked.Read(ref _lastRateLimitEvent);
 
-    public BackpressureMonitor(IDiagnosticLogger? logger, ISystemClock? clock = null, bool enablePeriodicHealthCheck = true)
+    public BackpressureMonitor(IDiagnosticLogger? logger, ISystemClock? clock = null, bool enablePeriodicHealthCheck = true,
+        TaskScheduler? scheduler = null)
     {
         _logger = logger;
         _clock = clock ?? SystemClock.Clock;
@@ -48,7 +49,12 @@ internal class BackpressureMonitor : IDisposable
         if (enablePeriodicHealthCheck)
         {
             _logger?.LogDebug("Starting BackpressureMonitor.");
-            _workerTask = Task.Run(() => DoWorkAsync(_cts.Token));
+            // Default to the thread pool. The scheduler is only injected by tests, to model single-threaded
+            // runtimes (e.g. Unity WebGL) where the worker and its continuations run on the same thread.
+            _workerTask = scheduler is null
+                ? Task.Run(() => DoWorkAsync(_cts.Token))
+                : Task.Factory.StartNew(() => DoWorkAsync(_cts.Token), _cts.Token, TaskCreationOptions.None, scheduler)
+                    .Unwrap();
         }
         else
         {
@@ -146,12 +152,14 @@ internal class BackpressureMonitor : IDisposable
     {
         try
         {
+            // Request cancellation but do NOT block on _workerTask here. On single-threaded runtimes
+            // (e.g. Unity WebGL / browser-wasm) the worker's cancellation continuation can only be scheduled
+            // on the calling thread, so a synchronous _workerTask.Wait() would block the only thread that
+            // could complete it - a deadlock. The worker observes the token, exits its Task.Delay loop and
+            // unwinds on its own; it produces no result we need to await, and the methods callers may still
+            // invoke after disposal (GetDownsampleFactor / RecordQueueOverflow / RecordRateLimitHit) don't
+            // touch the cancellation token source. See https://github.com/getsentry/sentry-dotnet/issues/5237
             _cts.Cancel();
-            _workerTask.Wait();
-        }
-        catch (AggregateException ex) when (ex.InnerException is OperationCanceledException)
-        {
-            // Ignore cancellation
         }
         catch (Exception ex)
         {

--- a/src/Sentry/Internal/BackpressureMonitor.cs
+++ b/src/Sentry/Internal/BackpressureMonitor.cs
@@ -153,12 +153,9 @@ internal class BackpressureMonitor : IDisposable
         try
         {
             // Request cancellation but do NOT block on _workerTask here. On single-threaded runtimes
-            // (e.g. Unity WebGL / browser-wasm) the worker's cancellation continuation can only be scheduled
-            // on the calling thread, so a synchronous _workerTask.Wait() would block the only thread that
-            // could complete it - a deadlock. The worker observes the token, exits its Task.Delay loop and
-            // unwinds on its own; it produces no result we need to await, and the methods callers may still
-            // invoke after disposal (GetDownsampleFactor / RecordQueueOverflow / RecordRateLimitHit) don't
-            // touch the cancellation token source. See https://github.com/getsentry/sentry-dotnet/issues/5237
+            // (e.g. Unity WebGL / browser-wasm) _workerTask.Wait() would cause a deadlock.
+            // The worker observes the token and unwinds on its own.
+            // See https://github.com/getsentry/sentry-dotnet/issues/5237
             _cts.Cancel();
         }
         catch (Exception ex)

--- a/src/Sentry/Internal/BackpressureMonitor.cs
+++ b/src/Sentry/Internal/BackpressureMonitor.cs
@@ -166,10 +166,9 @@ internal class BackpressureMonitor : IDisposable
         }
         finally
         {
-            // Dispose the CancellationTokenSource only once the worker has stopped using the token, but
-            // without blocking the calling thread. Disposing it inline would race the worker: if it ran while
-            // the worker was registering its Task.Delay continuation, the worker could observe an
-            // ObjectDisposedException - which it doesn't catch - and fault with an unobserved task exception.
+            // Dispose the CTS once the worker has stopped using the token, but
+            // without blocking the calling thread. Disposing it inline would race the worker 
+            //  and could lead to an ObjectDisposedException
             _workerTask.ContinueWith(
                 static (_, state) => ((CancellationTokenSource)state!).Dispose(),
                 _cts,

--- a/src/Sentry/Internal/BackpressureMonitor.cs
+++ b/src/Sentry/Internal/BackpressureMonitor.cs
@@ -36,6 +36,7 @@ internal class BackpressureMonitor : IDisposable
     private readonly CancellationTokenSource _cts = new();
 
     private readonly Task _workerTask;
+    internal Task WorkerTask => _workerTask;
     internal int DownsampleLevel => _downsampleLevel;
     internal long LastQueueOverflowTicks => Interlocked.Read(ref _lastQueueOverflow);
     internal long LastRateLimitEventTicks => Interlocked.Read(ref _lastRateLimitEvent);
@@ -168,7 +169,16 @@ internal class BackpressureMonitor : IDisposable
         }
         finally
         {
-            _cts.Dispose();
+            // Dispose the CancellationTokenSource only once the worker has stopped using the token, but
+            // without blocking the calling thread. Disposing it inline would race the worker: if it ran while
+            // the worker was registering its Task.Delay continuation, the worker could observe an
+            // ObjectDisposedException - which it doesn't catch - and fault with an unobserved task exception.
+            _workerTask.ContinueWith(
+                static (_, state) => ((CancellationTokenSource)state!).Dispose(),
+                _cts,
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }
     }
 }

--- a/src/Sentry/Internal/BackpressureMonitor.cs
+++ b/src/Sentry/Internal/BackpressureMonitor.cs
@@ -51,12 +51,13 @@ internal class BackpressureMonitor : IDisposable
         if (enablePeriodicHealthCheck)
         {
             _logger?.LogDebug("Starting BackpressureMonitor.");
-            // Default to the thread pool. The scheduler is only injected by tests, to model single-threaded
-            // runtimes (e.g. Unity WebGL) where the worker and its continuations run on the same thread.
-            _workerTask = scheduler is null
-                ? Task.Run(() => DoWorkAsync(_cts.Token))
-                : Task.Factory.StartNew(() => DoWorkAsync(_cts.Token), _cts.Token, TaskCreationOptions.None, scheduler)
-                    .Unwrap();
+            // Equivalent to Task.Run(() => DoWorkAsync(_cts.Token)): same creation options (DenyChildAttach) and,
+            // by default, the same scheduler (the thread pool). Tests inject a scheduler to model single-threaded
+            // runtimes (e.g. Unity WebGL) where the worker and its continuations must run on the same thread.
+            scheduler ??= TaskScheduler.Default;
+            _workerTask = Task.Factory
+                .StartNew(() => DoWorkAsync(_cts.Token), CancellationToken.None, TaskCreationOptions.DenyChildAttach, scheduler)
+                .Unwrap();
         }
         else
         {

--- a/src/Sentry/Internal/BackpressureMonitor.cs
+++ b/src/Sentry/Internal/BackpressureMonitor.cs
@@ -36,6 +36,7 @@ internal class BackpressureMonitor : IDisposable
     private readonly CancellationTokenSource _cts = new();
 
     private readonly Task _workerTask;
+    private int _disposed;
     internal Task WorkerTask => _workerTask;
     internal int DownsampleLevel => _downsampleLevel;
     internal long LastQueueOverflowTicks => Interlocked.Read(ref _lastQueueOverflow);
@@ -151,6 +152,13 @@ internal class BackpressureMonitor : IDisposable
 
     public void Dispose()
     {
+        // Idempotent and thread-safe: only the first caller runs the disposal logic. Without this guard a
+        // second call would hit an already-disposed _cts and log a spurious ObjectDisposedException.
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
         try
         {
             // Request cancellation but do NOT block on _workerTask here. On single-threaded runtimes

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -943,9 +943,8 @@ internal class Hub : IHub, IDisposable
         }
         //Don't dispose of ScopeManager since we want dangling transactions to still be able to access tags.
 
-        // Stop the backpressure monitor's worker so it doesn't outlive the hub. Its Dispose only cancels the
-        // worker (it does not block, and its public methods don't touch the cancellation token source), so the
-        // client can still safely read the downsample factor while it drains any remaining envelopes.
+        // Stop the backpressure monitor's worker so it doesn't outlive the hub...  this cancels the 
+        // worker but clients can still read the downsample factor while draining.
         _backpressureMonitor?.Dispose();
 
 #if __IOS__

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -943,8 +943,10 @@ internal class Hub : IHub, IDisposable
         }
         //Don't dispose of ScopeManager since we want dangling transactions to still be able to access tags.
 
-        // Don't dispose of _backpressureMonitor since we want the client to continue to process envelopes without
-        // throwing an ObjectDisposedException.
+        // Stop the backpressure monitor's worker so it doesn't outlive the hub. Its Dispose only cancels the
+        // worker (it does not block, and its public methods don't touch the cancellation token source), so the
+        // client can still safely read the downsample factor while it drains any remaining envelopes.
+        _backpressureMonitor?.Dispose();
 
 #if __IOS__
             // TODO

--- a/test/Sentry.Tests/Internals/BackpressureMonitorTests.cs
+++ b/test/Sentry.Tests/Internals/BackpressureMonitorTests.cs
@@ -181,6 +181,24 @@ public class BackpressureMonitorTests
         await disposed; // surface any exception thrown by Dispose
     }
 
+    [Fact]
+    public async Task Dispose_WorkerRunsToCompletionWithoutFaulting()
+    {
+        // Arrange - a real worker on the thread pool. Dispose cancels the token while the worker may still be
+        // inside Task.Delay; the CancellationTokenSource must not be disposed out from under it (which would
+        // surface an unobserved ObjectDisposedException). See https://github.com/getsentry/sentry-dotnet/issues/5237
+        _fixture.Clock.GetUtcNow().Returns(_fixture.Now);
+        var monitor = new BackpressureMonitor(null, _fixture.Clock, enablePeriodicHealthCheck: true);
+        var worker = monitor.WorkerTask;
+
+        // Act
+        monitor.Dispose();
+        await worker; // observes the task; throws if it faulted
+
+        // Assert
+        worker.Status.Should().Be(TaskStatus.RanToCompletion);
+    }
+
     /// <summary>
     /// A scheduler that queues tasks but never executes them - lets us hold the worker task in a state that
     /// never completes, so a Dispose that blocks on it would hang.

--- a/test/Sentry.Tests/Internals/BackpressureMonitorTests.cs
+++ b/test/Sentry.Tests/Internals/BackpressureMonitorTests.cs
@@ -199,6 +199,24 @@ public class BackpressureMonitorTests
         worker.Status.Should().Be(TaskStatus.RanToCompletion);
     }
 
+    [Fact]
+    public void Dispose_CalledMultipleTimes_IsIdempotent()
+    {
+        // Arrange
+        var logger = Substitute.For<IDiagnosticLogger>();
+        _fixture.Clock.GetUtcNow().Returns(_fixture.Now);
+        var monitor = new BackpressureMonitor(logger, _fixture.Clock, enablePeriodicHealthCheck: false);
+
+        // Act
+        monitor.Dispose();
+        monitor.Dispose();
+        monitor.Dispose();
+
+        // Assert - the second and third calls are no-ops; no ObjectDisposedException is logged.
+        logger.DidNotReceive().Log(
+            SentryLevel.Warning, Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<object[]>());
+    }
+
     /// <summary>
     /// A scheduler that queues tasks but never executes them - lets us hold the worker task in a state that
     /// never completes, so a Dispose that blocks on it would hang.

--- a/test/Sentry.Tests/Internals/BackpressureMonitorTests.cs
+++ b/test/Sentry.Tests/Internals/BackpressureMonitorTests.cs
@@ -160,4 +160,50 @@ public class BackpressureMonitorTests
         monitor.IsHealthy.Should().BeTrue();
         monitor.DownsampleLevel.Should().Be(0);
     }
+
+    [Fact]
+    public async Task Dispose_DoesNotBlockOnWorkerTask()
+    {
+        // Arrange
+        // Run the periodic worker on a scheduler we never pump, so the worker task never completes. This models
+        // a single-threaded runtime (e.g. Unity WebGL) where the only thread able to run the worker's
+        // cancellation continuation is the one calling Dispose. A blocking _workerTask.Wait() would deadlock
+        // there; Dispose must instead just cancel and return. See https://github.com/getsentry/sentry-dotnet/issues/5237
+        var scheduler = new NeverRunsTaskScheduler();
+        var monitor = new BackpressureMonitor(null, _fixture.Clock, enablePeriodicHealthCheck: true, scheduler: scheduler);
+
+        // Act
+        var disposed = Task.Run(() => monitor.Dispose());
+
+        // Assert
+        var completed = await Task.WhenAny(disposed, Task.Delay(TimeSpan.FromSeconds(10)));
+        completed.Should().BeSameAs(disposed, "Dispose must not block waiting on the worker task to complete");
+        await disposed; // surface any exception thrown by Dispose
+    }
+
+    /// <summary>
+    /// A scheduler that queues tasks but never executes them - lets us hold the worker task in a state that
+    /// never completes, so a Dispose that blocks on it would hang.
+    /// </summary>
+    private sealed class NeverRunsTaskScheduler : TaskScheduler
+    {
+        private readonly List<Task> _tasks = new();
+        protected override IEnumerable<Task> GetScheduledTasks()
+        {
+            lock (_tasks)
+            {
+                return _tasks.ToArray();
+            }
+        }
+
+        protected override void QueueTask(Task task)
+        {
+            lock (_tasks)
+            {
+                _tasks.Add(task);
+            }
+        }
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
+    }
 }


### PR DESCRIPTION
Fixes #5237

## Problem

On single-threaded runtimes (Unity WebGL / browser-wasm) there is no separate thread pool — `Task.Run` and `Task.Delay` continuations all run on the one main thread. `BackpressureMonitor.Dispose()` did:

```csharp
_cts.Cancel();
_workerTask.Wait();   // blocks the only thread
```

`_workerTask.Wait()` synchronously blocks the calling thread waiting for the worker's post-cancellation continuation, which on a single-threaded runtime can only be scheduled on that same blocked thread (e.g. calling `unityInstance.Quit()` in Unity WebGL).

`ConfigureAwait(false)` does not help here. On a desktop host the cancellation continuation escapes to a real thread-pool thread. On single-threaded targets the "thread pool" *is* the main thread, so the continuation has nowhere to run except the thread that is blocked in `Wait()`.

## Fix

`Dispose()` now only requests cancellation and returns — it does not block on the worker. The worker observes the token, exits its `Task.Delay` loop and unwinds on its own; it produces no result anyone needs to await.

Because the monitor's public methods (`DownsampleFactor` / `RecordQueueOverflow` / `RecordRateLimitHit`) never touch `_cts`, it is now safe to dispose the monitor even while the client keeps draining envelopes. This lets `Hub.Dispose()` dispose the monitor again rather than leaking the worker for the process lifetime.

## ⚠️ `Hub.Dispose()`

The call to `_backpressureMonitor?.Dispose()` was removed in #4613 with the comment:
> Don't dispose … without throwing an `ObjectDisposedException`

I've restored it because, with a non-blocking `Dispose()` that only cancels/disposes the CTS, none of the monitor's post-disposal call sites touch the disposed token source — so the original `ObjectDisposedException` should not recur. 

> [!WARNING]
> **TODO**: Confirm this matches the scenario #4613 was guarding against. We can always reinstate the fix from #4613 if we're concerned about this.

## Affected versions

The live deadlock path (`Hub.Dispose()` → `_backpressureMonitor?.Dispose()`) exists in 4.x/5.x (and the Sentry Unity 4.x that reported this). It was *incidentally* removed on `main`/6.0.0+ by #4613, so 6.x no longer reaches the deadlock - but at the cost of leaking the worker. `Dispose()` itself remained latently broken. This PR fixes the root cause so the call is safe again. Users on ≤5.x  operating in a single threaded environment should set `EnableBackpressureHandling = false` as a workaround instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)