### PR TITLE
fix: fetch default attributes from `Scope` first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features ✨
 
 - feat: Add exponential backoff and log deduplication to Spotlight transport by @mattico in [#5025](https://github.com/getsentry/sentry-dotnet/pull/5025)
+- feat: The `Environment` set on the `Scope` now gets synchronized to the native layers (`sentry-cocoa` and `sentry-native`) by @bitsandfoxes [#5365](https://github.com/getsentry/sentry-dotnet/pull/5365)
 
 ## 6.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - feat: Add exponential backoff and log deduplication to Spotlight transport by @mattico in [#5025](https://github.com/getsentry/sentry-dotnet/pull/5025)
 - feat: The `Environment` set on the `Scope` now gets synchronized to the native layers (`sentry-cocoa` and `sentry-native`) by @bitsandfoxes [#5365](https://github.com/getsentry/sentry-dotnet/pull/5365)
 
+### Fixes
+
+- fix: When setting `Environment` and `Release` on the `Scope` these are  now also getting applied on emitted Metrics and Logs by bitsandfoxes [#5376](https://github.com/getsentry/sentry-dotnet/pull/5376)
+
 ## 6.6.0
 
 ### Features ✨

--- a/src/Sentry/IScopeObserver.cs
+++ b/src/Sentry/IScopeObserver.cs
@@ -36,6 +36,11 @@ public interface IScopeObserver
     public void SetTrace(SentryId traceId, SpanId parentSpanId);
 
     /// <summary>
+    /// Sets the environment.
+    /// </summary>
+    public void SetEnvironment(string? environment);
+
+    /// <summary>
     /// Adds an attachment.
     /// </summary>
     public void AddAttachment(SentryAttachment attachment);

--- a/src/Sentry/Internal/ScopeObserver.cs
+++ b/src/Sentry/Internal/ScopeObserver.cs
@@ -97,7 +97,7 @@ internal abstract class ScopeObserver : Sentry.IScopeObserver
 
     public void SetEnvironment(string? environment)
     {
-        _options.DiagnosticLogger?.Log(SentryLevel.Debug, 
+        _options.DiagnosticLogger?.Log(SentryLevel.Debug,
             "{0} Scope Sync - Setting Environment e:\"{1}\"", null, _name, environment);
         SetEnvironmentImpl(environment);
     }

--- a/src/Sentry/Internal/ScopeObserver.cs
+++ b/src/Sentry/Internal/ScopeObserver.cs
@@ -95,6 +95,15 @@ internal abstract class ScopeObserver : Sentry.IScopeObserver
 
     public abstract void SetTraceImpl(SentryId traceId, SpanId parentSpanId);
 
+    public void SetEnvironment(string? environment)
+    {
+        _options.DiagnosticLogger?.Log(SentryLevel.Debug, 
+            "{0} Scope Sync - Setting Environment e:\"{1}\"", null, _name, environment);
+        SetEnvironmentImpl(environment);
+    }
+
+    public abstract void SetEnvironmentImpl(string? environment);
+
     public void AddAttachment(SentryAttachment attachment)
     {
         _options.DiagnosticLogger?.Log(SentryLevel.Debug,

--- a/src/Sentry/Platforms/Android/AndroidScopeObserver.cs
+++ b/src/Sentry/Platforms/Android/AndroidScopeObserver.cs
@@ -112,6 +112,18 @@ internal sealed class AndroidScopeObserver : IScopeObserver
         }
     }
 
+    public void SetEnvironment(string? environment)
+    {
+        try
+        {
+            // TODO: Missing corresponding scope-level functionality on the Android SDK
+        }
+        finally
+        {
+            _innerObserver?.SetEnvironment(environment);
+        }
+    }
+
     public void AddAttachment(SentryAttachment attachment)
     {
         try

--- a/src/Sentry/Platforms/Cocoa/CocoaScopeObserver.cs
+++ b/src/Sentry/Platforms/Cocoa/CocoaScopeObserver.cs
@@ -120,6 +120,18 @@ internal sealed class CocoaScopeObserver : IScopeObserver
         }
     }
 
+    public void SetEnvironment(string? environment)
+    {
+        try
+        {
+            SentryCocoaSdk.ConfigureScope(scope => scope.SetEnvironment(environment));
+        }
+        finally
+        {
+            _innerObserver?.SetEnvironment(environment);
+        }
+    }
+
     public void AddAttachment(SentryAttachment attachment)
     {
         try

--- a/src/Sentry/Platforms/Native/CFunctions.cs
+++ b/src/Sentry/Platforms/Native/CFunctions.cs
@@ -251,6 +251,9 @@ internal static class C
     [DllImport("sentry-native")]
     internal static extern void sentry_set_trace(string traceId, string parentSpanId);
 
+    [DllImport("sentry-native")]
+    internal static extern void sentry_set_environment(string? environment);
+
     internal static Dictionary<long, DebugImage> LoadDebugImages(IDiagnosticLogger? logger)
     {
         // It only makes sense to load them once because they're cached on the native side anyway. We could force

--- a/src/Sentry/Platforms/Native/NativeScopeObserver.cs
+++ b/src/Sentry/Platforms/Native/NativeScopeObserver.cs
@@ -43,6 +43,9 @@ internal class NativeScopeObserver : ScopeObserver
     public override void SetTraceImpl(SentryId traceId, SpanId parentSpanId) =>
         C.sentry_set_trace(traceId.ToString(), parentSpanId.ToString());
 
+    public override void SetEnvironmentImpl(string? environment) =>
+        C.sentry_set_environment(environment);
+
     public override void AddAttachmentImpl(SentryAttachment attachment)
     {
         // TODO: Missing corresponding functionality on the Native SDK

--- a/src/Sentry/Protocol/SentryAttributes.cs
+++ b/src/Sentry/Protocol/SentryAttributes.cs
@@ -97,17 +97,18 @@ internal class SentryAttributes : Dictionary<string, SentryAttribute>, ISentryJs
         this[key] = new SentryAttribute(value, "integer");
     }
 
-    internal void SetDefaultAttributes(SentryOptions options, SdkVersion sdk)
+    internal void SetDefaultAttributes(SentryOptions options, Scope? scope, SdkVersion? sdk = null)
     {
-        var environment = options.SettingLocator.GetEnvironment();
+        var environment = scope?.Environment ?? options.SettingLocator.GetEnvironment();
         SetAttribute("sentry.environment", environment);
 
-        var release = options.SettingLocator.GetRelease();
+        var release = scope?.Release ?? options.SettingLocator.GetRelease();
         if (release is not null)
         {
             SetAttribute("sentry.release", release);
         }
 
+        sdk ??= scope?.Sdk ?? SdkVersion.Instance;
         if (sdk.Name is { } name)
         {
             SetAttribute("sentry.sdk.name", name);

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -316,6 +316,7 @@ public class Scope : IEventLike
         Options = options ?? new SentryOptions();
         PropagationContext = new SentryPropagationContext(propagationContext);
 
+        // Skip scope sync with backing field. The native SDKs already received the environment set on the options.
         _environment = Options.Environment;
     }
 

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -144,8 +144,25 @@ public class Scope : IEventLike
     /// <inheritdoc />
     public string? Distribution { get; set; }
 
+    private string? _environment;
+
     /// <inheritdoc />
-    public string? Environment { get; set; }
+    public string? Environment
+    {
+        get => _environment;
+        set
+        {
+            if (_environment != value)
+            {
+                _environment = value;
+                if (Options.EnableScopeSync &&
+                    Options.ScopeObserver is { } observer)
+                {
+                    observer.SetEnvironment(value);
+                }
+            }
+        }
+    }
 
     // TransactionName is kept for legacy purposes because
     // SentryEvent still makes use of it.

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -434,7 +434,7 @@ public class Scope : IEventLike
         Request = new();
         Contexts.Clear();
         User = new();
-        Release = default;
+        Release = Options.Release;
         Distribution = default;
         Environment = Options.Environment; // Restore to keep in sync with native
         TransactionName = default;

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -152,14 +152,24 @@ public class Scope : IEventLike
         get => _environment;
         set
         {
-            if (_environment != value)
+            if (_environment == value)
+            {
+                return;
+            }
+
+            if (value is null)
+            {
+                Options.LogWarning("Environment cannot be null. Reverting to default value from the options.");
+                _environment = Options.Environment;
+            }
+            else
             {
                 _environment = value;
-                if (Options.EnableScopeSync &&
-                    Options.ScopeObserver is { } observer)
-                {
-                    observer.SetEnvironment(value);
-                }
+            }
+
+            if (Options is { EnableScopeSync: true, ScopeObserver: { } observer })
+            {
+                observer.SetEnvironment(_environment);
             }
         }
     }
@@ -305,6 +315,8 @@ public class Scope : IEventLike
     {
         Options = options ?? new SentryOptions();
         PropagationContext = new SentryPropagationContext(propagationContext);
+
+        _environment = Options.Environment;
     }
 
     // For testing. Should explicitly require SentryOptions.
@@ -423,7 +435,7 @@ public class Scope : IEventLike
         User = new();
         Release = default;
         Distribution = default;
-        Environment = default;
+        Environment = Options.Environment; // Restore to keep in sync with native
         TransactionName = default;
         Transaction = default;
         Fingerprint = Array.Empty<string>();

--- a/src/Sentry/Scope.cs
+++ b/src/Sentry/Scope.cs
@@ -317,6 +317,7 @@ public class Scope : IEventLike
         PropagationContext = new SentryPropagationContext(propagationContext);
 
         _environment = Options.Environment;
+        Release = Options.Release;
     }
 
     // For testing. Should explicitly require SentryOptions.

--- a/src/Sentry/SentryLog.cs
+++ b/src/Sentry/SentryLog.cs
@@ -136,8 +136,7 @@ public sealed class SentryLog
     internal void SetDefaultAttributes(SentryOptions options, Scope? scope, SdkVersion? sdk = null)
     {
         // Core Attributes
-        sdk ??= scope?.Sdk ?? SdkVersion.Instance;
-        Attributes.SetDefaultAttributes(options, sdk);
+        Attributes.SetDefaultAttributes(options, scope, sdk);
 
         // Server Attributes
         if (!string.IsNullOrEmpty(options.ServerName))

--- a/src/Sentry/SentryMetric.Factory.cs
+++ b/src/Sentry/SentryMetric.Factory.cs
@@ -20,7 +20,7 @@ public abstract partial class SentryMetric
         };
 
         scope ??= hub.GetScope();
-        metric.Attributes.SetDefaultAttributes(options, scope?.Sdk ?? SdkVersion.Instance);
+        metric.Attributes.SetDefaultAttributes(options, scope);
 
         return metric;
     }

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -65,6 +65,7 @@ static partial class SentrySdk
 
         // This happens before the native SDKs get initialized
         options.Environment = options.SettingLocator.GetEnvironment();
+        options.Release = options.SettingLocator.GetRelease();
 
         // Initialize native platform SDKs here
         if (options.InitNativeSdks)

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -63,6 +63,9 @@ static partial class SentrySdk
 #pragma warning restore 0162
 #pragma warning restore CS0162 // Unreachable code detected
 
+        // This happens before the native SDKs get initialized
+        options.Environment = options.SettingLocator.GetEnvironment();
+
         // Initialize native platform SDKs here
         if (options.InitNativeSdks)
         {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -220,6 +220,7 @@ namespace Sentry
         void AddAttachment(Sentry.SentryAttachment attachment);
         void AddBreadcrumb(Sentry.Breadcrumb breadcrumb);
         void ClearAttachments();
+        void SetEnvironment(string? environment);
         void SetExtra(string key, object? value);
         void SetTag(string key, string value);
         void SetTrace(Sentry.SentryId traceId, Sentry.SpanId parentSpanId);

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -220,6 +220,7 @@ namespace Sentry
         void AddAttachment(Sentry.SentryAttachment attachment);
         void AddBreadcrumb(Sentry.Breadcrumb breadcrumb);
         void ClearAttachments();
+        void SetEnvironment(string? environment);
         void SetExtra(string key, object? value);
         void SetTag(string key, string value);
         void SetTrace(Sentry.SentryId traceId, Sentry.SpanId parentSpanId);

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -220,6 +220,7 @@ namespace Sentry
         void AddAttachment(Sentry.SentryAttachment attachment);
         void AddBreadcrumb(Sentry.Breadcrumb breadcrumb);
         void ClearAttachments();
+        void SetEnvironment(string? environment);
         void SetExtra(string key, object? value);
         void SetTag(string key, string value);
         void SetTrace(Sentry.SentryId traceId, Sentry.SpanId parentSpanId);

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -208,6 +208,7 @@ namespace Sentry
         void AddAttachment(Sentry.SentryAttachment attachment);
         void AddBreadcrumb(Sentry.Breadcrumb breadcrumb);
         void ClearAttachments();
+        void SetEnvironment(string? environment);
         void SetExtra(string key, object? value);
         void SetTag(string key, string value);
         void SetTrace(Sentry.SentryId traceId, Sentry.SpanId parentSpanId);

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -708,7 +708,7 @@ public class ScopeTests
             ScopeObserver = observer,
             EnableScopeSync = observerEnable
         });
-        var expectedEnvironment = "staging";
+        const string expectedEnvironment = "staging";
         var expectedCount = observerEnable ? 1 : 0;
 
         // Act
@@ -719,25 +719,38 @@ public class ScopeTests
     }
 
     [Fact]
-    public void SetEnvironment_Null_ObserverClearsEnvironment()
+    public void SetEnvironment_Null_EnvironmentSetToOptionEnvironment()
     {
         // Arrange
+        const string expectedEnvironment = "staging";
+        var scope = new Scope(new SentryOptions { Environment = expectedEnvironment });
+
+        // Act
+        scope.Environment = null;
+
+        // Assert
+        scope.Environment.Should().Be(expectedEnvironment);
+    }
+
+    [Fact]
+    public void SetEnvironment_Null_ObserverReceivesOptionEnvironment()
+    {
+        // Arrange
+        const string expectedEnvironment = "staging";
         var observer = Substitute.For<IScopeObserver>();
         var scope = new Scope(new SentryOptions
         {
             ScopeObserver = observer,
-            EnableScopeSync = true
-        })
-        {
-            Environment = "staging"
-        };
+            EnableScopeSync = true,
+            Environment = expectedEnvironment
+        });
         observer.ClearReceivedCalls();
 
         // Act
         scope.Environment = null;
 
         // Assert
-        observer.Received(1).SetEnvironment(Arg.Is((string?)null));
+        observer.Received(1).SetEnvironment(Arg.Is(expectedEnvironment));
     }
 
     [Fact]

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -427,6 +427,29 @@ public class ScopeTests
     }
 
     [Fact]
