### PR TITLE
ci: group dependabot updates for multi-subpath actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,7 +55,7 @@ updates:
     interval: weekly
   # Dependabot treats each subpath of an action repo as a separate dependency, so
   # without these groups it bumps e.g. codeql-action/init without codeql-action/analyze
-  # and the mismatched versions break CI. Group each repo so subpaths move in lockstep.
+  # Grouping ensures dependencies from the same subpath are upgraded together
   groups:
     codeql-action:
       patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,3 +53,19 @@ updates:
     - "/.github/actions/*"
   schedule:
     interval: weekly
+  # Dependabot treats each subpath of an action repo as a separate dependency, so
+  # without these groups it bumps e.g. codeql-action/init without codeql-action/analyze
+  # and the mismatched versions break CI. Group each repo so subpaths move in lockstep.
+  groups:
+    codeql-action:
+      patterns:
+        - "github/codeql-action*"
+    github-workflows:
+      patterns:
+        - "getsentry/github-workflows*"
+    craft:
+      patterns:
+        - "getsentry/craft*"
+    actions-cache:
+      patterns:
+        - "actions/cache*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,18 +54,10 @@ updates:
   schedule:
     interval: weekly
   # Dependabot treats each subpath of an action repo as a separate dependency, so
-  # without these groups it bumps e.g. codeql-action/init without codeql-action/analyze
-  # and the mismatched versions break CI. Group each repo so subpaths move in lockstep.
+  # ungrouped it bumps e.g. codeql-action/init without codeql-action/analyze and the
+  # mismatched versions break CI. One group keeps every action in a single PR, which
+  # also cuts down on version-bump noise. Matches getsentry/sentry-java.
   groups:
-    codeql-action:
+    github-actions:
       patterns:
-        - "github/codeql-action*"
-    github-workflows:
-      patterns:
-        - "getsentry/github-workflows*"
-    craft:
-      patterns:
-        - "getsentry/craft*"
-    actions-cache:
-      patterns:
-        - "actions/cache*"
+        - "*"


### PR DESCRIPTION
#skip-changelog

## Summary

Fixes #5466.

Dependabot treats each subpath of an action repository as a separate dependency. That's why #5461 bumped `github/codeql-action/init` to 4.37.3 and left `analyze` on 4.37.1 — CodeQL then failed with:

```
Loaded a configuration file for version '4.37.3', but running version '4.37.1'
```

This adds a single wildcard `groups` entry to the `github-actions` ecosystem, so every action is bumped together in one PR:

```yaml
groups:
  github-actions:
    patterns:
      - "*"
```

This is the same approach [getsentry/sentry-java](https://github.com/getsentry/sentry-java/blob/main/.github/dependabot.yml) already uses. Besides fixing the mismatch, it collapses the weekly stream of one-PR-per-action version bumps into a single PR, which is a good deal less noisy. It also covers any action repo added later without needing further config.

Repos in this repository that are consumed via more than one subpath, and so depend on this lockstep:

- `github/codeql-action` — `init`, `analyze`
- `getsentry/github-workflows` — `danger`, `validate-pr`, `updater`, `sentry-cli/integration-test`
- `getsentry/craft` — root action + the `changelog-preview.yml` reusable workflow
- `actions/cache` — root + `restore`

## References

- [Dependabot options reference → `groups`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups) — syntax; `applies-to` defaults to version updates
- [Optimizing PR creation for version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates) — `patterns` match dependency names, `*` wildcard supported

One behaviour this relies on is **not** covered by those docs: grouping for the `github-actions` ecosystem is never explicitly documented as supported. It's in active production use in [getsentry/sentry-java](https://github.com/getsentry/sentry-java/blob/main/.github/dependabot.yml) and GitHub's own [actions/checkout](https://github.com/actions/checkout/blob/main/.github/dependabot.yml), which is the basis for relying on it here.

## Notes for review

- **`getsentry/craft` is already drifted on `main`** and this PR does not correct it: [release.yml:38](https://github.com/getsentry/sentry-dotnet/blob/main/.github/workflows/release.yml#L38) pins `2.26.14` while [changelog-preview.yml:19](https://github.com/getsentry/sentry-dotnet/blob/main/.github/workflows/changelog-preview.yml#L19) pins `2.26.12`. Nothing is broken today because the two are used independently, and the new group should pull them back into lockstep on Dependabot's next run. Flagging it in case you'd rather see it corrected explicitly here.
- `.github/dependabot.yml` changes only take effect once merged to the default branch, so CI on this PR can't demonstrate the fix. The `init`/`analyze` mismatch that prompted it was fixed directly on #5461, where `Analyze` is now green.
