### PR TITLE
fix: Create a single TaskBlockingListener per process for CaptureBlockingCalls

### DIFF
--- a/src/Sentry.AspNetCore/SentryMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryMiddleware.cs
@@ -35,11 +35,11 @@ internal class SentryMiddleware : IMiddleware
     private static readonly string ProtocolPackageName = "nuget:" + NameAndVersion.Name;
 
     // Ben.BlockingDetector
-    private readonly BlockingMonitor? _monitor;
+    private readonly IBlockingMonitor? _monitor;
     private readonly TaskBlockingListener? _listener;
 
     // Internal for testing
-    internal BlockingMonitor? Monitor => _monitor;
+    internal IBlockingMonitor? Monitor => _monitor;
     internal TaskBlockingListener? Listener => _listener;
 
     /// <summary>
@@ -81,7 +81,7 @@ internal class SentryMiddleware : IMiddleware
         if (_options.CaptureBlockingCalls)
         {
             // Resolve shared singletons to keep overhead constant - See #5378.
-            _monitor = serviceProvider.GetRequiredService<BlockingMonitor>();
+            _monitor = serviceProvider.GetRequiredService<IBlockingMonitor>();
             _listener = serviceProvider.GetRequiredService<TaskBlockingListener>();
         }
     }

--- a/src/Sentry.AspNetCore/SentryMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryMiddleware.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Sentry.AspNetCore.Extensions;
@@ -35,8 +36,12 @@ internal class SentryMiddleware : IMiddleware
 
     // Ben.BlockingDetector
     private readonly BlockingMonitor? _monitor;
-    private readonly DetectBlockingSynchronizationContext? _detectBlockingSyncCtx;
     private readonly TaskBlockingListener? _listener;
+
+    // Exposed for tests, to verify that a single monitor/listener is shared across
+    // (transient) middleware instances rather than being allocated per request.
+    internal BlockingMonitor? Monitor => _monitor;
+    internal TaskBlockingListener? Listener => _listener;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SentryMiddleware"/> class.
@@ -48,6 +53,7 @@ internal class SentryMiddleware : IMiddleware
     /// <param name="eventExceptionProcessors">Custom Event Exception Processors</param>
     /// <param name="eventProcessors">Custom Event Processors</param>
     /// <param name="transactionProcessors">Custom Transaction Processors</param>
+    /// <param name="serviceProvider">The service provider, used to resolve shared blocking-call detection services.</param>
     /// <exception cref="ArgumentNullException">
     /// next
     /// or
@@ -60,7 +66,8 @@ internal class SentryMiddleware : IMiddleware
         ILogger<SentryMiddleware> logger,
         IEnumerable<ISentryEventExceptionProcessor> eventExceptionProcessors,
         IEnumerable<ISentryEventProcessor> eventProcessors,
-        IEnumerable<ISentryTransactionProcessor> transactionProcessors)
+        IEnumerable<ISentryTransactionProcessor> transactionProcessors,
+        IServiceProvider serviceProvider)
     {
         ArgumentNullException.ThrowIfNull(getHub);
 
@@ -74,9 +81,15 @@ internal class SentryMiddleware : IMiddleware
 
         if (_options.CaptureBlockingCalls)
         {
-            _monitor = new BlockingMonitor(_getHub, _options);
-            _detectBlockingSyncCtx = new DetectBlockingSynchronizationContext(_monitor);
-            _listener = new TaskBlockingListener(_monitor);
+            // The monitor and listener are registered as process-wide singletons (see
+            // SentryWebHostBuilderExtensions). This middleware is transient (one instance per
+            // request), so constructing them here would create - and never dispose - a new
+            // TaskBlockingListener (an EventListener) on every request. Each leaked listener stays
+            // rooted in the runtime's global listener chain, keeps TplEventSource enabled, and makes
+            // EventSource.DispatchToAllListeners walk an ever-growing chain on every await in the
+            // process. Resolving the shared singletons instead keeps the overhead constant. See #5378.
+            _monitor = serviceProvider.GetRequiredService<BlockingMonitor>();
+            _listener = serviceProvider.GetRequiredService<TaskBlockingListener>();
         }
     }
 