+    public void Clear_OptionsHaveEnvironmentAndRelease_RestoresToOptionsValues()
+    {
+        // Arrange
+        var options = new SentryOptions
+        {
+            Environment = "options-environment",
+            Release = "options-release",
+        };
+        var sut = new Scope(options);
+        sut.ApplyFakeValues();
+
+        // Act
+        sut.Clear();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            sut.Environment.Should().Be("options-environment");
+            sut.Release.Should().Be("options-release");
+        }
+    }
+
+    [Fact]
     public void Clear_ResetsPropagationContext()
     {
         var options = new SentryOptions();

--- a/test/Sentry.Tests/ScopeTests.cs
+++ b/test/Sentry.Tests/ScopeTests.cs
@@ -696,6 +696,69 @@ public class ScopeTests
         observer.Received(expectedCount).AddBreadcrumb(Arg.Is(breadcrumb));
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SetEnvironment_ObserverExist_ObserverSetsEnvironmentIfEnabled(bool observerEnable)
+    {
+        // Arrange
+        var observer = Substitute.For<IScopeObserver>();
+        var scope = new Scope(new SentryOptions
+        {
+            ScopeObserver = observer,
+            EnableScopeSync = observerEnable
+        });
+        var expectedEnvironment = "staging";
+        var expectedCount = observerEnable ? 1 : 0;
+
+        // Act
+        scope.Environment = expectedEnvironment;
+
+        // Assert
+        observer.Received(expectedCount).SetEnvironment(Arg.Is(expectedEnvironment));
+    }
+
+    [Fact]
+    public void SetEnvironment_Null_ObserverClearsEnvironment()
+    {
+        // Arrange
+        var observer = Substitute.For<IScopeObserver>();
+        var scope = new Scope(new SentryOptions
+        {
+            ScopeObserver = observer,
+            EnableScopeSync = true
+        })
+        {
+            Environment = "staging"
+        };
+        observer.ClearReceivedCalls();
+
+        // Act
+        scope.Environment = null;
+
+        // Assert
+        observer.Received(1).SetEnvironment(Arg.Is((string?)null));
+    }
+
+    [Fact]
+    public void SetEnvironment_SameValue_ObserverNotifiedOnce()
+    {
+        // Arrange
+        var observer = Substitute.For<IScopeObserver>();
+        var scope = new Scope(new SentryOptions
+        {
+            ScopeObserver = observer,
+            EnableScopeSync = true
+        });
+
+        // Act
+        scope.Environment = "staging";
+        scope.Environment = "staging";
+
+        // Assert
+        observer.Received(1).SetEnvironment(Arg.Is("staging"));
+    }
+
     [Fact]
     public void Filtered_tags_are_not_set()
     {

--- a/test/Sentry.Tests/SentryLogTests.cs
+++ b/test/Sentry.Tests/SentryLogTests.cs
@@ -77,6 +77,42 @@ public class SentryLogTests
     }
 
     [Fact]
+    public void SetDefaultAttributes_ScopeOverridesOptions_UsesScopeValues()
+    {
+        var options = new SentryOptions
+        {
+            Environment = "options-environment",
+            Release = "options-release",
+        };
+        var scope = new Scope(options)
+        {
+            Environment = "scope-environment",
+            Release = "scope-release",
+        };
+        var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Info, "message");
+
+        log.SetDefaultAttributes(options, scope);
+
+        log.Attributes.ShouldContain<string>("sentry.environment", "scope-environment");
+        log.Attributes.ShouldContain<string>("sentry.release", "scope-release");
+    }
+
+    [Fact]
+    public void SetDefaultAttributes_NullScope_FallsBackToOptionsSettings()
+    {
+        var options = new SentryOptions
+        {
+            Release = "options-release",
+        };
+        var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Info, "message");
+
+        log.SetDefaultAttributes(options, scope: null);
+
+        log.Attributes.ShouldContain<string>("sentry.environment", options.SettingLocator.GetEnvironment());
+        log.Attributes.ShouldContain<string>("sentry.release", options.SettingLocator.GetRelease());
+    }
+
+    [Fact]
     public void SetDefaultAttributes_OptionsServerName_SetsServerAddress()
     {
         var options = new SentryOptions { ServerName = "my-server" };

--- a/test/Sentry.Tests/SentryLogTests.cs
+++ b/test/Sentry.Tests/SentryLogTests.cs
@@ -102,6 +102,7 @@ public class SentryLogTests
     {
         var options = new SentryOptions
         {
+            Environment = "options-environment",
             Release = "options-release",
         };
         var log = new SentryLog(Timestamp, TraceId, SentryLogLevel.Info, "message");

--- a/test/Sentry.Tests/SentryMetricTests.cs
+++ b/test/Sentry.Tests/SentryMetricTests.cs
@@ -103,6 +103,7 @@ public class SentryMetricTests
     {
         var options = new SentryOptions
         {
+            Environment = "options-environment",
             Release = "options-release",
         };
         var metric = new SentryMetric<int>(Timestamp, TraceId, SentryMetricType.Counter, "sentry_tests.sentry_metric_tests.counter", 1);
@@ -123,7 +124,7 @@ public class SentryMetricTests
         };
 
         var metric = new SentryMetric<int>(Timestamp, TraceId, SentryMetricType.Counter, "sentry_tests.sentry_metric_tests.counter", 1);
-        metric.Attributes.SetDefaultAttributes(options, new Scope());
+        metric.Attributes.SetDefaultAttributes(options, new Scope(options));
 
         var envelope = Envelope.FromMetric(new TraceMetric([metric]));
 
@@ -201,7 +202,7 @@ public class SentryMetricTests
         metric.SetAttribute("boolean-attribute", true);
         metric.SetAttribute("integer-attribute", 3);
         metric.SetAttribute("double-attribute", 4.4);
-        metric.Attributes.SetDefaultAttributes(options, new Scope { Sdk = { Name = "Sentry.Test.SDK", Version = "1.2.3-test+Sentry" } });
+        metric.Attributes.SetDefaultAttributes(options, new Scope(options) { Sdk = { Name = "Sentry.Test.SDK", Version = "1.2.3-test+Sentry" } });
 
         var envelope = EnvelopeItem.FromMetric(new TraceMetric([metric]));
 

--- a/test/Sentry.Tests/SentryMetricTests.cs
+++ b/test/Sentry.Tests/SentryMetricTests.cs
@@ -44,10 +44,13 @@ public class SentryMetricTests
             Environment = "my-environment",
             Release = "my-release",
         };
-        var sdk = new SdkVersion
+        var scope = new Scope(options)
         {
-            Name = "Sentry.Test.SDK",
-            Version = "1.2.3-test+Sentry",
+            Sdk =
+            {
+                Name = "Sentry.Test.SDK",
+                Version = "1.2.3-test+Sentry"
+            }
         };
 
         var metric = new SentryMetric<int>(Timestamp, TraceId, SentryMetricType.Counter, "sentry_tests.sentry_metric_tests.counter", 1)
@@ -56,7 +59,7 @@ public class SentryMetricTests
             Unit = "test_unit",
         };
         metric.SetAttribute("attribute", "value");
