### PR TITLE
docs: mention the skip-changelog label

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,9 +126,9 @@ Public API diffs are stored as Verify snapshot files. After any public API chang
 
 ## Changelog
 
-- If the change is not user-facing, add `#skip-changelog` to the PR description
-- Otherwise generated automatically from [Commit message conventions](https://develop.sentry.dev/engineering-practices/commit-messages/).
-  - Do **NOT** add changelogs manually.
+- If the change is not user-facing, either write `#skip-changelog` to the PR description or add the `skip-changelog` label to the PR
+- Otherwise generated automatically from [Commit message conventions](https://develop.sentry.dev/engineering-practices/commit-messages/)
+  - Do **NOT** add changelogs manually
 
 ```sh
 # Get PR number for current branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,9 @@ Below that, you'll add heading 3 mentioned above. For example, if you're adding 
 - Attach screenshots when capturing errors on WPF (#PR number)
 ```
 
-There's a GitHub action check to verify if an entry was added. If the entry isn't a user-facing change, you can skip the verification with `#skip-changelog` written to the PR description. The bot writes a comment in the PR with a suggestion entry to the changelog based on the PR title.
+There's a GitHub action check to verify if an entry was added.
+If the entry isn't a user-facing change, you can skip the verification with either `#skip-changelog` written to the PR description or the `skip-changelog` label added to the PR.
+The bot writes a comment in the PR with a suggestion entry to the changelog based on the PR title.
 
 ## Naming tests
 


### PR DESCRIPTION
### Summary

Mention the `skip-changelog` GitHub label in regards to the auto-changelog generated by `Craft`.

### Remarks

When reviewing #5178, an Agent mentioned:
```
...
Remaining minor/low-severity items (not blocking)

1. Missing #skip-changelog — per this repo's convention (CLAUDE.md), non-user-facing changes should carry this tag. This PR touches only dev tooling/docs, never ships in the NuGet packages, and the title (Add optional pre-commit hook...) doesn't follow the type: description convention used elsewhere in this repo's changelog (chore:, docs:, etc.). Actionable: add #skip-changelog to the description, or retitle to chore: add optional pre-commit hook for code formatting.

...
```

The Agent is currently oblivious to the `skip-changelog` GitHub label:
<img width="356" height="100" alt="image" src="https://github.com/user-attachments/assets/1a5301da-35b5-4747-929d-26c6f2e51c7d" />

This change should be teaching the Agent to consider the Labels too.

#skip-changelog