@@ -150,7 +163,12 @@ internal class SentryMiddleware : IMiddleware
                 if (_options.CaptureBlockingCalls && _monitor is not null)
                 {
                     var syncCtx = SynchronizationContext.Current;
-                    SynchronizationContext.SetSynchronizationContext(syncCtx == null ? _detectBlockingSyncCtx : new DetectBlockingSynchronizationContext(_monitor, syncCtx));
+                    // The synchronization context wraps per-request suppression state, so it must be
+                    // created per request - unlike the monitor/listener, which are shared singletons.
+                    var detectingSyncCtx = syncCtx is null
+                        ? new DetectBlockingSynchronizationContext(_monitor)
+                        : new DetectBlockingSynchronizationContext(_monitor, syncCtx);
+                    SynchronizationContext.SetSynchronizationContext(detectingSyncCtx);
                     try
                     {
                         // For detection to work we need ConfigureAwait=true

--- a/src/Sentry.AspNetCore/SentryMiddleware.cs
+++ b/src/Sentry.AspNetCore/SentryMiddleware.cs
@@ -38,8 +38,7 @@ internal class SentryMiddleware : IMiddleware
     private readonly BlockingMonitor? _monitor;
     private readonly TaskBlockingListener? _listener;
 
-    // Exposed for tests, to verify that a single monitor/listener is shared across
-    // (transient) middleware instances rather than being allocated per request.
+    // Internal for testing
     internal BlockingMonitor? Monitor => _monitor;
     internal TaskBlockingListener? Listener => _listener;
 
@@ -53,7 +52,7 @@ internal class SentryMiddleware : IMiddleware
     /// <param name="eventExceptionProcessors">Custom Event Exception Processors</param>
     /// <param name="eventProcessors">Custom Event Processors</param>
     /// <param name="transactionProcessors">Custom Transaction Processors</param>
-    /// <param name="serviceProvider">The service provider, used to resolve shared blocking-call detection services.</param>
+    /// <param name="serviceProvider">The service provider, used to resolve dependencies.</param>
     /// <exception cref="ArgumentNullException">
     /// next
     /// or
@@ -81,13 +80,7 @@ internal class SentryMiddleware : IMiddleware
 
         if (_options.CaptureBlockingCalls)
         {
-            // The monitor and listener are registered as process-wide singletons (see
-            // SentryWebHostBuilderExtensions). This middleware is transient (one instance per
-            // request), so constructing them here would create - and never dispose - a new
-            // TaskBlockingListener (an EventListener) on every request. Each leaked listener stays
-            // rooted in the runtime's global listener chain, keeps TplEventSource enabled, and makes
-            // EventSource.DispatchToAllListeners walk an ever-growing chain on every await in the
-            // process. Resolving the shared singletons instead keeps the overhead constant. See #5378.
+            // Resolve shared singletons to keep overhead constant - See #5378.
             _monitor = serviceProvider.GetRequiredService<BlockingMonitor>();
             _listener = serviceProvider.GetRequiredService<TaskBlockingListener>();
         }

--- a/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
@@ -3,7 +3,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Options;
+using Sentry;
 using Sentry.AspNetCore;
+using Sentry.Ben.BlockingDetector;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.AspNetCore.Hosting;
@@ -112,6 +114,15 @@ public static class SentryWebHostBuilderExtensions
         _ = builder.ConfigureServices(c => _ =
             c.AddTransient<IStartupFilter, SentryStartupFilter>()
              .AddTransient<IStartupFilter, SentryTracingStartupFilter>()
+             // Blocking-call detection uses an EventListener that registers itself in the runtime's
+             // process-global listener chain, so exactly one must exist per process. Register the
+             // monitor and listener as singletons; the transient SentryMiddleware resolves (rather
+             // than constructs) them, avoiding a per-request listener leak. See issue #5378.
+             .AddSingleton<BlockingMonitor>(p => new BlockingMonitor(
+                 p.GetRequiredService<Func<IHub>>(),
+                 p.GetRequiredService<IOptions<SentryAspNetCoreOptions>>().Value))
+             .AddSingleton<TaskBlockingListener>(p => new TaskBlockingListener(
+                 p.GetRequiredService<BlockingMonitor>()))
              .AddTransient<SentryMiddleware>()
         );
 

--- a/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
@@ -114,9 +114,7 @@ public static class SentryWebHostBuilderExtensions
             c.AddTransient<IStartupFilter, SentryStartupFilter>()
              .AddTransient<IStartupFilter, SentryTracingStartupFilter>()
              // Single listener/monitor per process (the listener is a global EventListener) - See #5378.
-             // The IBlockingMonitor forward keeps the listener on the same monitor instance.
-             .AddSingleton<BlockingMonitor>()
-             .AddSingleton<IBlockingMonitor>(p => p.GetRequiredService<BlockingMonitor>())
+             .AddSingleton<IBlockingMonitor, BlockingMonitor>()
              .AddSingleton<TaskBlockingListener>()
              .AddTransient<SentryMiddleware>()
         );

--- a/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
@@ -114,10 +114,6 @@ public static class SentryWebHostBuilderExtensions
         _ = builder.ConfigureServices(c => _ =
             c.AddTransient<IStartupFilter, SentryStartupFilter>()
              .AddTransient<IStartupFilter, SentryTracingStartupFilter>()
-             // Blocking-call detection uses an EventListener that registers itself in the runtime's
-             // process-global listener chain, so exactly one must exist per process. Register the
-             // monitor and listener as singletons; the transient SentryMiddleware resolves (rather
-             // than constructs) them, avoiding a per-request listener leak. See issue #5378.
              .AddSingleton<BlockingMonitor>(p => new BlockingMonitor(
                  p.GetRequiredService<Func<IHub>>(),
                  p.GetRequiredService<IOptions<SentryAspNetCoreOptions>>().Value))

--- a/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
+++ b/src/Sentry.AspNetCore/SentryWebHostBuilderExtensions.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Options;
-using Sentry;
 using Sentry.AspNetCore;
 using Sentry.Ben.BlockingDetector;
 
@@ -118,11 +117,12 @@ public static class SentryWebHostBuilderExtensions
              // process-global listener chain, so exactly one must exist per process. Register the
              // monitor and listener as singletons; the transient SentryMiddleware resolves (rather
              // than constructs) them, avoiding a per-request listener leak. See issue #5378.
-             .AddSingleton<BlockingMonitor>(p => new BlockingMonitor(
-                 p.GetRequiredService<Func<IHub>>(),
-                 p.GetRequiredService<IOptions<SentryAspNetCoreOptions>>().Value))
-             .AddSingleton<TaskBlockingListener>(p => new TaskBlockingListener(
-                 p.GetRequiredService<BlockingMonitor>()))
+             // BlockingMonitor(Func<IHub>, SentryOptions) and TaskBlockingListener(IBlockingMonitor)
+             // are both constructed by DI - Func<IHub> and SentryOptions are already registered, and
+             // the IBlockingMonitor forward ensures the listener shares the same monitor instance.
+             .AddSingleton<BlockingMonitor>()
+             .AddSingleton<IBlockingMonitor>(p => p.GetRequiredService<BlockingMonitor>())
+             .AddSingleton<TaskBlockingListener>()
              .AddTransient<SentryMiddleware>()
         );
 

--- a/src/Sentry/Ben.BlockingDetector/TaskBlockingListener.cs
+++ b/src/Sentry/Ben.BlockingDetector/TaskBlockingListener.cs
@@ -12,8 +12,7 @@ namespace Sentry.Ben.BlockingDetector
         private readonly IBlockingMonitor _monitor;
         private readonly ITaskBlockingListenerState _state;
 
-        private static Lazy<StaticTaskBlockingListenerState> LazyDefaultState => new();
-        internal static StaticTaskBlockingListenerState DefaultState => LazyDefaultState.Value;
+        internal static StaticTaskBlockingListenerState DefaultState { get; } = new();
 
         public TaskBlockingListener(IBlockingMonitor monitor)
             : this(monitor, null)

--- a/test/Sentry.AspNetCore.Tests/MiddlewareLoggerIntegration.cs
+++ b/test/Sentry.AspNetCore.Tests/MiddlewareLoggerIntegration.cs
@@ -61,7 +61,8 @@ public class MiddlewareLoggerIntegration : IDisposable
                 MiddlewareLogger,
                 EventExceptionProcessors,
                 EventProcessors,
-                TransactionProcessors);
+                TransactionProcessors,
+                Substitute.For<IServiceProvider>());
 
         public void Dispose() => _disposable.Dispose();
     }

