### PR TITLE
ci: pin Xcode 26.6 for .NET iOS 26.5 workload

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -43,7 +43,7 @@ runs:
     - name: Pin the Xcode Version
       if: runner.os == 'macOS'
       shell: bash
-      run: sudo xcode-select --switch /Applications/Xcode_26.5.app
+      run: sudo xcode-select --switch /Applications/Xcode_26.6.app
 
     # Java 21 is needed by .NET Android
     - name: Install Java 21

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,6 +49,6 @@ jobs:
         run: dotnet build Sentry-CI-CodeQL.slnf --no-restore --nologo
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: '/language:csharp'


### PR DESCRIPTION
The `10.0.302` .NET workload ships the iOS SDK pack `26.5.10301`, which requires **Xcode 26.6**. CI was pinning Xcode 26.5, so iOS/MacCatalyst sample builds and the iOS device tests failed with:

> This version of .NET for iOS (26.5.10301) requires Xcode 26.6. The current version of Xcode is 26.5.

The macOS jobs already run on the `macos-26` runner, which [ships Xcode 26.6](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md#xcode) at `/Applications/Xcode_26.6.app`. This just bumps the `xcode-select` pin in the shared environment action from 26.5 → 26.6, keeping the toolchain aligned rather than reverting the SDK upgrade.

Fixes #5406

> [!NOTE]
> this PR also includes a small, somewhat unrelated CI fix. Dependabot's bump of `codeql-action/init` to v4.37.1 (#5407-ish) left `codeql-action/analyze` on v4.37.0, and CodeQL requires all steps to be on the same version — so CodeQL has been failing on `main` and every branch since. I aligned `analyze` to v4.37.1 here to get CI green rather than stacking a separate PR. Merging this also repairs CodeQL on `main`. 

#skip-changelog