### PR TITLE
fix(serilog): logs from application namespaces beginning with "Sentry" are discarded

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -19,6 +19,7 @@ targets:
       nuget:Sentry.Hangfire:
       nuget:Sentry.Log4Net:
       nuget:Sentry.Maui:
+      nuget:Sentry.Maui.CommunityToolkit.Mvvm:
       nuget:Sentry.NLog:
       nuget:Sentry.OpenTelemetry:
       nuget:Sentry.OpenTelemetry.Exporter:

--- a/src/Sentry.Extensions.Logging/SentryLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryLogger.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Sentry.Infrastructure;
+using Sentry.Internal;
 
 namespace Sentry.Extensions.Logging;
 
@@ -182,22 +183,7 @@ internal sealed class SentryLogger : ILogger
                    exception));
 
 
-    private bool IsFromSentry()
-    {
-        if (string.Equals(CategoryName, "Sentry", StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-#if DEBUG
-        if (CategoryName.StartsWith("Sentry.Samples.", StringComparison.Ordinal))
-        {
-            return false;
-        }
-#endif
-
-        return CategoryName.StartsWith("Sentry.", StringComparison.Ordinal);
-    }
+    private bool IsFromSentry() => SentrySdkNamespaces.IsSentrySdk(CategoryName);
 
     internal static bool IsEfExceptionMessage(EventId eventId)
     {

--- a/src/Sentry.Serilog/Sentry.Serilog.csproj
+++ b/src/Sentry.Serilog/Sentry.Serilog.csproj
@@ -19,6 +19,7 @@
     <Using Include="Sentry" />
     <Using Include="Sentry.Extensibility" />
     <Using Include="Sentry.Infrastructure" />
+    <Using Include="Sentry.Internal" />
     <Using Include="Sentry.Reflection" />
     <Using Include="Sentry.Serilog" />
     <Using Include="Serilog.Configuration" />

--- a/src/Sentry.Serilog/SentrySink.cs
+++ b/src/Sentry.Serilog/SentrySink.cs
@@ -91,7 +91,7 @@ internal sealed partial class SentrySink : ILogEventSink, IDisposable
     {
         if (logEvent.TryGetSourceContext(out var context))
         {
-            if (IsSentryContext(context))
+            if (SentrySdkNamespaces.IsSentrySdk(context))
             {
                 return;
             }
@@ -174,10 +174,6 @@ internal sealed partial class SentrySink : ILogEventSink, IDisposable
             CaptureStructuredLog(hub, options, logEvent, formatted, template);
         }
     }
-
-    private static bool IsSentryContext(string context) =>
-        context.StartsWith("Sentry.") ||
-        string.Equals(context, "Sentry", StringComparison.Ordinal);
 
     private string FormatLogEvent(LogEvent logEvent)
     {

--- a/src/Sentry/Internal/SentrySdkNamespaces.cs
+++ b/src/Sentry/Internal/SentrySdkNamespaces.cs
@@ -1,0 +1,61 @@
+namespace Sentry.Internal;
+
+/// <summary>
+/// Identifies logger names that belong to the Sentry SDK itself, so the logging integrations can
+/// skip them rather than feeding the SDK's own output back into Sentry.
+/// </summary>
+/// <remarks>
+/// The <c>PackageRoots</c> half of this class is generated from <c>.craft.yml</c> - see the
+/// <c>GenerateSentrySdkNamespaces</c> target in <c>Sentry.csproj</c>.
+/// </remarks>
+internal static partial class SentrySdkNamespaces
+{
+    private const string Prefix = "Sentry";
+
+    /// <summary>
+    /// The core <c>Sentry</c> package can't be matched by prefix the way the other packages can:
+    /// all of its types live directly under <c>Sentry.</c>, and so does application code that
+    /// happens to use that namespace (<c>Sentry.Samples.*</c>, <c>Sentry.MyApp.*</c>). Matching on
+    /// <c>Sentry.</c> would therefore silently discard the user's own logs.
+    ///
+    /// Core has no logging dependency of its own, so the only name it ever logs under is the one
+    /// <c>MelDiagnosticLogger</c> (in Sentry.Extensions.Logging) gets from
+    /// <c>ILogger&lt;ISentryClient&gt;</c>. Matching that exactly is enough.
+    /// </summary>
+    private static readonly string[] CoreNames = { Prefix, "Sentry.ISentryClient" };
+
+    /// <summary>
+    /// Whether <paramref name="loggerName"/> - a Serilog <c>SourceContext</c>, a
+    /// <c>Microsoft.Extensions.Logging</c> category, or an equivalent from another framework -
+    /// belongs to the Sentry SDK.
+    /// </summary>
+    internal static bool IsSentrySdk(string? loggerName)
+    {
+        if (loggerName is null || !loggerName.StartsWith(Prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        foreach (var name in CoreNames)
+        {
+            if (string.Equals(loggerName, name, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        foreach (var root in PackageRoots)
+        {
+            // Either the package's own namespace, or something nested inside it. Comparing the
+            // character after the root keeps a package named e.g. 'Sentry.Maui' from matching an
+            // unrelated 'Sentry.MauiSomething'.
+            if (loggerName.StartsWith(root, StringComparison.Ordinal) &&
+                (loggerName.Length == root.Length || loggerName[root.Length] == '.'))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -225,4 +225,72 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    The logging integrations need to recognise log messages that the SDK itself emitted, so they can
+    skip them instead of feeding them back into Sentry. That means knowing which namespace roots
+    belong to the SDK. Rather than hand-maintaining that list (and letting it go stale as packages
+    are added), it's generated from the package list in .craft.yml, which is already kept current for
+    releases. Consumed by Internal\SentrySdkNamespaces.cs.
+  -->
+  <PropertyGroup>
+    <_SentryCraftManifest>$(MSBuildThisFileDirectory)..\..\.craft.yml</_SentryCraftManifest>
+  </PropertyGroup>
+
+  <Target Name="GenerateSentrySdkNamespaces"
+          Inputs="$(_SentryCraftManifest);$(MSBuildThisFileFullPath)"
+          Outputs="$(IntermediateOutputPath)SentrySdkNamespaces.g.cs">
+
+    <ReadLinesFromFile File="$(_SentryCraftManifest)">
+      <Output TaskParameter="Lines" ItemName="_SentryCraftLine" />
+    </ReadLinesFromFile>
+
+    <ItemGroup>
+      <!-- Entries look like "      nuget:Sentry.AspNetCore:" -->
+      <_SentrySdkPackage Include="$([System.Text.RegularExpressions.Regex]::Replace('%(_SentryCraftLine.Identity)', '^\s*nuget:([A-Za-z0-9\.]+):\s*$', '$1'))"
+                         Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(_SentryCraftLine.Identity)', '^\s*nuget:[A-Za-z0-9\.]+:\s*$'))" />
+      <!--
+        'Sentry' is deliberately excluded. Every SDK type lives under the 'Sentry.' namespace, so
+        using it as a prefix would also match user code that happens to sit under 'Sentry.' - which
+        is the bug this list exists to avoid. The core package is matched explicitly instead, see
+        Internal\SentrySdkNamespaces.cs.
+      -->
+      <_SentrySdkPackage Remove="Sentry" />
+    </ItemGroup>
+
+    <Error Condition="'@(_SentrySdkPackage)' == ''"
+           Text="No 'nuget:&lt;package&gt;:' entries could be read from $(_SentryCraftManifest). Without them the logging integrations cannot identify the SDK's own log messages, which risks feedback loops - so this is a hard failure rather than an empty list." />
+
+    <ItemGroup>
+      <_SentrySdkNamespacesLine Include="// &lt;auto-generated/&gt;" />
+      <_SentrySdkNamespacesLine Include="// Generated from .craft.yml by the GenerateSentrySdkNamespaces target in Sentry.csproj." />
+      <_SentrySdkNamespacesLine Include="namespace Sentry.Internal%3B" />
+      <_SentrySdkNamespacesLine Include="internal static partial class SentrySdkNamespaces" />
+      <_SentrySdkNamespacesLine Include="{" />
+      <_SentrySdkNamespacesLine Include="    // Namespace roots owned by SDK packages other than the core 'Sentry' package." />
+      <_SentrySdkNamespacesLine Include="    internal static readonly string[] PackageRoots =" />
+      <_SentrySdkNamespacesLine Include="    {" />
+      <_SentrySdkNamespacesLine Include="        &quot;%(_SentrySdkPackage.Identity)&quot;," />
+      <_SentrySdkNamespacesLine Include="    }%3B" />
+      <_SentrySdkNamespacesLine Include="}" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(IntermediateOutputPath)SentrySdkNamespaces.g.cs"
+                      Lines="@(_SentrySdkNamespacesLine)"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
+  </Target>
+
+  <!--
+    Kept separate from the target above so the Compile item is still added on incremental builds,
+    where that target is skipped as up to date.
+  -->
+  <Target Name="IncludeSentrySdkNamespaces"
+          BeforeTargets="BeforeCompile;CoreCompile"
+          DependsOnTargets="GenerateSentrySdkNamespaces">
+    <ItemGroup>
+      <Compile Include="$(IntermediateOutputPath)SentrySdkNamespaces.g.cs" />
+      <FileWrites Include="$(IntermediateOutputPath)SentrySdkNamespaces.g.cs" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
@@ -218,11 +218,15 @@ public class SentryLoggerTests
             .CaptureEvent(Arg.Any<SentryEvent>());
     }
 
-    [Fact]
-    public void Log_SentryCategory_DoesNotSendEvent()
+    [Theory]
+    [InlineData("Sentry")]
+    [InlineData("Sentry.ISentryClient")]
+    [InlineData("Sentry.Extensions.Logging.SentryLogger")]
+    [InlineData("Sentry.AspNetCore.SentryMiddleware")]
+    public void Log_SentryCategory_DoesNotSendEvent(string categoryName)
     {
         var expectedException = new Exception("expected message");
-        _fixture.CategoryName = "Sentry.Some.Class";
+        _fixture.CategoryName = categoryName;
         var sut = _fixture.GetSut();
 
         sut.Log<object>(LogLevel.Critical, default, null, expectedException, null);
@@ -231,25 +235,17 @@ public class SentryLoggerTests
             .CaptureEvent(Arg.Any<SentryEvent>());
     }
 
-    [Fact]
-    public void Log_SentryRootCategory_DoesNotSendEvent()
-    {
-        var expectedException = new Exception("expected message");
-        _fixture.CategoryName = "Sentry";
-        var sut = _fixture.GetSut();
-
-        sut.Log<object>(LogLevel.Critical, default, null, expectedException, null);
-
-        _ = _fixture.Hub.DidNotReceive()
-            .CaptureEvent(Arg.Any<SentryEvent>());
-    }
-
+    // A category under a "Sentry" namespace that isn't one of ours belongs to the application.
     // https://github.com/getsentry/sentry-dotnet/issues/132
-    [Fact]
-    public void Log_SentrySomethingCategory_SendEvent()
+    // https://github.com/getsentry/sentry-dotnet/issues/5265
+    [Theory]
+    [InlineData("SentrySomething")]
+    [InlineData("Sentry.Some.Class")]
+    [InlineData("Sentry.Samples.AspNetCore.Serilog.Program")]
+    public void Log_UserCategory_SendsEvent(string categoryName)
     {
         var expectedException = new Exception("expected message");
-        _fixture.CategoryName = "SentrySomething";
+        _fixture.CategoryName = categoryName;
         var sut = _fixture.GetSut();
 
         sut.Log<object>(LogLevel.Critical, default, null, expectedException, null);

--- a/test/Sentry.Serilog.Tests/AspNetCoreIntegrationTests.cs
+++ b/test/Sentry.Serilog.Tests/AspNetCoreIntegrationTests.cs
@@ -72,13 +72,10 @@ public class AspNetCoreIntegrationTests : SerilogAspNetSentrySdkTestFixture
         Assert.Contains(Logs, log => log.Level == SentryLogLevel.Info && log.Message == "Hello, World!");
     }
 
-    // Logging through ILogger from a namespace that merely starts with "Sentry" used to be discarded
-    // by the sink, so nothing was captured and event processors never ran.
-    // https://github.com/getsentry/sentry-dotnet/issues/5265
     [Fact]
     public async Task ILoggerFromApplicationNamespaceStartingWithSentry_CapturesEventAndRunsEventProcessors()
     {
-        // The namespace our own ASP.NET Core Serilog sample uses, which is where the report came from.
+        // Logs from our samples shouldn't be filtered - only logs from our SDK should be
         const string category = "Sentry.Samples.AspNetCore.Serilog.Program";
 
         var processor = new RecordingEventProcessor();

--- a/test/Sentry.Serilog.Tests/AspNetCoreIntegrationTests.cs
+++ b/test/Sentry.Serilog.Tests/AspNetCoreIntegrationTests.cs
@@ -71,5 +71,49 @@ public class AspNetCoreIntegrationTests : SerilogAspNetSentrySdkTestFixture
         Assert.NotEmpty(Logs);
         Assert.Contains(Logs, log => log.Level == SentryLogLevel.Info && log.Message == "Hello, World!");
     }
+
+    // Logging through ILogger from a namespace that merely starts with "Sentry" used to be discarded
+    // by the sink, so nothing was captured and event processors never ran.
+    // https://github.com/getsentry/sentry-dotnet/issues/5265
+    [Fact]
+    public async Task ILoggerFromApplicationNamespaceStartingWithSentry_CapturesEventAndRunsEventProcessors()
+    {
+        // The namespace our own ASP.NET Core Serilog sample uses, which is where the report came from.
+        const string category = "Sentry.Samples.AspNetCore.Serilog.Program";
+
+        var processor = new RecordingEventProcessor();
+        ConfigureServices = services => services.AddSingleton<ISentryEventProcessor>(processor);
+
+        var handler = new RequestHandler
+        {
+            Path = "/log",
+            Handler = context =>
+            {
+                context.RequestServices.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger(category)
+                    .LogError(new InvalidOperationException("hello?"), "This is a problem");
+                return Task.CompletedTask;
+            }
+        };
+
+        Handlers = new[] { handler };
+        Build();
+        await HttpClient.GetAsync(handler.Path);
+        await ServiceProvider.GetRequiredService<IHub>().FlushAsync();
+
+        Assert.Contains(Events, e => e.Logger == category);
+        Assert.True(processor.Invoked);
+    }
+
+    private class RecordingEventProcessor : ISentryEventProcessor
+    {
+        public bool Invoked { get; private set; }
+
+        public SentryEvent Process(SentryEvent @event)
+        {
+            Invoked = true;
+            return @event;
+        }
+    }
 }
 #endif

--- a/test/Sentry.Serilog.Tests/SentrySinkTests.cs
+++ b/test/Sentry.Serilog.Tests/SentrySinkTests.cs
@@ -319,8 +319,7 @@ public partial class SentrySinkTests
         _fixture.Hub.DidNotReceive().ConfigureScope(Arg.Any<Action<Scope>>());
     }
 
-    // Application code is free to live under a namespace beginning with "Sentry", and used to be
-    // discarded for it. https://github.com/getsentry/sentry-dotnet/issues/5265
+    // See https://github.com/getsentry/sentry-dotnet/issues/5265
     [Theory]
     [InlineData("Sentry.Samples.AspNetCore.Serilog.Program")]
     [InlineData("Sentry.Some.Class")]

--- a/test/Sentry.Serilog.Tests/SentrySinkTests.cs
+++ b/test/Sentry.Serilog.Tests/SentrySinkTests.cs
@@ -281,60 +281,61 @@ public partial class SentrySinkTests
             && p.Message.Message == expectedMessage));
     }
 
-    [Fact]
-    public void Emit_SourceContextMatchesSentry_NoEventSent()
+    [Theory]
+    [InlineData("Sentry")]
+    [InlineData("Sentry.ISentryClient")]
+    [InlineData("Sentry.Serilog")]
+    [InlineData("Sentry.Serilog.SentrySink")]
+    [InlineData("Sentry.AspNetCore.SentryMiddleware")]
+    [InlineData("Sentry.Extensions.Logging.MelDiagnosticLogger")]
+    public void Emit_SourceContextFromSentrySdk_NoEventSent(string sourceContext)
     {
         var sut = _fixture.GetSut();
 
         var evt = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Error, null,
             new MessageTemplateParser().Parse("message"),
-            new[] { new LogEventProperty("SourceContext", new ScalarValue("Sentry.Serilog")) });
+            new[] { new LogEventProperty("SourceContext", new ScalarValue(sourceContext)) });
 
         sut.Emit(evt);
 
         _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
     }
 
-    [Fact]
-    public void Emit_SourceContextContainsSentry_NoEventSent()
+    [Theory]
+    [InlineData("Sentry")]
+    [InlineData("Sentry.ISentryClient")]
+    [InlineData("Sentry.Serilog")]
+    [InlineData("Sentry.AspNetCore.SentryMiddleware")]
+    public void Emit_SourceContextFromSentrySdk_NoScopeConfigured(string sourceContext)
     {
         var sut = _fixture.GetSut();
 
         var evt = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Error, null,
             new MessageTemplateParser().Parse("message"),
-            new[] { new LogEventProperty("SourceContext", new ScalarValue("Sentry")) });
-
-        sut.Emit(evt);
-
-        _fixture.Hub.DidNotReceive().CaptureEvent(Arg.Any<SentryEvent>());
-    }
-
-    [Fact]
-    public void Emit_SourceContextMatchesSentry_NoScopeConfigured()
-    {
-        var sut = _fixture.GetSut();
-
-        var evt = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Error, null,
-            new MessageTemplateParser().Parse("message"),
-            new[] { new LogEventProperty("SourceContext", new ScalarValue("Sentry.Serilog")) });
+            new[] { new LogEventProperty("SourceContext", new ScalarValue(sourceContext)) });
 
         sut.Emit(evt);
 
         _fixture.Hub.DidNotReceive().ConfigureScope(Arg.Any<Action<Scope>>());
     }
 
-    [Fact]
-    public void Emit_SourceContextContainsSentry_NoScopeConfigured()
+    // Application code is free to live under a namespace beginning with "Sentry", and used to be
+    // discarded for it. https://github.com/getsentry/sentry-dotnet/issues/5265
+    [Theory]
+    [InlineData("Sentry.Samples.AspNetCore.Serilog.Program")]
+    [InlineData("Sentry.Some.Class")]
+    [InlineData("SentrySomething")]
+    public void Emit_SourceContextFromUserCode_EventSent(string sourceContext)
     {
         var sut = _fixture.GetSut();
 
         var evt = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Error, null,
             new MessageTemplateParser().Parse("message"),
-            new[] { new LogEventProperty("SourceContext", new ScalarValue("Sentry")) });
+            new[] { new LogEventProperty("SourceContext", new ScalarValue(sourceContext)) });
 
         sut.Emit(evt);
 