--- a/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
@@ -1,7 +1,10 @@
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Sentry.Ben.BlockingDetector;
 
 #if NETCOREAPP3_1_OR_GREATER
 using IHostingEnvironment = Microsoft.AspNetCore.Hosting.IWebHostEnvironment;
@@ -27,6 +30,7 @@ public class SentryMiddlewareTests
         public IEnumerable<ISentryTransactionProcessor> TransactionProcessors { get; set; } = Substitute.For<IEnumerable<ISentryTransactionProcessor>>();
         public IFeatureCollection FeatureCollection { get; set; } = Substitute.For<IFeatureCollection>();
         public Scope Scope { get; set; }
+        public IServiceProvider ServiceProvider { get; }
 
         public Fixture()
         {
@@ -40,6 +44,17 @@ public class SentryMiddlewareTests
             _ = Hub.IsEnabled.Returns(true);
             _ = Hub.StartTransaction("", "").ReturnsForAnyArgs(new TransactionTracer(Hub, "test", "test"));
             _ = HttpContext.Features.Returns(FeatureCollection);
+
+            // Mirrors the singleton registrations in SentryWebHostBuilderExtensions so the
+            // (transient) middleware can resolve the shared blocking monitor/listener.
+            ServiceProvider = new ServiceCollection()
+                .AddSingleton(HubAccessor)
+                .AddSingleton(Microsoft.Extensions.Options.Options.Create(Options))
+                .AddSingleton(p => new BlockingMonitor(
+                    p.GetRequiredService<Func<IHub>>(),
+                    p.GetRequiredService<IOptions<SentryAspNetCoreOptions>>().Value))
+                .AddSingleton(p => new TaskBlockingListener(p.GetRequiredService<BlockingMonitor>()))
+                .BuildServiceProvider();
         }
 
         public SentryMiddleware GetSut()
