### PR TITLE
ci: repoint watch-upstream to relocated AssemblyStore reader

### DIFF
--- a/.github/workflows/watch-upstream.yml
+++ b/.github/workflows/watch-upstream.yml
@@ -20,8 +20,7 @@ jobs:
         include:
           - name: dotnet/android - AssemblyStore reader
             repo: dotnet/android
-            # Upstream moved this out of tools/assembly-store-reader-mk2/ in dotnet/android#12108
-            # (commit f1aecf9). The parser we vendor now lives under the read-assembly-store skill.
+            # Upstream moved from tools/assembly-store-reader-mk2/ to the read-assembly-store skill in dotnet/android#12108 (f1aecf9). 
             path: .github/skills/read-assembly-store/src/AssemblyStore
             local_path: src/Sentry.Android.AssemblyReader/
     steps:

--- a/.github/workflows/watch-upstream.yml
+++ b/.github/workflows/watch-upstream.yml
@@ -18,9 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: dotnet/android - assembly-store-reader-mk2
+          - name: dotnet/android - AssemblyStore reader
             repo: dotnet/android
-            path: tools/assembly-store-reader-mk2
+            # Upstream moved this out of tools/assembly-store-reader-mk2/ in dotnet/android#12108
+            # (commit f1aecf9). The parser we vendor now lives under the read-assembly-store skill.
+            path: .github/skills/read-assembly-store/src/AssemblyStore
             local_path: src/Sentry.Android.AssemblyReader/
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

[dotnet/android#12108](https://github.com/dotnet/android/pull/12108) (commit [`f1aecf9`](https://github.com/dotnet/android/commit/f1aecf9e6ae80fe3f3992ec1f52ef953dac7c06b)) deleted `tools/assembly-store-reader-mk2/` and moved the AssemblyStore parser we vendor into `.github/skills/read-assembly-store/src/AssemblyStore/`.

Our `watch-upstream` matrix still tracked the old path. That path will never receive another commit, so the watcher would silently stop alerting us to upstream changes. This repoints it at the new location (and freshens the matrix `name`).

Surfaced by the watcher itself in #5451.

## Follow-ups (next major, not in this PR)

The move rides on a stack (#12104 / #12108) that also introduced upstream logic we don't yet vendor:

- Zstandard (over LZ4) per-assembly compression + decompressed-file caching — already tracked in #5346.
- v4 / CoreCLR store format, `_assembly_store` ELF symbol payload lookup, and variable index-entry sizing — tracked in #5454.

## Issues

Closes #5451

#skip-changelog
