### PR TITLE
fix: Heap dump files are now deleted from disk once they have been sent to Sentry

### DIFF
--- a/src/Sentry/FileAttachmentContent.cs
+++ b/src/Sentry/FileAttachmentContent.cs
@@ -9,6 +9,8 @@ public class FileAttachmentContent : IAttachmentContent
 {
     private readonly bool _readFileAsynchronously;
 
+    private readonly bool _deleteOnClose;
+
     /// <summary>
     /// The path to the file to attach.
     /// </summary>
@@ -18,7 +20,7 @@ public class FileAttachmentContent : IAttachmentContent
     /// Creates a new instance of <see cref="FileAttachmentContent"/>.
     /// </summary>
     /// <param name="filePath">The path to the file to attach.</param>
-    public FileAttachmentContent(string filePath) : this(filePath, true)
+    public FileAttachmentContent(string filePath) : this(filePath, true, false)
     {
     }
 
@@ -27,18 +29,40 @@ public class FileAttachmentContent : IAttachmentContent
     /// </summary>
     /// <param name="filePath">The path to the file to attach.</param>
     /// <param name="readFileAsynchronously">Whether to use async file I/O to read the file.</param>
-    public FileAttachmentContent(string filePath, bool readFileAsynchronously)
+    public FileAttachmentContent(string filePath, bool readFileAsynchronously) : this(filePath, readFileAsynchronously, false)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="FileAttachmentContent"/>.
+    /// </summary>
+    /// <param name="filePath">The path to the file to attach.</param>
+    /// <param name="readFileAsynchronously">Whether to use async file I/O to read the file.</param>
+    /// <param name="deleteOnClose">Whether to delete the file when it closed.</param>
+    public FileAttachmentContent(string filePath, bool readFileAsynchronously, bool deleteOnClose)
     {
         FilePath = filePath;
         _readFileAsynchronously = readFileAsynchronously;
+        _deleteOnClose = deleteOnClose;
     }
 
     /// <inheritdoc />
-    public Stream GetStream() => new FileStream(
-        FilePath,
-        FileMode.Open,
-        FileAccess.Read,
-        FileShare.ReadWrite,
-        bufferSize: 4096,
-        useAsync: _readFileAsynchronously);
+    public Stream GetStream()
+    {
+        var options = FileOptions.None;
+
+        if (_readFileAsynchronously)
+            options |= FileOptions.Asynchronous;
+
+        if (_deleteOnClose)
+            options |= FileOptions.DeleteOnClose;
+
+        return new FileStream(
+            FilePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite,
+            bufferSize: 4096,
+            options);
+    }
 }

--- a/src/Sentry/FileAttachmentContent.cs
+++ b/src/Sentry/FileAttachmentContent.cs
@@ -52,10 +52,14 @@ public class FileAttachmentContent : IAttachmentContent
         var options = FileOptions.None;
 
         if (_readFileAsynchronously)
+        {
             options |= FileOptions.Asynchronous;
+        }
 
         if (_deleteOnClose)
+        {
             options |= FileOptions.DeleteOnClose;
+        }
 
         return new FileStream(
             FilePath,

--- a/src/Sentry/Http/HttpTransportBase.cs
+++ b/src/Sentry/Http/HttpTransportBase.cs
@@ -162,37 +162,8 @@ public abstract class HttpTransportBase
                 item.TryGetFileName(),
                 item.TryGetLength());
 
-            if (item.LocalFilePath is { } localFilePath &&
-                item.Header.TryGetValue("attachment_type", out var attachmentType) &&
-                string.Equals(attachmentType as string, "event.heapdump", StringComparison.Ordinal))
-            {
-                item.Dispose();
+            item.Dispose();
 
-                try
-                {
-                    if (_options.FileSystem.DeleteFile(localFilePath))
-                    {
-                        _options.LogDebug(
-                            "{0}: Local heap dump file '{1}' exceeded the attachment size limit and was deleted.",
-                            _typeName,
-                            localFilePath);
-                    }
-                    else
-                    {
-                        _options.LogError(
-                            "{0}: Failed to delete local heap dump file '{1}' after exceeding the attachment size limit.",
-                            _typeName,
-                            localFilePath);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _options.LogError(ex,
-                        "{0}: Failed to delete local heap dump file '{1}'.",
-                        _typeName,
-                        localFilePath);
-                }
-            }
             return;
         }
 

