### PR TITLE
feat: Allow users to control Mechanism.Handled for captured exceptions

### DIFF
--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -273,6 +273,7 @@ public static class HubExtensions
     {
         // Integrations always call `SetSentryMechanism` before calling this method (e.g. WinUI forwards the
         // platform's Handled value), so this fallback is defensive only. In practice, it never executes.
+        // Terminal is left unset (not false) so a missing SetSentryMechanism call still reads as a crash.
         if (!ex.Data.Contains(Mechanism.HandledKey))
         {
             ex.Data[Mechanism.HandledKey] = false;
@@ -291,22 +292,26 @@ public static class HubExtensions
         hub.CaptureEvent(new SentryEvent(ex), configureScope);
 
     /// <summary>
-    /// Captures the exception with a configurable scope callback, explicitly marking it as handled or unhandled.
+    /// Captures the exception with a configurable scope callback, explicitly marking it as handled or unhandled
+    /// and whether it terminated the application.
     /// </summary>
     /// <param name="hub">The Sentry hub.</param>
     /// <param name="ex">The exception.</param>
     /// <param name="handled">Whether the exception was handled. Recorded on the exception, overriding any flag
     /// previously set on it, including one set via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.</param>
+    /// <param name="terminal">Whether the app crashed. Only used when <paramref name="handled"/> is
+    /// <c>false</c>. If <c>true</c>, the session ends as crashed and the active transaction is aborted.</param>
     /// <param name="configureScope">The callback to configure the scope.</param>
     /// <returns>The Id of the event</returns>
-    public static SentryId CaptureException(this IHub hub, Exception ex, bool handled, Action<Scope> configureScope)
+    public static SentryId CaptureException(this IHub hub, Exception ex, bool handled, bool terminal,
+        Action<Scope> configureScope)
     {
         if (!hub.IsEnabled)
         {
             return SentryId.Empty;
         }
 
-        ex.Data[Mechanism.HandledKey] = handled;
+        ex.RecordMechanismFlags(handled, terminal);
         return hub.CaptureEvent(new SentryEvent(ex), configureScope);
     }
 

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -271,39 +271,19 @@ public static class HubExtensions
 
     internal static SentryId CaptureExceptionInternal(this IHub hub, Exception ex)
     {
-        // Integrations capture exceptions that were not handled by user code, so default the
-        // mechanism to handled: false, unless the integration has already set the flag explicitly.
-        if (ex.Data[Mechanism.HandledKey] is not bool)
-        {
-            ex.Data[Mechanism.HandledKey] = false;
-        }
+        ex.Data[Mechanism.HandledKey] = false;
         return hub.CaptureEvent(new SentryEvent(ex));
     }
 
     /// <summary>
     /// Captures the exception with a configurable scope callback.
     /// </summary>
-    /// <remarks>
-    /// The exception is reported as handled, unless a flag was already set on it,
-    /// e.g. via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.
-    /// </remarks>
     /// <param name="hub">The Sentry hub.</param>
     /// <param name="ex">The exception.</param>
     /// <param name="configureScope">The callback to configure the scope.</param>
     /// <returns>The Id of the event</returns>
-    public static SentryId CaptureException(this IHub hub, Exception ex, Action<Scope> configureScope)
-    {
-        if (!hub.IsEnabled)
-        {
-            return SentryId.Empty;
-        }
-
-        if (ex.Data[Mechanism.HandledKey] is not bool)
-        {
-            ex.Data[Mechanism.HandledKey] = true;
-        }
-        return hub.CaptureEvent(new SentryEvent(ex), configureScope);
-    }
+    public static SentryId CaptureException(this IHub hub, Exception ex, Action<Scope> configureScope) =>
+        hub.CaptureEvent(new SentryEvent(ex), configureScope);
 
     /// <summary>
     /// Captures the exception with a configurable scope callback, explicitly marking it as handled or unhandled.
@@ -316,11 +296,6 @@ public static class HubExtensions
     /// <returns>The Id of the event</returns>
     public static SentryId CaptureException(this IHub hub, Exception ex, Action<Scope> configureScope, bool handled)
     {
-        if (!hub.IsEnabled)
-        {
-            return SentryId.Empty;
-        }
-
         ex.Data[Mechanism.HandledKey] = handled;
         return hub.CaptureEvent(new SentryEvent(ex), configureScope);
     }

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -271,8 +271,8 @@ public static class HubExtensions
 
     internal static SentryId CaptureExceptionInternal(this IHub hub, Exception ex)
     {
-        // Integrations stamp the flag via SetSentryMechanism before calling this (e.g. WinUI forwards the
-        // platform's Handled value); only default to unhandled when nothing was declared.
+        // Integrations always call `SetSentryMechanism` before calling this method (e.g. WinUI forwards the
+        // platform's Handled value), so this fallback is defensive only. In practice, it never executes.
         if (!ex.Data.Contains(Mechanism.HandledKey))
         {
             ex.Data[Mechanism.HandledKey] = false;
@@ -295,12 +295,17 @@ public static class HubExtensions
     /// </summary>
     /// <param name="hub">The Sentry hub.</param>
     /// <param name="ex">The exception.</param>
-    /// <param name="configureScope">The callback to configure the scope.</param>
     /// <param name="handled">Whether the exception was handled. Recorded on the exception, overriding any flag
     /// previously set on it, including one set via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.</param>
+    /// <param name="configureScope">The callback to configure the scope.</param>
     /// <returns>The Id of the event</returns>
-    public static SentryId CaptureException(this IHub hub, Exception ex, Action<Scope> configureScope, bool handled)
+    public static SentryId CaptureException(this IHub hub, Exception ex, bool handled, Action<Scope> configureScope)
     {
+        if (!hub.IsEnabled)
+        {
+            return SentryId.Empty;
+        }
+
         ex.Data[Mechanism.HandledKey] = handled;
         return hub.CaptureEvent(new SentryEvent(ex), configureScope);
     }

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -271,7 +271,12 @@ public static class HubExtensions
 
     internal static SentryId CaptureExceptionInternal(this IHub hub, Exception ex)
     {
-        ex.Data[Mechanism.HandledKey] = false;
+        // Integrations stamp the flag via SetSentryMechanism before calling this (e.g. WinUI forwards the
+        // platform's Handled value); only default to unhandled when nothing was declared.
+        if (!ex.Data.Contains(Mechanism.HandledKey))
+        {
+            ex.Data[Mechanism.HandledKey] = false;
+        }
         return hub.CaptureEvent(new SentryEvent(ex));
     }
 

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -2,6 +2,7 @@ using Sentry.Extensibility;
 using Sentry.Infrastructure;
 using Sentry.Internal;
 using Sentry.Internal.Extensions;
+using Sentry.Protocol;
 
 namespace Sentry;
 
@@ -268,18 +269,61 @@ public static class HubExtensions
         public void Dispose() => _scope.Dispose();
     }
 
-    internal static SentryId CaptureExceptionInternal(this IHub hub, Exception ex) =>
-        hub.CaptureEvent(new SentryEvent(ex));
+    internal static SentryId CaptureExceptionInternal(this IHub hub, Exception ex)
+    {
+        // Integrations capture exceptions that were not handled by user code, so default the
+        // mechanism to handled: false, unless the integration has already set the flag explicitly.
+        if (ex.Data[Mechanism.HandledKey] is not bool)
+        {
+            ex.Data[Mechanism.HandledKey] = false;
+        }
+        return hub.CaptureEvent(new SentryEvent(ex));
+    }
 
     /// <summary>
     /// Captures the exception with a configurable scope callback.
     /// </summary>
+    /// <remarks>
+    /// The exception is reported as handled, unless a flag was already set on it,
+    /// e.g. via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.
+    /// </remarks>
     /// <param name="hub">The Sentry hub.</param>
     /// <param name="ex">The exception.</param>
     /// <param name="configureScope">The callback to configure the scope.</param>
     /// <returns>The Id of the event</returns>
-    public static SentryId CaptureException(this IHub hub, Exception ex, Action<Scope> configureScope) =>
-        hub.CaptureEvent(new SentryEvent(ex), configureScope);
+    public static SentryId CaptureException(this IHub hub, Exception ex, Action<Scope> configureScope)
+    {
+        if (!hub.IsEnabled)
+        {
+            return SentryId.Empty;
+        }
+
+        if (ex.Data[Mechanism.HandledKey] is not bool)
+        {
+            ex.Data[Mechanism.HandledKey] = true;
+        }
+        return hub.CaptureEvent(new SentryEvent(ex), configureScope);
+    }
+
+    /// <summary>
+    /// Captures the exception with a configurable scope callback, explicitly marking it as handled or unhandled.
+    /// </summary>
+    /// <param name="hub">The Sentry hub.</param>
+    /// <param name="ex">The exception.</param>
+    /// <param name="configureScope">The callback to configure the scope.</param>
+    /// <param name="handled">Whether the exception was handled. Recorded on the exception, overriding any flag
+    /// previously set on it, including one set via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.</param>
+    /// <returns>The Id of the event</returns>
+    public static SentryId CaptureException(this IHub hub, Exception ex, Action<Scope> configureScope, bool handled)
+    {
+        if (!hub.IsEnabled)
+        {
+            return SentryId.Empty;
+        }
+
+        ex.Data[Mechanism.HandledKey] = handled;
+        return hub.CaptureEvent(new SentryEvent(ex), configureScope);
+    }
 
     /// <summary>
     /// Captures feedback from the user.

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -174,17 +174,15 @@ internal class MainExceptionProcessor : ISentryEventExceptionProcessor
             mechanism.Handled = handled;
             exception.Data.Remove(Mechanism.HandledKey);
         }
-        else if (exception.StackTrace != null)
-        {
-            // The exception was thrown, but it was caught by the user, not an integration.
-            // Thus, we can mark it as handled.
-            mechanism.Handled = true;
-        }
         else
         {
-            // The exception was never thrown.  It was just constructed and then captured.
-            // Thus, it is neither handled nor unhandled.
-            mechanism.Handled = null;
+            // No integration claimed this exception, so it reached us because user code captured it explicitly -
+            // whether it was thrown and caught, or merely constructed and passed to CaptureException. Either way
+            // that counts as handled:
+            // https://getsentry.github.io/relay/relay_event_schema/protocol/struct.Mechanism.html#structfield.handled
+            // "Exceptions captured using capture_exception (called from user code) are handled=true as the user
+            // explicitly captured the exception (and therefore kind of handled it)."
+            mechanism.Handled = true;
         }
 
         if (exception.Data[Mechanism.MechanismKey] is string mechanismType)

--- a/src/Sentry/Internal/MainExceptionProcessor.cs
+++ b/src/Sentry/Internal/MainExceptionProcessor.cs
@@ -176,9 +176,6 @@ internal class MainExceptionProcessor : ISentryEventExceptionProcessor
         }
         else
         {
-            // No integration claimed this exception, so it reached us because user code captured it explicitly -
-            // whether it was thrown and caught, or merely constructed and passed to CaptureException. Either way
-            // that counts as handled:
             // https://getsentry.github.io/relay/relay_event_schema/protocol/struct.Mechanism.html#structfield.handled
             // "Exceptions captured using capture_exception (called from user code) are handled=true as the user
             // explicitly captured the exception (and therefore kind of handled it)."

--- a/src/Sentry/SentryClientExtensions.cs
+++ b/src/Sentry/SentryClientExtensions.cs
@@ -1,5 +1,6 @@
 using Sentry.Extensibility;
 using Sentry.Internal;
+using Sentry.Protocol;
 
 namespace Sentry;
 
@@ -12,11 +13,45 @@ public static class SentryClientExtensions
     /// <summary>
     /// Captures the exception.
     /// </summary>
+    /// <remarks>
+    /// The exception is reported as handled, unless a flag was already set on it,
+    /// e.g. via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.
+    /// </remarks>
     /// <param name="client">The Sentry client.</param>
     /// <param name="ex">The exception.</param>
     /// <returns>The Id of the event</returns>
-    public static SentryId CaptureException(this ISentryClient client, Exception ex) =>
-        client.IsEnabled ? client.CaptureEvent(new SentryEvent(ex)) : SentryId.Empty;
+    public static SentryId CaptureException(this ISentryClient client, Exception ex)
+    {
+        if (!client.IsEnabled)
+        {
+            return SentryId.Empty;
+        }
+
+        if (ex.Data[Mechanism.HandledKey] is not bool)
+        {
+            ex.Data[Mechanism.HandledKey] = true;
+        }
+        return client.CaptureEvent(new SentryEvent(ex));
+    }
+
+    /// <summary>
+    /// Captures the exception, explicitly marking it as handled or unhandled.
+    /// </summary>
+    /// <param name="client">The Sentry client.</param>
+    /// <param name="ex">The exception.</param>
+    /// <param name="handled">Whether the exception was handled. Recorded on the exception, overriding any flag
+    /// previously set on it, including one set via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.</param>
+    /// <returns>The Id of the event</returns>
+    public static SentryId CaptureException(this ISentryClient client, Exception ex, bool handled)
+    {
+        if (!client.IsEnabled)
+        {
+            return SentryId.Empty;
+        }
+
+        ex.Data[Mechanism.HandledKey] = handled;
+        return client.CaptureEvent(new SentryEvent(ex));
+    }
 
     /// <summary>
     /// Captures a message.

--- a/src/Sentry/SentryClientExtensions.cs
+++ b/src/Sentry/SentryClientExtensions.cs
@@ -26,15 +26,19 @@ public static class SentryClientExtensions
     /// <param name="ex">The exception.</param>
     /// <param name="handled">Whether the exception was handled. Recorded on the exception, overriding any flag
     /// previously set on it, including one set via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.</param>
+    /// <param name="terminal">Whether the app crashed. Only used when <paramref name="handled"/> is
+    /// <c>false</c>. If <c>true</c>, the session ends as crashed, aborting the active transaction on
+    /// <see cref="IHub"/> clients.</param>
     /// <returns>The Id of the event</returns>
-    public static SentryId CaptureException(this ISentryClient client, Exception ex, bool handled)
+    public static SentryId CaptureException(this ISentryClient client, Exception ex, bool handled,
+        bool terminal = false)
     {
         if (!client.IsEnabled)
         {
             return SentryId.Empty;
         }
 
-        ex.Data[Mechanism.HandledKey] = handled;
+        ex.RecordMechanismFlags(handled, terminal);
         return client.CaptureEvent(new SentryEvent(ex));
     }
 

--- a/src/Sentry/SentryClientExtensions.cs
+++ b/src/Sentry/SentryClientExtensions.cs
@@ -13,26 +13,11 @@ public static class SentryClientExtensions
     /// <summary>
     /// Captures the exception.
     /// </summary>
-    /// <remarks>
-    /// The exception is reported as handled, unless a flag was already set on it,
-    /// e.g. via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.
-    /// </remarks>
     /// <param name="client">The Sentry client.</param>
     /// <param name="ex">The exception.</param>
     /// <returns>The Id of the event</returns>
-    public static SentryId CaptureException(this ISentryClient client, Exception ex)
-    {
-        if (!client.IsEnabled)
-        {
-            return SentryId.Empty;
-        }
-
-        if (ex.Data[Mechanism.HandledKey] is not bool)
-        {
-            ex.Data[Mechanism.HandledKey] = true;
-        }
-        return client.CaptureEvent(new SentryEvent(ex));
-    }
+    public static SentryId CaptureException(this ISentryClient client, Exception ex) =>
+        client.IsEnabled ? client.CaptureEvent(new SentryEvent(ex)) : SentryId.Empty;
 
     /// <summary>
     /// Captures the exception, explicitly marking it as handled or unhandled.

--- a/src/Sentry/SentryExceptionExtensions.cs
+++ b/src/Sentry/SentryExceptionExtensions.cs
@@ -65,4 +65,26 @@ public static class SentryExceptionExtensions
             ex.Data[Mechanism.TerminalKey] = terminal;
         }
     }