-        _fixture.Hub.DidNotReceive().ConfigureScope(Arg.Any<Action<Scope>>());
+        _fixture.Hub.Received(1).CaptureEvent(Arg.Is<SentryEvent>(e => e.Logger == sourceContext));
     }
 
     [Fact]

--- a/test/Sentry.Tests/Internals/SentrySdkNamespacesTests.cs
+++ b/test/Sentry.Tests/Internals/SentrySdkNamespacesTests.cs
@@ -1,0 +1,50 @@
+namespace Sentry.Tests.Internals;
+
+public class SentrySdkNamespacesTests
+{
+    [Theory]
+    [InlineData("Sentry")]
+    [InlineData("Sentry.ISentryClient")]
+    [InlineData("Sentry.AspNetCore")]
+    [InlineData("Sentry.AspNetCore.SentryMiddleware")]
+    [InlineData("Sentry.AspNetCore.RequestDecompression.RequestDecompressionMiddleware")]
+    [InlineData("Sentry.Extensions.Logging.MelDiagnosticLogger")]
+    [InlineData("Sentry.Serilog.SentrySink")]
+    [InlineData("Sentry.Maui.SentryMauiOptions")]
+    public void IsSentrySdk_SdkLoggerName_True(string loggerName)
+        => SentrySdkNamespaces.IsSentrySdk(loggerName).Should().BeTrue();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("MyApp.Program")]
+    [InlineData("Microsoft.AspNetCore.Hosting.Diagnostics")]
+    // Application namespaces that merely start with "Sentry" - the regression this guards against.
+    // https://github.com/getsentry/sentry-dotnet/issues/5265
+    [InlineData("Sentry.Samples.AspNetCore.Serilog.Program")]
+    [InlineData("Sentry.Samples.Console.Basic")]
+    [InlineData("Sentry.Some.Class")]
+    [InlineData("Sentry.MyApp.Worker")]
+    // https://github.com/getsentry/sentry-dotnet/issues/132
+    [InlineData("SentrySomething")]
+    // A package root must match on a namespace boundary, not just as a string prefix.
+    [InlineData("Sentry.MauiSomething.Thing")]
+    [InlineData("Sentry.AspNetCoreExtras.Thing")]
+    public void IsSentrySdk_NotAnSdkLoggerName_False(string loggerName)
+        => SentrySdkNamespaces.IsSentrySdk(loggerName).Should().BeFalse();
+
+    [Fact]
+    public void PackageRoots_GeneratedFromCraftManifest_ExcludesCoreAndCoversIntegrations()
+    {
+        // Guards the .craft.yml parsing in the GenerateSentrySdkNamespaces target: a silently empty
+        // or malformed list would stop the integrations recognising the SDK's own log messages.
+        SentrySdkNamespaces.PackageRoots.Should()
+            .NotBeEmpty()
+            .And.OnlyContain(root => root.StartsWith("Sentry.", StringComparison.Ordinal))
+            .And.Contain("Sentry.AspNetCore")
+            .And.Contain("Sentry.Extensions.Logging")
+            .And.Contain("Sentry.Serilog")
+            // 'Sentry' itself cannot be a prefix root - see SentrySdkNamespaces.CoreNames.
+            .And.NotContain("Sentry");
+    }
+}

