### PR TITLE
feat: Add BeforeSendFeedback callback to inspect, modify, or drop user feedback before it's sent

### DIFF
--- a/src/Sentry/CaptureFeedbackErrorReason.cs
+++ b/src/Sentry/CaptureFeedbackErrorReason.cs
@@ -44,4 +44,9 @@ public enum CaptureFeedbackResult
     /// The <see cref="SentryFeedback"/> was discarded by an event processor.
     /// </summary>
     DroppedByEventProcessor,
+    /// <summary>
+    /// The <see cref="SentryFeedback"/> was discarded by the <c>BeforeSendFeedback</c> callback
+    /// either by returning null or by throwing an exception.
+    /// </summary>
+    DroppedByBeforeSendFeedback,
 }

--- a/src/Sentry/Internal/SentryEventHelper.cs
+++ b/src/Sentry/Internal/SentryEventHelper.cs
@@ -74,4 +74,31 @@ internal static class SentryEventHelper
 
         return @event;
     }
+
+    public static SentryEvent? DoBeforeSendFeedback(SentryEvent? @event, SentryHint hint, SentryOptions options)
+    {
+        if (@event is null || options.BeforeSendFeedbackInternal is null)
+        {
+            return @event;
+        }
+
+        options.LogDebug("Calling the BeforeSendFeedback callback.");
+        try
+        {
+            @event = options.BeforeSendFeedbackInternal.Invoke(@event, hint);
+            if (@event == null)
+            {
+                options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Feedback);
+                options.LogInfo("Feedback dropped by BeforeSendFeedback callback.");
+            }
+        }
+        catch (Exception e)
+        {
+            options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Feedback);
+            options.LogError(e, "The BeforeSendFeedback callback threw an exception. The feedback will be dropped.");
+            return null;
+        }
+
+        return @event;
+    }
 }

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -125,6 +125,14 @@ public class SentryClient : ISentryClient, IDisposable
             return SentryId.Empty;  // Dropped by an event processor
         }
 
+        if (SentryEventHelper.DoBeforeSendFeedback(processedEvent, hint, _options) is not { } feedbackEvent)
+        {
+            result = CaptureFeedbackResult.DroppedByBeforeSendFeedback;
+            return SentryId.Empty;
+        }
+
+        processedEvent = feedbackEvent;
+
         var attachments = hint.Attachments.ToList();
         var envelope = Envelope.FromFeedback(processedEvent, _options.DiagnosticLogger, attachments, scope.SessionUpdate);
         if (CaptureEnvelope(envelope))

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -548,8 +548,15 @@ public class SentryOptions
     internal Func<SentryEvent, SentryHint, SentryEvent?>? BeforeSendFeedbackInternal => _beforeSendFeedback;
 
     /// <summary>
-    /// Configures a callback to invoke before sending user feedback to Sentry
+    /// Configures a callback function to be invoked before sending user feedback to Sentry
     /// </summary>
+    /// <remarks>
+    /// The event returned by this callback will be sent to Sentry. This allows the
+    /// application a chance to inspect and/or modify the user feedback before it's sent.
+    /// If the feedback should not be sent at all, return null from the callback. Unlike
+    /// <see cref="SetBeforeSend(Func{SentryEvent, SentryHint, SentryEvent?})"/>, an exception
+    /// thrown from this callback also drops the feedback (fail closed) rather than sending it.
+    /// </remarks>
     /// <param name="beforeSendFeedback">The callback</param>
     public void SetBeforeSendFeedback(Func<SentryEvent, SentryHint, SentryEvent?> beforeSendFeedback)
     {
@@ -557,8 +564,15 @@ public class SentryOptions
     }
 
     /// <summary>
-    /// Configures a callback to invoke before sending user feedback to Sentry
+    /// Configures a callback function to be invoked before sending user feedback to Sentry
     /// </summary>