+
+    /// <summary>
+    /// Records the mechanism flags for an explicit user capture, fully overriding any previously set values.
+    /// </summary>
+    /// <remarks>
+    /// <c>Terminal</c> is only meaningful when the exception is unhandled, so it is removed when
+    /// <paramref name="handled"/> is <c>true</c> rather than left over from an earlier
+    /// <see cref="SetSentryMechanism"/> call. Mirrors that method's null-removes semantics.
+    /// </remarks>
+    internal static void RecordMechanismFlags(this Exception ex, bool handled, bool terminal)
+    {
+        ex.Data[Mechanism.HandledKey] = handled;
+
+        if (handled)
+        {
+            ex.Data.Remove(Mechanism.TerminalKey);
+        }
+        else
+        {
+            ex.Data[Mechanism.TerminalKey] = terminal;
+        }
+    }
 }

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -530,10 +530,12 @@ static partial class SentrySdk
     /// <param name="exception">The exception.</param>
     /// <param name="handled">Whether the exception was handled. Recorded on the exception, overriding any flag
     /// previously set on it, including one set via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.</param>
+    /// <param name="terminal">Whether the app crashed. Only used when <paramref name="handled"/> is
+    /// <c>false</c>. If <c>true</c>, the session ends as crashed and the active transaction is aborted.</param>
     /// <returns>The Id of the event.</returns>
     [DebuggerStepThrough]
-    public static SentryId CaptureException(Exception exception, bool handled)
-        => CurrentHub.CaptureException(exception, handled);
+    public static SentryId CaptureException(Exception exception, bool handled, bool terminal = false)
+        => CurrentHub.CaptureException(exception, handled, terminal);
 
     /// <summary>
     /// Captures the exception with a configurable scope.
@@ -549,7 +551,8 @@ static partial class SentrySdk
         => CurrentHub.CaptureException(exception, configureScope);
 
     /// <summary>