--- a/src/Sentry/Http/HttpTransportBase.cs
+++ b/src/Sentry/Http/HttpTransportBase.cs
@@ -162,6 +162,37 @@ public abstract class HttpTransportBase
                 item.TryGetFileName(),
                 item.TryGetLength());
 
+            if (item.LocalFilePath is { } localFilePath &&
+                item.Header.TryGetValue("attachment_type", out var attachmentType) &&
+                string.Equals(attachmentType as string, "event.heapdump", StringComparison.Ordinal))
+            {
+                item.Dispose();
+
+                try
+                {
+                    if (_options.FileSystem.DeleteFile(localFilePath))
+                    {
+                        _options.LogDebug(
+                            "{0}: Local heap dump file '{1}' exceeded the attachment size limit and was deleted.",
+                            _typeName,
+                            localFilePath);
+                    }
+                    else
+                    {
+                        _options.LogError(
+                            "{0}: Failed to delete local heap dump file '{1}' after exceeding the attachment size limit.",
+                            _typeName,
+                            localFilePath);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _options.LogError(ex,
+                        "{0}: Failed to delete local heap dump file '{1}'.",
+                        _typeName,
+                        localFilePath);
+                }
+            }
             return;
         }
 

--- a/src/Sentry/Http/HttpTransportBase.cs
+++ b/src/Sentry/Http/HttpTransportBase.cs
@@ -162,8 +162,6 @@ public abstract class HttpTransportBase
                 item.TryGetFileName(),
                 item.TryGetLength());
 
-            item.Dispose();
-
             return;
         }
 

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -759,7 +759,7 @@ internal class Hub : IHub, IDisposable
                 Level = _options.HeapDumpOptions?.Level ?? SentryLevel.Warning,
             };
             var hint = new SentryHint(_options);
-            hint.AddAttachment(dumpFile);
+            hint.AddAttachment(dumpFile, AttachmentType.HeapDump);
             CaptureEvent(evt, CurrentScope, hint);
         }
         catch (Exception e)

--- a/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
@@ -31,6 +31,11 @@ public sealed class EnvelopeItem : ISerializable, IDisposable
     private const string FileNameKey = "filename";
 
     /// <summary>
+    /// The local file path associated with this envelope item.
+    /// </summary>
+    internal string? LocalFilePath { get; }
+
+    /// <summary>
     /// Header associated with this envelope item.
     /// </summary>
     public IReadOnlyDictionary<string, object?> Header { get; }
@@ -72,10 +77,11 @@ public sealed class EnvelopeItem : ISerializable, IDisposable
     /// <summary>
     /// Initializes an instance of <see cref="EnvelopeItem"/>.
     /// </summary>
-    public EnvelopeItem(IReadOnlyDictionary<string, object?> header, ISerializable payload)
+    public EnvelopeItem(IReadOnlyDictionary<string, object?> header, ISerializable payload, string? localFilePath = null)
     {
         Header = header;
         Payload = payload;
+        LocalFilePath = localFilePath;
     }
 
     /// <summary>
@@ -342,6 +348,7 @@ public sealed class EnvelopeItem : ISerializable, IDisposable
             AttachmentType.UnrealContext => "unreal.context",
             AttachmentType.UnrealLogs => "unreal.logs",
             AttachmentType.ViewHierarchy => "event.view_hierarchy",
+            AttachmentType.HeapDump => "event.heapdump",
             _ => "event.attachment"
         };
 
@@ -354,7 +361,9 @@ public sealed class EnvelopeItem : ISerializable, IDisposable
             ["content_type"] = attachment.ContentType
         };
 
-        return new EnvelopeItem(header, new StreamSerializable(stream));
+        var localFilePath = attachment.Content is FileAttachmentContent fileContent ? fileContent.FilePath : null;
+
+        return new EnvelopeItem(header, new StreamSerializable(stream), localFilePath);
     }
 
     /// <summary>

--- a/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
@@ -31,11 +31,6 @@ public sealed class EnvelopeItem : ISerializable, IDisposable
     private const string FileNameKey = "filename";
 
     /// <summary>
