### PR TITLE
ci: Remove model override from warden.toml

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -13,7 +13,6 @@ version = 1
 # Default settings inherited by all skills
 [defaults]
 runtime = "pi"
-model = "anthropic/claude-opus-4-5"
 # Severity levels: critical, high, medium, low, info
 # failOn: minimum severity that fails the check
 failOn = "high"


### PR DESCRIPTION
## Summary

Warden checks have been failing "inexplicably" on PRs (e.g. #5417, #5412). The runner logs show the actual error:

```
warden: ERROR: code-review - Authentication failed: No API key found for anthropic.
```

Root cause: the org-level Warden workflow only supplies `WARDEN_OPENROUTER_API_KEY`, but this repo's `warden.toml` overrides the default model to `anthropic/claude-opus-4-5` — a provider CI has no credentials for. Any skill that actually invoked the model failed with `auth_failed`; skills with nothing to analyze no-opped and passed, which is why failures looked intermittent (they tracked whether the diff triggered a real model call, not flakiness).

Removing the `model` override lets skills inherit the org default (currently `openrouter/x-ai/grok-4.5`), which matches the credentials the org workflow actually provides — and keeps the two from drifting apart again if the org default changes.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)