-    /// Captures the exception with a configurable scope, explicitly marking it as handled or unhandled.
+    /// Captures the exception with a configurable scope, explicitly marking it as handled or unhandled and
+    /// whether it terminated the application.
     /// </summary>
     /// <remarks>
     /// This allows modifying a scope without affecting other events.
@@ -557,11 +560,14 @@ static partial class SentrySdk
     /// <param name="exception">The exception.</param>
     /// <param name="handled">Whether the exception was handled. Recorded on the exception, overriding any flag
     /// previously set on it, including one set via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.</param>
+    /// <param name="terminal">Whether the app crashed. Only used when <paramref name="handled"/> is
+    /// <c>false</c>. If <c>true</c>, the session ends as crashed and the active transaction is aborted.</param>
     /// <param name="configureScope">The callback to configure the scope.</param>
     /// <returns>The Id of the event.</returns>
     [DebuggerStepThrough]
-    public static SentryId CaptureException(Exception exception, bool handled, Action<Scope> configureScope)
-        => CurrentHub.CaptureException(exception, handled, configureScope);
+    public static SentryId CaptureException(Exception exception, bool handled, bool terminal,
+        Action<Scope> configureScope)
+        => CurrentHub.CaptureException(exception, handled, terminal, configureScope);
 
     /// <summary>
     /// Captures the message.

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -518,6 +518,10 @@ static partial class SentrySdk
     /// <summary>
     /// Captures the exception.
     /// </summary>
+    /// <remarks>
+    /// The exception is reported as handled, unless a flag was already set on it,
+    /// e.g. via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.
+    /// </remarks>
     /// <param name="exception">The exception.</param>
     /// <returns>The Id of the event.</returns>
     [DebuggerStepThrough]
@@ -525,10 +529,23 @@ static partial class SentrySdk
         => CurrentHub.CaptureException(exception);
 
     /// <summary>
+    /// Captures the exception, explicitly marking it as handled or unhandled.
+    /// </summary>
+    /// <param name="exception">The exception.</param>
+    /// <param name="handled">Whether the exception was handled. Recorded on the exception, overriding any flag
+    /// previously set on it, including one set via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.</param>
+    /// <returns>The Id of the event.</returns>
+    [DebuggerStepThrough]
+    public static SentryId CaptureException(Exception exception, bool handled)
+        => CurrentHub.CaptureException(exception, handled);
+
+    /// <summary>
     /// Captures the exception with a configurable scope.
     /// </summary>
     /// <remarks>
     /// This allows modifying a scope without affecting other events.
+    /// The exception is reported as handled, unless a flag was already set on it,
+    /// e.g. via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.
     /// </remarks>
     /// <param name="exception">The exception.</param>
     /// <param name="configureScope">The callback to configure the scope.</param>
@@ -536,6 +553,21 @@ static partial class SentrySdk
     [DebuggerStepThrough]
     public static SentryId CaptureException(Exception exception, Action<Scope> configureScope)
         => CurrentHub.CaptureException(exception, configureScope);
+
+    /// <summary>
+    /// Captures the exception with a configurable scope, explicitly marking it as handled or unhandled.
+    /// </summary>
+    /// <remarks>
+    /// This allows modifying a scope without affecting other events.
+    /// </remarks>
+    /// <param name="exception">The exception.</param>
+    /// <param name="configureScope">The callback to configure the scope.</param>
+    /// <param name="handled">Whether the exception was handled. Recorded on the exception, overriding any flag
+    /// previously set on it, including one set via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.</param>
+    /// <returns>The Id of the event.</returns>
+    [DebuggerStepThrough]
+    public static SentryId CaptureException(Exception exception, Action<Scope> configureScope, bool handled)
+        => CurrentHub.CaptureException(exception, configureScope, handled);
 
     /// <summary>
     /// Captures the message.

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -555,13 +555,13 @@ static partial class SentrySdk
     /// This allows modifying a scope without affecting other events.
     /// </remarks>
     /// <param name="exception">The exception.</param>
-    /// <param name="configureScope">The callback to configure the scope.</param>
     /// <param name="handled">Whether the exception was handled. Recorded on the exception, overriding any flag
     /// previously set on it, including one set via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.</param>
+    /// <param name="configureScope">The callback to configure the scope.</param>
     /// <returns>The Id of the event.</returns>
     [DebuggerStepThrough]
-    public static SentryId CaptureException(Exception exception, Action<Scope> configureScope, bool handled)
-        => CurrentHub.CaptureException(exception, configureScope, handled);
+    public static SentryId CaptureException(Exception exception, bool handled, Action<Scope> configureScope)
+        => CurrentHub.CaptureException(exception, handled, configureScope);
 
     /// <summary>
     /// Captures the message.

--- a/src/Sentry/SentrySdk.cs
+++ b/src/Sentry/SentrySdk.cs
@@ -518,10 +518,6 @@ static partial class SentrySdk
     /// <summary>
     /// Captures the exception.
     /// </summary>
-    /// <remarks>
-    /// The exception is reported as handled, unless a flag was already set on it,
-    /// e.g. via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.
-    /// </remarks>
     /// <param name="exception">The exception.</param>
     /// <returns>The Id of the event.</returns>
     [DebuggerStepThrough]
@@ -544,8 +540,6 @@ static partial class SentrySdk
     /// </summary>
     /// <remarks>
     /// This allows modifying a scope without affecting other events.
-    /// The exception is reported as handled, unless a flag was already set on it,
-    /// e.g. via <see cref="SentryExceptionExtensions.SetSentryMechanism"/>.
     /// </remarks>
     /// <param name="exception">The exception.</param>
     /// <param name="configureScope">The callback to configure the scope.</param>

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet10_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet10_0.verified.txt
@@ -13,6 +13,7 @@
           Value: my exception,
           Mechanism: {
             Type: generic,
+            Handled: true,
             Synthetic: false,
             IsExceptionGroup: false,
             Data: {

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet10_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet10_0.verified.txt
@@ -13,7 +13,6 @@
           Value: my exception,
           Mechanism: {
             Type: generic,
-            Handled: true,
             Synthetic: false,
             IsExceptionGroup: false,
             Data: {

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet8_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet8_0.verified.txt
@@ -13,6 +13,7 @@
           Value: my exception,
           Mechanism: {
             Type: generic,
+            Handled: true,
             Synthetic: false,
             IsExceptionGroup: false,
             Data: {

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet8_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet8_0.verified.txt
@@ -13,7 +13,6 @@
           Value: my exception,
           Mechanism: {
             Type: generic,
-            Handled: true,
             Synthetic: false,
             IsExceptionGroup: false,
             Data: {

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet9_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet9_0.verified.txt
@@ -13,6 +13,7 @@
           Value: my exception,
           Mechanism: {
             Type: generic,
+            Handled: true,
             Synthetic: false,
             IsExceptionGroup: false,
             Data: {

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet9_0.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.DotNet9_0.verified.txt
@@ -13,7 +13,6 @@
           Value: my exception,
           Mechanism: {
             Type: generic,
-            Handled: true,
             Synthetic: false,
             IsExceptionGroup: false,
             Data: {

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.Net4_8.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.Net4_8.verified.txt
@@ -13,6 +13,7 @@
           Value: my exception,
           Mechanism: {
             Type: generic,
+            Handled: true,
             Synthetic: false,
             IsExceptionGroup: false,
             Data: {

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.Net4_8.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsEfAsync.Net4_8.verified.txt
@@ -13,7 +13,6 @@
           Value: my exception,
           Mechanism: {
             Type: generic,
-            Handled: true,
             Synthetic: false,
             IsExceptionGroup: false,
             Data: {

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsSqlAsync.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsSqlAsync.verified.txt
@@ -13,6 +13,7 @@
           Value: my exception,
           Mechanism: {
             Type: generic,
+            Handled: true,
             Synthetic: false,
             IsExceptionGroup: false,
             Data: {

--- a/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsSqlAsync.verified.txt
+++ b/test/Sentry.DiagnosticSource.IntegrationTests/SqlListenerTests.RecordsSqlAsync.verified.txt
@@ -13,7 +13,6 @@
           Value: my exception,
           Mechanism: {
             Type: generic,
-            Handled: true,
             Synthetic: false,
             IsExceptionGroup: false,
             Data: {

--- a/test/Sentry.EntityFramework.Tests/IntegrationTests.Simple.verified.txt
+++ b/test/Sentry.EntityFramework.Tests/IntegrationTests.Simple.verified.txt
@@ -13,6 +13,7 @@
           Value: my exception,
           Mechanism: {
             Type: generic,
+            Handled: true,
             Synthetic: false,
             IsExceptionGroup: false,
             Data: {

--- a/test/Sentry.EntityFramework.Tests/IntegrationTests.Simple.verified.txt
+++ b/test/Sentry.EntityFramework.Tests/IntegrationTests.Simple.verified.txt
@@ -13,7 +13,6 @@
           Value: my exception,
           Mechanism: {
             Type: generic,
-            Handled: true,
             Synthetic: false,
             IsExceptionGroup: false,
             Data: {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -148,7 +148,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, bool terminal, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.IHub hub, string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void LockScope(this Sentry.IHub hub) { }
@@ -492,7 +492,7 @@ namespace Sentry
     public static class SentryClientExtensions
     {
         public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex) { }
-        public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex, bool handled) { }
+        public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex, bool handled, bool terminal = false) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, string message, string? contactEmail = null, string? name = null, string? replayId = null, string? url = null, Sentry.SentryId? associatedEventId = default, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.ISentryClient client, string message, Sentry.SentryLevel level = 1) { }
@@ -980,8 +980,8 @@ namespace Sentry
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled) { }
-        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, bool terminal = false) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, bool terminal, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, out Sentry.CaptureFeedbackResult result, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -148,6 +148,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope, bool handled) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.IHub hub, string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void LockScope(this Sentry.IHub hub) { }
@@ -491,6 +492,7 @@ namespace Sentry
     public static class SentryClientExtensions
     {
         public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex) { }
+        public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex, bool handled) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, string message, string? contactEmail = null, string? name = null, string? replayId = null, string? url = null, Sentry.SentryId? associatedEventId = default, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.ISentryClient client, string message, Sentry.SentryLevel level = 1) { }
@@ -978,6 +980,8 @@ namespace Sentry
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope, bool handled) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, out Sentry.CaptureFeedbackResult result, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -148,7 +148,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope, bool handled) { }
+        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.IHub hub, string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void LockScope(this Sentry.IHub hub) { }
@@ -981,7 +981,7 @@ namespace Sentry
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, bool handled) { }
-        public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope, bool handled) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, out Sentry.CaptureFeedbackResult result, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -148,7 +148,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, bool terminal, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.IHub hub, string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void LockScope(this Sentry.IHub hub) { }
@@ -492,7 +492,7 @@ namespace Sentry
     public static class SentryClientExtensions
     {
         public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex) { }
-        public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex, bool handled) { }
+        public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex, bool handled, bool terminal = false) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, string message, string? contactEmail = null, string? name = null, string? replayId = null, string? url = null, Sentry.SentryId? associatedEventId = default, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.ISentryClient client, string message, Sentry.SentryLevel level = 1) { }
@@ -980,8 +980,8 @@ namespace Sentry
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled) { }
-        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, bool terminal = false) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, bool terminal, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, out Sentry.CaptureFeedbackResult result, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -148,6 +148,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope, bool handled) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.IHub hub, string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void LockScope(this Sentry.IHub hub) { }
@@ -491,6 +492,7 @@ namespace Sentry
     public static class SentryClientExtensions
     {
         public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex) { }
+        public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex, bool handled) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, string message, string? contactEmail = null, string? name = null, string? replayId = null, string? url = null, Sentry.SentryId? associatedEventId = default, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.ISentryClient client, string message, Sentry.SentryLevel level = 1) { }
@@ -978,6 +980,8 @@ namespace Sentry
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope, bool handled) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, out Sentry.CaptureFeedbackResult result, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -148,7 +148,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope, bool handled) { }
+        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.IHub hub, string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void LockScope(this Sentry.IHub hub) { }
@@ -981,7 +981,7 @@ namespace Sentry
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, bool handled) { }
-        public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope, bool handled) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, out Sentry.CaptureFeedbackResult result, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -148,7 +148,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, bool terminal, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.IHub hub, string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void LockScope(this Sentry.IHub hub) { }
@@ -492,7 +492,7 @@ namespace Sentry
     public static class SentryClientExtensions
     {
         public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex) { }