-    /// The local file path associated with this envelope item.
-    /// </summary>
-    internal string? LocalFilePath { get; }
-
-    /// <summary>
     /// Header associated with this envelope item.
     /// </summary>
     public IReadOnlyDictionary<string, object?> Header { get; }
@@ -77,11 +72,10 @@ public sealed class EnvelopeItem : ISerializable, IDisposable
     /// <summary>
     /// Initializes an instance of <see cref="EnvelopeItem"/>.
     /// </summary>
-    public EnvelopeItem(IReadOnlyDictionary<string, object?> header, ISerializable payload, string? localFilePath = null)
+    public EnvelopeItem(IReadOnlyDictionary<string, object?> header, ISerializable payload)
     {
         Header = header;
         Payload = payload;
-        LocalFilePath = localFilePath;
     }
 
     /// <summary>
@@ -361,9 +355,7 @@ public sealed class EnvelopeItem : ISerializable, IDisposable
             ["content_type"] = attachment.ContentType
         };
 
-        var localFilePath = attachment.Content is FileAttachmentContent fileContent ? fileContent.FilePath : null;
-
-        return new EnvelopeItem(header, new StreamSerializable(stream), localFilePath);
+        return new EnvelopeItem(header, new StreamSerializable(stream));
     }
 
     /// <summary>

--- a/src/Sentry/SentryAttachment.cs
+++ b/src/Sentry/SentryAttachment.cs
@@ -36,7 +36,14 @@ public enum AttachmentType
     /// <summary>
     /// A JSON attachment containing the View Hierarchy
     /// </summary>
-    ViewHierarchy
+    ViewHierarchy,
+
+    /// <summary>
+    /// A .gcdump file captured when a configured memory threshold is exceeded.
+    /// Used internally to allow the SDK to clean up the file from disk if it can't be sent to Sentry
+    /// (e.g. because it exceeds the attachment size limit).
+    /// </summary>
+    HeapDump
 }
 
 /// <summary>

--- a/src/Sentry/SentryHint.cs
+++ b/src/Sentry/SentryHint.cs
@@ -71,10 +71,12 @@ public class SentryHint
     {
         if (_options is not null)
         {
+            var deleteOnClose = type == AttachmentType.HeapDump;
+
             _attachments.Add(
                 new SentryAttachment(
                     type,
-                    new FileAttachmentContent(filePath, _options.UseAsyncFileIO),
+                    new FileAttachmentContent(filePath, _options.UseAsyncFileIO, deleteOnClose),
                     Path.GetFileName(filePath),
                     contentType));
         }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -9,6 +9,7 @@ namespace Sentry
         UnrealContext = 3,
         UnrealLogs = 4,
         ViewHierarchy = 5,
+        HeapDump = 6,
     }
     public class BaggageHeader
     {
@@ -2048,7 +2049,7 @@ namespace Sentry.Protocol.Envelopes
     }
     public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
     {
-        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload, string? localFilePath = null) { }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
         public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
         public void Dispose() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -110,6 +110,7 @@ namespace Sentry
     {
         public FileAttachmentContent(string filePath) { }
         public FileAttachmentContent(string filePath, bool readFileAsynchronously) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously, bool deleteOnClose) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasExtraExtensions
@@ -2049,7 +2050,7 @@ namespace Sentry.Protocol.Envelopes
     }
     public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
     {
-        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload, string? localFilePath = null) { }
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
         public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
         public void Dispose() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -9,6 +9,7 @@ namespace Sentry
         UnrealContext = 3,
         UnrealLogs = 4,
         ViewHierarchy = 5,
+        HeapDump = 6,
     }
     public class BaggageHeader
     {
@@ -2048,7 +2049,7 @@ namespace Sentry.Protocol.Envelopes
     }
     public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
     {
-        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload, string? localFilePath = null) { }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
         public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
         public void Dispose() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -110,6 +110,7 @@ namespace Sentry
     {
         public FileAttachmentContent(string filePath) { }
         public FileAttachmentContent(string filePath, bool readFileAsynchronously) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously, bool deleteOnClose) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasExtraExtensions
