### PR TITLE
SamplingTransactionProfilerFactory.Dispose disposes the Task, not the SampleProfilerSession (resource leak)

### DIFF
--- a/src/Sentry.Profiling/SamplingTransactionProfilerFactory.cs
+++ b/src/Sentry.Profiling/SamplingTransactionProfilerFactory.cs
@@ -83,6 +83,6 @@ internal class SamplingTransactionProfilerFactory : IDisposable, ITransactionPro
 
     public void Dispose()
     {
-        _sessionTask.ContinueWith(session => session.Dispose());
+        _sessionTask.ContinueWith(task => task.Result.Dispose(), TaskContinuationOptions.OnlyOnRanToCompletion);
     }
 }


### PR DESCRIPTION
Fixed Dispose() to call task.Result.Dispose() on the SampleProfilerSession instead of disposing the Task itself

Found via automated repo scanning, fix written and reviewed before opening.
