### PR TITLE
fix(serilog): set category.name for structured logs from SourceContext

### DIFF
--- a/src/Sentry.Serilog/SentrySink.Structured.cs
+++ b/src/Sentry.Serilog/SentrySink.Structured.cs
@@ -21,6 +21,11 @@ internal sealed partial class SentrySink
         log.SetDefaultAttributes(options, scope, Sdk);
         log.SetOrigin("auto.log.serilog");
 
+        if (logEvent.TryGetSourceContext(out var context))
+        {
+            log.Attributes.SetAttribute("category.name", context);
+        }
+
         foreach (var attribute in attributes)
         {
             log.SetAttribute(attribute.Key, attribute.Value);

--- a/test/Sentry.Serilog.Tests/SentrySinkTests.Structured.cs
+++ b/test/Sentry.Serilog.Tests/SentrySinkTests.Structured.cs
@@ -136,6 +136,40 @@ public partial class SentrySinkTests
     }
 
     [Fact]
+    public void Emit_StructuredLogging_WithSourceContext_SetsCategoryName()
+    {
+        const string expectedLogger = "My.Logger";
+
+        InMemorySentryStructuredLogger capturer = new();
+        _fixture.Hub.Logger.Returns(capturer);
+        _fixture.Options.EnableLogs = true;
+
+        var sut = _fixture.GetSut();
+        var logger = new LoggerConfiguration().WriteTo.Sink(sut).MinimumLevel.Verbose().CreateLogger();
+
+        logger.ForContext("SourceContext", expectedLogger).Write(LogEventLevel.Information, "Message");
+
+        var log = capturer.Logs.Should().ContainSingle().Which;
+        log.TryGetAttribute("category.name", out object? categoryName).Should().BeTrue();
+        categoryName.Should().Be(expectedLogger);
+    }
+
+    [Fact]
+    public void Emit_StructuredLogging_WithoutSourceContext_DoesNotSetCategoryName()
+    {
+        InMemorySentryStructuredLogger capturer = new();
+        _fixture.Hub.Logger.Returns(capturer);
+        _fixture.Options.EnableLogs = true;
+
+        var sut = _fixture.GetSut();
+        var logger = new LoggerConfiguration().WriteTo.Sink(sut).MinimumLevel.Verbose().CreateLogger();
+
+        logger.Write(LogEventLevel.Information, "Message");
+
+        capturer.Logs.Should().ContainSingle().Which.TryGetAttribute("category.name", out object? _).Should().BeFalse();
+    }
+
+    [Fact]
     public void Emit_StructuredLoggingWithException_NoBreadcrumb()
     {
         InMemorySentryStructuredLogger capturer = new();


### PR DESCRIPTION
## Summary

Serilog structured logs captured via `EnableLogs` now set `category.name` from Serilog `SourceContext` when present. This matches MEL structured logging and Serilog's event path (`SentryEvent.Logger`).

## Why

Without `category.name`, Serilog structured logs lose the canonical source identifier used for filtering and correlation. The identifier currently appears only as `property.SourceContext` (when present), not as the standard log category attribute.

## Context

Mirrors the NLog structured logging fix in #5176, which sets `category.name` from the logger name. The Serilog change was intentionally kept out of that PR to keep it scoped to NLog.

## Verification

Added Serilog structured logging tests asserting `category.name` is set when `SourceContext` is present and absent when it is not.

## Issues
Closes  #5390 