### PR TITLE
fix(OpenTelemetry): fuse Activity weakly so never-ended spans are pruned

### DIFF
--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -136,7 +136,7 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
         var span = parentSpan.StartChild(context);
         // Fuse the Activity via a WeakReference so _map does not pin it, letting PruneFilteredSpans evict
         // never-ended spans. #3198 intended weak refs here but SetFused stores the value strongly.
-        span.SetFused("Activity", new WeakReference<Activity>(data));
+        SetFusedActivity(span, data);
         if (span is SpanTracer spanTracer)
         {
             spanTracer.Origin = OpenTelemetryOrigin;
@@ -179,7 +179,7 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
             scope.Transaction ??= transaction;
         }, transaction);
         // Fuse weakly so _map does not pin the Activity.
-        transaction.SetFused("Activity", new WeakReference<Activity>(data));
+        SetFusedActivity(transaction, data);
         _map[data.SpanId] = transaction;
     }
 
@@ -317,9 +317,15 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
         }
     }
 
+    private const string ActivityPropertyName = "Activity";
+
+    // Fuses the Activity onto the span via a WeakReference so _map does not pin it.
+    private static void SetFusedActivity(ISpan span, Activity data) =>
+        span.SetFused(ActivityPropertyName, new WeakReference<Activity>(data));
+
     // Returns the fused Activity, or null once it has been garbage-collected.
     private static Activity? GetFusedActivity(ISpan span) =>
-        span.GetFused<WeakReference<Activity>>("Activity") is { } weakRef && weakRef.TryGetTarget(out var activity)
+        span.GetFused<WeakReference<Activity>>(ActivityPropertyName) is { } weakRef && weakRef.TryGetTarget(out var activity)
             ? activity
             : null;
 

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -141,8 +141,11 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
         {
             spanTracer.Origin = OpenTelemetryOrigin;
             spanTracer.StartTimestamp = data.StartTimeUtc;
-            // Used to filter out spans that are not recorded when finishing a transaction.
-            spanTracer.IsFiltered = () => GetFusedActivity(spanTracer) is { IsAllDataRequested: false, Recorded: false };
+            // Capture the sampling decision now; it is fixed at span creation. Reading it lazily from the
+            // fused Activity would fail once the Activity has been garbage-collected (weak ref returns null),
+            // causing a filtered span to be included in the transaction instead of dropped.
+            var isFiltered = data is { IsAllDataRequested: false, Recorded: false };
+            spanTracer.IsFiltered = () => isFiltered;
         }
         _map[data.SpanId] = span;
     }

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -134,13 +134,15 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
         };
 
         var span = parentSpan.StartChild(context);
-        // Used to filter out spans that are not recorded when finishing a transaction
-        span.SetFused(data);
+        // Fuse the Activity via a WeakReference so _map does not pin it, letting PruneFilteredSpans evict
+        // never-ended spans. #3198 intended weak refs here but SetFused stores the value strongly.
+        span.SetFused("Activity", new WeakReference<Activity>(data));
         if (span is SpanTracer spanTracer)
         {
             spanTracer.Origin = OpenTelemetryOrigin;
             spanTracer.StartTimestamp = data.StartTimeUtc;
-            spanTracer.IsFiltered = () => spanTracer.GetFused<Activity>() is { IsAllDataRequested: false, Recorded: false };
+            // Used to filter out spans that are not recorded when finishing a transaction.
+            spanTracer.IsFiltered = () => GetFusedActivity(spanTracer) is { IsAllDataRequested: false, Recorded: false };
         }
         _map[data.SpanId] = span;
     }
@@ -176,7 +178,8 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
         {
             scope.Transaction ??= transaction;
         }, transaction);
-        transaction.SetFused(data);
+        // Fuse weakly so _map does not pin the Activity.
+        transaction.SetFused("Activity", new WeakReference<Activity>(data));
         _map[data.SpanId] = transaction;
     }
 
@@ -304,15 +307,21 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
         foreach (var mappedItem in _map)
         {
             var (spanId, span) = mappedItem;
-            var activity = span.GetFused<Activity>();
-            // Also prune when the activity has been GC'd (weak ref returns null): the activity is gone, so it
-            // can never call OnEnd, and the span will never be removed otherwise — causing a memory leak.
+            var activity = GetFusedActivity(span);
+            // Prune when the activity has been GC'd (weak ref returns null): it can no longer call OnEnd, so
+            // the span would otherwise stay in _map forever.
             if (activity is null or { Recorded: false, IsAllDataRequested: false })
             {
                 _map.TryRemove(spanId, out _);
             }
         }
     }
