### PR TITLE
feat: Add IgnoreTransactions option to filter transactions by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Features ✨
 
-- Add `IgnoreTransactions` option to filter out transactions by name, matching substrings or regular expressions against the transaction name ([#5377](https://github.com/getsentry/sentry-dotnet/pull/5377))
 - feat: Add exponential backoff and log deduplication to Spotlight transport by @mattico in [#5025](https://github.com/getsentry/sentry-dotnet/pull/5025)
 
 ## 6.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features ✨
 
+- Add `IgnoreTransactions` option to filter out transactions by name, matching substrings or regular expressions against the transaction name ([#5377](https://github.com/getsentry/sentry-dotnet/pull/5377))
 - feat: Add exponential backoff and log deduplication to Spotlight transport by @mattico in [#5025](https://github.com/getsentry/sentry-dotnet/pull/5025)
 
 ## 6.6.0

--- a/src/Sentry/BindableSentryOptions.cs
+++ b/src/Sentry/BindableSentryOptions.cs
@@ -11,6 +11,7 @@ internal partial class BindableSentryOptions
     public bool? EnableScopeSync { get; set; }
     public bool? EnableBackpressureHandling { get; set; }
     public List<string>? TagFilters { get; set; }
+    public List<string>? IgnoreTransactions { get; set; }
     public bool? SendDefaultPii { get; set; }
     public bool? IsEnvironmentUser { get; set; }
     public string? ServerName { get; set; }
@@ -66,6 +67,7 @@ internal partial class BindableSentryOptions
         options.EnableScopeSync = EnableScopeSync ?? options.EnableScopeSync;
         options.EnableBackpressureHandling = EnableBackpressureHandling ?? options.EnableBackpressureHandling;
         options.TagFilters = TagFilters?.Select(s => new StringOrRegex(s)).ToList() ?? options.TagFilters;
+        options.IgnoreTransactions = IgnoreTransactions?.Select(s => new StringOrRegex(s)).ToList() ?? options.IgnoreTransactions;
         options.SendDefaultPii = SendDefaultPii ?? options.SendDefaultPii;
         options.IsEnvironmentUser = IsEnvironmentUser ?? options.IsEnvironmentUser;
         options.ServerName = ServerName ?? options.ServerName;

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -163,18 +163,6 @@ public class SentryClient : ISentryClient, IDisposable
             return;
         }
 
-        if (_options.IgnoreTransactions.MatchesSubstringOrRegex(transaction.Name))
-        {
-            // IgnoreTransactions is a built-in filter, so discards are recorded under
-            // EventProcessor (matching the exception filter path and the JS inbound filters),
-            // not BeforeSend, which is reserved for the user's BeforeSendTransaction callback.
-            var ignoredSpanCount = transaction.Spans.Count + 1; // 1 for each span + 1 for the transaction itself
-            _options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.EventProcessor, DataCategory.Transaction);
-            _options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.EventProcessor, DataCategory.Span, ignoredSpanCount);
-            _options.LogInfo("Transaction dropped by IgnoreTransactions option.");
-            return;
-        }
-
         // Unfinished transaction can only happen if the user calls this method instead of
         // transaction.Finish().
         // We still send these transactions over, but warn the user not to do it.
@@ -194,6 +182,19 @@ public class SentryClient : ISentryClient, IDisposable
             _options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.SampleRate, DataCategory.Transaction);
             _options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.SampleRate, DataCategory.Span, spanCount);
             _options.LogDebug("Transaction dropped by sampling.");
+            return;
+        }
+
+        // Applied after the sampling check so that a transaction which is sampled out is
+        // still attributed to sampling, not to this filter. IgnoreTransactions is a built-in
+        // filter, so its discards are recorded under EventProcessor (matching the exception
+        // filter path and the JS inbound filters), not BeforeSend, which is reserved for the
+        // user's BeforeSendTransaction callback.
+        if (_options.IgnoreTransactions.MatchesSubstringOrRegex(transaction.Name))
+        {
+            _options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.EventProcessor, DataCategory.Transaction);
+            _options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.EventProcessor, DataCategory.Span, spanCount);
+            _options.LogInfo("Transaction dropped by IgnoreTransactions option.");
             return;
         }
 

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -165,9 +165,12 @@ public class SentryClient : ISentryClient, IDisposable
 
         if (_options.IgnoreTransactions.MatchesSubstringOrRegex(transaction.Name))
         {
+            // IgnoreTransactions is a built-in filter, so discards are recorded under
+            // EventProcessor (matching the exception filter path and the JS inbound filters),
+            // not BeforeSend, which is reserved for the user's BeforeSendTransaction callback.
             var ignoredSpanCount = transaction.Spans.Count + 1; // 1 for each span + 1 for the transaction itself
-            _options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Transaction);
-            _options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Span, ignoredSpanCount);
+            _options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.EventProcessor, DataCategory.Transaction);
+            _options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.EventProcessor, DataCategory.Span, ignoredSpanCount);
             _options.LogInfo("Transaction dropped by IgnoreTransactions option.");
             return;
         }

