### PR TITLE
fix: rate limit on one data category no longer blocks all others

### DIFF
--- a/src/Sentry/Internal/Http/RetryAfterHandler.cs
+++ b/src/Sentry/Internal/Http/RetryAfterHandler.cs
@@ -3,7 +3,8 @@ using Sentry.Infrastructure;
 namespace Sentry.Internal.Http;
 
 /// <summary>
-/// Retry After Handler which short-circuit requests following an HTTP 429.
+/// Retry After Handler which short-circuits requests following an HTTP 429 that carries no per-category
+/// rate limits. Responses that do carry them are left to the transport to apply per envelope item.
 /// </summary>
 /// <seealso href="https://tools.ietf.org/html/rfc6585#section-4" />
 /// <seealso href="https://develop.sentry.dev/sdk/overview/#writing-an-sdk"/>
@@ -62,7 +63,7 @@ internal class RetryAfterHandler : DelegatingHandler
 
         var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-        if (response.StatusCode == TooManyRequests)
+        if (response.StatusCode == TooManyRequests && !HasCategoryRateLimits(response))
         {
             var retryAfterTimestamp = GetRetryAfterTimestamp(response);
             _ = Interlocked.Exchange(ref _retryAfterUtcTicks, retryAfterTimestamp.UtcTicks);
@@ -70,6 +71,18 @@ internal class RetryAfterHandler : DelegatingHandler
 
         return response;
     }
+
+    /// <summary>
+    /// Whether the response carries per-category rate limits, which are applied by the transport
+    /// (see <see cref="Sentry.Http.HttpTransportBase"/>) on a per-envelope-item basis.
+    /// </summary>
+    /// <remarks>
+    /// When present, this header takes precedence over the blanket back off implemented here: a limit on one
+    /// category (say, transactions) must not stop us sending another (say, errors).
+    /// See https://develop.sentry.dev/sdk/expected-features/rate-limiting/#parsing-the-response
+    /// </remarks>
+    private static bool HasCategoryRateLimits(HttpResponseMessage response) =>
+        response.Headers.Contains("X-Sentry-Rate-Limits");
 
     private DateTimeOffset GetRetryAfterTimestamp(HttpResponseMessage response)
     {

--- a/src/Sentry/Internal/Http/RetryAfterHandler.cs
+++ b/src/Sentry/Internal/Http/RetryAfterHandler.cs
@@ -63,8 +63,7 @@ internal class RetryAfterHandler : DelegatingHandler
 
         var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-        // A 429 carrying per-category limits is applied by the transport, per envelope item, so backing off
-        // globally here would stop us sending categories that aren't limited at all.
+        // 429 responses carrying a `X-Sentry-Rate-Limits` header are handled separately.
         // See https://github.com/getsentry/sentry-dotnet/pull/5482
         if (response.StatusCode == TooManyRequests && !response.Headers.Contains("X-Sentry-Rate-Limits"))
         {

--- a/src/Sentry/Internal/Http/RetryAfterHandler.cs
+++ b/src/Sentry/Internal/Http/RetryAfterHandler.cs
@@ -63,7 +63,10 @@ internal class RetryAfterHandler : DelegatingHandler
 
         var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-        if (response.StatusCode == TooManyRequests && !HasCategoryRateLimits(response))
+        // A 429 carrying per-category limits is applied by the transport, per envelope item, so backing off
+        // globally here would stop us sending categories that aren't limited at all.
+        // See https://github.com/getsentry/sentry-dotnet/pull/5482
+        if (response.StatusCode == TooManyRequests && !response.Headers.Contains("X-Sentry-Rate-Limits"))
         {
             var retryAfterTimestamp = GetRetryAfterTimestamp(response);
             _ = Interlocked.Exchange(ref _retryAfterUtcTicks, retryAfterTimestamp.UtcTicks);
@@ -71,18 +74,6 @@ internal class RetryAfterHandler : DelegatingHandler
 
         return response;
     }
-
-    /// <summary>
-    /// Whether the response carries per-category rate limits, which are applied by the transport
-    /// (see <see cref="Sentry.Http.HttpTransportBase"/>) on a per-envelope-item basis.
-    /// </summary>
-    /// <remarks>
-    /// When present, this header takes precedence over the blanket back off implemented here: a limit on one
-    /// category (say, transactions) must not stop us sending another (say, errors).
-    /// See https://develop.sentry.dev/sdk/expected-features/rate-limiting/#parsing-the-response
-    /// </remarks>
-    private static bool HasCategoryRateLimits(HttpResponseMessage response) =>
-        response.Headers.Contains("X-Sentry-Rate-Limits");
 
     private DateTimeOffset GetRetryAfterTimestamp(HttpResponseMessage response)
     {

--- a/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
@@ -1072,4 +1072,47 @@ public partial class HttpTransportTests
             e.Level == SentryLevel.Error &&
             e.Message.Contains("Sentry rejected the envelope"));
     }
+
+    [Fact]
+    public async Task SendEnvelopeAsync_TransactionRateLimited_ErrorEnvelopeStillSent()
+    {
+        // Arrange
+        // Note this goes through DefaultSentryHttpClientFactory, so that the RetryAfterHandler is part of the
+        // pipeline, as it is in production. See https://github.com/getsentry/sentry-dotnet/issues/3947
+        var requestCount = 0;
+        using var httpHandler = new FakeHttpMessageHandler(() =>
+        {
+            requestCount++;
+            return requestCount == 1
+                ? SentryResponses.GetRateLimitResponse(
+                    "60:transaction;profile;span:organization:transaction_usage_exceeded, " +
+                    "60:transaction:project:project_quota_transaction_usage_exceeded")
+                : SentryResponses.GetOkResponse();
+        });
+
+        var options = new SentryOptions
+        {
+            Dsn = ValidDsn,
+            DiagnosticLogger = _testOutputLogger,
+            Debug = true,
+            CreateHttpMessageHandler = () => httpHandler
+        };
+
+        var httpTransport = new HttpTransport(
+            options,
+            new DefaultSentryHttpClientFactory().Create(options),
+            null,
+            clock: _fakeClock);
+
+        // Act
+        // Transactions are over quota...
+        var transaction = new SentryTransaction("test", "test.op") { IsSampled = true };
+        await httpTransport.SendEnvelopeAsync(Envelope.FromTransaction(transaction));
+
+        // ...but errors are not, so this one should still go out
+        await httpTransport.SendEnvelopeAsync(Envelope.FromEvent(new SentryEvent()));
+
+        // Assert
+        requestCount.Should().Be(2);
+    }
 }

