### PR TITLE
fix: make attachment payloads replayable

### DIFF
--- a/src/Sentry/FileAttachmentContent.cs
+++ b/src/Sentry/FileAttachmentContent.cs
@@ -9,7 +9,10 @@ public class FileAttachmentContent : IAttachmentContent
 {
     private readonly bool _readFileAsynchronously;
 
-    private readonly bool _deleteOnClose;
+    /// <summary>
+    /// Whether to delete the file when the stream is closed.
+    /// </summary>
+    internal bool DeleteOnClose { get; }
 
     /// <summary>
     /// The path to the file to attach.
@@ -38,12 +41,12 @@ public class FileAttachmentContent : IAttachmentContent
     /// </summary>
     /// <param name="filePath">The path to the file to attach.</param>
     /// <param name="readFileAsynchronously">Whether to use async file I/O to read the file.</param>
-    /// <param name="deleteOnClose">Whether to delete the file when it closed.</param>
+    /// <param name="deleteOnClose">Whether to delete the file when the stream is closed.</param>
     public FileAttachmentContent(string filePath, bool readFileAsynchronously, bool deleteOnClose)
     {
         FilePath = filePath;
+        DeleteOnClose = deleteOnClose;
         _readFileAsynchronously = readFileAsynchronously;
-        _deleteOnClose = deleteOnClose;
     }
 
     /// <inheritdoc />
@@ -56,7 +59,7 @@ public class FileAttachmentContent : IAttachmentContent
             options |= FileOptions.Asynchronous;
         }
 
-        if (_deleteOnClose)
+        if (DeleteOnClose)
         {
             options |= FileOptions.DeleteOnClose;
         }