@@ -50,10 +65,33 @@ public class SentryMiddlewareTests
                 Logger,
                 EventExceptionProcessors,
                 EventProcessors,
-                TransactionProcessors);
+                TransactionProcessors,
+                ServiceProvider);
     }
 
     private readonly Fixture _fixture = new();
+
+    [Fact]
+    public void Constructor_CaptureBlockingCalls_SharesSingleListenerAcrossInstances()
+    {
+        _fixture.Options.CaptureBlockingCalls = true;
+
+        // The middleware is registered as transient, so DI creates a new instance per request.
+        // Simulate two requests: distinct instances must share the one process-wide monitor and
+        // listener rather than each allocating (and leaking) their own EventListener. See #5378.
+        var first = _fixture.GetSut();
+        var second = _fixture.GetSut();
+
+        Assert.NotSame(first, second);
+        Assert.NotNull(first.Listener);
+        Assert.NotNull(first.Monitor);
+        Assert.Same(first.Listener, second.Listener);
+        Assert.Same(first.Monitor, second.Monitor);
+
+        // Dispose the shared listener so it doesn't remain registered as a global EventListener
+        // (and keep TplEventSource enabled) for the rest of the test run.
+        (_fixture.ServiceProvider as IDisposable)?.Dispose();
+    }
 
     [Fact]
     public async Task InvokeAsync_DisabledSdk_InvokesNextHandlers()