@@ -2049,7 +2050,7 @@ namespace Sentry.Protocol.Envelopes
     }
     public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
     {
-        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload, string? localFilePath = null) { }
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
         public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
         public void Dispose() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -9,6 +9,7 @@ namespace Sentry
         UnrealContext = 3,
         UnrealLogs = 4,
         ViewHierarchy = 5,
+        HeapDump = 6,
     }
     public class BaggageHeader
     {
@@ -2048,7 +2049,7 @@ namespace Sentry.Protocol.Envelopes
     }
     public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
     {
-        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload, string? localFilePath = null) { }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
         public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
         public void Dispose() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -110,6 +110,7 @@ namespace Sentry
     {
         public FileAttachmentContent(string filePath) { }
         public FileAttachmentContent(string filePath, bool readFileAsynchronously) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously, bool deleteOnClose) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasExtraExtensions
@@ -2049,7 +2050,7 @@ namespace Sentry.Protocol.Envelopes
     }
     public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
     {
-        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload, string? localFilePath = null) { }
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
         public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
         public void Dispose() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -100,6 +100,7 @@ namespace Sentry
     {
         public FileAttachmentContent(string filePath) { }
         public FileAttachmentContent(string filePath, bool readFileAsynchronously) { }
+        public FileAttachmentContent(string filePath, bool readFileAsynchronously, bool deleteOnClose) { }
         public System.IO.Stream GetStream() { }
     }
     public static class HasExtraExtensions
@@ -2025,7 +2026,7 @@ namespace Sentry.Protocol.Envelopes
     }
     public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
     {
-        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload, string? localFilePath = null) { }
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
         public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
         public void Dispose() { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -9,6 +9,7 @@ namespace Sentry
         UnrealContext = 3,
         UnrealLogs = 4,
         ViewHierarchy = 5,
+        HeapDump = 6,
     }
     public class BaggageHeader
     {
@@ -2024,7 +2025,7 @@ namespace Sentry.Protocol.Envelopes
     }
     public sealed class EnvelopeItem : Sentry.Protocol.Envelopes.ISerializable, System.IDisposable
     {
-        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload) { }
+        public EnvelopeItem(System.Collections.Generic.IReadOnlyDictionary<string, object?> header, Sentry.Protocol.Envelopes.ISerializable payload, string? localFilePath = null) { }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Header { get; }
         public Sentry.Protocol.Envelopes.ISerializable Payload { get; }
         public void Dispose() { }

--- a/test/Sentry.Tests/HintTests.cs
+++ b/test/Sentry.Tests/HintTests.cs
@@ -175,5 +175,48 @@ public class HintTests : IDisposable
         hint.Attachments.Should().Contain(attachment2);
     }
 
+    [Fact]
+    public void AddAttachment_HeapDump_DeletesFileWhenStreamIsClosed()
+    {
+        // Arrange
+        var attachmentPath = Path.Combine(_testDirectory, "dump.gcdump");
+        File.WriteAllText(attachmentPath, "fake heap dump");
+
+        var hint = new SentryHint(new SentryOptions());
+
+        // Act
+        hint.AddAttachment(attachmentPath, AttachmentType.HeapDump);
+
+        // Assert
+        var attachment = Assert.Single(hint.Attachments);
+        using (attachment.Content.GetStream())
+        {
+            File.Exists(attachmentPath).Should().BeTrue("the dump must survive while it is being read");
+        }
+
+        File.Exists(attachmentPath).Should().BeFalse("heap dumps are deleted once the stream is closed");
+    }
+
+    [Fact]
+    public void AddAttachment_NonHeapDump_LeavesFileInPlaceWhenStreamIsClosed()
+    {
+        // Arrange
+        var attachmentPath = Path.Combine(_testDirectory, "attachment.txt");
+        File.WriteAllText(attachmentPath, "some user attachment");
+
+        var hint = new SentryHint(new SentryOptions());
+
+        // Act
+        hint.AddAttachment(attachmentPath, AttachmentType.Default);
+
+        // Assert
+        var attachment = Assert.Single(hint.Attachments);
+        using (attachment.Content.GetStream())
+        {
+        }
+
+        File.Exists(attachmentPath).Should().BeTrue("we must never delete attachments supplied by the user");
+    }
+
     public void Dispose() => Directory.Delete(_testDirectory, true);
 }