-        public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex, bool handled) { }
+        public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex, bool handled, bool terminal = false) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, string message, string? contactEmail = null, string? name = null, string? replayId = null, string? url = null, Sentry.SentryId? associatedEventId = default, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.ISentryClient client, string message, Sentry.SentryLevel level = 1) { }
@@ -980,8 +980,8 @@ namespace Sentry
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled) { }
-        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, bool terminal = false) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, bool terminal, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, out Sentry.CaptureFeedbackResult result, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -148,6 +148,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope, bool handled) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.IHub hub, string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void LockScope(this Sentry.IHub hub) { }
@@ -491,6 +492,7 @@ namespace Sentry
     public static class SentryClientExtensions
     {
         public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex) { }
+        public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex, bool handled) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, string message, string? contactEmail = null, string? name = null, string? replayId = null, string? url = null, Sentry.SentryId? associatedEventId = default, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.ISentryClient client, string message, Sentry.SentryLevel level = 1) { }
@@ -978,6 +980,8 @@ namespace Sentry
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope, bool handled) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, out Sentry.CaptureFeedbackResult result, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -148,7 +148,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope, bool handled) { }
+        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.IHub hub, string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void LockScope(this Sentry.IHub hub) { }
@@ -981,7 +981,7 @@ namespace Sentry
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, bool handled) { }
-        public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope, bool handled) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, out Sentry.CaptureFeedbackResult result, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -136,7 +136,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope, bool handled) { }
+        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.IHub hub, string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void LockScope(this Sentry.IHub hub) { }
@@ -962,7 +962,7 @@ namespace Sentry
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, bool handled) { }
-        public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope, bool handled) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, out Sentry.CaptureFeedbackResult result, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -136,7 +136,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, bool terminal, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.IHub hub, string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void LockScope(this Sentry.IHub hub) { }
@@ -480,7 +480,7 @@ namespace Sentry
     public static class SentryClientExtensions
     {
         public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex) { }
-        public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex, bool handled) { }
+        public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex, bool handled, bool terminal = false) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, string message, string? contactEmail = null, string? name = null, string? replayId = null, string? url = null, Sentry.SentryId? associatedEventId = default, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.ISentryClient client, string message, Sentry.SentryLevel level = 1) { }
@@ -961,8 +961,8 @@ namespace Sentry
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
-        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled) { }
-        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, bool terminal = false) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled, bool terminal, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, out Sentry.CaptureFeedbackResult result, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -136,6 +136,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope, bool handled) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.IHub hub, string message, System.Action<Sentry.Scope> configureScope, Sentry.SentryLevel level = 1) { }
         public static void LockScope(this Sentry.IHub hub) { }
@@ -479,6 +480,7 @@ namespace Sentry
     public static class SentryClientExtensions
     {
         public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex) { }
+        public static Sentry.SentryId CaptureException(this Sentry.ISentryClient client, System.Exception ex, bool handled) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.ISentryClient client, string message, string? contactEmail = null, string? name = null, string? replayId = null, string? url = null, Sentry.SentryId? associatedEventId = default, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureMessage(this Sentry.ISentryClient client, string message, Sentry.SentryLevel level = 1) { }
@@ -959,6 +961,8 @@ namespace Sentry
         public static Sentry.SentryId CaptureEvent(Sentry.SentryEvent evt, Sentry.SentryHint? hint, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(System.Exception exception) { }
         public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, bool handled) { }
+        public static Sentry.SentryId CaptureException(System.Exception exception, System.Action<Sentry.Scope> configureScope, bool handled) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }
         public static Sentry.SentryId CaptureFeedback(Sentry.SentryFeedback feedback, out Sentry.CaptureFeedbackResult result, Sentry.Scope? scope = null, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/HubExtensionsTests.cs
+++ b/test/Sentry.Tests/HubExtensionsTests.cs
@@ -57,7 +57,7 @@ public class HubExtensionsTests
     }
 
     [Fact]
-    public void CaptureException_ScopeCallback_NoHandledArgument_DefaultsToHandledTrue()
+    public void CaptureException_ScopeCallback_NoHandledArgument_DoesNotSetHandledFlag()
     {
         // Arrange
         _ = Sut.IsEnabled.Returns(true);
@@ -67,7 +67,8 @@ public class HubExtensionsTests
         _ = Sut.CaptureException(ex, _ => { });
 
         // Assert
-        Assert.Equal(true, ex.Data[Mechanism.HandledKey]);
+        Assert.False(ex.Data.Contains(Mechanism.HandledKey));
+        _ = Sut.Received(1).CaptureEvent(Arg.Any<SentryEvent>(), Arg.Any<Action<Scope>>());
     }
 
     [Fact]
@@ -83,22 +84,6 @@ public class HubExtensionsTests
 
         // Assert
         Assert.Equal(false, ex.Data[Mechanism.HandledKey]);
-    }
-
-    [Fact]
-    public void CaptureException_ScopeCallback_DisabledHub_NoHandledArgument_DoesNotMutateException()
-    {
-        // Arrange
-        _ = Sut.IsEnabled.Returns(false);
-        var ex = new Exception();
-
-        // Act
-        var id = Sut.CaptureException(ex, _ => { });
-
-        // Assert
-        _ = Sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>(), Arg.Any<Action<Scope>>());
-        Assert.Equal(default, id);
-        Assert.False(ex.Data.Contains(Mechanism.HandledKey));
     }
 
     [Theory]