+    /// <remarks>
+    /// The event returned by this callback will be sent to Sentry. This allows the
+    /// application a chance to inspect and/or modify the user feedback before it's sent.
+    /// If the feedback should not be sent at all, return null from the callback. Unlike
+    /// <see cref="SetBeforeSend(Func{SentryEvent, SentryEvent?})"/>, an exception thrown
+    /// from this callback also drops the feedback (fail closed) rather than sending it.
+    /// </remarks>
     /// <param name="beforeSendFeedback">The callback</param>
     public void SetBeforeSendFeedback(Func<SentryEvent, SentryEvent?> beforeSendFeedback)
     {

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -543,6 +543,28 @@ public class SentryOptions
         _beforeSendTransaction = (transaction, _) => beforeSendTransaction(transaction);
     }
 
+    private Func<SentryEvent, SentryHint, SentryEvent?>? _beforeSendFeedback;
+
+    internal Func<SentryEvent, SentryHint, SentryEvent?>? BeforeSendFeedbackInternal => _beforeSendFeedback;
+
+    /// <summary>
+    /// Configures a callback to invoke before sending user feedback to Sentry
+    /// </summary>
+    /// <param name="beforeSendFeedback">The callback</param>
+    public void SetBeforeSendFeedback(Func<SentryEvent, SentryHint, SentryEvent?> beforeSendFeedback)
+    {
+        _beforeSendFeedback = beforeSendFeedback;
+    }
+
+    /// <summary>
+    /// Configures a callback to invoke before sending user feedback to Sentry
+    /// </summary>
+    /// <param name="beforeSendFeedback">The callback</param>
+    public void SetBeforeSendFeedback(Func<SentryEvent, SentryEvent?> beforeSendFeedback)
+    {
+        _beforeSendFeedback = (@event, _) => beforeSendFeedback(@event);
+    }
+
     private Func<Breadcrumb, SentryHint, Breadcrumb?>? _beforeBreadcrumb;
 
     internal Func<Breadcrumb, SentryHint, Breadcrumb?>? BeforeBreadcrumbInternal => _beforeBreadcrumb;

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -548,15 +548,9 @@ public class SentryOptions
     internal Func<SentryEvent, SentryHint, SentryEvent?>? BeforeSendFeedbackInternal => _beforeSendFeedback;
 
     /// <summary>
-    /// Configures a callback function to be invoked before sending user feedback to Sentry
+    /// Configures a callback to invoke before sending user feedback to Sentry.
+    /// Return null or throw to drop the feedback.
     /// </summary>
-    /// <remarks>
-    /// The event returned by this callback will be sent to Sentry. This allows the
-    /// application a chance to inspect and/or modify the user feedback before it's sent.
-    /// If the feedback should not be sent at all, return null from the callback. Unlike
-    /// <see cref="SetBeforeSend(Func{SentryEvent, SentryHint, SentryEvent?})"/>, an exception
-    /// thrown from this callback also drops the feedback (fail closed) rather than sending it.
-    /// </remarks>
     /// <param name="beforeSendFeedback">The callback</param>
     public void SetBeforeSendFeedback(Func<SentryEvent, SentryHint, SentryEvent?> beforeSendFeedback)
     {
@@ -564,15 +558,9 @@ public class SentryOptions
     }
 
     /// <summary>
-    /// Configures a callback function to be invoked before sending user feedback to Sentry
+    /// Configures a callback to invoke before sending user feedback to Sentry.
+    /// Return null or throw to drop the feedback.
     /// </summary>
-    /// <remarks>
-    /// The event returned by this callback will be sent to Sentry. This allows the
-    /// application a chance to inspect and/or modify the user feedback before it's sent.
-    /// If the feedback should not be sent at all, return null from the callback. Unlike
-    /// <see cref="SetBeforeSend(Func{SentryEvent, SentryEvent?})"/>, an exception thrown
-    /// from this callback also drops the feedback (fail closed) rather than sending it.
-    /// </remarks>
     /// <param name="beforeSendFeedback">The callback</param>
     public void SetBeforeSendFeedback(Func<SentryEvent, SentryEvent?> beforeSendFeedback)
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -52,6 +52,7 @@ namespace Sentry
         DisabledHub = 2,
         EmptyMessage = 3,
         DroppedByEventProcessor = 4,