--- a/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/CachingTransportTests.cs
@@ -80,6 +80,44 @@ public class CachingTransportTests : IDisposable
     }
 
     [Fact]
+    public async Task WithHeapDumpAttachment_DeletesLocalFileButStillSendsIt()
+    {
+        // Arrange
+        string httpContent = null;
+        var innerTransport = new HttpTransport(_options, new HttpClient(new CallbackHttpClientHandler(async message =>
+        {
+            httpContent = await message.Content!.ReadAsStringAsync();
+        })));
+
+        await using var transport = CachingTransport.Create(innerTransport, _options, startWorker: false);
+
+        const string dumpContent = "fake heap dump";
+        var dumpFile = Path.Combine(_cacheDirectory.Path, "dump.gcdump");
+        File.WriteAllText(dumpFile, dumpContent);
+
+        var attachment = new SentryAttachment(
+            AttachmentType.HeapDump,
+            new FileAttachmentContent(dumpFile, readFileAsynchronously: true, deleteOnClose: true),
+            "dump.gcdump",
+            null);
+
+        var envelope = Envelope.FromEvent(new SentryEvent(), attachments: new[] { attachment });
+
+        // Act
+        // The caching transport writes the envelope (including the dump) to the cache directory
+        // before the envelope is disposed, which is what BackgroundWorker does after each send.
+        await transport.SendEnvelopeAsync(envelope);
+        File.Exists(dumpFile).Should().BeTrue("the dump must survive until it has been cached");
+
+        envelope.Dispose();
+        await transport.FlushAsync();
+
+        // Assert
+        File.Exists(dumpFile).Should().BeFalse("the dump should be deleted once the envelope is disposed");
+        httpContent.Should().Contain(dumpContent, "the cached copy should still be sent to Sentry");
+    }
+
+    [Fact]
     public async Task WorksInBackground()
     {
         // Arrange

--- a/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
@@ -622,12 +622,16 @@ public partial class HttpTransportTests
     }
 
     [Fact]
-    public async Task SendEnvelopeAsync_HeapDumpAttachmentTooLarge_DeleteFilesAndLogsDebug()
+    public async Task SendEnvelopeAsync_HeapDumpAttachmentTooLarge_FileIsDeleted()
     {
-        var tempFilePath = Path.GetTempFileName();
-        File.WriteAllBytes(tempFilePath, new byte[] { 1, 2, 3, 4, 5 });
+        // Arrange
+        using var httpHandler = new RecordingHttpMessageHandler(
+            new FakeHttpMessageHandler());
 
         var logger = new InMemoryDiagnosticLogger();
+
+        var tempFilePath = Path.GetTempFileName();
+        File.WriteAllBytes(tempFilePath, new byte[] { 1, 2, 3, 4, 5 });
 
         var httpTransport = new HttpTransport(
             new SentryOptions
@@ -637,18 +641,59 @@ public partial class HttpTransportTests
                 DiagnosticLogger = logger,
                 Debug = true
             },
-            new HttpClient(new RecordingHttpMessageHandler(new FakeHttpMessageHandler())));
+            new HttpClient(httpHandler));
 