@@ -134,22 +119,6 @@ public class HubExtensionsTests
     }
 
     [Fact]
-    public void CaptureException_ScopeCallback_DisabledHub_ExplicitHandled_DoesNotMutateException()
-    {
-        // Arrange
-        _ = Sut.IsEnabled.Returns(false);
-        var ex = new Exception();
-
-        // Act
-        var id = Sut.CaptureException(ex, _ => { }, handled: false);
-
-        // Assert
-        _ = Sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>(), Arg.Any<Action<Scope>>());
-        Assert.Equal(default, id);
-        Assert.False(ex.Data.Contains(Mechanism.HandledKey));
-    }
-
-    [Fact]
     public void CaptureExceptionInternal_NoPresetFlag_DefaultsToUnhandled()
     {
         // Arrange
@@ -164,7 +133,7 @@ public class HubExtensionsTests
     }
 
     [Fact]
-    public void CaptureExceptionInternal_PresetFlag_IsPreserved()
+    public void CaptureExceptionInternal_PresetFlag_IsOverriddenToUnhandled()
     {
         // Arrange
         var ex = new Exception();
@@ -174,7 +143,7 @@ public class HubExtensionsTests
         _ = Sut.CaptureExceptionInternal(ex);
 
         // Assert
-        Assert.Equal(true, ex.Data[Mechanism.HandledKey]);
+        Assert.Equal(false, ex.Data[Mechanism.HandledKey]);
     }
 
     [Fact]

--- a/test/Sentry.Tests/HubExtensionsTests.cs
+++ b/test/Sentry.Tests/HubExtensionsTests.cs
@@ -57,6 +57,127 @@ public class HubExtensionsTests
     }
 
     [Fact]
+    public void CaptureException_ScopeCallback_NoHandledArgument_DefaultsToHandledTrue()
+    {
+        // Arrange
+        _ = Sut.IsEnabled.Returns(true);
+        var ex = new Exception();
+
+        // Act
+        _ = Sut.CaptureException(ex, _ => { });
+
+        // Assert
+        Assert.Equal(true, ex.Data[Mechanism.HandledKey]);
+    }
+
+    [Fact]
+    public void CaptureException_ScopeCallback_NoHandledArgument_PresetFlagIsPreserved()
+    {
+        // Arrange
+        _ = Sut.IsEnabled.Returns(true);
+        var ex = new Exception();
+        ex.SetSentryMechanism("SomeMechanism", handled: false);
+
+        // Act
+        _ = Sut.CaptureException(ex, _ => { });
+
+        // Assert
+        Assert.Equal(false, ex.Data[Mechanism.HandledKey]);
+    }
+
+    [Fact]
+    public void CaptureException_ScopeCallback_DisabledHub_NoHandledArgument_DoesNotMutateException()
+    {
+        // Arrange
+        _ = Sut.IsEnabled.Returns(false);
+        var ex = new Exception();
+
+        // Act
+        var id = Sut.CaptureException(ex, _ => { });
+
+        // Assert
+        _ = Sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>(), Arg.Any<Action<Scope>>());
+        Assert.Equal(default, id);
+        Assert.False(ex.Data.Contains(Mechanism.HandledKey));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CaptureException_ScopeCallback_ExplicitHandled_RecordsFlagOnException(bool handled)
+    {
+        // Arrange
+        _ = Sut.IsEnabled.Returns(true);
+        var ex = new Exception();
+
+        // Act
+        _ = Sut.CaptureException(ex, _ => { }, handled);
+
+        // Assert
+        Assert.Equal(handled, ex.Data[Mechanism.HandledKey]);
+        _ = Sut.Received(1).CaptureEvent(Arg.Any<SentryEvent>(), Arg.Any<Action<Scope>>());
+    }
+
+    [Fact]
+    public void CaptureException_ScopeCallback_ExplicitHandled_OverridesFlagSetBySetSentryMechanism()
+    {
+        // Arrange
+        _ = Sut.IsEnabled.Returns(true);
+        var ex = new Exception();
+        ex.SetSentryMechanism("SomeMechanism", handled: true);
+
+        // Act
+        _ = Sut.CaptureException(ex, _ => { }, handled: false);
+
+        // Assert
+        Assert.Equal(false, ex.Data[Mechanism.HandledKey]);
+    }
+
+    [Fact]
+    public void CaptureException_ScopeCallback_DisabledHub_ExplicitHandled_DoesNotMutateException()
+    {
+        // Arrange
+        _ = Sut.IsEnabled.Returns(false);
+        var ex = new Exception();
+
+        // Act
+        var id = Sut.CaptureException(ex, _ => { }, handled: false);
+
+        // Assert
+        _ = Sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>(), Arg.Any<Action<Scope>>());
+        Assert.Equal(default, id);
+        Assert.False(ex.Data.Contains(Mechanism.HandledKey));
+    }
+
+    [Fact]
+    public void CaptureExceptionInternal_NoPresetFlag_DefaultsToUnhandled()
+    {
+        // Arrange
+        var ex = new Exception();
+
+        // Act
+        _ = Sut.CaptureExceptionInternal(ex);
+
+        // Assert
+        Assert.Equal(false, ex.Data[Mechanism.HandledKey]);
+        _ = Sut.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
+    }
+
+    [Fact]
+    public void CaptureExceptionInternal_PresetFlag_IsPreserved()
+    {
+        // Arrange
+        var ex = new Exception();
+        ex.SetSentryMechanism("SomeMechanism", handled: true);
+
+        // Act
+        _ = Sut.CaptureExceptionInternal(ex);
+
+        // Assert
+        Assert.Equal(true, ex.Data[Mechanism.HandledKey]);
+    }
+
+    [Fact]
     public void AddBreadcrumb_MinimalArguments_CreatesBreadcrumb()
     {
         const string expectedMessage = "message";

--- a/test/Sentry.Tests/HubExtensionsTests.cs
+++ b/test/Sentry.Tests/HubExtensionsTests.cs
@@ -96,7 +96,7 @@ public class HubExtensionsTests
         var ex = new Exception();
 
         // Act
-        _ = Sut.CaptureException(ex, _ => { }, handled);
+        _ = Sut.CaptureException(ex, handled, _ => { });
 
         // Assert
         Assert.Equal(handled, ex.Data[Mechanism.HandledKey]);
@@ -112,10 +112,26 @@ public class HubExtensionsTests
         ex.SetSentryMechanism("SomeMechanism", handled: true);
 
         // Act
-        _ = Sut.CaptureException(ex, _ => { }, handled: false);
+        _ = Sut.CaptureException(ex, handled: false, _ => { });
 
         // Assert
         Assert.Equal(false, ex.Data[Mechanism.HandledKey]);
+    }
+
+    [Fact]
+    public void CaptureException_ScopeCallback_ExplicitHandled_DisabledHub_DoesNotRecordFlagOnException()
+    {
+        // Arrange
+        _ = Sut.IsEnabled.Returns(false);
+        var ex = new Exception();
+
+        // Act
+        var id = Sut.CaptureException(ex, handled: false, _ => { });
+
+        // Assert
+        Assert.Equal(SentryId.Empty, id);
+        Assert.False(ex.Data.Contains(Mechanism.HandledKey));
+        _ = Sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>(), Arg.Any<Action<Scope>>());
     }
 
     [Fact]

--- a/test/Sentry.Tests/HubExtensionsTests.cs
+++ b/test/Sentry.Tests/HubExtensionsTests.cs
@@ -132,18 +132,22 @@ public class HubExtensionsTests
         _ = Sut.Received(1).CaptureEvent(Arg.Any<SentryEvent>());
     }
 
-    [Fact]
-    public void CaptureExceptionInternal_PresetFlag_IsOverriddenToUnhandled()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CaptureExceptionInternal_PresetFlag_IsNotOverwritten(bool handled)
     {
         // Arrange
+        // E.g. WinUIUnhandledExceptionIntegration forwards the platform's Handled value
+        // via SetSentryMechanism before capturing.
         var ex = new Exception();
-        ex.SetSentryMechanism("SomeMechanism", handled: true);
+        ex.SetSentryMechanism("SomeMechanism", handled: handled);
 
         // Act
         _ = Sut.CaptureExceptionInternal(ex);
 
         // Assert
-        Assert.Equal(false, ex.Data[Mechanism.HandledKey]);
+        Assert.Equal(handled, ex.Data[Mechanism.HandledKey]);
     }
 
     [Fact]

--- a/test/Sentry.Tests/HubExtensionsTests.cs
+++ b/test/Sentry.Tests/HubExtensionsTests.cs
@@ -96,7 +96,7 @@ public class HubExtensionsTests
         var ex = new Exception();
 
         // Act
-        _ = Sut.CaptureException(ex, handled, _ => { });
+        _ = Sut.CaptureException(ex, handled, terminal: false, _ => { });
 
         // Assert
         Assert.Equal(handled, ex.Data[Mechanism.HandledKey]);
