### PR TITLE
ci: add PR risk experiment workflow

### DIFF
--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -1,0 +1,36 @@
+name: PR Risk Experiment
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-risk-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  risk:
+    name: Score PR risk
+    runs-on: ubuntu-24.04
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Score current PR
+        uses: getsentry/pr-risk-action@v0
+        with:
+          repo: ${{ github.repository }}
+          pr-number: ${{ github.event.pull_request.number }}
+          result-path: risk-pr-result.json
+          skip-reviews: "true"
+          apply-label: "true"
+
+      - name: Upload risk result
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: risk-pr-result
+          path: risk-pr-result.json


### PR DESCRIPTION
## Overview

Adds the PR Risk Action as an advisory workflow for non-draft pull requests. It runs on `pull_request_target` so it can keep the `risk: low|medium|high` label in sync, but it does not checkout or execute PR code.

The Action now has a bundled `getsentry__sentry-dotnet` profile in `getsentry/pr-risk-action@v0`, so this repo does not need to vendor any scorer code or model artifacts.

## Validation

- Built a full sentry-dotnet profile from GitHub API pull request history: 3,286 PRs from 2018-05-22 to 2026-07-01, reviews skipped.
- Verified `getsentry/pr-risk-action@v0` includes the sentry-dotnet profile and can score `getsentry/sentry-dotnet#5333` locally.
- Ran the `pr-risk-action` unit tests: 39 tests passing.
- Checked the workflow contains the expected trigger, permissions, draft guard, and Action reference.

#skip-changelog
