### PR TITLE
fix(otel): only set Scope.Transaction in SentrySpanProcessor when null

### DIFF
--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -172,7 +172,15 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
             tracer.Contexts.Trace.Origin = OpenTelemetryOrigin;
             tracer.StartTimestamp = data.StartTimeUtc;
         }
-        _hub.ConfigureScope(static (scope, transaction) => scope.Transaction = transaction, transaction);
+        // Only set Scope.Transaction when null to avoid clobbering an existing transaction
+        // when two root OTel activities overlap. See #5314.
+        _hub.ConfigureScope(static (scope, transaction) =>
+        {
+            if (scope.Transaction is null)
+            {
+                scope.Transaction = transaction;
+            }
+        }, transaction);
         transaction.SetFused(data);
         _map[data.SpanId] = transaction;
     }

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -172,14 +172,9 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
             tracer.Contexts.Trace.Origin = OpenTelemetryOrigin;
             tracer.StartTimestamp = data.StartTimeUtc;
         }
-        // Only set Scope.Transaction when null to avoid clobbering an existing transaction
-        // when two root OTel activities overlap. See #5314.
         _hub.ConfigureScope(static (scope, transaction) =>
         {
-            if (scope.Transaction is null)
-            {
-                scope.Transaction = transaction;
-            }
+            scope.Transaction ??= transaction;
         }, transaction);
         transaction.SetFused(data);
         _map[data.SpanId] = transaction;

--- a/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
@@ -1012,4 +1012,29 @@ public class SentrySpanProcessorTests : ActivitySourceTests
         description.Should().Be("POST https://example.com/foo");
         source.Should().Be(TransactionNameSource.Custom);
     }
+
+    [Fact]
+    public void OnStart_WithExistingTransactionOnScope_DoesNotOverwriteExistingTransaction()
+    {
+        // Arrange
+        _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
+        _fixture.Options.TracesSampleRate = 1.0;
+        _fixture.ScopeManager = Substitute.For<IInternalScopeManager>();
+        var scope = new Scope();
+        var clientScope = new KeyValuePair<Scope, ISentryClient>(scope, _fixture.Client);
+        _fixture.ScopeManager.GetCurrent().Returns(clientScope);
+        var sut = _fixture.GetSut();
+
+        using var firstActivity = Tracer.StartActivity("Existing");
+        sut.OnStart(firstActivity!);
+        var existingTransaction = scope.Transaction;
+
+        // Act: second root activity starts while Existing is still on the scope
+        using var secondActivity = Tracer.StartActivity("NewRootActivity");
+        sut.OnStart(secondActivity!);
+
+        // Assert
+        scope.Transaction.Should().BeSameAs(existingTransaction,
+            "CreateRootSpan should not overwrite an already-set Scope.Transaction");
+    }
 }

--- a/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
@@ -1016,21 +1016,31 @@ public class SentrySpanProcessorTests : ActivitySourceTests
     [Fact]
     public void OnStart_WithExistingTransactionOnScope_DoesNotOverwriteExistingTransaction()
     {
+        // Arrange
         _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
-        _fixture.Options.TracesSampleRate = 1.0;
         var sut = _fixture.GetSut();
 
-        using var firstActivity = Tracer.StartActivity("Existing");
-        sut.OnStart(firstActivity!);
-        Assert.True(sut._map.TryGetValue(firstActivity.SpanId, out var firstTransaction));
+        var parentContext = new TransactionContext("Program", "Main")
+        {
+            Instrumenter = Instrumenter.OpenTelemetry,
+        };
+        var parent = _fixture.Hub.StartTransaction(parentContext);
+        _fixture.Hub.ConfigureScope(scope => scope.Transaction = parent);
 
-        using var secondActivity = Tracer.StartActivity("NewRootActivity");
-        sut.OnStart(secondActivity!);
+        using var data = Tracer.StartActivity("TestActivity");
+
+        // Act
+        sut.OnStart(data!);
+
+        // Assert
+        data.ParentSpanId.Should().Be(default(ActivitySpanId), $"{nameof(data)} should be a new root Activity, not a child Activity");
+        Assert.True(sut._map.TryGetValue(data.SpanId, out var span));
+        span.Should().BeOfType<TransactionTracer>($"{nameof(data)} should be a new root Transaction, not a child Span");
 
         object scopeTransaction = null;
         _fixture.Hub.ConfigureScope(scope => scopeTransaction = scope.Transaction);
 
-        scopeTransaction.Should().BeSameAs(firstTransaction,
+        scopeTransaction.Should().BeSameAs(parent,
             "CreateRootSpan should not overwrite an already-set Scope.Transaction");
     }
 }

--- a/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
@@ -1016,25 +1016,21 @@ public class SentrySpanProcessorTests : ActivitySourceTests
     [Fact]
     public void OnStart_WithExistingTransactionOnScope_DoesNotOverwriteExistingTransaction()
     {
-        // Arrange
         _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
         _fixture.Options.TracesSampleRate = 1.0;
-        _fixture.ScopeManager = Substitute.For<IInternalScopeManager>();
-        var scope = new Scope();
-        var clientScope = new KeyValuePair<Scope, ISentryClient>(scope, _fixture.Client);
-        _fixture.ScopeManager.GetCurrent().Returns(clientScope);
         var sut = _fixture.GetSut();
 
         using var firstActivity = Tracer.StartActivity("Existing");
         sut.OnStart(firstActivity!);
-        var existingTransaction = scope.Transaction;
+        Assert.True(sut._map.TryGetValue(firstActivity.SpanId, out var firstTransaction));
 
-        // Act: second root activity starts while Existing is still on the scope
         using var secondActivity = Tracer.StartActivity("NewRootActivity");
         sut.OnStart(secondActivity!);
 
-        // Assert
-        scope.Transaction.Should().BeSameAs(existingTransaction,
+        object scopeTransaction = null;
+        _fixture.Hub.ConfigureScope(scope => scopeTransaction = scope.Transaction);
+
+        scopeTransaction.Should().BeSameAs(firstTransaction,
             "CreateRootSpan should not overwrite an already-set Scope.Transaction");
     }
 }


### PR DESCRIPTION
Fixes #5314.

## Problem

`SentrySpanProcessor.OnStart` calls `ConfigureScope` unconditionally:

```csharp
_hub.ConfigureScope(static (scope, transaction) => scope.Transaction = transaction, transaction);
```

When two root OTel activities overlap and neither is a child of the other, this silently overwrites whatever transaction was already on the scope with the new one. As the issue notes, the intuitive default is to _not_ overwrite an existing transaction.

## Fix

Add a null-check guard inside the `ConfigureScope` lambda:

```csharp
_hub.ConfigureScope(static (scope, transaction) =>
{
    if (scope.Transaction is null)
    {
        scope.Transaction = transaction;
    }
}, transaction);
```

`Scope.Transaction` is only set when it is currently `null`; an already-present transaction is left unchanged.

## Test

Added `OnStart_WithExistingTransactionOnScope_DoesNotOverwriteExistingTransaction` to `SentrySpanProcessorTests`: sets a transaction on the scope, starts a new root activity, calls `OnStart`, and asserts the scope still holds the original transaction.

This is intentionally **not** bundled with #2399 (the `AutoSetScopeTransactions` opt-in), per the issue's notes.