@@ -112,7 +112,7 @@ public class HubExtensionsTests
         ex.SetSentryMechanism("SomeMechanism", handled: true);
 
         // Act
-        _ = Sut.CaptureException(ex, handled: false, _ => { });
+        _ = Sut.CaptureException(ex, handled: false, terminal: false, _ => { });
 
         // Assert
         Assert.Equal(false, ex.Data[Mechanism.HandledKey]);
@@ -126,7 +126,7 @@ public class HubExtensionsTests
         var ex = new Exception();
 
         // Act
-        var id = Sut.CaptureException(ex, handled: false, _ => { });
+        var id = Sut.CaptureException(ex, handled: false, terminal: false, _ => { });
 
         // Assert
         Assert.Equal(SentryId.Empty, id);
@@ -269,5 +269,39 @@ public class HubExtensionsTests
         // Assert
         traceId.Should().Be(SentryId.Empty);
         spanId.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CaptureException_ScopeCallback_ExplicitTerminal_RecordsTerminalFlagOnException(bool terminal)
+    {
+        // Arrange
+        _ = Sut.IsEnabled.Returns(true);
+        var ex = new Exception();
+
+        // Act
+        _ = Sut.CaptureException(ex, handled: false, terminal, _ => { });
+
+        // Assert
+        Assert.Equal(false, ex.Data[Mechanism.HandledKey]);
+        Assert.Equal(terminal, ex.Data[Mechanism.TerminalKey]);
+        _ = Sut.Received(1).CaptureEvent(Arg.Any<SentryEvent>(), Arg.Any<Action<Scope>>());
+    }
+
+    [Fact]
+    public void CaptureException_ScopeCallback_ExplicitTerminal_DisabledHub_DoesNotRecordFlagsOnException()
+    {
+        // Arrange
+        _ = Sut.IsEnabled.Returns(false);
+        var ex = new Exception();
+
+        // Act
+        var id = Sut.CaptureException(ex, handled: false, terminal: true, _ => { });
+
+        // Assert
+        Assert.Equal(SentryId.Empty, id);
+        Assert.False(ex.Data.Contains(Mechanism.HandledKey));
+        Assert.False(ex.Data.Contains(Mechanism.TerminalKey));
     }
 }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -546,6 +546,59 @@ public partial class HubTests : IDisposable
     }
 
     [Fact]
+    public void CaptureException_Terminal_AbortsActiveTransaction()
+    {
+        // Arrange
+        _fixture.Options.TracesSampleRate = 1.0;
+        var hub = _fixture.GetSut();
+
+        var transaction = hub.StartTransaction("test", "operation");
+        hub.ConfigureScope(scope => scope.Transaction = transaction);
+
+        // Act
+        hub.CaptureException(new Exception("test"), handled: false, terminal: true, _ => { });
+
+        // Assert
+        transaction.Status.Should().Be(SpanStatus.Aborted);
+        transaction.IsFinished.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CaptureException_TerminalWithoutScopeCallback_AbortsActiveTransaction()
+    {
+        // Arrange
+        _fixture.Options.TracesSampleRate = 1.0;
+        var hub = _fixture.GetSut();
+
+        var transaction = hub.StartTransaction("test", "operation");
+        hub.ConfigureScope(scope => scope.Transaction = transaction);
+
+        // Act
+        hub.CaptureException(new Exception("test"), handled: false, terminal: true);
+
+        // Assert
+        transaction.Status.Should().Be(SpanStatus.Aborted);
+        transaction.IsFinished.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CaptureException_NonTerminal_LeavesActiveTransactionRunning()
+    {
+        // Arrange
+        _fixture.Options.TracesSampleRate = 1.0;
+        var hub = _fixture.GetSut();
+
+        var transaction = hub.StartTransaction("test", "operation");
+        hub.ConfigureScope(scope => scope.Transaction = transaction);
+
+        // Act
+        hub.CaptureException(new Exception("test"), handled: false, terminal: false, _ => { });
+
+        // Assert
+        transaction.IsFinished.Should().BeFalse();
+    }
+
+    [Fact]
     public void CaptureEvent_TerminalUnhandledException_DoesNotAbortOpenTelemetryTransaction()
     {
         // OpenTelemetry-instrumented transactions are owned and finished by the SentrySpanProcessor

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate.verified.txt
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.CreateSentryException_Aggregate.verified.txt
@@ -5,6 +5,7 @@
     Mechanism: {
       Type: chained,
       Source: InnerExceptions[1],
+      Handled: true,
       Synthetic: false,
       IsExceptionGroup: false,
       ExceptionId: 2,
@@ -20,6 +21,7 @@
     Mechanism: {
       Type: chained,
       Source: InnerExceptions[0],
+      Handled: true,
       Synthetic: false,
       IsExceptionGroup: false,
       ExceptionId: 1,

--- a/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
+++ b/test/Sentry.Tests/Internals/MainExceptionProcessorTests.cs
@@ -56,8 +56,9 @@ public partial class MainExceptionProcessorTests
 
         sut.Process(exp, evt);
 
+        // No integration set the flag, so this was captured by user code, which counts as handled.
         Assert.NotNull(evt.SentryExceptions);
-        Assert.Single(evt.SentryExceptions, p => p.Mechanism?.Handled == null);
+        Assert.Single(evt.SentryExceptions, p => p.Mechanism?.Handled == true);
     }
 
     [Fact]

--- a/test/Sentry.Tests/SentryClientExtensionsTests.cs
+++ b/test/Sentry.Tests/SentryClientExtensionsTests.cs
@@ -23,7 +23,7 @@ public class SentryClientExtensionsTests
     }
 
     [Fact]
-    public void CaptureException_NoHandledArgument_DefaultsToHandledTrue()
+    public void CaptureException_NoHandledArgument_DoesNotSetHandledFlag()
     {
         // Arrange
         _ = _sut.IsEnabled.Returns(true);
@@ -33,7 +33,7 @@ public class SentryClientExtensionsTests
         _ = _sut.CaptureException(ex);
 
         // Assert
-        Assert.Equal(true, ex.Data[Mechanism.HandledKey]);
+        Assert.False(ex.Data.Contains(Mechanism.HandledKey));
     }
 
     [Fact]

--- a/test/Sentry.Tests/SentryClientExtensionsTests.cs
+++ b/test/Sentry.Tests/SentryClientExtensionsTests.cs
@@ -209,4 +209,67 @@ public class SentryClientExtensionsTests
 
         await _sut.Received(1).FlushAsync(timeout);
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CaptureException_ExplicitTerminal_RecordsTerminalFlagOnException(bool terminal)
+    {
+        // Arrange
+        _ = _sut.IsEnabled.Returns(true);
+        var ex = new Exception();
+
+        // Act
+        _ = _sut.CaptureException(ex, handled: false, terminal: terminal);
+
+        // Assert
+        Assert.Equal(false, ex.Data[Mechanism.HandledKey]);
+        Assert.Equal(terminal, ex.Data[Mechanism.TerminalKey]);
+    }
+
+    [Fact]
+    public void CaptureException_NoTerminalArgument_DefaultsToNonTerminal()
+    {
+        // Arrange
+        _ = _sut.IsEnabled.Returns(true);
+        var ex = new Exception();
+
+        // Act
+        _ = _sut.CaptureException(ex, handled: false);
+
+        // Assert
+        Assert.Equal(false, ex.Data[Mechanism.TerminalKey]);
+    }
+
+    [Fact]
+    public void CaptureException_HandledTrue_ClearsPresetTerminalFlag()
+    {
+        // Arrange
+        _ = _sut.IsEnabled.Returns(true);
+        var ex = new Exception();
+        ex.SetSentryMechanism("SomeMechanism", handled: false, terminal: true);
+
+        // Act
+        _ = _sut.CaptureException(ex, handled: true);
+
+        // Assert
+        Assert.Equal(true, ex.Data[Mechanism.HandledKey]);
+        Assert.False(ex.Data.Contains(Mechanism.TerminalKey));
+    }
+
+    [Fact]
+    public void CaptureException_ExplicitTerminal_DisabledClient_DoesNotRecordFlagsOnException()
+    {
+        // Arrange
+        _ = _sut.IsEnabled.Returns(false);
+        var ex = new Exception();
+
+        // Act
+        var id = _sut.CaptureException(ex, handled: false, terminal: true);
+
+        // Assert
+        Assert.Equal(default, id);
+        Assert.False(ex.Data.Contains(Mechanism.HandledKey));
+        Assert.False(ex.Data.Contains(Mechanism.TerminalKey));
+    }
 }

--- a/test/Sentry.Tests/SentryClientExtensionsTests.cs
+++ b/test/Sentry.Tests/SentryClientExtensionsTests.cs
@@ -23,6 +23,98 @@ public class SentryClientExtensionsTests
     }
 
     [Fact]
+    public void CaptureException_NoHandledArgument_DefaultsToHandledTrue()
+    {
+        // Arrange
+        _ = _sut.IsEnabled.Returns(true);
+        var ex = new Exception();
+
+        // Act
+        _ = _sut.CaptureException(ex);
+
+        // Assert
+        Assert.Equal(true, ex.Data[Mechanism.HandledKey]);
+    }
+
+    [Fact]
+    public void CaptureException_NoHandledArgument_PresetFlagIsPreserved()
+    {
+        // Arrange
+        _ = _sut.IsEnabled.Returns(true);
+        var ex = new Exception();
+        ex.SetSentryMechanism("SomeMechanism", handled: false);
+
+        // Act
+        _ = _sut.CaptureException(ex);
+
+        // Assert
+        Assert.Equal(false, ex.Data[Mechanism.HandledKey]);
+    }
+
+    [Fact]
+    public void CaptureException_DisabledClient_NoHandledArgument_DoesNotMutateException()
+    {
+        // Arrange
+        _ = _sut.IsEnabled.Returns(false);
+        var ex = new Exception();
+
+        // Act
+        var id = _sut.CaptureException(ex);
+
+        // Assert
+        _ = _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+        Assert.Equal(default, id);
+        Assert.False(ex.Data.Contains(Mechanism.HandledKey));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CaptureException_ExplicitHandled_RecordsFlagOnException(bool handled)
+    {
+        // Arrange
+        _ = _sut.IsEnabled.Returns(true);
+        var ex = new Exception();
+
+        // Act
+        _ = _sut.CaptureException(ex, handled);
+
+        // Assert
+        Assert.Equal(handled, ex.Data[Mechanism.HandledKey]);
+    }
+
+    [Fact]
+    public void CaptureException_ExplicitHandled_OverridesFlagSetBySetSentryMechanism()
+    {
+        // Arrange
+        _ = _sut.IsEnabled.Returns(true);
+        var ex = new Exception();
+        ex.SetSentryMechanism("SomeMechanism", handled: false);
+
+        // Act
+        _ = _sut.CaptureException(ex, handled: true);
+
+        // Assert
+        Assert.Equal(true, ex.Data[Mechanism.HandledKey]);
+    }
+
+    [Fact]
+    public void CaptureException_DisabledClient_ExplicitHandled_DoesNotMutateException()
+    {
+        // Arrange
+        _ = _sut.IsEnabled.Returns(false);
+        var ex = new Exception();
+
+        // Act
+        var id = _sut.CaptureException(ex, handled: false);
+
+        // Assert
+        _ = _sut.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
+        Assert.Equal(default, id);
+        Assert.False(ex.Data.Contains(Mechanism.HandledKey));
+    }
+
+    [Fact]
     public void CaptureMessage_DisabledClient_DoesNotCaptureEvent()
     {
         _ = _sut.IsEnabled.Returns(false);

--- a/test/Sentry.Tests/SentryClientTests.cs
+++ b/test/Sentry.Tests/SentryClientTests.cs
@@ -2095,4 +2095,64 @@ public partial class SentryClientTests : IDisposable
         // Assert
         _fixture.SessionManager.Received().MarkSessionAsUnhandled();
     }
+
+    [Fact]
+    public void CaptureException_Handled_ReportsError()
+    {
+        // Arrange
+        var client = _fixture.GetSut();
+
+        // Act
+        client.CaptureException(new Exception(), handled: true);
+
+        // Assert
+        _fixture.SessionManager.Received(1).ReportError();
+        _fixture.SessionManager.DidNotReceive().EndSession(SessionEndStatus.Crashed);
+        _fixture.SessionManager.DidNotReceive().MarkSessionAsUnhandled();
+    }
+
+    [Fact]
+    public void CaptureException_UnhandledNonTerminal_MarksSessionUnhandledWithoutEndingIt()
+    {
+        // Arrange
+        var client = _fixture.GetSut();
+
+        // Act
+        client.CaptureException(new Exception(), handled: false, terminal: false);
+
+        // Assert
+        _fixture.SessionManager.Received(1).MarkSessionAsUnhandled();
+        _fixture.SessionManager.DidNotReceive().EndSession(SessionEndStatus.Crashed);
+    }
+
+    [Fact]
+    public void CaptureException_UnhandledTerminal_EndsSessionAsCrashed()
+    {
+        // Arrange
+        var client = _fixture.GetSut();
+
+        // Act
+        client.CaptureException(new Exception(), handled: false, terminal: true);
+
+        // Assert
+        _fixture.SessionManager.Received(1).EndSession(SessionEndStatus.Crashed);
+        _fixture.SessionManager.DidNotReceive().MarkSessionAsUnhandled();
+    }
+
+    [Fact]
+    public void CaptureException_UnhandledWithoutTerminalArgument_DoesNotEndSessionAsCrashed()
+    {
+        // This is the behaviour change the terminal parameter exists for: a manual unhandled capture
+        // must not dent the crash-free-sessions rate when nothing actually crashed.
+
+        // Arrange
+        var client = _fixture.GetSut();
+
+        // Act
+        client.CaptureException(new Exception(), handled: false);
+
+        // Assert
+        _fixture.SessionManager.Received(1).MarkSessionAsUnhandled();
+        _fixture.SessionManager.DidNotReceive().EndSession(SessionEndStatus.Crashed);
+    }
 }

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -673,7 +673,7 @@ public class SentrySdkTests : IDisposable
     }
 
     [Fact]