--- a/src/Sentry/SentryClient.cs
+++ b/src/Sentry/SentryClient.cs
@@ -163,6 +163,15 @@ public class SentryClient : ISentryClient, IDisposable
             return;
         }
 
+        if (_options.IgnoreTransactions.MatchesSubstringOrRegex(transaction.Name))
+        {
+            var ignoredSpanCount = transaction.Spans.Count + 1; // 1 for each span + 1 for the transaction itself
+            _options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Transaction);
+            _options.ClientReportRecorder.RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Span, ignoredSpanCount);
+            _options.LogInfo("Transaction dropped by IgnoreTransactions option.");
+            return;
+        }
+
         // Unfinished transaction can only happen if the user calls this method instead of
         // transaction.Finish().
         // We still send these transactions over, but warn the user not to do it.

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -244,6 +244,15 @@ public class SentryOptions
     public IList<StringOrRegex> TagFilters { get; set; } = new List<StringOrRegex>();
 
     /// <summary>
+    /// A list of transaction names to be ignored. A transaction whose name matches any of the
+    /// given substrings or regular expression patterns will not be sent to Sentry.
+    /// </summary>
+    /// <remarks>
+    /// This is applied before the BeforeSendTransaction callback.
+    /// </remarks>
+    public IList<StringOrRegex> IgnoreTransactions { get; set; } = new List<StringOrRegex>();
+
+    /// <summary>
     /// The worker used by the client to pass envelopes.
     /// </summary>
     public IBackgroundWorker? BackgroundWorker { get; set; }

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -248,7 +248,10 @@ public class SentryOptions
     /// given substrings or regular expression patterns will not be sent to Sentry.
     /// </summary>
     /// <remarks>
-    /// This is applied before the BeforeSendTransaction callback.
+    /// Matching transactions are dropped before the BeforeSendTransaction callback runs, so that
+    /// callback is not invoked for them. This mirrors the behavior of the <c>ignoreTransactions</c>
+    /// option in the Sentry JavaScript and Python SDKs, where the built-in filter runs ahead of the
+    /// user's <c>before_send_transaction</c> hook.
     /// </remarks>
     public IList<StringOrRegex> IgnoreTransactions { get; set; } = new List<StringOrRegex>();
 

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -822,6 +822,7 @@ namespace Sentry
         public System.Collections.Generic.IList<Sentry.StringOrRegex> FailedRequestTargets { get; set; }
         public System.TimeSpan FlushTimeout { get; set; }
         public System.Net.IWebProxy? HttpProxy { get; set; }
