### PR TITLE
ci: fail the nightly vulnerable-packages scan when vulnerabilities are found

### DIFF
--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -1,10 +1,16 @@
 name: List vulnerable packages
 
+# Deliberately NOT triggered on `pull_request`.
+#
+# `dotnet package list --vulnerable` consults live advisory data, so a GHSA published
+# overnight against one of our transitive dependencies would turn every open PR red -
+# halting unrelated work until the dependency is updated, which is routine maintenance
+# rather than a defect in the PR. Running on a schedule keeps the signal without making
+# it a gate on everybody's work.
 on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *" # once a day
-  pull_request:
 
 jobs:
   list-vulnerable-packages:
@@ -31,5 +37,8 @@ jobs:
         shell: bash
         run: |
           dotnet package list --project Sentry.slnx --vulnerable --include-transitive --no-restore | tee vulnerable.txt
-          # https://github.com/getsentry/sentry-dotnet/issues/2814
-          # ! grep 'has the following vulnerable packages' vulnerable.txt
+
+          if grep -q 'has the following vulnerable packages' vulnerable.txt; then
+            echo "::error::Vulnerable packages detected - see the job output above for the affected projects and advisories."
+            exit 1
+          fi


### PR DESCRIPTION
Closes #5275

#skip-changelog

## Summary

The `List vulnerable packages` workflow has never been able to fail. `dotnet package list` [doesn't set an exit code on detection](https://github.com/NuGet/Home/issues/11315#issuecomment-1243055173), and the `grep` that was meant to compensate has been commented out since #2814 — which was closed as completed on 2025-11-26, so the original blocker is gone. Today the job prints its findings into logs nobody reads and always exits 0.

This enables the check, and **drops the `pull_request` trigger** so it runs on the nightly schedule (and `workflow_dispatch`) only.

## Why not run the gate on PRs

`--vulnerable` consults live advisory data rather than anything in the diff. Leaving it on `pull_request` means a GHSA published overnight against one of our transitive dependencies turns *every* open PR red until the dependency is updated — halting unrelated work over what is routine maintenance, not a defect in the PR.

The tradeoff is that a PR which introduces a vulnerable dependency is caught by the next nightly rather than on the PR itself. That seems like the right trade given the alternative is a repo-wide stop-the-world on someone else's advisory.

I checked both repo rulesets (`Default branch`, `Default production ruleset [don't modify]`) — neither has a `required_status_checks` rule, and classic branch protection isn't configured, so removing the trigger won't leave PRs waiting on a check that no longer reports.

## Heads-up: the first nightly after this merges will be red

I dispatched this workflow against the branch to check end-to-end: [run 33036863576](https://github.com/getsentry/sentry-dotnet/actions/runs/33036863576) fails at the `List vulnerable packages` step with exit code 1, as intended. **16 projects currently report vulnerable transitive packages**, including four shipped ones:

| Shipped package | Vulnerable transitive |
| --- | --- |
| `Sentry.Hangfire` | Newtonsoft.Json 5.0.1 / 11.0.1 — High ([GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr)) |
| `Sentry.Log4Net` | log4net 2.0.12 — Moderate ([GHSA-4f7c-pmjv-c25w](https://github.com/advisories/GHSA-4f7c-pmjv-c25w)) |
| `Sentry.OpenTelemetry` | OpenTelemetry.Api 1.6.0 — Moderate ([GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j)) |
| `Sentry.OpenTelemetry.Exporter` | OpenTelemetry.Api 1.10.0, OpenTelemetry.Exporter.OpenTelemetryProtocol 1.10.0 — Moderate |

The rest are samples and tests (plus `SQLitePCLRaw.lib.e_sqlite3` — High — in `Sentry.DiagnosticSource.Tests`).

These are all *minimum-version floors* inherited from our direct dependencies, not versions we picked. Clearing them means adding explicit references that raise the floor, which for the four shipped packages raises our published minimums — consistent with the `Breaking Change` / `Next Major` labels already on #5275.

So this PR makes the signal real but does not clear the backlog. Worth deciding before merge whether we'd rather land the floor bumps first so the nightly goes green immediately, or land this now and accept a red nightly while they're worked through. Happy to do either.