+        DroppedByBeforeSendFeedback = 5,
     }
     public enum CheckInStatus
     {
@@ -903,6 +904,8 @@ namespace Sentry
         public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.SentryHint, Sentry.Breadcrumb?> beforeBreadcrumb) { }
         public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryEvent?> beforeSend) { }
         public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryHint, Sentry.SentryEvent?> beforeSend) { }
+        public void SetBeforeSendFeedback(System.Func<Sentry.SentryEvent, Sentry.SentryEvent?> beforeSendFeedback) { }
+        public void SetBeforeSendFeedback(System.Func<Sentry.SentryEvent, Sentry.SentryHint, Sentry.SentryEvent?> beforeSendFeedback) { }
         public void SetBeforeSendLog(System.Func<Sentry.SentryLog, Sentry.SentryLog?> beforeSendLog) { }
         public void SetBeforeSendMetric(System.Func<Sentry.SentryMetric, Sentry.SentryMetric?> beforeSendMetric) { }
         public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.SentryTransaction?> beforeSendTransaction) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -52,6 +52,7 @@ namespace Sentry
         DisabledHub = 2,
         EmptyMessage = 3,
         DroppedByEventProcessor = 4,
+        DroppedByBeforeSendFeedback = 5,
     }
     public enum CheckInStatus
     {
@@ -903,6 +904,8 @@ namespace Sentry
         public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.SentryHint, Sentry.Breadcrumb?> beforeBreadcrumb) { }
         public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryEvent?> beforeSend) { }
         public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryHint, Sentry.SentryEvent?> beforeSend) { }
+        public void SetBeforeSendFeedback(System.Func<Sentry.SentryEvent, Sentry.SentryEvent?> beforeSendFeedback) { }
+        public void SetBeforeSendFeedback(System.Func<Sentry.SentryEvent, Sentry.SentryHint, Sentry.SentryEvent?> beforeSendFeedback) { }
         public void SetBeforeSendLog(System.Func<Sentry.SentryLog, Sentry.SentryLog?> beforeSendLog) { }
         public void SetBeforeSendMetric(System.Func<Sentry.SentryMetric, Sentry.SentryMetric?> beforeSendMetric) { }
         public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.SentryTransaction?> beforeSendTransaction) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -52,6 +52,7 @@ namespace Sentry
         DisabledHub = 2,
         EmptyMessage = 3,
         DroppedByEventProcessor = 4,
+        DroppedByBeforeSendFeedback = 5,
     }
     public enum CheckInStatus
     {
@@ -903,6 +904,8 @@ namespace Sentry
         public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.SentryHint, Sentry.Breadcrumb?> beforeBreadcrumb) { }
         public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryEvent?> beforeSend) { }
         public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryHint, Sentry.SentryEvent?> beforeSend) { }
+        public void SetBeforeSendFeedback(System.Func<Sentry.SentryEvent, Sentry.SentryEvent?> beforeSendFeedback) { }
+        public void SetBeforeSendFeedback(System.Func<Sentry.SentryEvent, Sentry.SentryHint, Sentry.SentryEvent?> beforeSendFeedback) { }
         public void SetBeforeSendLog(System.Func<Sentry.SentryLog, Sentry.SentryLog?> beforeSendLog) { }
         public void SetBeforeSendMetric(System.Func<Sentry.SentryMetric, Sentry.SentryMetric?> beforeSendMetric) { }
         public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.SentryTransaction?> beforeSendTransaction) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -52,6 +52,7 @@ namespace Sentry
         DisabledHub = 2,
         EmptyMessage = 3,
         DroppedByEventProcessor = 4,