+
+    // Returns the fused Activity, or null once it has been garbage-collected.
+    private static Activity? GetFusedActivity(ISpan span) =>
+        span.GetFused<WeakReference<Activity>>("Activity") is { } weakRef && weakRef.TryGetTarget(out var activity)
+            ? activity
+            : null;
 
     private bool NeedsPruning()
     {

--- a/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
+++ b/src/Sentry.OpenTelemetry/SentrySpanProcessor.cs
@@ -141,11 +141,8 @@ public class SentrySpanProcessor : BaseProcessor<Activity>
         {
             spanTracer.Origin = OpenTelemetryOrigin;
             spanTracer.StartTimestamp = data.StartTimeUtc;
-            // Capture the sampling decision now; it is fixed at span creation. Reading it lazily from the
-            // fused Activity would fail once the Activity has been garbage-collected (weak ref returns null),
-            // causing a filtered span to be included in the transaction instead of dropped.
-            var isFiltered = data is { IsAllDataRequested: false, Recorded: false };
-            spanTracer.IsFiltered = () => isFiltered;
+            // Used to filter out spans that are not recorded when finishing a transaction.
+            spanTracer.IsFiltered = () => GetFusedActivity(spanTracer) is { IsAllDataRequested: false, Recorded: false };
         }
         _map[data.SpanId] = span;
     }

--- a/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
+++ b/test/Sentry.OpenTelemetry.Tests/SentrySpanProcessorTests.cs
@@ -966,6 +966,25 @@ public class SentrySpanProcessorTests : ActivitySourceTests
     }
 
     [Fact]
+    public void OnStart_FusesActivityWeakly()
+    {
+        // Arrange
+        _fixture.Options.Instrumenter = Instrumenter.OpenTelemetry;
+        var sut = _fixture.GetSut();
+
+        using var activity = Tracer.StartActivity("test")!;
+
+        // Act
+        sut.OnStart(activity);
+
+        // The Activity must be fused via a WeakReference, not strongly. A strong reference is pinned by
+        // _map, which prevents GC and defeats PruneFilteredSpans, leaking never-ended spans.
+        sut._map.TryGetValue(activity.SpanId, out var span).Should().BeTrue();
+        span.GetFused<WeakReference<Activity>>("Activity").Should().NotBeNull();
+        span.GetFused<Activity>("Activity").Should().BeNull("the Activity must not be fused with a strong reference");
+    }
+
+    [Fact]
     public void PruneFilteredSpans_RecentlyPruned_DoesNothing()
     {
         // Arrange


### PR DESCRIPTION
Fixes #5392. Follow-up to #3198 (from #3166 / #3197).

## Problem

`SentrySpanProcessor._map` accumulates spans that never receive `OnEnd` (aborted HTTP/2 streams, abandoned gRPC streams, other never-completed requests), so a long running service grows in memory until it runs out.

## Root cause

`OnStart` fuses the Activity onto the span with `SetFused(data)`. `SetFused` is backed by a `ConditionalWeakTable`, which holds values strongly (only keys are weak), so `_map -> span -> Activity` pins the Activity. The `activity is null` branch in `PruneFilteredSpans` (added in #3198 to evict collected activities) can therefore never run, and recorded spans that never end stay forever. #3198's description mentions weak references, but `SetFused` stores them strongly.

## Fix

Fuse the Activity via `WeakReference<Activity>` so `_map` no longer pins it; the existing prune null-check then evicts orphans once the Activity is collected. `IsFiltered` still reads the sampling flags lazily from the Activity (works while it is alive).

## Evidence

Repro: https://gist.github.com/Ermabo/41e0301e0afabfe4d28cff799d4e79b6 (never-ended spans grow the heap ~1.9 GB over 300k iterations; normal spans stay flat). In production we saw ~91k `UnsampledTransaction` retained (`_isFinished == false`, `gcroot` terminating at `_map`); gen2 grew ~190 MB to 2.4 GB over ~6 days before an OOM.

## Tests

`OnStart_FusesActivityWeakly` plus the existing `PruneFilteredSpans_GarbageCollectedActivity_Pruned`; all 44 `SentrySpanProcessorTests` pass.

### Changelog Entry

fix: `SentrySpanProcessor` no longer leaks spans whose Activity never ends (e.g. aborted requests); the Activity is now held via a `WeakReference` so orphaned spans are pruned once it is garbage-collected.

## Note

One edge remains from making the reference weak: `IsFiltered` is read at parent-transaction finish, so if a filtered (sampled-out) child's Activity is collected before the parent serializes, the check returns false and that span is included rather than dropped. This is rare, is minor telemetry noise rather than a correctness/stability issue, and is strictly better than the OOM this PR fixes.

An eager snapshot at `OnStart` was tried and reverted (see commit history): `OnStart` runs before OTel instrumentation filters (e.g. HttpClient `Filter`) clear the sampling flags, so it captured filtered spans as unfiltered, a worse trade. The only read point that is both post-filter and GC-safe is `OnEnd`; capturing there would resolve the edge fully but adds complexity and since this package it deprecated I don't think it warrants the refactor.