--- a/test/Sentry.Tests/Internals/SentrySdkNamespacesTests.cs
+++ b/test/Sentry.Tests/Internals/SentrySdkNamespacesTests.cs
@@ -19,13 +19,12 @@ public class SentrySdkNamespacesTests
     [InlineData("")]
     [InlineData("MyApp.Program")]
     [InlineData("Microsoft.AspNetCore.Hosting.Diagnostics")]
-    // Application namespaces that merely start with "Sentry" - the regression this guards against.
-    // https://github.com/getsentry/sentry-dotnet/issues/5265
+    // Logs from our samples shouldn't be filtered
     [InlineData("Sentry.Samples.AspNetCore.Serilog.Program")]
     [InlineData("Sentry.Samples.Console.Basic")]
     [InlineData("Sentry.Some.Class")]
     [InlineData("Sentry.MyApp.Worker")]
-    // https://github.com/getsentry/sentry-dotnet/issues/132
+    // Starts with Sentry but not one of our SDK namespaces
     [InlineData("SentrySomething")]
     // A package root must match on a namespace boundary, not just as a string prefix.
     [InlineData("Sentry.MauiSomething.Thing")]


### PR DESCRIPTION
Closes #5265

## Summary

`SentrySink` discarded any Serilog event whose `SourceContext` started with `"Sentry."`. That heuristic dates back to 2019 ("don't log self log") and is meant to stop the SDK's own diagnostics looping back into Sentry — but it also matches application code. An app logging under, say, `Sentry.Samples.AspNetCore.Serilog.Program` had its log events dropped before anything was created: no event, no breadcrumb, no structured log, and therefore no event processors run. That last symptom is how #5265 was reported, but `ISentryEventProcessor` was never the problem.