--- a/src/Sentry/Http/SpotlightHttpTransport.cs
+++ b/src/Sentry/Http/SpotlightHttpTransport.cs
@@ -45,9 +45,7 @@ internal class SpotlightHttpTransport : HttpTransport
             try
             {
                 // Send to spotlight
-                // Deliberately not disposed here: these are the caller's EnvelopeItem instances,
-                // shared with the still in-flight sentryTask above. Disposing them would close
-                // the attachment streams out from under that request. The caller owns them.
+                // Caller to dispose
                 var processedEnvelope = ProcessEnvelope(envelope);
                 if (processedEnvelope.Items.Count > 0)
                 {

--- a/src/Sentry/Http/SpotlightHttpTransport.cs
+++ b/src/Sentry/Http/SpotlightHttpTransport.cs
@@ -45,7 +45,10 @@ internal class SpotlightHttpTransport : HttpTransport
             try
             {
                 // Send to spotlight
-                using var processedEnvelope = ProcessEnvelope(envelope);
+                // Deliberately not disposed here: these are the caller's EnvelopeItem instances,
+                // shared with the still in-flight sentryTask above. Disposing them would close
+                // the attachment streams out from under that request. The caller owns them.
+                var processedEnvelope = ProcessEnvelope(envelope);
                 if (processedEnvelope.Items.Count > 0)
                 {
                     using var request = CreateRequest(processedEnvelope);

--- a/src/Sentry/Internal/Http/HttpTransport.cs
+++ b/src/Sentry/Internal/Http/HttpTransport.cs
@@ -35,9 +35,7 @@ internal class HttpTransport : HttpTransportBase, ITransport
     /// </remarks>
     public virtual async Task SendEnvelopeAsync(Envelope envelope, CancellationToken cancellationToken = default)
     {
-        // Deliberately not disposed here: ProcessEnvelope returns a new Envelope wrapping the
-        // caller's EnvelopeItem instances, so this transport is a borrower, not the owner.
-        // The caller (e.g. BackgroundWorker) disposes them once the send has completed.
+        // Caller to dispose
         var processedEnvelope = ProcessEnvelope(envelope);
         if (processedEnvelope.Items.Count > 0)
         {

--- a/src/Sentry/Internal/Http/HttpTransport.cs
+++ b/src/Sentry/Internal/Http/HttpTransport.cs
@@ -35,7 +35,10 @@ internal class HttpTransport : HttpTransportBase, ITransport
     /// </remarks>
     public virtual async Task SendEnvelopeAsync(Envelope envelope, CancellationToken cancellationToken = default)
     {
-        using var processedEnvelope = ProcessEnvelope(envelope);
+        // Deliberately not disposed here: ProcessEnvelope returns a new Envelope wrapping the
+        // caller's EnvelopeItem instances, so this transport is a borrower, not the owner.
+        // The caller (e.g. BackgroundWorker) disposes them once the send has completed.
+        var processedEnvelope = ProcessEnvelope(envelope);
         if (processedEnvelope.Items.Count > 0)
         {
             using var request = CreateRequest(processedEnvelope);

--- a/src/Sentry/Protocol/Envelopes/AttachmentSerializable.cs
+++ b/src/Sentry/Protocol/Envelopes/AttachmentSerializable.cs
@@ -1,0 +1,31 @@
+using Sentry.Extensibility;
+
+namespace Sentry.Protocol.Envelopes;
+
+/// <summary>
+/// Represents attachment content that obtains a stream for each serialization.
+/// </summary>
+internal sealed class AttachmentSerializable : ISerializable
+{
+    private readonly IAttachmentContent _content;
+
+    /// <summary>
+    /// Initializes an instance of <see cref="AttachmentSerializable"/>.
+    /// </summary>
+    /// <param name="content">The attachment content to serialize.</param>
+    public AttachmentSerializable(IAttachmentContent content) => _content = content;
+
+    /// <inheritdoc />
+    public async Task SerializeAsync(Stream stream, IDiagnosticLogger? logger, CancellationToken cancellationToken = default)
+    {
+        using var contentStream = _content.GetStream();
+        await contentStream.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public void Serialize(Stream stream, IDiagnosticLogger? logger)
+    {
+        using var contentStream = _content.GetStream();
+        contentStream.CopyTo(stream);
+    }
+}

--- a/src/Sentry/Protocol/Envelopes/BufferedStreamSerializable.cs
+++ b/src/Sentry/Protocol/Envelopes/BufferedStreamSerializable.cs
@@ -1,0 +1,60 @@
+using Sentry.Extensibility;
+
+namespace Sentry.Protocol.Envelopes;
+
+/// <summary>
+/// Represents stream content that is buffered lazily for repeated serialization.
+/// </summary>
+internal sealed class BufferedStreamSerializable : ISerializable, IDisposable
+{
+    // Retain ownership of the source so it is disposed with the envelope item.
+    private readonly Stream _source;
+    private readonly Lazy<Task<byte[]>> _bufferTask;
+
+    /// <summary>
+    /// Initializes an instance of <see cref="BufferedStreamSerializable"/>.
+    /// </summary>
+    /// <param name="source">The source stream to buffer.</param>
+    public BufferedStreamSerializable(Stream source)
+    {
+        _source = source;
+        _bufferTask = new Lazy<Task<byte[]>>(BufferAsync);
+    }
+
+    /// <inheritdoc />
+    public async Task SerializeAsync(
+        Stream stream,
+        IDiagnosticLogger? logger,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var buffer = await _bufferTask.Value.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await stream.WriteAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public void Serialize(Stream stream, IDiagnosticLogger? logger)
+    {
+        var buffer = _bufferTask.Value.GetAwaiter().GetResult();
+        stream.Write(buffer, 0, buffer.Length);
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _source.Dispose();
+
+    private async Task<byte[]> BufferAsync()
+    {
+        try
+        {
+            using var buffer = new MemoryStream();
+            await _source.CopyToAsync(buffer).ConfigureAwait(false);
+            return buffer.ToArray();
+        }
+        catch
+        {
+            _source.Dispose();
+            throw;
+        }
+    }
+}

--- a/src/Sentry/Protocol/Envelopes/Envelope.cs
+++ b/src/Sentry/Protocol/Envelopes/Envelope.cs
@@ -285,13 +285,15 @@ public sealed class Envelope : ISerializable, IDisposable
             if (attachment.Content is FileAttachmentContent { DeleteOnClose: false } fileAttachment &&
                 fileAttachment.GetType() == typeof(FileAttachmentContent))
             {
-                using var lengthStream = fileAttachment.GetStream();
-                if (lengthStream.TryGetLength() != 0)
+                var item = EnvelopeItem.FromAttachment(attachment);
+                if (item.TryGetLength() != 0)
                 {
-                    items.Add(EnvelopeItem.FromAttachment(attachment));
+                    items.Add(item);
                 }
                 else
                 {
+                    item.Dispose();
+
                     logger?.LogWarning("Did not add '{0}' to envelope because the file was empty.",
                         attachment.FileName);
                 }

--- a/src/Sentry/Protocol/Envelopes/Envelope.cs
+++ b/src/Sentry/Protocol/Envelopes/Envelope.cs
@@ -265,6 +265,40 @@ public sealed class Envelope : ISerializable, IDisposable
     {
         try
         {
+            // Derived content types may provide a different stream implementation.
+            if (attachment.Content is ByteAttachmentContent byteAttachment &&
+                byteAttachment.GetType() == typeof(ByteAttachmentContent))
+            {
+                if (byteAttachment.Bytes.Length != 0)
+                {
+                    items.Add(EnvelopeItem.FromAttachment(attachment));
+                }
+                else
+                {
+                    logger?.LogWarning("Did not add '{0}' to envelope because the byte array was empty.",
+                        attachment.FileName);
+                }
+
+                return;
+            }
+
+            if (attachment.Content is FileAttachmentContent { DeleteOnClose: false } fileAttachment &&
+                fileAttachment.GetType() == typeof(FileAttachmentContent))
+            {
+                using var lengthStream = fileAttachment.GetStream();
+                if (lengthStream.TryGetLength() != 0)
+                {
+                    items.Add(EnvelopeItem.FromAttachment(attachment));
+                }
+                else
+                {
+                    logger?.LogWarning("Did not add '{0}' to envelope because the file was empty.",
+                        attachment.FileName);
+                }
+
+                return;
+            }
+
             // We pull the stream out here so we can length check
             // to avoid adding an invalid attachment
             var stream = attachment.Content.GetStream();

--- a/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
+++ b/src/Sentry/Protocol/Envelopes/EnvelopeItem.cs
@@ -329,11 +329,43 @@ public sealed class EnvelopeItem : ISerializable, IDisposable
     /// </summary>
     public static EnvelopeItem FromAttachment(SentryAttachment attachment)
     {
+        if (attachment.Content is ByteAttachmentContent byteContent &&
+            byteContent.GetType() == typeof(ByteAttachmentContent))
+        {
+            var payload = new AttachmentSerializable(byteContent);
+            var payloadLength = byteContent.Bytes.Length;
+
+            return CreateAttachmentItem(attachment, payload, payloadLength);
+        }
+
+        if (attachment.Content is FileAttachmentContent { DeleteOnClose: false } fileContent &&
+            fileContent.GetType() == typeof(FileAttachmentContent))
+        {
+            using var lengthStream = fileContent.GetStream();
+
+            var payload = new AttachmentSerializable(fileContent);
+            var payloadLength = lengthStream.TryGetLength();
+
+            return CreateAttachmentItem(attachment, payload, payloadLength);
+        }
+
         var stream = attachment.Content.GetStream();
+
         return FromAttachment(attachment, stream);
     }
 
     internal static EnvelopeItem FromAttachment(SentryAttachment attachment, Stream stream)
+    {
+        var payloadLength = stream.TryGetLength();
+        var payload = new BufferedStreamSerializable(stream);
+
+        return CreateAttachmentItem(attachment, payload, payloadLength);
+    }
+
+    private static EnvelopeItem CreateAttachmentItem(
+        SentryAttachment attachment,
+        ISerializable payload,
+        long? payloadLength)
     {
         var attachmentType = attachment.Type switch
         {
@@ -349,13 +381,13 @@ public sealed class EnvelopeItem : ISerializable, IDisposable
         var header = new Dictionary<string, object?>(5, StringComparer.Ordinal)
         {
             [TypeKey] = TypeValueAttachment,
-            [LengthKey] = stream.TryGetLength(),
+            [LengthKey] = payloadLength,
             [FileNameKey] = attachment.FileName,
             ["attachment_type"] = attachmentType,
             ["content_type"] = attachment.ContentType
         };
 
-        return new EnvelopeItem(header, new StreamSerializable(stream));
+        return new EnvelopeItem(header, payload);
     }
 
     /// <summary>

--- a/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
+++ b/test/Sentry.Tests/Internals/Http/HttpTransportTests.cs
@@ -711,9 +711,15 @@ public partial class HttpTransportTests
             // Act
             await httpTransport.SendEnvelopeAsync(envelope);
 
+            // The transport doesn't own the envelope items, so the file outlives the send.
+            File.Exists(tempFilePath).Should().BeTrue();
+
+            envelope.Dispose();
+
             // Assert
-            // The file is streamed as part of the successful send, and should be
-            // deleted once the stream backing the envelope item is closed/disposed.
+            // The file is streamed as part of the successful send, and is deleted once the
+            // stream backing the envelope item is closed - which happens when the owning
+            // envelope is disposed, as BackgroundWorker does after each send.
             File.Exists(tempFilePath).Should().BeFalse();
         }
         finally

--- a/test/Sentry.Tests/Protocol/Envelopes/AttachmentSerializationTests.Types.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/AttachmentSerializationTests.Types.cs
@@ -1,0 +1,128 @@
+namespace Sentry.Tests.Protocol.Envelopes;
+
+public partial class AttachmentSerializationTests
+{
+    private sealed class NonSeekableReadStream : Stream
+    {
+        private readonly Stream _inner;
+
+        public NonSeekableReadStream(Stream inner) => _inner = inner;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class SingleStreamAttachmentContent : IAttachmentContent
+    {
+        private readonly Stream _stream;
+
+        public SingleStreamAttachmentContent(Stream stream)
+        {
+            _stream = stream;
+        }
+
+        public Stream GetStream() => _stream;
+    }
+
+    private sealed class AsyncOnlyReadStream : Stream
+    {
+        private readonly MemoryStream _inner;
+
+        public AsyncOnlyReadStream(byte[] buffer)
+        {
+            _inner = new MemoryStream(buffer);
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => true;
+
+        public override bool CanWrite => false;
+
+        public override long Length => _inner.Length;
+
+        public override long Position
+        {
+            get => _inner.Position;
+            set => _inner.Position = value;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException("Synchronous reads are not supported.");
+
+        public override Task<int> ReadAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken) =>
+            _inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            _inner.Seek(offset, origin);
+
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class SingleStreamDerivedByteAttachmentContent :
+        ByteAttachmentContent,
+        IAttachmentContent
+    {
+        private readonly Stream _stream;
+
+        public SingleStreamDerivedByteAttachmentContent(
+            byte[] bytes,
+            Stream stream)
+            : base(bytes)
+        {
+            _stream = stream;
+        }
+
+        Stream IAttachmentContent.GetStream() => _stream;
+    }
+}

--- a/test/Sentry.Tests/Protocol/Envelopes/AttachmentSerializationTests.Types.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/AttachmentSerializationTests.Types.cs
@@ -125,4 +125,17 @@ public partial class AttachmentSerializationTests
 
         Stream IAttachmentContent.GetStream() => _stream;
     }
+
+    private sealed class SingleStreamDerivedFileAttachmentContent : FileAttachmentContent, IAttachmentContent
+    {
+        private readonly Stream _stream;
+
+        public SingleStreamDerivedFileAttachmentContent(Stream stream)
+            : base("unused")
+        {
+            _stream = stream;
+        }
+
+        Stream IAttachmentContent.GetStream() => _stream;
+    }
 }

--- a/test/Sentry.Tests/Protocol/Envelopes/AttachmentSerializationTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/AttachmentSerializationTests.cs
@@ -158,6 +158,32 @@ public partial class AttachmentSerializationTests
     }
 
     [Fact]
+    public void Serialization_SameEventEnvelopeWithByteAttachmentTwiceSynchronously_PreservesPayload()
+    {
+        // Arrange
+        const string attachmentContent = "test attachment content";
+        var attachment = new SentryAttachment(
+            AttachmentType.Default,
+            new ByteAttachmentContent(Encoding.UTF8.GetBytes(attachmentContent)),
+            "test.txt",
+            "text/plain");
+
+        using var envelope = Envelope.FromEvent(
+            new SentryEvent(),
+            attachments: [attachment]);
+
+        // Act
+        var firstSerialization =
+            envelope.SerializeToString(_testOutputLogger, _fakeClock);
+        var secondSerialization =
+            envelope.SerializeToString(_testOutputLogger, _fakeClock);
+
+        // Assert
+        firstSerialization.Should().Contain(attachmentContent);
+        secondSerialization.Should().Be(firstSerialization);
+    }
+
+    [Fact]
     public void Serialization_SameEventEnvelopeWithStreamAttachmentTwiceSynchronously_PreservesPayload()
     {
         // Arrange
@@ -310,5 +336,57 @@ public partial class AttachmentSerializationTests
         // Assert
         firstSerialization.Should().Contain(attachmentContent);
         secondSerialization.Should().Be(firstSerialization);
+    }
+
+    [Fact]
+    public async Task Serialization_SameEnvelopeWithDerivedFileAttachmentContentTwice_PreservesPayload()
+    {
+        // Arrange
+        const string attachmentContent = "test attachment content";
+        using var attachmentStream =
+            new MemoryStream(Encoding.UTF8.GetBytes(attachmentContent));
+
+        var attachment = new SentryAttachment(
+            AttachmentType.Default,
+            new SingleStreamDerivedFileAttachmentContent(attachmentStream),
+            "test.txt",
+            "text/plain");
+
+        using var envelope = Envelope.FromEvent(
+            new SentryEvent(),
+            attachments: [attachment]);
+
+        // Act
+        var firstSerialization =
+            await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+        var secondSerialization =
+            await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+
+        // Assert
+        firstSerialization.Should().Contain(attachmentContent);
+        secondSerialization.Should().Be(firstSerialization);
+    }
+
+    [Fact]
+    public void FromEvent_EmptyByteAttachment_DoesNotAddAttachment()
+    {
+        // Arrange
+        var attachment = new SentryAttachment(
+            AttachmentType.Default,
+            new ByteAttachmentContent([]),
+            "empty.txt",
+            "text/plain");
+
+        // Act
+        using var envelope = Envelope.FromEvent(
+            new SentryEvent(),
+            attachments: [attachment],
+            logger: _testOutputLogger);
+
+        // Assert
+        envelope.Items
+            .Count(item => item.TryGetType() == EnvelopeItem.TypeValueAttachment)
+            .Should()
+            .Be(0);
     }
 }

--- a/test/Sentry.Tests/Protocol/Envelopes/AttachmentSerializationTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/AttachmentSerializationTests.cs
@@ -1,0 +1,314 @@
+namespace Sentry.Tests.Protocol.Envelopes;
+
+public partial class AttachmentSerializationTests
+{
+    private readonly IDiagnosticLogger _testOutputLogger;
+    private readonly MockClock _fakeClock;
+
+    public AttachmentSerializationTests(ITestOutputHelper output)
+    {
+        _testOutputLogger = new TestOutputDiagnosticLogger(output);
+        _fakeClock = new MockClock(DateTimeOffset.MaxValue);
+    }
+
+    [Fact]
+    public async Task Serialization_SameByteAttachmentEnvelopeTwice_PreservesPayload()
+    {
+        // Arrange
+        var attachment = new SentryAttachment(
+            AttachmentType.Default,
+            new ByteAttachmentContent("test attachment content"u8.ToArray()),
+            "test.txt",
+            "text/plain");
+
+        using var envelope = Envelope.FromAttachment(SentryId.Create(), attachment);
+
+        // Act
+        var firstSerialization = await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+        var secondSerialization = await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+
+        // Assert
+        firstSerialization.Should().Contain("test attachment content");
+        secondSerialization.Should().Be(firstSerialization);
+    }
+
+    [Fact]
+    public async Task Serialization_SameEventEnvelopeWithByteAttachmentTwice_PreservesPayload()
+    {
+        // Arrange
+        var attachment = new SentryAttachment(
+            AttachmentType.Default,
+            new ByteAttachmentContent("test attachment content"u8.ToArray()),
+            "test.txt",
+            "text/plain");
+
+        using var envelope = Envelope.FromEvent(new SentryEvent(), attachments: [attachment]);
+
+        // Act
+        var firstSerialization = await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+        var secondSerialization = await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+
+        // Assert
+        envelope.Items.Count(item => item.TryGetType() == EnvelopeItem.TypeValueAttachment).Should().Be(1);
+        firstSerialization.Should().Contain("test attachment content");
+        secondSerialization.Should().Be(firstSerialization);
+    }
+
+    [Fact]
+    public async Task Serialization_SameEventEnvelopeWithFileAttachmentTwice_PreservesPayload()
+    {
+        // Arrange
+        var path = Path.GetTempFileName();
+        const string attachmentContent = "test attachment content";
+        File.WriteAllText(path, attachmentContent);
+
+        try
+        {
+            var attachment = new SentryAttachment(
+                AttachmentType.Default,
+                new FileAttachmentContent(path),
+                "test.txt",
+                "text/plain");
+
+            using var envelope = Envelope.FromEvent(new SentryEvent(), attachments: [attachment]);
+
+            // Act
+            var firstSerialization = await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+            var secondSerialization = await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+
+            // Assert
+            firstSerialization.Should().Contain(attachmentContent);
+            secondSerialization.Should().Be(firstSerialization);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task Serialization_SameEventEnvelopeWithStreamAttachmentTwice_PreservesPayload()
+    {
+        // Arrange
+        const string attachmentContent = "test attachment content";
+        using var attachmentStream = new MemoryStream(Encoding.UTF8.GetBytes(attachmentContent));
+        var attachment = new SentryAttachment(
+            AttachmentType.Default,
+            new StreamAttachmentContent(attachmentStream),
+            "test.txt",
+            "text/plain");
+
+        using var envelope = Envelope.FromEvent(new SentryEvent(), attachments: [attachment]);
+
+        // Act
+        var firstSerialization = await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+        var secondSerialization = await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+
+        // Assert
+        firstSerialization.Should().Contain(attachmentContent);
+        secondSerialization.Should().Be(firstSerialization);
+    }
+
+    [Fact]
+    public async Task Serialization_SameEventEnvelopeWithStreamAttachmentConcurrently_PreservesPayload()
+    {
+        // Arrange
+        const string attachmentContent = "test attachment content";
+        using var attachmentStream = new MemoryStream(Encoding.UTF8.GetBytes(attachmentContent));
+        var attachment = new SentryAttachment(
+            AttachmentType.Default,
+            new StreamAttachmentContent(attachmentStream),
+            "test.txt",
+            "text/plain");
+
+        using var envelope = Envelope.FromEvent(new SentryEvent(), attachments: [attachment]);
+
+        // Act
+        var serializations = await Task.WhenAll(
+            envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock),
+            envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock));
+
+        // Assert
+        serializations[0].Should().Contain(attachmentContent);
+        serializations[1].Should().Be(serializations[0]);
+    }
+
+    [Fact]
+    public async Task Serialization_NonSeekableStreamAttachmentTwice_PreservesPayload()
+    {
+        // Arrange
+        const string attachmentContent = "test attachment content";
+        using var attachmentStream = new NonSeekableReadStream(
+            new MemoryStream(Encoding.UTF8.GetBytes(attachmentContent)));
+        var attachment = new SentryAttachment(
+            AttachmentType.Default,
+            new StreamAttachmentContent(attachmentStream),
+            "test.txt",
+            "text/plain");
+
+        using var envelope = Envelope.FromEvent(new SentryEvent(), attachments: [attachment]);
+
+        // Act
+        var firstSerialization = await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+        var secondSerialization = await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+
+        // Assert
+        firstSerialization.Should().Contain(attachmentContent);
+        secondSerialization.Should().Be(firstSerialization);
+    }
+
+    [Fact]
+    public void Serialization_SameEventEnvelopeWithStreamAttachmentTwiceSynchronously_PreservesPayload()
+    {
+        // Arrange
+        const string attachmentContent = "test attachment content";
+        using var attachmentStream = new MemoryStream(Encoding.UTF8.GetBytes(attachmentContent));
+        var attachment = new SentryAttachment(
+            AttachmentType.Default,
+            new StreamAttachmentContent(attachmentStream),
+            "test.txt",
+            "text/plain");
+
+        using var envelope = Envelope.FromEvent(new SentryEvent(), attachments: [attachment]);
+
+        // Act
+        var firstSerialization = envelope.SerializeToString(_testOutputLogger, _fakeClock);
+        var secondSerialization = envelope.SerializeToString(_testOutputLogger, _fakeClock);
+
+        // Assert
+        firstSerialization.Should().Contain(attachmentContent);
+        secondSerialization.Should().Be(firstSerialization);
+    }
+
+    [Fact]
+    public async Task Serialization_SameEventEnvelopeWithDeleteOnCloseFileAttachmentTwice_PreservesPayload()
+    {
+        // Arrange
+        var path = Path.GetTempFileName();
+        const string attachmentContent = "test attachment content";
+        File.WriteAllText(path, attachmentContent);
+
+        try
+        {
+            var attachment = new SentryAttachment(
+                AttachmentType.Default,
+                new FileAttachmentContent(
+                    path,
+                    readFileAsynchronously: false,
+                    deleteOnClose: true),
+                "test.txt",
+                "text/plain");
+
+            using var envelope = Envelope.FromEvent(new SentryEvent(), attachments: [attachment]);
+
+            // Act
+            var firstSerialization = await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+            var secondSerialization = await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+
+            // Assert
+            firstSerialization.Should().Contain(attachmentContent);
+            secondSerialization.Should().Be(firstSerialization);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void FromEvent_StreamAttachment_DoesNotReadStream()
+    {
+        // Arrange
+        const string attachmentContent = "test attachment content";
+        using var attachmentStream = new MemoryStream(Encoding.UTF8.GetBytes(attachmentContent));
+        var attachment = new SentryAttachment(
+            AttachmentType.Default,
+            new StreamAttachmentContent(attachmentStream),
+            "test.txt",
+            "text/plain");
+
+        // Act
+        using var envelope = Envelope.FromEvent(new SentryEvent(), attachments: [attachment]);
+
+        // Assert
+        attachmentStream.Position.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Serialization_SameEventEnvelopeWithCustomAttachmentContentTwice_PreservesPayload()
+    {
+        // Arrange
+        const string attachmentContent = "test attachment content";
+        using var attachmentStream = new MemoryStream(Encoding.UTF8.GetBytes(attachmentContent));
+        var attachment = new SentryAttachment(
+            AttachmentType.Default,
+            new SingleStreamAttachmentContent(attachmentStream),
+            "test.txt",
+            "text/plain");
+
+        using var envelope = Envelope.FromEvent(
+            new SentryEvent(),
+            attachments: [attachment]);
+
+        // Act
+        var firstSerialization = await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+        var secondSerialization = await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+
+        // Assert
+        firstSerialization.Should().Contain(attachmentContent);
+        secondSerialization.Should().Be(firstSerialization);
+    }
+
+    [Fact]
+    public async Task Serialization_AsyncOnlyStreamAttachment_Succeeds()
+    {
+        // Arrange
+        const string attachmentContent = "test attachment content";
+        using var attachmentStream =
+            new AsyncOnlyReadStream(Encoding.UTF8.GetBytes(attachmentContent));
+        var attachment = new SentryAttachment(
+            AttachmentType.Default,
+            new StreamAttachmentContent(attachmentStream),
+            "test.txt",
+            "text/plain");
+
+        using var envelope = Envelope.FromEvent(
+            new SentryEvent(),
+            attachments: [attachment]);
+
+        // Act
+        var serialization =
+            await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+
+        // Assert
+        serialization.Should().Contain(attachmentContent);
+    }
+
+    [Fact]
+    public async Task Serialization_SameEnvelopeWithDerivedByteAttachmentContentTwice_PreservesPayload()
+    {
+        // Arrange
+        const string attachmentContent = "test attachment content";
+        var bytes = Encoding.UTF8.GetBytes(attachmentContent);
+        using var attachmentStream = new MemoryStream(bytes);
+        var attachment = new SentryAttachment(
+            AttachmentType.Default,
+            new SingleStreamDerivedByteAttachmentContent(bytes, attachmentStream),
+            "test.txt",
+            "text/plain");
+
+        using var envelope = Envelope.FromEvent(
+            new SentryEvent(),
+            attachments: [attachment]);
+
+        // Act
+        var firstSerialization =
+            await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+        var secondSerialization =
+            await envelope.SerializeToStringAsync(_testOutputLogger, _fakeClock);
+
+        // Assert
+        firstSerialization.Should().Contain(attachmentContent);
+        secondSerialization.Should().Be(firstSerialization);
+    }
+}

--- a/test/Sentry.Tests/Protocol/Envelopes/BufferedStreamSerializableTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/BufferedStreamSerializableTests.cs
@@ -45,6 +45,25 @@ public class BufferedStreamSerializableTests
             .Should().Be(attachmentContent);
     }
 
+    [Fact]
+    public async Task SerializeAsync_SourceThrows_DisposesSourceAndPropagatesException()
+    {
+        // Arrange
+        using var source = new ThrowingReadStream();
+        using var serializable = new BufferedStreamSerializable(source);
+        using var output = new MemoryStream();
+
+        // Act
+        Func<Task> action = () => serializable.SerializeAsync(output, null);
+
+        // Assert
+        await action.Should()
+            .ThrowAsync<IOException>()
+            .WithMessage("Test exception.");
+
+        source.WasDisposed.Should().BeTrue();
+    }
+
     private sealed class GatedMemoryStream : MemoryStream
     {
         private readonly TaskCompletionSource<bool> _copyStarted =
@@ -71,6 +90,27 @@ public class BufferedStreamSerializableTests
 
             await _continueCopy.Task.ConfigureAwait(false);
             await base.CopyToAsync(destination, bufferSize, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class ThrowingReadStream : MemoryStream
+    {
+        public bool WasDisposed { get; private set; }
+
+        public override Task CopyToAsync(
+            Stream destination,
+            int bufferSize,
+            CancellationToken cancellationToken) =>
+            Task.FromException(new IOException("Test exception."));
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                WasDisposed = true;
+            }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/test/Sentry.Tests/Protocol/Envelopes/BufferedStreamSerializableTests.cs
+++ b/test/Sentry.Tests/Protocol/Envelopes/BufferedStreamSerializableTests.cs
@@ -1,0 +1,76 @@
+namespace Sentry.Tests.Protocol.Envelopes;
+
+public class BufferedStreamSerializableTests
+{
+    [Fact]
+    public async Task SerializeAsync_CancelledWaiter_DoesNotCancelSharedBuffer()
+    {
+        // Arrange
+        const string attachmentContent = "test attachment content";
+        using var source = new GatedMemoryStream(Encoding.UTF8.GetBytes(attachmentContent));
+        using var serializable = new BufferedStreamSerializable(source);
+        using var cancelledOutput = new MemoryStream();
+        using var successfulOutput = new MemoryStream();
+        using var cancellationSource = new CancellationTokenSource();
+
+        // Act
+        var cancelledSerialization = serializable.SerializeAsync(
+            cancelledOutput,
+            null,
+            cancellationSource.Token);
+
+        await source.CopyStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var successfulSerialization = serializable.SerializeAsync(
+            successfulOutput,
+            null);
+
+        cancellationSource.Cancel();
+
+        var completedTask = await Task.WhenAny(
+            cancelledSerialization,
+            Task.Delay(TimeSpan.FromSeconds(1)));
+
+        source.Release();
+
+        await successfulSerialization;
+
+        // Assert
+        completedTask.Should().BeSameAs(cancelledSerialization);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => cancelledSerialization);
+
+        Encoding.UTF8.GetString(successfulOutput.ToArray())
+            .Should().Be(attachmentContent);
+    }
+
+    private sealed class GatedMemoryStream : MemoryStream
+    {
+        private readonly TaskCompletionSource<bool> _copyStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private readonly TaskCompletionSource<bool> _continueCopy =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public GatedMemoryStream(byte[] buffer)
+            : base(buffer)
+        {
+        }
+
+        public Task CopyStarted => _copyStarted.Task;
+
+        public void Release() => _continueCopy.TrySetResult(true);
+
+        public override async Task CopyToAsync(
+            Stream destination,
+            int bufferSize,
+            CancellationToken cancellationToken)
+        {
+            _copyStarted.TrySetResult(true);
+
+            await _continueCopy.Task.ConfigureAwait(false);
+            await base.CopyToAsync(destination, bufferSize, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #5499.

When Spotlight is enabled, the same envelope can be serialized by both the
primary transport and the Spotlight transport. Attachment payloads previously
shared a single stream, so one serialization could consume the content before
the other transport read it.

This change makes attachment payloads replayable:

- Built-in byte attachments obtain an independent stream for each
  serialization.
- Built-in reusable file attachments open an independent file stream for each
  serialization.
- Stream-backed, custom or derived attachment content, and delete-on-close
  files are buffered in memory on first serialization and reuse that buffer
  for subsequent serializations.

## Implementation notes

The buffering path obtains the source stream while creating the envelope item
for length validation, but does not read its content until the first
serialization. The resulting buffer is shared by repeated and concurrent
serializations.

Exact type checks are used for the built-in byte and file attachment types
because derived or custom implementations may return streams with different
lifetime or replayability behavior.

Envelope and transport ownership semantics are unchanged.

## Testing

Regression coverage includes:

- Repeated byte, file, and stream attachment serialization
- Concurrent serialization
- Synchronous and asynchronous serialization
- Non-seekable and asynchronous-only streams
- Custom and derived attachment content
- Delete-on-close file attachments
- Lazy buffering and cancellation behavior

### Changelog Entry

fix: Attachments not being sent properly when Spotlight is enabled