### PR TITLE
feat: `SentryOptions.EnableMetrics` is obsolete and ignored

### DIFF
--- a/src/Sentry/BindableSentryOptions.cs
+++ b/src/Sentry/BindableSentryOptions.cs
@@ -79,7 +79,9 @@ internal partial class BindableSentryOptions
         options.Environment = Environment ?? options.Environment;
         options.Dsn = Dsn ?? options.Dsn;
         options.EnableLogs = EnableLogs ?? options.EnableLogs;
+#pragma warning disable CS0618 // Bound so existing configuration keys still resolve; the value is ignored.
         options.EnableMetrics = EnableMetrics ?? options.EnableMetrics;
+#pragma warning restore CS0618
         options.MaxQueueItems = MaxQueueItems ?? options.MaxQueueItems;
         options.MaxCacheItems = MaxCacheItems ?? options.MaxCacheItems;
         options.ShutdownTimeout = ShutdownTimeout ?? options.ShutdownTimeout;

--- a/src/Sentry/IHub.cs
+++ b/src/Sentry/IHub.cs
@@ -35,7 +35,6 @@ public interface IHub : ISentryClient, ISentryScopeManager
     /// <remarks>
     /// Available options:
     /// <list type="bullet">
-    /// <item><see cref="Sentry.SentryOptions.EnableMetrics"/></item>
     /// <item><see cref="Sentry.SentryOptions.SetBeforeSendMetric(System.Func{SentryMetric, SentryMetric})"/></item>
     /// </list>
     /// </remarks>

--- a/src/Sentry/Internal/DefaultSentryMetricEmitter.cs
+++ b/src/Sentry/Internal/DefaultSentryMetricEmitter.cs
@@ -14,7 +14,6 @@ internal sealed class DefaultSentryMetricEmitter : SentryMetricEmitter, IDisposa
     internal DefaultSentryMetricEmitter(IHub hub, SentryOptions options, ISystemClock clock, int batchCount, TimeSpan batchInterval)
     {
         Debug.Assert(hub.IsEnabled);
-        Debug.Assert(options is { EnableMetrics: true });
 
         _hub = hub;
         _options = options;

--- a/src/Sentry/SentryMetricEmitter.cs
+++ b/src/Sentry/SentryMetricEmitter.cs
@@ -13,9 +13,7 @@ public abstract partial class SentryMetricEmitter
 
     internal static SentryMetricEmitter Create(IHub hub, SentryOptions options, ISystemClock clock, int batchCount, TimeSpan batchInterval)
     {
-        return options.EnableMetrics
-            ? new DefaultSentryMetricEmitter(hub, options, clock, batchCount, batchInterval)
-            : DisabledSentryMetricEmitter.Instance;
+        return new DefaultSentryMetricEmitter(hub, options, clock, batchCount, batchInterval);
     }
 
     private protected SentryMetricEmitter()

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -632,12 +632,24 @@ public class SentryOptions
         _beforeSendLog = beforeSendLog;
     }
 
+    internal const string ObsoleteEnableMetrics =
+        "Metrics are always enabled. This option is ignored and will be removed in version 7.0.0. " +
+        "To drop metrics, use SetBeforeSendMetric and return null.";
+
     /// <summary>
-    /// When set to <see langword="false"/>, the SDK does not generate and send metrics to Sentry via <see cref="SentrySdk.Metrics"/>.
-    /// Defaults to <see langword="true"/>.
+    /// Metrics are always sent to Sentry via <see cref="SentrySdk.Metrics"/>.
     /// </summary>
+    /// <remarks>
+    /// This option no longer has any effect. The getter always returns <see langword="true"/> and the setter is ignored.
+    /// To filter or drop metrics, use <see cref="SetBeforeSendMetric(Func{SentryMetric, SentryMetric})"/> and return <see langword="null"/>.
+    /// </remarks>
     /// <seealso href="https://develop.sentry.dev/sdk/telemetry/metrics/"/>