+        DroppedByBeforeSendFeedback = 5,
     }
     public enum CheckInStatus
     {
@@ -884,6 +885,8 @@ namespace Sentry
         public void SetBeforeBreadcrumb(System.Func<Sentry.Breadcrumb, Sentry.SentryHint, Sentry.Breadcrumb?> beforeBreadcrumb) { }
         public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryEvent?> beforeSend) { }
         public void SetBeforeSend(System.Func<Sentry.SentryEvent, Sentry.SentryHint, Sentry.SentryEvent?> beforeSend) { }
+        public void SetBeforeSendFeedback(System.Func<Sentry.SentryEvent, Sentry.SentryEvent?> beforeSendFeedback) { }
+        public void SetBeforeSendFeedback(System.Func<Sentry.SentryEvent, Sentry.SentryHint, Sentry.SentryEvent?> beforeSendFeedback) { }
         public void SetBeforeSendLog(System.Func<Sentry.SentryLog, Sentry.SentryLog?> beforeSendLog) { }
         public void SetBeforeSendMetric(System.Func<Sentry.SentryMetric, Sentry.SentryMetric?> beforeSendMetric) { }
         public void SetBeforeSendTransaction(System.Func<Sentry.SentryTransaction, Sentry.SentryTransaction?> beforeSendTransaction) { }

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -1036,6 +1036,116 @@ public partial class SentryClientTests : IDisposable
     }
 
     [Fact]