-        var HeapDumpAttachment = new SentryAttachment(
+        var heapDumpAttachment = new SentryAttachment(
             AttachmentType.HeapDump,
-            new FileAttachmentContent(tempFilePath),
+            new FileAttachmentContent(tempFilePath, readFileAsynchronously: true, deleteOnClose: true),
             Path.GetFileName(tempFilePath),
             null);
 
         using var envelope = Envelope.FromEvent(
             new SentryEvent(),
             null,
-            new[] { HeapDumpAttachment });
+            new[] { heapDumpAttachment });
+
+        // Act
+        await httpTransport.SendEnvelopeAsync(envelope);
+
+        // Assert
+        File.Exists(tempFilePath).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SendEnvelopeAsync_HeapDumpAttachmentSentSuccessfully_FileIsDeleted()
+    {
+        // Arrange
+        using var httpHandler = new RecordingHttpMessageHandler(
+            new FakeHttpMessageHandler());
+
+        var logger = new InMemoryDiagnosticLogger();
+
+        var tempFilePath = Path.GetTempFileName();
+        File.WriteAllBytes(tempFilePath, new byte[] { 1, 2, 3, 4, 5 });
+
+        var httpTransport = new HttpTransport(
+            new SentryOptions
+            {
+                Dsn = ValidDsn,
+                // Large enough that this attachment is NOT dropped for being too big
+                MaxAttachmentSize = 1_000_000,
+                DiagnosticLogger = logger,
+                Debug = true
+            },
+            new HttpClient(httpHandler));
+
+        var heapDumpAttachment = new SentryAttachment(
+            AttachmentType.HeapDump,
+            new FileAttachmentContent(tempFilePath, readFileAsynchronously: true, deleteOnClose: true),
+            Path.GetFileName(tempFilePath),
+            null);
+
+        using var envelope = Envelope.FromEvent(
+            new SentryEvent(),
+            null,
+            new[] { heapDumpAttachment });
 
         try
         {
@@ -656,37 +701,42 @@ public partial class HttpTransportTests
             await httpTransport.SendEnvelopeAsync(envelope);
 
             // Assert
+            // The file is streamed as part of the successful send, and should be
+            // deleted once the stream backing the envelope item is closed/disposed.
             File.Exists(tempFilePath).Should().BeFalse();
-
-            logger.Entries.Should().Contain(e =>
-                e.Level == SentryLevel.Debug &&
-                string.Format(e.Message, e.Args).Contains("exceeded the attachment size limit and was deleted"));
         }
         finally
         {
-            File.Delete(tempFilePath);
+            if (File.Exists(tempFilePath))
+            {
+                File.Delete(tempFilePath);
+            }
         }
     }
 
     [Fact]
-    public async Task SendEnvelopeAsync_NonHeapDumpAttachmentTooLarge_DoesNotDeleteFile()
+    public async Task SendEnvelopeAsync_NonHeapDumpAttachment_FileIsNotDeleted()
     {
-        var tempFilePath = Path.GetTempFileName();
-        File.WriteAllBytes(tempFilePath, new byte[] { 1, 2, 3, 4, 5 });
+        // Arrange
+        using var httpHandler = new RecordingHttpMessageHandler(
+            new FakeHttpMessageHandler());
 
         var logger = new InMemoryDiagnosticLogger();
+
+        var tempFilePath = Path.GetTempFileName();
+        File.WriteAllBytes(tempFilePath, new byte[] { 1, 2, 3, 4, 5 });
 
         var httpTransport = new HttpTransport(
             new SentryOptions
             {
                 Dsn = ValidDsn,
-                MaxAttachmentSize = 1,
+                MaxAttachmentSize = 1_000_000,
                 DiagnosticLogger = logger,
                 Debug = true
             },
-            new HttpClient(new RecordingHttpMessageHandler(new FakeHttpMessageHandler())));
+            new HttpClient(httpHandler));
 