-        metric.Attributes.SetDefaultAttributes(options, sdk);
+        metric.Attributes.SetDefaultAttributes(options, scope);
 
         metric.Timestamp.Should().Be(Timestamp);
         metric.TraceId.Should().Be(TraceId);
@@ -69,9 +72,45 @@ public class SentryMetricTests
         metric.Attributes.ShouldContain("attribute", "value");
         metric.Attributes.ShouldContain("sentry.environment", options.Environment);
         metric.Attributes.ShouldContain("sentry.release", options.Release);
-        metric.Attributes.ShouldContain("sentry.sdk.name", sdk.Name);
-        metric.Attributes.ShouldContain("sentry.sdk.version", sdk.Version);
+        metric.Attributes.ShouldContain("sentry.sdk.name", scope.Sdk.Name);
+        metric.Attributes.ShouldContain("sentry.sdk.version", scope.Sdk.Version);
         metric.Attributes.ShouldNotContain<object>("not-found");
+    }
+
+    [Fact]
+    public void SetDefaultAttributes_ScopeOverridesOptions_UsesScopeValues()
+    {
+        var options = new SentryOptions
+        {
+            Environment = "options-environment",
+            Release = "options-release",
+        };
+        var scope = new Scope(options)
+        {
+            Environment = "scope-environment",
+            Release = "scope-release",
+        };
+        var metric = new SentryMetric<int>(Timestamp, TraceId, SentryMetricType.Counter, "sentry_tests.sentry_metric_tests.counter", 1);
+
+        metric.Attributes.SetDefaultAttributes(options, scope);
+
+        metric.Attributes.ShouldContain("sentry.environment", "scope-environment");
+        metric.Attributes.ShouldContain("sentry.release", "scope-release");
+    }
+
+    [Fact]
+    public void SetDefaultAttributes_NullScope_FallsBackToOptionsSettings()
+    {
+        var options = new SentryOptions
+        {
+            Release = "options-release",
+        };
+        var metric = new SentryMetric<int>(Timestamp, TraceId, SentryMetricType.Counter, "sentry_tests.sentry_metric_tests.counter", 1);
+
+        metric.Attributes.SetDefaultAttributes(options, scope: null);
+
+        metric.Attributes.ShouldContain("sentry.environment", options.SettingLocator.GetEnvironment());
+        metric.Attributes.ShouldContain("sentry.release", options.SettingLocator.GetRelease());
     }
 
     [Fact]