-    public bool EnableMetrics { get; set; } = true;
+    [Obsolete(ObsoleteEnableMetrics)]
+    public bool EnableMetrics
+    {
+        get => true;
+        set { }
+    }
 
     private Func<SentryMetric, SentryMetric?>? _beforeSendMetric;
 

--- a/test/Sentry.Compiler.Extensions.Tests/Analyzers/TraceConnectedMetricsAnalyzerTests.cs
+++ b/test/Sentry.Compiler.Extensions.Tests/Analyzers/TraceConnectedMetricsAnalyzerTests.cs
@@ -34,11 +34,6 @@ public class TraceConnectedMetricsAnalyzerTests
 
                     public class AnalyzerTest
                     {
-                        public void Init(SentryOptions options)
-                        {
-                            options.EnableMetrics = false;
-                        }
-
                         public void Emit(IHub hub)
                         {
                             var metrics = SentrySdk.Metrics;

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -838,6 +838,8 @@ namespace Sentry
         public string? Dsn { get; set; }
         public bool EnableBackpressureHandling { get; set; }
         public bool EnableLogs { get; set; }
+        [System.Obsolete("Metrics are always enabled. This option is ignored and will be removed in version" +
+            " 7.0.0. To drop metrics, use SetBeforeSendMetric and return null.")]
         public bool EnableMetrics { get; set; }
         public bool EnableScopeSync { get; set; }
         public bool EnableSpotlight { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -838,6 +838,8 @@ namespace Sentry
         public string? Dsn { get; set; }
         public bool EnableBackpressureHandling { get; set; }
         public bool EnableLogs { get; set; }
+        [System.Obsolete("Metrics are always enabled. This option is ignored and will be removed in version" +
+            " 7.0.0. To drop metrics, use SetBeforeSendMetric and return null.")]
         public bool EnableMetrics { get; set; }
         public bool EnableScopeSync { get; set; }
         public bool EnableSpotlight { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -838,6 +838,8 @@ namespace Sentry
         public string? Dsn { get; set; }
         public bool EnableBackpressureHandling { get; set; }
         public bool EnableLogs { get; set; }
+        [System.Obsolete("Metrics are always enabled. This option is ignored and will be removed in version" +
+            " 7.0.0. To drop metrics, use SetBeforeSendMetric and return null.")]
         public bool EnableMetrics { get; set; }
         public bool EnableScopeSync { get; set; }
         public bool EnableSpotlight { get; set; }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -825,6 +825,8 @@ namespace Sentry
         public string? Dsn { get; set; }
         public bool EnableBackpressureHandling { get; set; }
         public bool EnableLogs { get; set; }
+        [System.Obsolete("Metrics are always enabled. This option is ignored and will be removed in version" +
+            " 7.0.0. To drop metrics, use SetBeforeSendMetric and return null.")]
         public bool EnableMetrics { get; set; }
         public bool EnableScopeSync { get; set; }
         public bool EnableSpotlight { get; set; }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -2112,30 +2112,9 @@ public partial class HubTests : IDisposable
     }
 
     [Fact]
-    public void Metrics_IsDisabled_DoesNotCaptureMetric()
+    public void Metrics_DoesCaptureMetric()
     {
         // Arrange
-        _fixture.Options.EnableMetrics = false;
-        var hub = _fixture.GetSut();
-
-        // Act
-        hub.Metrics.EmitCounter("sentry_tests.hub_tests.counter", 1);
-        hub.Metrics.Flush();
-
-        // Assert
-        _fixture.Client.Received(0).CaptureEnvelope(
-            Arg.Is<Envelope>(envelope =>
-                envelope.Items.Single(item => item.Header["type"].Equals("trace_metric")).Payload.GetType().IsAssignableFrom(typeof(JsonSerializable))
-            )
-        );
-        hub.Metrics.Should().BeOfType<DisabledSentryMetricEmitter>();
-    }
-
-    [Fact]
-    public void Metrics_IsEnabled_DoesCaptureMetric()
-    {
-        // Arrange
-        Assert.True(_fixture.Options.EnableMetrics);
         var hub = _fixture.GetSut();
 
         // Act
@@ -2152,38 +2131,9 @@ public partial class HubTests : IDisposable
     }
 
     [Fact]
-    public void Metrics_EnableAfterCreate_HasNoEffect()
-    {
-        // Arrange
-        _fixture.Options.EnableMetrics = false;
-        var hub = _fixture.GetSut();
-
-        // Act
-        _fixture.Options.EnableMetrics = true;
-
-        // Assert
-        hub.Metrics.Should().BeOfType<DisabledSentryMetricEmitter>();
-    }
-
-    [Fact]
-    public void Metrics_DisableAfterCreate_HasNoEffect()
-    {
-        // Arrange
-        Assert.True(_fixture.Options.EnableMetrics);
-        var hub = _fixture.GetSut();
-
-        // Act
-        _fixture.Options.EnableMetrics = false;
-
-        // Assert
-        hub.Metrics.Should().BeOfType<DefaultSentryMetricEmitter>();
-    }
-
-    [Fact]
     public async Task Metrics_FlushAsync_DoesCaptureMetric()
     {
         // Arrange
-        Assert.True(_fixture.Options.EnableMetrics);
         var hub = _fixture.GetSut();
 
         // Act
@@ -2208,7 +2158,6 @@ public partial class HubTests : IDisposable
     public void Metrics_Dispose_DoesCaptureMetric()
     {
         // Arrange
-        Assert.True(_fixture.Options.EnableMetrics);
         var hub = _fixture.GetSut();
 
         // Act

--- a/test/Sentry.Tests/SentryMetricEmitterTests.Options.cs
+++ b/test/Sentry.Tests/SentryMetricEmitterTests.Options.cs
@@ -5,11 +5,17 @@ namespace Sentry.Tests;
 public partial class SentryMetricEmitterTests
 {
     [Fact]
-    public void EnableMetrics_Default_True()
+    public void EnableMetrics_IsObsoleteAndAlwaysEnabled()
     {
         var options = new SentryOptions();
 
+#pragma warning disable CS0618 // Type or member is obsolete
         options.EnableMetrics.Should().BeTrue();
+
+        options.EnableMetrics = false;
+
+        options.EnableMetrics.Should().BeTrue();
+#pragma warning restore CS0618
     }
 
     [Fact]

--- a/test/Sentry.Tests/SentryMetricEmitterTests.Types.cs
+++ b/test/Sentry.Tests/SentryMetricEmitterTests.Types.cs
@@ -8,9 +8,8 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Counter)]
     [InlineData(SentryMetricType.Gauge)]
     [InlineData(SentryMetricType.Distribution)]
-    public void Emit_Enabled_CapturesEnvelope(SentryMetricType type)
+    public void Emit_CapturesEnvelope(SentryMetricType type)
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -27,24 +26,8 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Counter)]
     [InlineData(SentryMetricType.Gauge)]
     [InlineData(SentryMetricType.Distribution)]
-    public void Emit_Disabled_DoesNotCaptureEnvelope(SentryMetricType type)
+    public void Emit_Attributes_CapturesEnvelope(SentryMetricType type)
     {
-        _fixture.Options.EnableMetrics = false;
-        var metrics = _fixture.GetSut();
-
-        metrics.Emit<int>(type, 1, []);
-        metrics.Flush();
-
-        _fixture.Hub.Received(0).CaptureEnvelope(Arg.Any<Envelope>());
-    }
-
-    [Theory]
-    [InlineData(SentryMetricType.Counter)]
-    [InlineData(SentryMetricType.Gauge)]
-    [InlineData(SentryMetricType.Distribution)]
-    public void Emit_Attributes_Enabled_CapturesEnvelope(SentryMetricType type)
-    {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -61,24 +44,8 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Counter)]
     [InlineData(SentryMetricType.Gauge)]
     [InlineData(SentryMetricType.Distribution)]
-    public void Emit_Attributes_Disabled_DoesNotCaptureEnvelope(SentryMetricType type)
-    {
-        _fixture.Options.EnableMetrics = false;
-        var metrics = _fixture.GetSut();
-
-        metrics.Emit<int>(type, 1, [new KeyValuePair<string, object>("attribute-key", "attribute-value")]);
-        metrics.Flush();
-
-        _fixture.Hub.Received(0).CaptureEnvelope(Arg.Any<Envelope>());
-    }
-
-    [Theory]
-    [InlineData(SentryMetricType.Counter)]
-    [InlineData(SentryMetricType.Gauge)]
-    [InlineData(SentryMetricType.Distribution)]
     public void Emit_Byte_CapturesEnvelope(SentryMetricType type)
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -97,7 +64,6 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Distribution)]
     public void Emit_Int16_CapturesEnvelope(SentryMetricType type)
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -116,7 +82,6 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Distribution)]
     public void Emit_Int32_CapturesEnvelope(SentryMetricType type)
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -135,7 +100,6 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Distribution)]
     public void Emit_Int64_CapturesEnvelope(SentryMetricType type)
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -154,7 +118,6 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Distribution)]
     public void Emit_Single_CapturesEnvelope(SentryMetricType type)
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -173,7 +136,6 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Distribution)]
     public void Emit_Double_CapturesEnvelope(SentryMetricType type)
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -192,7 +154,6 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Distribution)]
     public void Emit_Decimal_DoesNotCaptureEnvelope(SentryMetricType type)
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         metrics.Emit<decimal>(type, 1m, []);
@@ -213,7 +174,6 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Distribution)]
     public void Emit_Half_DoesNotCaptureEnvelope(SentryMetricType type)
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         metrics.Emit<Half>(type, Half.One, []);
@@ -234,7 +194,6 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Distribution)]
     public void Emit_Enum_DoesNotCaptureEnvelope(SentryMetricType type)
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         metrics.Emit<StringComparison>(type, (StringComparison)1, []);
@@ -254,7 +213,6 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Distribution, nameof(SentryMetricType.Distribution), typeof(int))]
     public void Emit_Name_Null_DoesNotCaptureEnvelope(SentryMetricType type, string arg0, Type arg1)
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         metrics.Emit<int>(type, null!, 1);
@@ -274,7 +232,6 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Distribution, nameof(SentryMetricType.Distribution), typeof(int))]
     public void Emit_Name_Empty_DoesNotCaptureEnvelope(SentryMetricType type, string arg0, Type arg1)
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         metrics.Emit<int>(type, "", 1);
@@ -320,7 +277,6 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Distribution)]
     public void Emit_Unit_String_CapturesEnvelope(SentryMetricType type)
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -338,7 +294,6 @@ public partial class SentryMetricEmitterTests
     [InlineData(SentryMetricType.Distribution)]
     public void Emit_Unit_MeasurementUnit_CapturesEnvelope(SentryMetricType type)
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         Envelope envelope = null!;