+        public System.Collections.Generic.IList<Sentry.StringOrRegex> IgnoreTransactions { get; set; }
         public System.TimeSpan InitCacheFlushTimeout { get; set; }
         public bool IsEnvironmentUser { get; set; }
         public bool IsGlobalModeEnabled { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -822,6 +822,7 @@ namespace Sentry
         public System.Collections.Generic.IList<Sentry.StringOrRegex> FailedRequestTargets { get; set; }
         public System.TimeSpan FlushTimeout { get; set; }
         public System.Net.IWebProxy? HttpProxy { get; set; }
+        public System.Collections.Generic.IList<Sentry.StringOrRegex> IgnoreTransactions { get; set; }
         public System.TimeSpan InitCacheFlushTimeout { get; set; }
         public bool IsEnvironmentUser { get; set; }
         public bool IsGlobalModeEnabled { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -822,6 +822,7 @@ namespace Sentry
         public System.Collections.Generic.IList<Sentry.StringOrRegex> FailedRequestTargets { get; set; }
         public System.TimeSpan FlushTimeout { get; set; }
         public System.Net.IWebProxy? HttpProxy { get; set; }
+        public System.Collections.Generic.IList<Sentry.StringOrRegex> IgnoreTransactions { get; set; }
         public System.TimeSpan InitCacheFlushTimeout { get; set; }
         public bool IsEnvironmentUser { get; set; }
         public bool IsGlobalModeEnabled { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -809,6 +809,7 @@ namespace Sentry
         public System.Collections.Generic.IList<Sentry.StringOrRegex> FailedRequestTargets { get; set; }
         public System.TimeSpan FlushTimeout { get; set; }
         public System.Net.IWebProxy? HttpProxy { get; set; }
+        public System.Collections.Generic.IList<Sentry.StringOrRegex> IgnoreTransactions { get; set; }
         public System.TimeSpan InitCacheFlushTimeout { get; set; }
         public bool IsEnvironmentUser { get; set; }
         public bool IsGlobalModeEnabled { get; set; }

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -1297,6 +1297,68 @@ public partial class SentryClientTests : IDisposable
     }
 
     [Fact]
+    public void CaptureTransaction_MatchesIgnoreTransactions_Dropped()
+    {
+        // Arrange
+        _fixture.SentryOptions.IgnoreTransactions = new List<StringOrRegex> { "GET /health" };
+        var client = _fixture.GetSut();
+
+        var sentryTransaction = new SentryTransaction("GET /health", "http.server")
+        {
+            IsSampled = true,
+            EndTimestamp = DateTimeOffset.Now // finished
+        };
+
+        // Act
+        client.CaptureTransaction(sentryTransaction);
+
+        // Assert
+        _ = client.Worker.DidNotReceive().EnqueueEnvelope(Arg.Any<Envelope>());
+
+        var expectedSpanCount = sentryTransaction.Spans.Count + 1; // 1 for each span + one for the root transaction
+        _fixture.ClientReportRecorder.Received(1).RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Transaction);
+        _fixture.ClientReportRecorder.Received(1).RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Span, expectedSpanCount);
+    }
+
+    [Fact]
+    public void CaptureTransaction_MatchesIgnoreTransactionsRegex_Dropped()
+    {
+        // Arrange
+        _fixture.SentryOptions.IgnoreTransactions = new List<StringOrRegex> { new(new Regex(@"^GET /health/\d+$")) };
+        var client = _fixture.GetSut();
+
+        // Act
+        client.CaptureTransaction(
+            new SentryTransaction("GET /health/123", "http.server")
+            {
+                IsSampled = true,
+                EndTimestamp = DateTimeOffset.Now // finished
+            });
+
+        // Assert
+        _ = client.Worker.DidNotReceive().EnqueueEnvelope(Arg.Any<Envelope>());
+    }
+
+    [Fact]
+    public void CaptureTransaction_DoesNotMatchIgnoreTransactions_Sent()
+    {
+        // Arrange
+        _fixture.SentryOptions.IgnoreTransactions = new List<StringOrRegex> { "GET /health" };
+        var client = _fixture.GetSut();
+
+        // Act
+        client.CaptureTransaction(
+            new SentryTransaction("GET /api/users", "http.server")
+            {
+                IsSampled = true,
+                EndTimestamp = DateTimeOffset.Now // finished
+            });
+
+        // Assert
+        _ = client.Worker.Received(1).EnqueueEnvelope(Arg.Any<Envelope>());
+    }
+
+    [Fact]
     public void CaptureTransaction_NotFinished_Sent()
     {
         // Arrange

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -1359,6 +1359,33 @@ public partial class SentryClientTests : IDisposable
     }
 
     [Fact]