@@ -84,7 +123,7 @@ public class SentryMetricTests
         };
 
         var metric = new SentryMetric<int>(Timestamp, TraceId, SentryMetricType.Counter, "sentry_tests.sentry_metric_tests.counter", 1);
-        metric.Attributes.SetDefaultAttributes(options, new SdkVersion());
+        metric.Attributes.SetDefaultAttributes(options, new Scope());
 
         var envelope = Envelope.FromMetric(new TraceMetric([metric]));
 
@@ -162,7 +201,7 @@ public class SentryMetricTests
         metric.SetAttribute("boolean-attribute", true);
         metric.SetAttribute("integer-attribute", 3);
         metric.SetAttribute("double-attribute", 4.4);
-        metric.Attributes.SetDefaultAttributes(options, new SdkVersion { Name = "Sentry.Test.SDK", Version = "1.2.3-test+Sentry" });
+        metric.Attributes.SetDefaultAttributes(options, new Scope { Sdk = { Name = "Sentry.Test.SDK", Version = "1.2.3-test+Sentry" } });
 
         var envelope = EnvelopeItem.FromMetric(new TraceMetric([metric]));
 


### PR DESCRIPTION
Follows #5365 

The issue I see is that 
- We keep the `Scope` basically unpopulated
- We let users overwrite things on the `Scope`, i.e. `Environment`, or `Release`
- To make sure certain stuff is there we let the `Enricher` backfill (because they were never set on the scope) https://github.com/getsentry/sentry-dotnet/blob/ebef6ff26030703420a20931174fad325064b621/src/Sentry/Internal/Enricher.cs#L81
- And now we have a secondary processing pipeline with the `SetDefaultAttributes` that lives outside of either mechanism. 

