### PR TITLE
ref: Add internal sensitive-data denylist and key-value filter utility

### DIFF
--- a/src/Sentry/Internal/DataCollection/KeyValueFilterBehavior.cs
+++ b/src/Sentry/Internal/DataCollection/KeyValueFilterBehavior.cs
@@ -1,0 +1,49 @@
+namespace Sentry.Internal.DataCollection;
+
+/// <summary>
+/// How a key-value collection (HTTP headers, cookies, URL query parameters) should be collected, per the
+/// DataCollection spec: https://develop.sentry.dev/sdk/foundations/client/data-collection/
+/// </summary>
+internal enum KeyValueFilterMode
+{
+    /// <summary>Neither keys nor values are collected.</summary>
+    Off,
+
+    /// <summary>All keys are collected; values of sensitive keys are replaced with "[Filtered]".</summary>
+    DenyList,
+
+    /// <summary>All keys are collected; only values of allow-listed, non-sensitive keys are kept.</summary>
+    AllowList
+}
+
+/// <summary>
+/// A <see cref="KeyValueFilterMode"/> plus the terms that parameterize it: extra deny terms in
+/// <see cref="KeyValueFilterMode.DenyList"/> mode, allowed key terms in <see cref="KeyValueFilterMode.AllowList"/>
+/// mode. Terms match key names as case-insensitive substrings. Internal precursor to the public behavior type that
+/// ships with the DataCollection option.
+/// </summary>
+internal readonly struct KeyValueFilterBehavior
+{
+    private readonly string[]? _terms;
+
+    private KeyValueFilterBehavior(KeyValueFilterMode mode, string[]? terms)
+    {
+        Mode = mode;
+        _terms = terms;
+    }
+
+    public KeyValueFilterMode Mode { get; }
+
+    public string[] Terms => _terms ?? [];
+
+    public static KeyValueFilterBehavior Off => new(KeyValueFilterMode.Off, null);
+
+    /// <summary>The default behavior: collect everything, replacing values of sensitive keys.</summary>
+    public static KeyValueFilterBehavior DenyList => new(KeyValueFilterMode.DenyList, null);
+
+    public static KeyValueFilterBehavior DenyListWith(params string[] extraDenyTerms) =>
+        new(KeyValueFilterMode.DenyList, extraDenyTerms);
+
+    public static KeyValueFilterBehavior AllowList(params string[] allowedTerms) =>
+        new(KeyValueFilterMode.AllowList, allowedTerms);
+}