-        var NonHeapDumpAttachment = new SentryAttachment(
+        var normalAttachment = new SentryAttachment(
             AttachmentType.Default,
             new FileAttachmentContent(tempFilePath),
             Path.GetFileName(tempFilePath),
@@ -695,7 +745,7 @@ public partial class HttpTransportTests
         using var envelope = Envelope.FromEvent(
             new SentryEvent(),
             null,
-            new[] { NonHeapDumpAttachment });
+            new[] { normalAttachment });
 
         try
         {
@@ -704,9 +754,6 @@ public partial class HttpTransportTests
 
             // Assert
             File.Exists(tempFilePath).Should().BeTrue();
-
-            logger.Entries.Should().NotContain(e =>
-                string.Format(e.Message, e.Args).Contains("exceeded the attachment size limit and was deleted"));
         }
         finally
         {

--- a/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
@@ -622,6 +622,99 @@ public partial class HttpTransportTests
     }
 
     [Fact]
+    public async Task SendEnvelopeAsync_HeapDumpAttachmentTooLarge_DeleteFilesAndLogsDebug()
+    {
+        var tempFilePath = Path.GetTempFileName();
+        File.WriteAllBytes(tempFilePath, new byte[] { 1, 2, 3, 4, 5 });
+
+        var logger = new InMemoryDiagnosticLogger();
+
+        var httpTransport = new HttpTransport(
+            new SentryOptions
+            {
+                Dsn = ValidDsn,
+                MaxAttachmentSize = 1,
+                DiagnosticLogger = logger,
+                Debug = true
+            },
+            new HttpClient(new RecordingHttpMessageHandler(new FakeHttpMessageHandler())));
+
+        var HeapDumpAttachment = new SentryAttachment(
+            AttachmentType.HeapDump,
+            new FileAttachmentContent(tempFilePath),
+            Path.GetFileName(tempFilePath),
+            null);
+
+        using var envelope = Envelope.FromEvent(
+            new SentryEvent(),
+            null,
+            new[] { HeapDumpAttachment });
+
+        try
+        {
+            // Act
+            await httpTransport.SendEnvelopeAsync(envelope);
+
+            // Assert
+            File.Exists(tempFilePath).Should().BeFalse();
+
+            logger.Entries.Should().Contain(e =>
+                e.Level == SentryLevel.Debug &&
+                string.Format(e.Message, e.Args).Contains("exceeded the attachment size limit and was deleted"));
+        }
+        finally
+        {
+            File.Delete(tempFilePath);
+        }
+    }
+
+    [Fact]
+    public async Task SendEnvelopeAsync_NonHeapDumpAttachmentTooLarge_DoesNotDeleteFile()
+    {
+        var tempFilePath = Path.GetTempFileName();
+        File.WriteAllBytes(tempFilePath, new byte[] { 1, 2, 3, 4, 5 });
+
+        var logger = new InMemoryDiagnosticLogger();
+
+        var httpTransport = new HttpTransport(
+            new SentryOptions
+            {
+                Dsn = ValidDsn,
+                MaxAttachmentSize = 1,
+                DiagnosticLogger = logger,
+                Debug = true
+            },
+            new HttpClient(new RecordingHttpMessageHandler(new FakeHttpMessageHandler())));
+
+        var NonHeapDumpAttachment = new SentryAttachment(
+            AttachmentType.Default,
+            new FileAttachmentContent(tempFilePath),
+            Path.GetFileName(tempFilePath),
+            null);
+
+        using var envelope = Envelope.FromEvent(
+            new SentryEvent(),
+            null,
+            new[] { NonHeapDumpAttachment });
+
+        try
+        {
+            // Act
+            await httpTransport.SendEnvelopeAsync(envelope);
+
+            // Assert
+            File.Exists(tempFilePath).Should().BeTrue();
+
+            logger.Entries.Should().NotContain(e =>
+                string.Format(e.Message, e.Args).Contains("exceeded the attachment size limit and was deleted"));
+        }
+        finally
+        {
+            File.Delete(tempFilePath);
+        }
+    }
+
+    [Fact]
     public async Task SendEnvelopeAsync_ItemRateLimit_PromotesNextSessionWithSameId()
     {
         // Arrange

--- a/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
@@ -651,11 +651,28 @@ public partial class HttpTransportTests
             null,
             [heapDumpAttachment]);
 
-        // Act
-        await httpTransport.SendEnvelopeAsync(envelope);
+        try
+        {
+            // Act
+            await httpTransport.SendEnvelopeAsync(envelope);
 
-        // Assert
-        File.Exists(tempFilePath).Should().BeFalse();
+            // The oversized item is dropped before sending, so it never reaches the processed
+            // envelope. The original envelope still owns it, so the file survives until that
+            // envelope is disposed - which is what BackgroundWorker does after each send.
+            File.Exists(tempFilePath).Should().BeTrue();
+
+            envelope.Dispose();
+
+            // Assert
+            File.Exists(tempFilePath).Should().BeFalse();
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath))
+            {
+                File.Delete(tempFilePath);
+            }
+        }
     }
 
     [Fact]

--- a/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
@@ -628,8 +628,6 @@ public partial class HttpTransportTests
         using var httpHandler = new RecordingHttpMessageHandler(
             new FakeHttpMessageHandler());
 
-        var logger = new InMemoryDiagnosticLogger();
-
         var tempFilePath = Path.GetTempFileName();
         File.WriteAllBytes(tempFilePath, new byte[] { 1, 2, 3, 4, 5 });
 