--- a/test/Sentry.Tests/Internals/Http/RetryAfterHandlerTests.cs
+++ b/test/Sentry.Tests/Internals/Http/RetryAfterHandlerTests.cs
@@ -52,6 +52,48 @@ public class RetryAfterHandlerTests
     }
 
     [Fact]
+    public async Task SendAsync_TooManyRequestsWithCategoryRateLimits_RetryAfterNotSet()
+    {
+        // Per-category limits are applied by the transport, per envelope item. Backing off globally here would
+        // stop us sending categories that aren't rate limited at all. See https://github.com/getsentry/sentry-dotnet/issues/3947
+        var expected = new HttpResponseMessage(TooManyRequests);
+        expected.Headers.Add("X-Sentry-Rate-Limits", "60:transaction;profile;span:organization:transaction_usage_exceeded");
+        expected.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(60));
+        _fixture.StubHandler.SendAsyncFunc = (_, _) => expected;
+
+        var invoker = _fixture.GetInvoker();
+        var actual = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/"), None);
+
+        Assert.Equal(expected, actual);
+        Assert.Equal(0, _fixture.Sut.RetryAfterUtcTicks);
+        Assert.True(_fixture.StubHandler.SendAsyncCalled);
+    }
+
+    [Fact]
+    public async Task SendAsync_TooManyRequestsWithCategoryRateLimits_SecondRequestIsNotThrottled()
+    {
+        var rateLimited = new HttpResponseMessage(TooManyRequests);
+        rateLimited.Headers.Add("X-Sentry-Rate-Limits", "60:transaction;profile;span:organization:transaction_usage_exceeded");
+        _fixture.StubHandler.SendAsyncFunc = (_, _) => rateLimited;
+
+        var invoker = _fixture.GetInvoker();
+
+        // First call: rate limited for transactions only
+        _ = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/"), None);
+        Assert.True(_fixture.StubHandler.SendAsyncCalled);
+
+        // Change the response: OK
+        var expected = new HttpResponseMessage(HttpStatusCode.OK);
+        _fixture.StubHandler.SendAsyncFunc = (_, _) => expected;
+        _fixture.StubHandler.SendAsyncCalled = false;
+
+        var actual = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/"), None);
+
+        Assert.Equal(expected, actual);
+        Assert.True(_fixture.StubHandler.SendAsyncCalled);
+    }
+
+    [Fact]
     public async Task SendAsync_TooManyRequestsWithRetryAfterHeaderDate_RetryAfterSet()
     {
         var expected = new HttpResponseMessage(TooManyRequests);


### PR DESCRIPTION
Fixes #3947

## Summary

An org over its **transaction** quota also stopped sending **errors**, for the duration of every rate-limit window.

Two independent rate-limit mechanisms exist in the SDK:

1. **Per-category** — `HttpTransportBase.ExtractRateLimits` parses `X-Sentry-Rate-Limits` into `CategoryLimitResets` and drops only the matching envelope *items*. This is correct.
2. **Global** — `RetryAfterHandler` sits at the top of the handler pipeline and short-circuits *every* subsequent request on *any* 429, without looking at `X-Sentry-Rate-Limits` at all.

(2) runs above (1), so the correct per-category logic was bypassed entirely: a `60:transaction;profile;span:...` limit gated errors, sessions, check-ins and everything else for 60s.

`RetryAfterHandler` now applies its blanket back off only to a 429 that carries no `X-Sentry-Rate-Limits` header — i.e. the proxy / older-Sentry global-limit case it was written for. This matches [the spec](https://develop.sentry.dev/sdk/expected-features/rate-limiting/#parsing-the-response) (`X-Sentry-Rate-Limits` first; `Retry-After` on 429 only "without the above headers") and sentry-python, whose `Retry-After` branch is a literal `elif` on the header being absent.

## Notes for review

- **This was data loss, not deferred delivery.** The short-circuit returns a synthetic 429 *response* rather than throwing, so `HandleFailure` just logs and returns, and `CachingTransport` then deletes the cache file. Blocked envelopes were gone for good. The empty `Server response:` in the reporter's log is the tell-tale of that synthetic response.
- **Why no test caught this:** every existing `HttpTransportTests` case builds `new HttpClient(handler)` directly, which leaves `RetryAfterHandler` out of the pipeline. The new transport-level test goes through `DefaultSentryHttpClientFactory` so the handler is present, as in production. It fails on `main` with `Expected requestCount to be 2 ... but found 1`.
- **A fully-limited envelope still costs no request.** A global limit expressed as `X-Sentry-Rate-Limits` with empty categories is handled by `RateLimitCategory.IsMatchAll`, and `HttpTransport.SendEnvelopeAsync` skips the HTTP call when `ProcessEnvelope` leaves zero items — so delegating to the transport doesn't trade the bug for extra traffic.
- The existing `RetryAfterHandlerTests` all use bare 429s, so they're unaffected and still assert the fallback behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)