-    public void CaptureException_NoHandledArgument_LeavesMechanismHandledUnset()
+    public void CaptureException_NoHandledArgument_NeverThrown_DefaultsToHandled()
     {
         SentryEvent captured = null;
         using var _ = SentrySdk.Init(o =>
@@ -691,8 +691,9 @@ public class SentrySdkTests : IDisposable
 
         SentrySdk.CaptureException(new Exception("test"));
 
+        // The plain overload writes no flag; MainExceptionProcessor infers handled for a never-thrown exception.
         Assert.NotNull(captured);
-        Assert.Null(Assert.Single(captured.SentryExceptions!).Mechanism?.Handled);
+        Assert.True(Assert.Single(captured.SentryExceptions!).Mechanism!.Handled);
     }
 
     [Theory]

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -740,7 +740,7 @@ public class SentrySdkTests : IDisposable
             });
         });
 
-        SentrySdk.CaptureException(new Exception("test"), s => s.SetTag("scope-callback", "ran"), handled);
+        SentrySdk.CaptureException(new Exception("test"), handled, s => s.SetTag("scope-callback", "ran"));
 
         Assert.NotNull(captured);
         Assert.Equal(handled, Assert.Single(captured.SentryExceptions!).Mechanism!.Handled);

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -672,6 +672,83 @@ public class SentrySdkTests : IDisposable
         Assert.True(scopeCallbackWasInvoked);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CaptureException_ExplicitHandled_SetsMechanismHandledOnEvent(bool handled)
+    {
+        SentryEvent captured = null;
+        using var _ = SentrySdk.Init(o =>
+        {
+            o.Dsn = ValidDsn;
+            o.AutoSessionTracking = false;
+            o.BackgroundWorker = Substitute.For<IBackgroundWorker>();
+            o.InitNativeSdks = false;
+            o.SetBeforeSend(e =>
+            {
+                captured = e;
+                return e;
+            });
+        });
+
+        SentrySdk.CaptureException(new Exception("test"), handled);
+
+        Assert.NotNull(captured);
+        Assert.Equal(handled, Assert.Single(captured.SentryExceptions!).Mechanism!.Handled);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CaptureException_WithConfiguredScope_ExplicitHandled_SetsMechanismHandledOnEvent(bool handled)
+    {
+        SentryEvent captured = null;
+        using var _ = SentrySdk.Init(o =>
+        {
+            o.Dsn = ValidDsn;
+            o.AutoSessionTracking = false;
+            o.BackgroundWorker = Substitute.For<IBackgroundWorker>();
+            o.InitNativeSdks = false;
+            o.SetBeforeSend(e =>
+            {
+                captured = e;
+                return e;
+            });
+        });
+
+        SentrySdk.CaptureException(new Exception("test"), s => s.SetTag("scope-callback", "ran"), handled);
+
+        Assert.NotNull(captured);
+        Assert.Equal(handled, Assert.Single(captured.SentryExceptions!).Mechanism!.Handled);
+        Assert.Equal("ran", captured.Tags["scope-callback"]);
+    }
+
+    [Fact]
+    public void CaptureException_ExplicitHandled_OverridesFlagSetBySetSentryMechanism()
+    {
+        SentryEvent captured = null;
+        using var _ = SentrySdk.Init(o =>
+        {
+            o.Dsn = ValidDsn;
+            o.AutoSessionTracking = false;
+            o.BackgroundWorker = Substitute.For<IBackgroundWorker>();
+            o.InitNativeSdks = false;
+            o.SetBeforeSend(e =>
+            {
+                captured = e;
+                return e;
+            });
+        });
+
+        var ex = new Exception("test");
+        ex.SetSentryMechanism("SomeMechanism", handled: false);
+
+        SentrySdk.CaptureException(ex, handled: true);
+
+        Assert.NotNull(captured);
+        Assert.True(Assert.Single(captured.SentryExceptions!).Mechanism!.Handled);
+    }
+
     [Fact]
     public void CaptureMessage_WithConfiguredScope_ScopeCallbackGetsInvoked()
     {

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -672,6 +672,29 @@ public class SentrySdkTests : IDisposable
         Assert.True(scopeCallbackWasInvoked);
     }
 
+    [Fact]
+    public void CaptureException_NoHandledArgument_LeavesMechanismHandledUnset()
+    {
+        SentryEvent captured = null;
+        using var _ = SentrySdk.Init(o =>
+        {
+            o.Dsn = ValidDsn;
+            o.AutoSessionTracking = false;
+            o.BackgroundWorker = Substitute.For<IBackgroundWorker>();
+            o.InitNativeSdks = false;
+            o.SetBeforeSend(e =>
+            {
+                captured = e;
+                return e;
+            });
+        });
+
+        SentrySdk.CaptureException(new Exception("test"));
+
+        Assert.NotNull(captured);
+        Assert.Null(Assert.Single(captured.SentryExceptions!).Mechanism?.Handled);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/test/Sentry.Tests/SentrySdkTests.cs
+++ b/test/Sentry.Tests/SentrySdkTests.cs
@@ -740,7 +740,7 @@ public class SentrySdkTests : IDisposable
             });
         });
 