+    public void CaptureFeedback_BeforeSendFeedbackSet_CallbackInvokedAndMutationApplied()
+    {
+        //Arrange
+        var feedback = new SentryFeedback("Everything is great!");
+        SentryEvent received = null;
+        _fixture.SentryOptions.SetBeforeSendFeedback((@event, _) =>
+        {
+            received = @event;
+            @event.SetTag("scrubbed", "true");
+            return @event;
+        });
+        var sut = _fixture.GetSut();
+
+        Envelope envelope = null;
+        sut.Worker.When(w => w.EnqueueEnvelope(Arg.Any<Envelope>()))
+            .Do(callback => envelope = callback.Arg<Envelope>());
+
+        //Act
+        var id = sut.CaptureFeedback(feedback, out var result);
+
+        //Assert
+        result.Should().Be(CaptureFeedbackResult.Success);
+        id.Should().NotBe(SentryId.Empty);
+        received.Should().NotBeNull();
+        received.Contexts.Feedback.Should().NotBeNull();
+        received.Contexts.Feedback!.Message.Should().Be("Everything is great!");
+        var item = envelope.Items.First(x => x.TryGetType() == EnvelopeItem.TypeValueFeedback);
+        var @event = (SentryEvent)((JsonSerializable)item.Payload).Source;
+        @event.Tags.Should().Contain(new KeyValuePair<string, string>("scrubbed", "true"));
+    }
+
+    [Fact]
+    public void CaptureFeedback_BeforeSendFeedbackSet_ReceivesHintFromCaller()
+    {
+        //Arrange
+        var feedback = new SentryFeedback("Everything is great!");
+        var hint = new SentryHint();
+        var attachment = AttachmentHelper.FakeAttachment("scrub-me.txt");
+        hint.Attachments.Add(attachment);
+        SentryHint receivedHint = null;
+        _fixture.SentryOptions.SetBeforeSendFeedback((@event, h) =>
+        {
+            receivedHint = h;
+            return @event;
+        });
+        var sut = _fixture.GetSut();
+
+        //Act
+        var id = sut.CaptureFeedback(feedback, out var result, null, hint);
+
+        //Assert
+        result.Should().Be(CaptureFeedbackResult.Success);
+        id.Should().NotBe(SentryId.Empty);
+        receivedHint.Should().BeSameAs(hint);
+        receivedHint.Attachments.Should().Contain(attachment);
+    }
+
+    [Fact]
+    public void CaptureFeedback_BeforeSendFeedbackReturnsNull_FeedbackDropped()
+    {
+        //Arrange
+        var feedback = new SentryFeedback("Everything is great!");
+        _fixture.SentryOptions.SetBeforeSendFeedback((SentryEvent _) => null);
+        var sut = _fixture.GetSut();
+
+        //Act
+        var id = sut.CaptureFeedback(feedback, out var result);
+
+        //Assert
+        result.Should().Be(CaptureFeedbackResult.DroppedByBeforeSendFeedback);
+        id.Should().Be(SentryId.Empty);
+        _ = sut.Worker.DidNotReceive().EnqueueEnvelope(Arg.Any<Envelope>());
+        _fixture.ClientReportRecorder.Received(1).RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Feedback);
+    }
+
+    [Fact]
+    public void CaptureFeedback_BeforeSendFeedbackThrows_FeedbackDropped()
+    {
+        //Arrange
+        var feedback = new SentryFeedback("Everything is great!");
+        _fixture.SentryOptions.SetBeforeSendFeedback((SentryEvent _) => throw new InvalidOperationException("boom"));
+        var sut = _fixture.GetSut();
+
+        //Act
+        var id = sut.CaptureFeedback(feedback, out var result);
+
+        //Assert
+        result.Should().Be(CaptureFeedbackResult.DroppedByBeforeSendFeedback);
+        id.Should().Be(SentryId.Empty);
+        _ = sut.Worker.DidNotReceive().EnqueueEnvelope(Arg.Any<Envelope>());
+        _fixture.ClientReportRecorder.Received(1).RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Feedback);
+    }
+
+    [Fact]
+    public void CaptureFeedback_EnqueueFails_ReturnsUnknownError()
+    {
+        //Arrange
+        var feedback = new SentryFeedback("Everything is great!");
+        _fixture.BackgroundWorker.EnqueueEnvelope(Arg.Any<Envelope>()).Returns(false);
+        var sut = _fixture.GetSut();
+
+        //Act
+        var id = sut.CaptureFeedback(feedback, out var result);
+
+        //Assert
+        result.Should().Be(CaptureFeedbackResult.UnknownError);
+        id.Should().Be(SentryId.Empty);
+    }
+
+    [Fact]
     public void CaptureFeedback_WithHint_HasHintAttachment()
     {
         //Arrange


### PR DESCRIPTION
Refers to #4092

#### Summary

Adds a `BeforeSendFeedback` callback to `SentryOptions`, mirroring the existing `BeforeSend` pattern but scoped to user feedback events. It lets applications inspect, modify, or drop user feedback before it is sent to Sentry.

#### Changes

- Two `SetBeforeSendFeedback` overloads on `SentryOptions` (with and without `SentryHint`), consistent with `SetBeforeSend` / `SetBeforeSendTransaction`.
- `SentryEventHelper.DoBeforeSendFeedback`, invoked in `SentryClient.CaptureFeedback` **after** event processors run.
- New `CaptureFeedbackResult.DroppedByBeforeSendFeedback` result value
- Dropped feedback is recorded via `ClientReportRecorder` under `DiscardReason.BeforeSend` / `DataCategory.Feedback`.  Originally, was specified the use of DataCategory USER_REPORT_V2.
https://github.com/getsentry/sentry/issues/88232#issuecomment-2779575605
 
#### Behavior notes for reviewers

Assumption: Feedback is a common place to scrub PII, so a callback that cannot complete should not leak partially-scrubbed or unintended feedback. 
Implementation: Both the null-return and throw paths record a client-report discard. This is documented on the public API and covered by tests.


#### Tests

`SentryClientTests` covers: callback invocation + mutation passthrough, hint received from caller, null and throw drops feedback.

#### Unrelated changes
Added a small unit test for CaptureFeedbackResult.UnknownError.