### PR TITLE
feat: Logs sent via `SentrySdk.Logger` no longer require `EnableLogs`

### DIFF
--- a/benchmarks/Sentry.Benchmarks/BatchProcessorBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/BatchProcessorBenchmarks.cs
@@ -27,7 +27,6 @@ public class BatchProcessorBenchmarks
         SentryOptions options = new()
         {
             Dsn = DsnSamples.ValidDsn,
-            EnableLogs = true,
         };
 
         var batchInterval = Timeout.InfiniteTimeSpan;

--- a/benchmarks/Sentry.Benchmarks/SentryStructuredLoggerBenchmarks.cs
+++ b/benchmarks/Sentry.Benchmarks/SentryStructuredLoggerBenchmarks.cs
@@ -20,7 +20,6 @@ public class SentryStructuredLoggerBenchmarks
         SentryOptions options = new()
         {
             Dsn = DsnSamples.ValidDsn,
-            EnableLogs = true,
         };
         options.SetBeforeSendLog((SentryLog log) =>
         {

--- a/samples/Sentry.Samples.Console.Basic/Program.cs
+++ b/samples/Sentry.Samples.Console.Basic/Program.cs
@@ -40,7 +40,6 @@ SentrySdk.Init(options =>
     // This option tells Sentry to capture 100% of traces. You still need to start transactions and spans.
     options.TracesSampleRate = 1.0;
 
-    // Logs created via SentrySdk.Logger are always sent - no option needed.
     options.SetBeforeSendLog(static log =>
     {
         // A demonstration of how you can drop logs based on some attribute they have

--- a/samples/Sentry.Samples.Console.Basic/Program.cs
+++ b/samples/Sentry.Samples.Console.Basic/Program.cs
@@ -40,8 +40,7 @@ SentrySdk.Init(options =>
     // This option tells Sentry to capture 100% of traces. You still need to start transactions and spans.
     options.TracesSampleRate = 1.0;
 
-    // This option enables Sentry Logs created via SentrySdk.Logger.
-    options.EnableLogs = true;
+    // Logs created via SentrySdk.Logger are always sent - no option needed.
     options.SetBeforeSendLog(static log =>
     {
         // A demonstration of how you can drop logs based on some attribute they have

--- a/src/Sentry/IHub.cs
+++ b/src/Sentry/IHub.cs
@@ -23,7 +23,6 @@ public interface IHub : ISentryClient, ISentryScopeManager
     /// <remarks>
     /// Available options:
     /// <list type="bullet">
-    /// <item><see cref="Sentry.SentryOptions.EnableLogs"/></item>
     /// <item><see cref="Sentry.SentryOptions.SetBeforeSendLog(System.Func{SentryLog, SentryLog})"/></item>
     /// </list>
     /// </remarks>

--- a/src/Sentry/Internal/DefaultSentryStructuredLogger.cs
+++ b/src/Sentry/Internal/DefaultSentryStructuredLogger.cs
@@ -14,7 +14,6 @@ internal sealed class DefaultSentryStructuredLogger : SentryStructuredLogger, ID
     internal DefaultSentryStructuredLogger(IHub hub, SentryOptions options, ISystemClock clock, int batchCount, TimeSpan batchInterval)
     {
         Debug.Assert(hub.IsEnabled);
-        Debug.Assert(options is { EnableLogs: true });
 
         _hub = hub;
         _options = options;

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -615,7 +615,6 @@ public class SentryOptions
     /// <remarks>
     /// This option does not apply to logs created directly via <see cref="SentryStructuredLogger"/>
     /// (typically <c>SentrySdk.Logger</c>), which are always sent.
-    /// To filter or drop those, use <see cref="SetBeforeSendLog(Func{SentryLog, SentryLog})"/>
     /// and return <see langword="null"/>.
     /// </remarks>
     /// <seealso href="https://develop.sentry.dev/sdk/telemetry/logs/"/>

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -608,9 +608,16 @@ public class SentryOptions
     }
 
     /// <summary>
-    /// When set to <see langword="true"/>, logs are sent to Sentry.
-    /// Defaults to <see langword="false"/>.
+    /// When set to <see langword="true"/>, logs captured by the logging integrations
+    /// (<c>Sentry.Extensions.Logging</c>, <c>Sentry.Serilog</c>, <c>Sentry.NLog</c>, <c>Sentry.Log4Net</c>)
+    /// are sent to Sentry. Defaults to <see langword="false"/>.
     /// </summary>
+    /// <remarks>
+    /// This option does not apply to logs created directly via <see cref="SentryStructuredLogger"/>
+    /// (typically <c>SentrySdk.Logger</c>), which are always sent.
+    /// To filter or drop those, use <see cref="SetBeforeSendLog(Func{SentryLog, SentryLog})"/>
+    /// and return <see langword="null"/>.
+    /// </remarks>
     /// <seealso href="https://develop.sentry.dev/sdk/telemetry/logs/"/>
     public bool EnableLogs { get; set; } = false;
 

--- a/src/Sentry/SentryOptions.cs
+++ b/src/Sentry/SentryOptions.cs
@@ -615,7 +615,6 @@ public class SentryOptions
     /// <remarks>
     /// This option does not apply to logs created directly via <see cref="SentryStructuredLogger"/>
     /// (typically <c>SentrySdk.Logger</c>), which are always sent.
-    /// and return <see langword="null"/>.
     /// </remarks>
     /// <seealso href="https://develop.sentry.dev/sdk/telemetry/logs/"/>
     public bool EnableLogs { get; set; } = false;

--- a/src/Sentry/SentryStructuredLogger.cs
+++ b/src/Sentry/SentryStructuredLogger.cs
@@ -13,8 +13,6 @@ public abstract partial class SentryStructuredLogger
 
     internal static SentryStructuredLogger Create(IHub hub, SentryOptions options, ISystemClock clock, int batchCount, TimeSpan batchInterval)
     {
-        // Logs created directly via this API are always captured. Someone reaching for SentrySdk.Logger
-        // has already opted in; the logging integrations still honour SentryOptions.EnableLogs themselves.
         return new DefaultSentryStructuredLogger(hub, options, clock, batchCount, batchInterval);
     }
 

--- a/src/Sentry/SentryStructuredLogger.cs
+++ b/src/Sentry/SentryStructuredLogger.cs
@@ -13,9 +13,9 @@ public abstract partial class SentryStructuredLogger
 
     internal static SentryStructuredLogger Create(IHub hub, SentryOptions options, ISystemClock clock, int batchCount, TimeSpan batchInterval)
     {
-        return options.EnableLogs
-            ? new DefaultSentryStructuredLogger(hub, options, clock, batchCount, batchInterval)
-            : DisabledSentryStructuredLogger.Instance;
+        // Logs created directly via this API are always captured. Someone reaching for SentrySdk.Logger
+        // has already opted in; the logging integrations still honour SentryOptions.EnableLogs themselves.
+        return new DefaultSentryStructuredLogger(hub, options, clock, batchCount, batchInterval);
     }
 
     private protected SentryStructuredLogger()

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1994,30 +1994,11 @@ public partial class HubTests : IDisposable
     }
 
     [Fact]
-    public void Logger_IsDisabled_DoesNotCaptureLog()
+    public void Logger_EnableLogsDisabled_StillCapturesLog()
     {
         // Arrange
+        // EnableLogs gates the logging integrations. Logs created directly via this API are always captured.
         Assert.False(_fixture.Options.EnableLogs);
-        var hub = _fixture.GetSut();
-
-        // Act
-        hub.Logger.LogWarning("Message");
-        hub.Logger.Flush();
-
-        // Assert
-        _fixture.Client.Received(0).CaptureEnvelope(
-            Arg.Is<Envelope>(envelope =>
-                envelope.Items.Single(item => item.Header["type"].Equals("log")).Payload.GetType().IsAssignableFrom(typeof(JsonSerializable))
-            )
-        );
-        hub.Logger.Should().BeOfType<DisabledSentryStructuredLogger>();
-    }
-
-    [Fact]
-    public void Logger_IsEnabled_DoesCaptureLog()
-    {
-        // Arrange
-        _fixture.Options.EnableLogs = true;
         var hub = _fixture.GetSut();
 
         // Act
@@ -2034,30 +2015,21 @@ public partial class HubTests : IDisposable
     }
 
     [Fact]
-    public void Logger_EnableAfterCreate_HasNoEffect()
+    public void Logger_DoesCaptureLog()
     {
         // Arrange
-        Assert.False(_fixture.Options.EnableLogs);
         var hub = _fixture.GetSut();
 
         // Act
-        _fixture.Options.EnableLogs = true;
+        hub.Logger.LogWarning("Message");
+        hub.Logger.Flush();
 
         // Assert
-        hub.Logger.Should().BeOfType<DisabledSentryStructuredLogger>();
-    }
-
-    [Fact]
-    public void Logger_DisableAfterCreate_HasNoEffect()
-    {
-        // Arrange
-        _fixture.Options.EnableLogs = true;
-        var hub = _fixture.GetSut();
-
-        // Act
-        _fixture.Options.EnableLogs = false;
-
-        // Assert
+        _fixture.Client.Received(1).CaptureEnvelope(
+            Arg.Is<Envelope>(envelope =>
+                envelope.Items.Single(item => item.Header["type"].Equals("log")).Payload.GetType().IsAssignableFrom(typeof(JsonSerializable))
+            )
+        );
         hub.Logger.Should().BeOfType<DefaultSentryStructuredLogger>();
     }
 
@@ -2065,7 +2037,6 @@ public partial class HubTests : IDisposable
     public async Task Logger_FlushAsync_DoesCaptureLog()
     {
         // Arrange
-        _fixture.Options.EnableLogs = true;
         var hub = _fixture.GetSut();
 
         // Act
@@ -2090,7 +2061,6 @@ public partial class HubTests : IDisposable
     public void Logger_Dispose_DoesCaptureLog()
     {
         // Arrange
-        _fixture.Options.EnableLogs = true;
         var hub = _fixture.GetSut();
 
         // Act

--- a/test/Sentry.Tests/SentryStructuredLoggerTests.Format.cs
+++ b/test/Sentry.Tests/SentryStructuredLoggerTests.Format.cs
@@ -11,9 +11,8 @@ public partial class SentryStructuredLoggerTests
     [InlineData(SentryLogLevel.Warning)]
     [InlineData(SentryLogLevel.Error)]
     [InlineData(SentryLogLevel.Fatal)]
-    public void Log_Enabled_CapturesEnvelope(SentryLogLevel level)
+    public void Log_CapturesEnvelope(SentryLogLevel level)
     {
-        _fixture.Options.EnableLogs = true;
         var logger = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -33,27 +32,8 @@ public partial class SentryStructuredLoggerTests
     [InlineData(SentryLogLevel.Warning)]
     [InlineData(SentryLogLevel.Error)]
     [InlineData(SentryLogLevel.Fatal)]
-    public void Log_Disabled_DoesNotCaptureEnvelope(SentryLogLevel level)
+    public void Log_ConfigureLog_CapturesEnvelope(SentryLogLevel level)
     {
-        _fixture.Options.EnableLogs.Should().BeFalse();
-        var logger = _fixture.GetSut();
-
-        logger.Log(level, "Template string with arguments: {0}, {1}, {2}, {3}", "string", true, 1, 2.2);
-        logger.Flush();
-
-        _fixture.Hub.Received(0).CaptureEnvelope(Arg.Any<Envelope>());
-    }
-
-    [Theory]
-    [InlineData(SentryLogLevel.Trace)]
-    [InlineData(SentryLogLevel.Debug)]
-    [InlineData(SentryLogLevel.Info)]
-    [InlineData(SentryLogLevel.Warning)]
-    [InlineData(SentryLogLevel.Error)]
-    [InlineData(SentryLogLevel.Fatal)]
-    public void Log_ConfigureLog_Enabled_CapturesEnvelope(SentryLogLevel level)
-    {
-        _fixture.Options.EnableLogs = true;
         var logger = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -73,27 +53,8 @@ public partial class SentryStructuredLoggerTests
     [InlineData(SentryLogLevel.Warning)]
     [InlineData(SentryLogLevel.Error)]
     [InlineData(SentryLogLevel.Fatal)]
-    public void Log_ConfigureLog_Disabled_DoesNotCaptureEnvelope(SentryLogLevel level)
-    {
-        _fixture.Options.EnableLogs.Should().BeFalse();
-        var logger = _fixture.GetSut();
-
-        logger.Log(level, ConfigureLog, "Template string with arguments: {0}, {1}, {2}, {3}", "string", true, 1, 2.2);
-        logger.Flush();
-
-        _fixture.Hub.Received(0).CaptureEnvelope(Arg.Any<Envelope>());
-    }
-
-    [Theory]
-    [InlineData(SentryLogLevel.Trace)]
-    [InlineData(SentryLogLevel.Debug)]
-    [InlineData(SentryLogLevel.Info)]
-    [InlineData(SentryLogLevel.Warning)]
-    [InlineData(SentryLogLevel.Error)]
-    [InlineData(SentryLogLevel.Fatal)]
     public void Log_WithoutParameters_DoesNotAttachTemplateAttribute(SentryLogLevel level)
     {
-        _fixture.Options.EnableLogs = true;
         var logger = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -123,7 +84,6 @@ public partial class SentryStructuredLoggerTests
     [InlineData(SentryLogLevel.Fatal)]
     public void Log_InvalidFormatButWithoutParameters_CapturesEnvelope(SentryLogLevel level)
     {
-        _fixture.Options.EnableLogs = true;
         var logger = _fixture.GetSut();
 
         Envelope envelope = null!;

--- a/test/Sentry.Tests/SentryStructuredLoggerTests.cs
+++ b/test/Sentry.Tests/SentryStructuredLoggerTests.cs
@@ -74,10 +74,8 @@ public partial class SentryStructuredLoggerTests : IDisposable
     }
 
     [Fact]
-    public void Create_Enabled_NewDefaultInstance()
+    public void Create_NewDefaultInstance()
     {
-        _fixture.Options.EnableLogs = true;
-
         var instance = _fixture.GetSut();
         var other = _fixture.GetSut();
 
@@ -86,22 +84,20 @@ public partial class SentryStructuredLoggerTests : IDisposable
     }
 
     [Fact]
-    public void Create_Disabled_CachedDisabledInstance()
+    public void Create_EnableLogsDisabled_NewDefaultInstance()
     {
+        // EnableLogs gates the logging integrations, not this API.
         _fixture.Options.EnableLogs.Should().BeFalse();
 
         var instance = _fixture.GetSut();
-        var other = _fixture.GetSut();
 
-        instance.Should().BeOfType<DisabledSentryStructuredLogger>();
-        instance.Should().BeSameAs(other);
+        instance.Should().BeOfType<DefaultSentryStructuredLogger>();
     }
 
     [Fact]
     public void Log_WithoutActiveSpan_CapturesEnvelope()
     {
         _fixture.WithoutActiveSpan();
-        _fixture.Options.EnableLogs = true;
         var logger = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -120,7 +116,6 @@ public partial class SentryStructuredLoggerTests : IDisposable
         var invocations = 0;
         SentryLog configuredLog = null!;
 
-        _fixture.Options.EnableLogs = true;
         _fixture.Options.SetBeforeSendLog((SentryLog log) =>
         {
             invocations++;
@@ -142,7 +137,6 @@ public partial class SentryStructuredLoggerTests : IDisposable
     {
         var invocations = 0;
 
-        _fixture.Options.EnableLogs = true;
         _fixture.Options.SetBeforeSendLog((SentryLog log) =>
         {
             invocations++;
@@ -159,7 +153,6 @@ public partial class SentryStructuredLoggerTests : IDisposable
     [Fact]
     public void Log_InvalidFormat_DoesNotCaptureEnvelope()
     {
-        _fixture.Options.EnableLogs = true;
         var logger = _fixture.GetSut();
 
         logger.LogTrace("Template string with arguments: {0}, {1}, {2}, {3}, {4}", "string", true, 1, 2.2);
@@ -175,7 +168,6 @@ public partial class SentryStructuredLoggerTests : IDisposable
     [Fact]
     public void Log_InvalidConfigureLog_DoesNotCaptureEnvelope()
     {
-        _fixture.Options.EnableLogs = true;
         var logger = _fixture.GetSut();
 
         logger.LogTrace(static (SentryLog log) => throw new InvalidOperationException(), "Template string with arguments: {0}, {1}, {2}, {3}", "string", true, 1, 2.2);
@@ -191,7 +183,6 @@ public partial class SentryStructuredLoggerTests : IDisposable
     [Fact]
     public void Log_InvalidBeforeSendLog_DoesNotCaptureEnvelope()
     {
-        _fixture.Options.EnableLogs = true;
         _fixture.Options.SetBeforeSendLog(static (SentryLog log) => throw new InvalidOperationException());
         var logger = _fixture.GetSut();
 
@@ -208,7 +199,6 @@ public partial class SentryStructuredLoggerTests : IDisposable
     [Fact]
     public void Flush_AfterLog_CapturesEnvelope()
     {
-        _fixture.Options.EnableLogs = true;
         var logger = _fixture.GetSut();
 
         Envelope envelope = null!;
@@ -230,7 +220,6 @@ public partial class SentryStructuredLoggerTests : IDisposable
     [Fact]
     public void Dispose_BeforeLog_DoesNotCaptureEnvelope()
     {
-        _fixture.Options.EnableLogs = true;
         var logger = _fixture.GetSut();
 
         var defaultLogger = logger.Should().BeOfType<DefaultSentryStructuredLogger>().Which;
@@ -253,7 +242,6 @@ public partial class SentryStructuredLoggerTests : IDisposable
         _fixture.Hub.SubstituteConfigureScope(scope);
 
         SentryLog capturedLog = null!;
-        _fixture.Options.EnableLogs = true;
         _fixture.Options.SetBeforeSendLog((SentryLog log) =>
         {
             capturedLog = log;
@@ -277,7 +265,6 @@ public partial class SentryStructuredLoggerTests : IDisposable
         _fixture.Hub.SubstituteConfigureScope(scope);
 
         SentryLog capturedLog = null!;
-        _fixture.Options.EnableLogs = true;
         _fixture.Options.SetBeforeSendLog((SentryLog log) =>
         {
             capturedLog = log;


### PR DESCRIPTION
Phase 1 of #5479, split out of #5504.

## Summary

Reaching for `SentrySdk.Logger` (or any `SentryStructuredLogger`) is already an explicit statement that you want those logs in Sentry, so requiring `EnableLogs = true` on top of it was an unnecessary hoop. That gate is gone.

The whole change is one branch in `SentryStructuredLogger.Create`:

```diff
-return options.EnableLogs
-    ? new DefaultSentryStructuredLogger(hub, options, clock, batchCount, batchInterval)
-    : DisabledSentryStructuredLogger.Instance;
+return new DefaultSentryStructuredLogger(hub, options, clock, batchCount, batchInterval);
```

## What this deliberately does *not* change

`SentryOptions.EnableLogs` stays, still defaults to `false`, and is **not** obsolete. The logging integrations — `Sentry.Extensions.Logging`, `Sentry.Serilog`, `Sentry.NLog`, `Sentry.Log4Net` — each check `EnableLogs` *themselves* before calling `hub.Logger.CaptureLog(...)`, so they are entirely unaffected and continue to honour the option.

That is what makes this seam clean: the integrations sit in front of the gate being removed, not behind it. The evidence is that **not a single Verify snapshot or API-approval file changed** — if any integration had started emitting logs, the `Simple` / `Versioning` snapshots would have moved, as they did in #5504.

Leaving them alone is deliberate rather than incidental. Those integrations instrument a general-purpose `ILogger`-style surface where "I configured logging" says much less about whether you want the logs in Sentry, and each one produces three different things from a single log call — breadcrumbs, events, and structured logs. Changing that is a breaking change, so it belongs in the next major version.

The option's XML doc now says exactly which of the two it governs.

## Notes for review

- `Sentry.Samples.Console.Basic` used the direct API only, and its comment claimed the option "enables Sentry Logs created via SentrySdk.Logger" — no longer true, so both are gone. Every other sample uses a logging integration and keeps `EnableLogs = true` untouched.
- Two `HubTests` cases described the option toggling this API and no longer have any meaning; `Logger_IsDisabled_DoesNotCaptureLog` is replaced by `Logger_EnableLogsDisabled_StillCapturesLog`, asserting the new behaviour directly. `Create_EnableLogsDisabled_NewDefaultInstance` covers the same at the factory.
- The existing integration tests that assert `EnableLogs` still gates them (`SentrySinkTests.Emit_StructuredLogging_IsEnabled`, `SentryAppenderTests.DoAppend_StructuredLogging_IsEnabled`, `SentryStructuredLoggerTests.IsEnabled_HubAndOptions_Returns`) are untouched and now serve as the guard against this phase leaking into the next.
- No `CHANGELOG.md` entry — `scripts/verify-changelog.sh` rejects manual `## Unreleased` sections, so the commit subject is the changelog line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)