Our own `samples/Sentry.Samples.AspNetCore.Serilog` uses that namespace, so the sample demonstrating the `ILogger` path was silently broken — which is where the reporter picked it up.

The filter can't simply be removed. `MelDiagnosticLogger` routes SDK diagnostics through `ILogger<ISentryClient>` whenever `Debug` is enabled (`ApplicationBuilderExtensions.cs`), and with Serilog as the MEL backend that's a genuine feedback loop. The `isReentrant` guard in the sink doesn't cover it, because the transport logs from the background worker thread.

So the check now matches the namespace roots the SDK actually owns, rather than a bare `"Sentry."` prefix.

## Notes for review

- **The root list is generated, not hand-maintained.** A `GenerateSentrySdkNamespaces` target in `Sentry.csproj` reads the package list out of `.craft.yml` at build time and emits `SentrySdkNamespaces.g.cs`. No reflection (AOT/trimming-safe) and no list to keep in sync as packages are added. `.craft.yml`'s line order is fixed, so output is deterministic. The target hard-errors rather than emitting an empty list, since an empty list would silently restore the loop risk.
- **The core `Sentry` package can't be a prefix root.** All of its types live under `Sentry.` — and so does user code — so treating it as a prefix would reproduce the original bug. Core has no logging dependency of its own, and the only category it ever logs under is `Sentry.ISentryClient` (from `MelDiagnosticLogger`), so that plus a bare `Sentry` are matched exactly. This is the one hardcoded string in the change; it's commented next to the thing that produces it.
- **`Sentry.Extensions.Logging` is included deliberately.** `SentryLogger.IsFromSentry()` carried the same heuristic plus a `#if DEBUG` carve-out for `Sentry.Samples.`, which only ever helped samples built from source — anyone on the released package was still affected. Both integrations now share one helper. `Sentry.NLog` and `Sentry.Log4Net` have never had this filter at all; that asymmetry is left as-is here.
- **`.craft.yml` gains `Sentry.Maui.CommunityToolkit.Mvvm`**, which is packable but was missing from the registry list. Worth a second pair of eyes: it's a release-config change riding along with a bug fix, and it means the release registry starts tracking that package... main reason for including it in this PR is that we're using `craft.yml` to generate the list of namespaces that we match against for log filtering.