+    public void CaptureTransaction_MatchesIgnoreTransactions_BeforeSendTransactionNotInvoked()
+    {
+        // Arrange: IgnoreTransactions is applied before the BeforeSendTransaction
+        // callback, so the callback must not observe an ignored transaction.
+        _fixture.SentryOptions.IgnoreTransactions = new List<StringOrRegex> { "GET /health" };
+        var beforeSendTransactionInvoked = false;
+        _fixture.SentryOptions.SetBeforeSendTransaction((tx, _) =>
+        {
+            beforeSendTransactionInvoked = true;
+            return tx;
+        });
+        var client = _fixture.GetSut();
+
+        // Act
+        client.CaptureTransaction(
+            new SentryTransaction("GET /health", "http.server")
+            {
+                IsSampled = true,
+                EndTimestamp = DateTimeOffset.Now // finished
+            });
+
+        // Assert
+        beforeSendTransactionInvoked.Should().BeFalse();
+        _ = client.Worker.DidNotReceive().EnqueueEnvelope(Arg.Any<Envelope>());
+    }
+
+    [Fact]
     public void CaptureTransaction_NotFinished_Sent()
     {
         // Arrange

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -1316,8 +1316,8 @@ public partial class SentryClientTests : IDisposable
         _ = client.Worker.DidNotReceive().EnqueueEnvelope(Arg.Any<Envelope>());
 
         var expectedSpanCount = sentryTransaction.Spans.Count + 1; // 1 for each span + one for the root transaction
-        _fixture.ClientReportRecorder.Received(1).RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Transaction);
-        _fixture.ClientReportRecorder.Received(1).RecordDiscardedEvent(DiscardReason.BeforeSend, DataCategory.Span, expectedSpanCount);
+        _fixture.ClientReportRecorder.Received(1).RecordDiscardedEvent(DiscardReason.EventProcessor, DataCategory.Transaction);
+        _fixture.ClientReportRecorder.Received(1).RecordDiscardedEvent(DiscardReason.EventProcessor, DataCategory.Span, expectedSpanCount);
     }
 
     [Fact]

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -1386,6 +1386,30 @@ public partial class SentryClientTests : IDisposable
     }
 
     [Fact]
+    public void CaptureTransaction_SampledOutAndMatchesIgnoreTransactions_RecordedAsSampleRate()
+    {
+        // Arrange: a sampled-out transaction whose name also matches an ignore pattern must be
+        // attributed to sampling (the earlier, primary drop reason), not to IgnoreTransactions.
+        _fixture.SentryOptions.IgnoreTransactions = new List<StringOrRegex> { "GET /health" };
+        var client = _fixture.GetSut();
+
+        var hub = Substitute.For<IHub>();
+        var transaction = new UnsampledTransaction(hub, new TransactionContext("GET /health", "http.server"));
+        transaction.StartChild("span1");
+
+        // Act
+        client.CaptureTransaction(new SentryTransaction(transaction));
+
+        // Assert
+        _ = client.Worker.DidNotReceive().EnqueueEnvelope(Arg.Any<Envelope>());
+
+        var expectedSpanCount = transaction.Spans.Count + 1; // 1 for each span + one for the root transaction
+        _fixture.ClientReportRecorder.Received(1).RecordDiscardedEvent(DiscardReason.SampleRate, DataCategory.Transaction);
+        _fixture.ClientReportRecorder.Received(1).RecordDiscardedEvent(DiscardReason.SampleRate, DataCategory.Span, expectedSpanCount);
+        _fixture.ClientReportRecorder.DidNotReceive().RecordDiscardedEvent(DiscardReason.EventProcessor, DataCategory.Transaction);
+    }
+
+    [Fact]
     public void CaptureTransaction_NotFinished_Sent()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Adds a first-class `SentryOptions.IgnoreTransactions` option: a list of substrings or regular expressions. A transaction whose name matches any entry is dropped before it is sent, mirroring [`ignoreTransactions`](https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-ignore-transactions) in the JavaScript and Python SDKs.

Previously this required writing a `BeforeSendTransaction` callback (as noted by the maintainers in the issue). The new option gives parity with the other SDKs and the same shape as the existing `TagFilters` / `TracePropagationTargets` options.

Fixes #2306

(The `ignoreErrors` half of that issue is intentionally out of scope — it was marked "won't do" there, since exception filters already cover it.)

### Changelog Entry

Add `IgnoreTransactions` option to filter out transactions by name, matching substrings or regular expressions against the transaction name ([#5377](https://github.com/getsentry/sentry-dotnet/pull/5377))

## Implementation

- `SentryOptions.IgnoreTransactions` — `IList<StringOrRegex>`, defaulting to empty (opt-in), matching the `TagFilters` pattern.
- `SentryClient.CaptureTransaction` — drops a transaction whose `Name` matches, using the existing `MatchesSubstringOrRegex` helper, right after the required-field validation and before `BeforeSendTransaction`. Discards are recorded against the client report recorder (`DiscardReason.EventProcessor`)
- `BindableSentryOptions` — added the `List<string>?` surrogate + `ApplyTo` mapping for AOT-safe configuration binding, as required by the `BindableProperties_MatchOptionsProperties` guard.