Personally, I am heavily in favour of having the scope as the source of truth. Especially, since the scope is used to sync data between the C# and the native layer.
And with this change whatever is set on the scope is at least getting applied where previously, any user set `Environment` on the Scope would just get ignored.

## Behaviour before this PR

Two separate inconsistent pipelines:

**1. Events / traces (`IEventLike`) — scope wins, Options is only a fallback**

- `Scope.Environment` / `Scope.Release` are plain settable properties, default `null` ([Scope.cs:142](sentry-dotnet/src/Sentry/Scope.cs#L142), [148](sentry-dotnet/src/Sentry/Scope.cs#L148)). The constructor does **not** seed them from Options ([Scope.cs:287](sentry-dotnet/src/Sentry/Scope.cs#L287)).
- `Scope.Apply` copies scope→event only if unset: `other.Environment ??= Environment; other.Release ??= Release;` ([Scope.cs:491-493](sentry-dotnet/src/Sentry/Scope.cs#L491)).
- Then the `Enricher` backfills from Options/env-var/default, again only if still null: `eventLike.Environment ??= _options.SettingLocator.GetEnvironment();` ([Enricher.cs:75,81](sentry-dotnet/src/Sentry/Internal/Enricher.cs#L75)).

So if a user sets `scope.Environment = "Staging"`, **that wins** and Options never overrides it. Options is purely the fallback.

**2. Logs / metrics (`SetDefaultAttributes`) — scope is ignored, Options wins**

- `SetDefaultAttributes` reads straight from `SettingLocator`, never looking at the scope: `options.SettingLocator.GetEnvironment()` / `GetRelease()` ([SentryAttributes.cs:100-109](sentry-dotnet/src/Sentry/Protocol/SentryAttributes.cs#L100)).
- `SettingLocator.GetEnvironment/GetRelease` resolve `Options.Environment ?? SENTRY_ENVIRONMENT ?? default` ([SettingLocator.cs:80,105](sentry-dotnet/src/Sentry/Internal/SettingLocator.cs#L80)) — and, notably, cache the resolved value back onto Options (`_options.Environment = environment`).

So for logs, a user-set `scope.Environment` **is silently ignored** — which is exactly bitsandfoxes' complaint ("any user set Environment on the Scope would just get ignored"). That statement is true *for the logs pipeline*, not for events.

## What sentry-python and sentry-java do

Both take the **opposite** stance from "scope as source of truth":

- **sentry-python:** `Scope` has no `environment`/`release` fields. They live in client `options`. On events, `_prepare_event` fills them only if absent: `if event.get(key) is None and self.options[key] is not None: event[key] = ...` for `release`/`environment`. Logs (`set_global_attributes`) read directly from `options`. There is **no per-scope override** for these fields.
- **sentry-java:** `Scope` has no `getEnvironment/setEnvironment/getRelease/setRelease`. `MainEventProcessor` does `if (event.getRelease() == null) event.setRelease(options.getRelease());` and likewise for environment. Again, options-level only, no scope override.

In both, `environment`/`release` are effectively program-lifetime invariants set at init on options.

## Recommendation ???

If we want consistency *and* to avoid the whole clone/override bug class, the java/python model is the cleaner solution??? @bitsandfoxes what do you think of this?