--- a/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
@@ -49,8 +49,7 @@ public class SentryMiddlewareTests
             ServiceProvider = new ServiceCollection()
                 .AddSingleton(HubAccessor)
                 .AddSingleton<SentryOptions>(Options)
-                .AddSingleton<BlockingMonitor>()
-                .AddSingleton<IBlockingMonitor>(p => p.GetRequiredService<BlockingMonitor>())
+                .AddSingleton<IBlockingMonitor, BlockingMonitor>()
                 .AddSingleton<TaskBlockingListener>()
                 .BuildServiceProvider();
         }

--- a/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
+++ b/test/Sentry.AspNetCore.Tests/SentryMiddlewareTests.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Sentry.Ben.BlockingDetector;
 
 #if NETCOREAPP3_1_OR_GREATER
@@ -49,11 +48,10 @@ public class SentryMiddlewareTests
             // (transient) middleware can resolve the shared blocking monitor/listener.
             ServiceProvider = new ServiceCollection()
                 .AddSingleton(HubAccessor)
-                .AddSingleton(Microsoft.Extensions.Options.Options.Create(Options))
-                .AddSingleton(p => new BlockingMonitor(
-                    p.GetRequiredService<Func<IHub>>(),
-                    p.GetRequiredService<IOptions<SentryAspNetCoreOptions>>().Value))
-                .AddSingleton(p => new TaskBlockingListener(p.GetRequiredService<BlockingMonitor>()))
+                .AddSingleton<SentryOptions>(Options)
+                .AddSingleton<BlockingMonitor>()
+                .AddSingleton<IBlockingMonitor>(p => p.GetRequiredService<BlockingMonitor>())
+                .AddSingleton<TaskBlockingListener>()
                 .BuildServiceProvider();
         }
 


### PR DESCRIPTION
## Summary

Fixes a per-request resource leak in `CaptureBlockingCalls` (ASP.NET Core), reported in #5378.

`SentryMiddleware` implements `IMiddleware` and is registered with `AddTransient<SentryMiddleware>()`, so DI constructs a **new instance per request**. With `CaptureBlockingCalls = true`, its constructor created a new `TaskBlockingListener` (a `System.Diagnostics.Tracing.EventListener`) on every request and never disposed it:

```csharp
_monitor = new BlockingMonitor(_getHub, _options);
_detectBlockingSyncCtx = new DetectBlockingSynchronizationContext(_monitor);
_listener = new TaskBlockingListener(_monitor); // registers itself globally, never disposed
```

Every `EventListener` registers itself in the runtime's **process-global** listener chain and enables `TplEventSource` (Verbose). So the chain grew by one per request and `EventSource.DispatchToAllListeners` walked the whole (ever-growing) chain on **every task-wait event of every `await` in the process** — not just inside requests.

The reporter observed, on effectively-idle services (only a 10s healthcheck): p95 of a trivial endpoint growing ~5 ms → ~150 ms over 5 days (~45k requests → ~45k leaked listeners), 96–97% of CPU inside `EventSource.DispatchToAllListeners`, and steadily growing background CPU and managed heap — all reset by a restart. Full credit to @gerardfontmora for the diagnosis.

## Fix

- Register `BlockingMonitor` and `TaskBlockingListener` as **singletons**, and have the transient middleware **resolve** (rather than construct) them, so exactly one `TaskBlockingListener` exists per process with constant overhead. They are only resolved when `CaptureBlockingCalls` is enabled, so disabling the feature has no cost.
- The per-request `DetectBlockingSynchronizationContext` swap in `InvokeAsync` is unchanged — it carries per-request suppression state and is correctly created per request.
- Drive-by: `TaskBlockingListener.DefaultState` was an expression-bodied property (`=> new()`) that allocated a fresh `Lazy<>` on every access instead of returning a single shared instance; changed to a static auto-property.

## Regression test

`Constructor_CaptureBlockingCalls_SharesSingleListenerAcrossInstances` builds two middleware instances (simulating two requests) and asserts they share one `Listener`/`Monitor`. Verified it fails against the previous per-request construction and passes with this change.

Fixes #5378