@@ -638,7 +636,6 @@ public partial class HttpTransportTests
             {
                 Dsn = ValidDsn,
                 MaxAttachmentSize = 1,
-                DiagnosticLogger = logger,
                 Debug = true
             },
             new HttpClient(httpHandler));
@@ -652,7 +649,7 @@ public partial class HttpTransportTests
         using var envelope = Envelope.FromEvent(
             new SentryEvent(),
             null,
-            new[] { heapDumpAttachment });
+            [heapDumpAttachment]);
 
         // Act
         await httpTransport.SendEnvelopeAsync(envelope);
@@ -668,8 +665,6 @@ public partial class HttpTransportTests
         using var httpHandler = new RecordingHttpMessageHandler(
             new FakeHttpMessageHandler());
 
-        var logger = new InMemoryDiagnosticLogger();
-
         var tempFilePath = Path.GetTempFileName();
         File.WriteAllBytes(tempFilePath, new byte[] { 1, 2, 3, 4, 5 });
 
@@ -679,7 +674,6 @@ public partial class HttpTransportTests
                 Dsn = ValidDsn,
                 // Large enough that this attachment is NOT dropped for being too big
                 MaxAttachmentSize = 1_000_000,
-                DiagnosticLogger = logger,
                 Debug = true
             },
             new HttpClient(httpHandler));
@@ -693,7 +687,7 @@ public partial class HttpTransportTests
         using var envelope = Envelope.FromEvent(
             new SentryEvent(),
             null,
-            new[] { heapDumpAttachment });
+            [heapDumpAttachment]);
 
         try
         {
@@ -721,8 +715,6 @@ public partial class HttpTransportTests
         using var httpHandler = new RecordingHttpMessageHandler(
             new FakeHttpMessageHandler());
 
-        var logger = new InMemoryDiagnosticLogger();
-
         var tempFilePath = Path.GetTempFileName();
         File.WriteAllBytes(tempFilePath, new byte[] { 1, 2, 3, 4, 5 });
 
@@ -731,7 +723,6 @@ public partial class HttpTransportTests
             {
                 Dsn = ValidDsn,
                 MaxAttachmentSize = 1_000_000,
-                DiagnosticLogger = logger,
                 Debug = true
             },
             new HttpClient(httpHandler));
@@ -745,7 +736,7 @@ public partial class HttpTransportTests
         using var envelope = Envelope.FromEvent(
             new SentryEvent(),
             null,
-            new[] { normalAttachment });
+            [normalAttachment]);
 
         try
         {


### PR DESCRIPTION
# Description
Heap dump (`.gcdump`) files created by the SDK were left on disk after being processed. This affected both successfully sent heap dumps and oversized heap dumps that were dropped before sending, potentially causing these files to accumulate over time.
This PR introduces a dedicated `AttachmentType.HeapDump` and opens the corresponding file streams with `FileOptions.DeleteOnClose`. Cleanup is therefore tied to the attachment stream and envelope lifecycle:

* A successfully processed heap dump is deleted when its stream is closed.
* An oversized heap dump remains owned by the original envelope and is deleted when that envelope is disposed.
* When caching is enabled, the heap dump is first serialized into the cache. The source file can then be deleted while the cached copy remains available for sending.
* Non-heap-dump file attachments retain their existing behavior and are not deleted.

# Changes

* Added `AttachmentType.HeapDump`.
* Marked heap dumps created by `CaptureHeapDump` with the new attachment type.
* Added `deleteOnClose` support to `FileAttachmentContent`.
* Configured `SentryHint` to enable `FileOptions.DeleteOnClose` only for heap dump attachments.
* Added the `event.heapdump` envelope attachment-type mapping.
* Updated the public API approval snapshots for the new enum value and constructor overload.
* Added tests covering heap dump cleanup, regular file attachments, oversized attachments, successful sends, and cached sends.

# Testing
Added tests verifying that:

* A heap dump file exists while its attachment stream is open and is deleted when the stream is closed.
* A regular file attachment is not deleted when its stream is closed.
* An oversized heap dump remains on disk until the original envelope is disposed.
* A successfully sent heap dump is deleted.
* With caching enabled, the heap dump is copied into the cache before the source file is deleted, and the cached content is still sent successfully.

The separate Spotlight envelope-item stream-sharing issue discovered during this work is tracked in #5499 .
Fixes #4009 