### PR TITLE
chore: pin floating NuGet package versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,10 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 2
+  ignore:
+    # FluentAssertions v8.0.0 changed license; see https://fluentassertions.com/releases/#800
+    - dependency-name: "FluentAssertions"
+      update-types: ["version-update:semver-major"]
 
 - package-ecosystem: "github-actions"
   directories:

--- a/samples/Sentry.Samples.Hangfire/Sentry.Samples.Hangfire.csproj
+++ b/samples/Sentry.Samples.Hangfire/Sentry.Samples.Hangfire.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.8.1" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.12" />
     <!-- https://github.com/advisories/GHSA-5crp-9r3c-p9vr -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -56,7 +56,7 @@
 
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <!-- FluentAssertions v8.0.0 changed license; see https://fluentassertions.com/releases/#800 -->
-    <PackageReference Include="FluentAssertions" Version="[7.2.2,8.0.0)" />
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />


### PR DESCRIPTION
## Summary

Closes #5276

Rather than introducing `packages.lock.json`, we've pinned the only two non-specific NuGet version declarations in the repo so the dependency graph is explicit. Both are pinned to the versions they already resolved to, verified by comparing `project.assets.json` before and after — restore output is unchanged.