--- a/src/Sentry/Internal/DataCollection/SensitiveDataFilter.cs
+++ b/src/Sentry/Internal/DataCollection/SensitiveDataFilter.cs
@@ -1,0 +1,148 @@
+namespace Sentry.Internal.DataCollection;
+
+/// <summary>
+/// Filters automatically collected key-value data (HTTP headers, cookies, URL query parameters) so that values of
+/// sensitive keys are replaced with "[Filtered]" before being sent to Sentry, per the DataCollection spec:
+/// https://develop.sentry.dev/sdk/foundations/client/data-collection/
+/// Key names are always preserved; only values are replaced. Only applies to automatically collected data —
+/// data explicitly set by the user is never filtered.
+/// </summary>
+internal static class SensitiveDataFilter
+{
+    internal const string FilteredValue = PiiExtensions.RedactedText;
+
+    /// <summary>
+    /// Case-insensitive substrings identifying sensitive key names, from the canonical denylist in the spec,
+    /// plus "set-cookie"/"cookie" so cookie headers are treated as sensitive wherever individual cookie
+    /// pairs cannot be extracted.
+    /// </summary>
+    internal static readonly string[] SensitiveKeyTerms =
+    [
+        "auth",
+        "token",
+        "secret",
+        "session",
+        "password",
+        "passwd",
+        "pwd",
+        "key",
+        "jwt",
+        "bearer",
+        "sso",
+        "saml",
+        "csrf",
+        "xsrf",
+        "credentials",
+        "sid",
+        "identity",
+        "set-cookie",
+        "cookie",
+    ];
+
+    /// <summary>
+    /// Extra substrings matched only against individual Cookie / Set-Cookie names (not header names), covering
+    /// common session secrets that do not match <see cref="SensitiveKeyTerms"/> (e.g. "connect.sid") without
+    /// false positives on arbitrary HTTP headers. Cookie-only terms already implied by a
+    /// <see cref="SensitiveKeyTerms"/> match (e.g. "oauth", "id_token") are omitted.
+    /// </summary>
+    internal static readonly string[] SensitiveCookieNameTerms =
+    [
+        // Express / Connect default session cookie
+        ".sid",
+        // Opaque session ids (PHPSESSID, ASPSESSIONID*, *sessid*, ...)
+        "sessid",
+        // "Remember me" tokens
+        "remember",
+        // OIDC / OAuth auxiliary ("oauth*" is covered by "auth")
+        "oidc",
+        "pkce",
+        "nonce",
+        // RFC 6265bis high-security cookie name prefixes
+        "__secure-",
+        "__host-",
+        // Load balancer / CDN sticky-session cookies (opaque routing tokens)
+        "awsalb",
+        "awselb",
+        "akamai",
+        // BaaS / IdP session cookies (names often omit "session")
+        "__stripe",
+        "cognito",
+        "firebase",
+        "supabase",
+        "sb-",
+        // Step-up / MFA cookies
+        "mfa",
+        "2fa",
+    ];
+
+    /// <summary>
+    /// Key-name substrings that identify end users (IP addresses, forwarding chains). Not filtered by default;
+    /// used to extend deny lists when replicating <c>SendDefaultPii = false</c> behavior (GDPR terms per the spec).
+    /// </summary>
+    internal static readonly string[] PiiKeyTerms = ["forwarded", "-ip", "remote-", "via", "-user"];
+
+    internal static bool IsSensitiveKey(string key) => MatchesAny(key, SensitiveKeyTerms);
+
+    /// <summary>
+    /// Filters a single value according to <paramref name="behavior"/>. Returns the value unchanged, or
+    /// <see cref="FilteredValue"/> in its place. Must not be called in <see cref="KeyValueFilterMode.Off"/> mode
+    /// (in off mode nothing should be collected at all).
+    /// </summary>
+    internal static string FilterValue(string key, string value, KeyValueFilterBehavior behavior,
+        string[]? additionalDenyTerms = null)
+    {
+        Debug.Assert(behavior.Mode != KeyValueFilterMode.Off,
+            "FilterValue must not be called in Off mode - collect nothing instead.");
+
+        if (MatchesAny(key, SensitiveKeyTerms) ||
+            (additionalDenyTerms is not null && MatchesAny(key, additionalDenyTerms)))
+        {
+            return FilteredValue;
+        }
+
+        return behavior.Mode switch
+        {
+            KeyValueFilterMode.DenyList => MatchesAny(key, behavior.Terms) ? FilteredValue : value,
+            KeyValueFilterMode.AllowList => MatchesAny(key, behavior.Terms) ? value : FilteredValue,
+            _ => value
+        };
+    }
+
+    /// <summary>
+    /// Filters key-value data according to <paramref name="behavior"/>. Key names are always preserved; values are
+    /// either kept or replaced with <see cref="FilteredValue"/>. In <see cref="KeyValueFilterMode.Off"/> mode an
+    /// empty dictionary is returned. <paramref name="additionalDenyTerms"/> are extra sensitive terms applied in
+    /// every mode, beyond the built-in denylist (e.g. <see cref="SensitiveCookieNameTerms"/> when filtering cookies).
+    /// </summary>
+    internal static Dictionary<string, string> FilterKeyValueData(
+        IEnumerable<KeyValuePair<string, string>> data,
+        KeyValueFilterBehavior behavior,
+        string[]? additionalDenyTerms = null)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (behavior.Mode == KeyValueFilterMode.Off)
+        {
+            return result;
+        }
+
+        foreach (var (key, value) in data)
+        {
+            result[key] = FilterValue(key, value, behavior, additionalDenyTerms);
+        }
+
+        return result;
+    }
+
+    private static bool MatchesAny(string key, string[] terms)
+    {
+        foreach (var term in terms)
+        {
+            if (key.Contains(term, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/test/Sentry.Tests/Internals/DataCollection/SensitiveDataFilterTests.cs
+++ b/test/Sentry.Tests/Internals/DataCollection/SensitiveDataFilterTests.cs
@@ -1,0 +1,254 @@
+using Sentry.Internal.DataCollection;
+
+namespace Sentry.Tests.Internals.DataCollection;
+
+public class SensitiveDataFilterTests
+{
+    [Theory]
+    [InlineData("auth")]
+    [InlineData("token")]
+    [InlineData("secret")]
+    [InlineData("session")]
+    [InlineData("password")]
+    [InlineData("passwd")]
+    [InlineData("pwd")]
+    [InlineData("key")]
+    [InlineData("jwt")]
+    [InlineData("bearer")]
+    [InlineData("sso")]
+    [InlineData("saml")]
+    [InlineData("csrf")]
+    [InlineData("xsrf")]
+    [InlineData("credentials")]
+    [InlineData("sid")]
+    [InlineData("identity")]
+    [InlineData("set-cookie")]
+    [InlineData("cookie")]
+    public void IsSensitiveKey_CanonicalDenylistTerm_ReturnsTrue(string term)
+    {
+        SensitiveDataFilter.IsSensitiveKey(term).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("Authorization")] // contains "auth"
+    [InlineData("X-Api-Key")] // contains "key"
+    [InlineData("PHPSESSID")] // contains "sid"
+    [InlineData("X-CSRF-TOKEN")]
+    [InlineData("Set-Cookie")]
+    public void IsSensitiveKey_KeyContainingTermInAnyCase_ReturnsTrue(string key)
+    {
+        SensitiveDataFilter.IsSensitiveKey(key).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("User-Agent")]
+    [InlineData("Accept")]
+    [InlineData("Content-Type")]
+    [InlineData("traceparent")]
+    public void IsSensitiveKey_BenignKey_ReturnsFalse(string key)
+    {
+        SensitiveDataFilter.IsSensitiveKey(key).Should().BeFalse();
+    }
+
+    [Fact]
+    public void FilterKeyValueData_OffMode_ReturnsEmpty()
+    {
+        // Arrange
+        var data = new Dictionary<string, string>
+        {
+            ["User-Agent"] = "TestAgent",
+            ["Authorization"] = "Bearer 123"
+        };
+
+        // Act
+        var result = SensitiveDataFilter.FilterKeyValueData(data, KeyValueFilterBehavior.Off);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FilterKeyValueData_DefaultBehavior_IsOff()
+    {
+        // The default struct value must be the most conservative mode
+        default(KeyValueFilterBehavior).Mode.Should().Be(KeyValueFilterMode.Off);
+        default(KeyValueFilterBehavior).Terms.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FilterKeyValueData_DenyListMode_FiltersSensitiveValuesAndPreservesKeys()
+    {
+        // Arrange
+        var data = new Dictionary<string, string>
+        {
+            ["User-Agent"] = "TestAgent",
+            ["Authorization"] = "Bearer 123",
+            ["X-API-KEY"] = "abc123"
+        };
+
+        // Act
+        var result = SensitiveDataFilter.FilterKeyValueData(data, KeyValueFilterBehavior.DenyList);
+
+        // Assert
+        result.Should().BeEquivalentTo(new Dictionary<string, string>
+        {
+            ["User-Agent"] = "TestAgent",
+            ["Authorization"] = "[Filtered]",
+            ["X-API-KEY"] = "[Filtered]"
+        });
+    }
+
+    [Fact]
+    public void FilterKeyValueData_DenyListModeWithExtraTerms_FiltersExtraTerms()
+    {
+        // Arrange
+        var data = new Dictionary<string, string>
+        {
+            ["X-Forwarded-For"] = "203.0.113.7",
+            ["Accept"] = "application/json"
+        };
+
+        // Act
+        var result = SensitiveDataFilter.FilterKeyValueData(data, KeyValueFilterBehavior.DenyListWith("forwarded"));
+
+        // Assert
+        result["X-Forwarded-For"].Should().Be("[Filtered]");
+        result["Accept"].Should().Be("application/json");
+    }
+
+    [Fact]
+    public void FilterKeyValueData_AllowListMode_OnlyAllowedKeysKeepValues()
+    {
+        // Arrange
+        var data = new Dictionary<string, string>
+        {
+            ["User-Agent"] = "TestAgent",
+            ["Accept"] = "application/json",
+            ["X-Custom"] = "value"
+        };
+
+        // Act
+        var result = SensitiveDataFilter.FilterKeyValueData(data, KeyValueFilterBehavior.AllowList("user-agent"));
+
+        // Assert
+        result.Should().BeEquivalentTo(new Dictionary<string, string>
+        {
+            ["User-Agent"] = "TestAgent",
+            ["Accept"] = "[Filtered]",
+            ["X-Custom"] = "[Filtered]"
+        });
+    }
+
+    [Fact]
+    public void FilterKeyValueData_AllowListMode_BuiltInDenylistWins()
+    {
+        // Arrange: allow-listing a sensitive key must not expose its value
+        var data = new Dictionary<string, string>
+        {
+            ["Authorization"] = "Bearer 123"
+        };
+
+        // Act
+        var result = SensitiveDataFilter.FilterKeyValueData(data, KeyValueFilterBehavior.AllowList("authorization"));
+
+        // Assert
+        result["Authorization"].Should().Be("[Filtered]");
+    }
+
+    [Fact]
+    public void FilterKeyValueData_AllowListMode_MatchesSubstrings()
+    {
+        // Arrange
+        var data = new Dictionary<string, string>
+        {
+            ["X-Tenant-Id"] = "acme",
+            ["X-Request-Id"] = "42"
+        };
+
+        // Act
+        var result = SensitiveDataFilter.FilterKeyValueData(data, KeyValueFilterBehavior.AllowList("tenant"));
+
+        // Assert
+        result["X-Tenant-Id"].Should().Be("acme");
+        result["X-Request-Id"].Should().Be("[Filtered]");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void FilterKeyValueData_AdditionalDenyTerms_AppliedInEveryMode(bool useAllowList)
+    {
+        // Arrange: "remember" is a cookie-name term, not part of the built-in denylist
+        var data = new Dictionary<string, string>
+        {
+            ["remember_me"] = "yes"
+        };
+        var behavior = useAllowList
+            ? KeyValueFilterBehavior.AllowList("remember_me")
+            : KeyValueFilterBehavior.DenyList;
+
+        // Act
+        var result = SensitiveDataFilter.FilterKeyValueData(
+            data, behavior, SensitiveDataFilter.SensitiveCookieNameTerms);
+
+        // Assert
+        result["remember_me"].Should().Be("[Filtered]");
+    }
+
+    [Theory]
+    [InlineData("connect.sid")]
+    [InlineData("PHPSESSID")]
+    [InlineData("remember_token")]
+    [InlineData("__Secure-next-auth.session-token")]
+    [InlineData("__Host-csrf")]
+    [InlineData("AWSALB")]
+    [InlineData("__stripe_mid")]
+    [InlineData("CognitoIdentityServiceProvider.foo")]
+    [InlineData("sb-access-token")]
+    [InlineData("mfa_pending")]
+    public void FilterKeyValueData_CommonSessionCookieNames_FilteredWithCookieTerms(string cookieName)
+    {
+        // Arrange
+        var data = new Dictionary<string, string> { [cookieName] = "value" };
+
+        // Act
+        var result = SensitiveDataFilter.FilterKeyValueData(
+            data, KeyValueFilterBehavior.DenyList, SensitiveDataFilter.SensitiveCookieNameTerms);
+
+        // Assert
+        result[cookieName].Should().Be("[Filtered]");
+    }
+
+    [Fact]
+    public void FilterValue_BenignKeyDenyListMode_ReturnsValueUnchanged()
+    {
+        SensitiveDataFilter.FilterValue("Accept", "text/html", KeyValueFilterBehavior.DenyList)
+            .Should().Be("text/html");
+    }
+
+    [Theory]
+    [InlineData("X-Forwarded-For")]
+    [InlineData("Client-IP")]
+    [InlineData("Remote-Addr")]
+    [InlineData("Via")]
+    [InlineData("X-Real-User")]
+    public void FilterValue_PiiKeyTermsAsDenyTerms_Filtered(string key)
+    {
+        // The GDPR terms are not filtered by default but must work as extra deny terms (SendDefaultPii=false bridge)
+        SensitiveDataFilter.FilterValue(key, "value", KeyValueFilterBehavior.DenyList, SensitiveDataFilter.PiiKeyTerms)
+            .Should().Be("[Filtered]");
+    }
+
+    [Fact]
+    public void FilterValue_PiiKeyTermsNotPassed_NotFilteredByDefault()
+    {
+        SensitiveDataFilter.FilterValue("X-Forwarded-For", "203.0.113.7", KeyValueFilterBehavior.DenyList)
+            .Should().Be("203.0.113.7");
+    }
+
+    [Fact]
+    public void FilterKeyValueData_EmptyData_ReturnsEmpty()
+    {
+        SensitiveDataFilter.FilterKeyValueData([], KeyValueFilterBehavior.DenyList).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Closes #5421 (part of #5420).

First step of the [DataCollection](https://develop.sentry.dev/sdk/foundations/client/data-collection/) migration: adds the internal sensitive-terms denylist and the shared key-value filtering utility that later PRs will wire into header, cookie and query-string collection (#5422, #5423, #5424).

- `SensitiveDataFilter` — canonical sensitive-key denylist from the spec (case-insensitive substring matching), cookie-name-only extra terms, GDPR/PII terms (for the future `SendDefaultPii=false` bridge, #5426), and `FilterKeyValueData`/`FilterValue` implementing the spec's filtering semantics: key names always preserved, sensitive values replaced with `[Filtered]`.
- `KeyValueFilterBehavior` — internal off / denyList / allowList behavior (precursor to the public behavior type that ships with the `DataCollection` option, #5425). The built-in denylist always applies, including in allowList mode.

Internal only — no public API change, and nothing is wired up yet, so no behavior change either. Mirrors `filterKeyValueData.ts` / `filtering-snippets.ts` from the JS reference implementation (getsentry/sentry-javascript#20965, getsentry/sentry-javascript#20989) so the two SDKs filter identically.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)