--- a/test/Sentry.Tests/SentryMetricEmitterTests.cs
+++ b/test/Sentry.Tests/SentryMetricEmitterTests.cs
@@ -74,10 +74,8 @@ public partial class SentryMetricEmitterTests : IDisposable
     }
 
     [Fact]
-    public void Create_Enabled_NewDefaultInstance()
+    public void Create_NewDefaultInstance()
     {
-        Assert.True(_fixture.Options.EnableMetrics);
-
         var instance = _fixture.GetSut();
         var other = _fixture.GetSut();
 
@@ -86,22 +84,9 @@ public partial class SentryMetricEmitterTests : IDisposable
     }
 
     [Fact]
-    public void Create_Disabled_CachedDisabledInstance()
-    {
-        _fixture.Options.EnableMetrics = false;
-
-        var instance = _fixture.GetSut();
-        var other = _fixture.GetSut();
-
-        instance.Should().BeOfType<DisabledSentryMetricEmitter>();
-        instance.Should().BeSameAs(other);
-    }
-
-    [Fact]
     public void Emit_WithoutActiveSpan_CapturesEnvelope()
     {
         _fixture.WithoutActiveSpan();
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -120,7 +105,6 @@ public partial class SentryMetricEmitterTests : IDisposable
         var invocations = 0;
         SentryMetric configuredMetric = null!;
 
-        Assert.True(_fixture.Options.EnableMetrics);
         _fixture.Options.SetBeforeSendMetric((SentryMetric metric) =>
         {
             invocations++;
@@ -142,7 +126,6 @@ public partial class SentryMetricEmitterTests : IDisposable
     {
         var invocations = 0;
 
-        Assert.True(_fixture.Options.EnableMetrics);
         _fixture.Options.SetBeforeSendMetric((SentryMetric metric) =>
         {
             invocations++;
@@ -159,7 +142,6 @@ public partial class SentryMetricEmitterTests : IDisposable
     [Fact]
     public void Emit_InvalidBeforeSendMetric_DoesNotCaptureEnvelope()
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         _fixture.Options.SetBeforeSendMetric(static (SentryMetric metric) => throw new InvalidOperationException());
         var metrics = _fixture.GetSut();
 
@@ -176,7 +158,6 @@ public partial class SentryMetricEmitterTests : IDisposable
     [Fact]
     public void Flush_AfterEmit_CapturesEnvelope()
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -198,7 +179,6 @@ public partial class SentryMetricEmitterTests : IDisposable
     [Fact]
     public void Dispose_BeforeEmit_DoesNotCaptureEnvelope()
     {
-        Assert.True(_fixture.Options.EnableMetrics);
         var metrics = _fixture.GetSut();
 
         var defaultMetrics = metrics.Should().BeOfType<DefaultSentryMetricEmitter>().Which;


### PR DESCRIPTION
## Guidance

| Guidance | .NET metrics today | Action |
| --- | --- | --- |
| Don't remove `enableMetrics` in a minor; remove in the next major | — | Kept, marked `[Obsolete]`, removal scheduled for 7.0.0 |
| Don't gate the **manual** APIs behind the option | ❌ `SentrySdk.Metrics` **is** gated | **Fixed here** |
| No real double opt-in | Already `true` by default, not a separate integration | Nothing to do |
| Don't change the default if it forces other opt-in config | Default was already `true` | Nothing to do |
| Auto-added integrations must not send metrics | No such integrations | N/A |

So the only mandated change is ungating the manual API — and in .NET that happens to be the whole option. `EnableMetrics` had exactly one functional consumer, `SentryMetricEmitter.Create`, which backs `SentrySdk.Metrics`. Nothing else reads it: there is no automatic metric collection to keep gating. Ungating the manual API and ignoring the option are therefore the same edit.

## Not a removal

The option stays on `SentryOptions`, still binds from configuration (an existing `"EnableMetrics"` key resolves and is ignored rather than throwing), and keeps its place in `BindableSentryOptions`. The getter returns `true`, the setter is a no-op, and the obsolete message names 7.0.0 as the removal version. To drop metrics, use `SetBeforeSendMetric` and return `null`.

## Notes for review

**`TraceConnectedMetricsAnalyzerTests`** had an `Init` method in its analyzer source snippet whose only purpose was setting `EnableMetrics = false`. With the option obsolete that snippet emits CS0618, which the Roslyn test harness reports as an unexpected diagnostic, so the method was dropped — it contributed nothing to what the analyzer test covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)