-        SentrySdk.CaptureException(new Exception("test"), handled, s => s.SetTag("scope-callback", "ran"));
+        SentrySdk.CaptureException(new Exception("test"), handled, terminal: false, s => s.SetTag("scope-callback", "ran"));
 
         Assert.NotNull(captured);
         Assert.Equal(handled, Assert.Single(captured.SentryExceptions!).Mechanism!.Handled);
@@ -771,6 +771,109 @@ public class SentrySdkTests : IDisposable
 
         Assert.NotNull(captured);
         Assert.True(Assert.Single(captured.SentryExceptions!).Mechanism!.Handled);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CaptureException_ExplicitTerminal_SetsMechanismTerminalOnEvent(bool terminal)
+    {
+        SentryEvent captured = null;
+        using var _ = SentrySdk.Init(o =>
+        {
+            o.Dsn = ValidDsn;
+            o.AutoSessionTracking = false;
+            o.BackgroundWorker = Substitute.For<IBackgroundWorker>();
+            o.InitNativeSdks = false;
+            o.SetBeforeSend(e =>
+            {
+                captured = e;
+                return e;
+            });
+        });
+
+        SentrySdk.CaptureException(new Exception("test"), handled: false, terminal: terminal);
+
+        Assert.NotNull(captured);
+        var mechanism = Assert.Single(captured.SentryExceptions!).Mechanism!;
+        Assert.False(mechanism.Handled);
+        Assert.Equal(terminal, mechanism.Terminal);
+    }
+
+    [Fact]
+    public void CaptureException_NoTerminalArgument_SetsMechanismTerminalToFalse()
+    {
+        SentryEvent captured = null;
+        using var _ = SentrySdk.Init(o =>
+        {
+            o.Dsn = ValidDsn;
+            o.AutoSessionTracking = false;
+            o.BackgroundWorker = Substitute.For<IBackgroundWorker>();
+            o.InitNativeSdks = false;
+            o.SetBeforeSend(e =>
+            {
+                captured = e;
+                return e;
+            });
+        });
+
+        SentrySdk.CaptureException(new Exception("test"), handled: false);
+
+        Assert.NotNull(captured);
+        Assert.False(Assert.Single(captured.SentryExceptions!).Mechanism!.Terminal);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CaptureException_WithConfiguredScope_ExplicitTerminal_SetsMechanismTerminalOnEvent(bool terminal)
+    {
+        SentryEvent captured = null;
+        using var _ = SentrySdk.Init(o =>
+        {
+            o.Dsn = ValidDsn;
+            o.AutoSessionTracking = false;
+            o.BackgroundWorker = Substitute.For<IBackgroundWorker>();
+            o.InitNativeSdks = false;
+            o.SetBeforeSend(e =>
+            {
+                captured = e;
+                return e;
+            });
+        });
+
+        SentrySdk.CaptureException(new Exception("test"), handled: false, terminal, _ => { });
+
+        Assert.NotNull(captured);
+        Assert.Equal(terminal, Assert.Single(captured.SentryExceptions!).Mechanism!.Terminal);
+    }
+
+    [Fact]
+    public void CaptureException_HandledTrue_LeavesMechanismTerminalUnset()
+    {
+        SentryEvent captured = null;
+        using var _ = SentrySdk.Init(o =>
+        {
+            o.Dsn = ValidDsn;
+            o.AutoSessionTracking = false;
+            o.BackgroundWorker = Substitute.For<IBackgroundWorker>();
+            o.InitNativeSdks = false;
+            o.SetBeforeSend(e =>
+            {
+                captured = e;
+                return e;
+            });
+        });
+
+        var ex = new Exception("test");
+        ex.SetSentryMechanism("SomeMechanism", handled: false, terminal: true);
+
+        SentrySdk.CaptureException(ex, handled: true);
+
+        Assert.NotNull(captured);
+        var mechanism = Assert.Single(captured.SentryExceptions!).Mechanism!;
+        Assert.True(mechanism.Handled);
+        Assert.Null(mechanism.Terminal);
     }
 
     [Fact]


### PR DESCRIPTION
Closes getsentry/sentry-dotnet#3383

Implements the approach agreed in [this comment](<https://github.com/getsentry/sentry-dotnet/issues/3383#issuecomment-4483725854>): SDK users get explicit control over `Mechanism.Handled`, and manually captured exceptions default to `handled: true`.

## API changes

New overloads for explicit control:

* `SentrySdk.CaptureException(Exception exception, bool handled, bool terminal = false)`
* `SentrySdk.CaptureException(Exception exception, bool handled, bool terminal, Action<Scope> configureScope)`
* `SentryClientExtensions.CaptureException(this ISentryClient client, Exception ex, bool handled, bool terminal = false)`
* `HubExtensions.CaptureException(this IHub hub, Exception ex, bool handled, bool terminal, Action<Scope> configureScope)`

The existing signatures are kept, so this is source- and binary-compatible. `handled` is a required parameter rather than optional: an optional one would be permanently shadowed by the existing exact-match overloads, and replacing those signatures would be binary-breaking.

## Behavior

* **Explicit wins.** Passing `handled` records that value, overriding any flag previously set on the exception (including via `SetSentryMechanism`).
* **The existing overloads are untouched.** They write nothing to `Exception.Data`, so there is no implicit precedence between a preset flag and a plain `CaptureException(ex)` call.
* **The default moved into** `MainExceptionProcessor`**.** Any exception no integration claimed is now marked `handled: true`, replacing the previous "thrown ⇒ true, never thrown ⇒ null" heuristic. This is what fixes the symptom getsentry/sentry-dotnet#3383 opens with: `SentrySdk.CaptureException(new Exception())` reported `Handled --` and now reports `Handled: true`, per the [protocol docs](<https://getsentry.github.io/relay/relay_event_schema/protocol/struct.Mechanism.html#structfield.handled>) ("exceptions captured using capture_exception are handled=true"), which are cited at the decision site. Thrown-and-caught exceptions reported `Handled: true` before and still do.
* `CaptureExceptionInternal` (the integration capture path) defaults to `handled: false` when no flag is already set, since integrations capture exceptions that user code did not handle. All four call sites set the flag via `SetSentryMechanism` first (WinUI forwards the platform's value), so the default is a defensive fallback only. `Terminal` is deliberately left unset there, so a missing `SetSentryMechanism` call still reads as a crash.
* **`Terminal` is now controllable too**, per the [discussion below](<https://github.com/getsentry/sentry-dotnet/pull/5449#discussion_r3649614113>). It only applies when `handled: false`; passing `handled: true` removes any terminal flag left over from an earlier `SetSentryMechanism` call, mirroring that method's null-removes semantics. The default `terminal: false` means a manual unhandled capture marks the session as unhandled without ending it as crashed and leaves the active transaction running — a manual capture should not dent the crash-free-sessions rate when nothing actually crashed. `terminal: true` ends the session as crashed and aborts the active transaction. This is a deliberate divergence from `SetSentryMechanism(type, handled: false)`, which leaves `Terminal` unset and therefore still counts as a crash. The WinUI integration is left as a follow-up rather than expanding this PR's scope.

## Testing

Unit tests cover explicit `true`/`false` on every capture path, explicit values overriding preset flags, the untouched plain overloads, and the integration-path default. Terminal coverage asserts the session outcome for each combination (`ReportError`, `MarkSessionAsUnhandled`, `EndSession(Crashed)`) and that only terminal captures abort the active transaction. Verify snapshots updated: API approvals for all four target frameworks, the aggregate-exception mechanism snapshot, and the `Sentry.DiagnosticSource` / `Sentry.EntityFramework` integration snapshots, where constructed-and-captured exceptions now report `Handled: true`.