### PR TITLE
feat: Provide the exception in the Hint passed to BeforeBreadcrumb

### DIFF
--- a/src/Sentry.Extensions.Logging/SentryLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryLogger.cs
@@ -83,7 +83,7 @@ internal sealed class SentryLogger : ILogger
                 null,
                 data,
                 logLevel.ToBreadcrumbLevel(),
-                exception is null ? null : new SentryHint(HintTypes.Exception, exception));
+                exception.ToHint());
         }
     }
 

--- a/src/Sentry.Extensions.Logging/SentryLogger.cs
+++ b/src/Sentry.Extensions.Logging/SentryLogger.cs
@@ -82,7 +82,8 @@ internal sealed class SentryLogger : ILogger
                 CategoryName,
                 null,
                 data,
-                logLevel.ToBreadcrumbLevel());
+                logLevel.ToBreadcrumbLevel(),
+                exception is null ? null : new SentryHint(HintTypes.Exception, exception));
         }
     }
 

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -172,8 +172,6 @@ public partial class SentryAppender : AppenderSkeleton
             .Where(kvp => kvp.Value != null)
             .ToDictionary(kvp => kvp.Key, kvp => kvp.Value!.ToString() ?? "");
 
-        var exception = loggingEvent.ExceptionObject;
-
         _hub.AddBreadcrumb(
             clock: null,
             message,
@@ -181,7 +179,7 @@ public partial class SentryAppender : AppenderSkeleton
             type: null,
             data,
             level ?? default,
-            hint: exception is null ? null : new SentryHint(HintTypes.Exception, exception));
+            hint: loggingEvent.ExceptionObject.ToHint());
         return;
     }
 

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -172,7 +172,16 @@ public partial class SentryAppender : AppenderSkeleton
             .Where(kvp => kvp.Value != null)
             .ToDictionary(kvp => kvp.Key, kvp => kvp.Value!.ToString() ?? "");
 
-        _hub.AddBreadcrumb(message, category, type: null, data, level ?? default);
+        var exception = loggingEvent.ExceptionObject;
+
+        _hub.AddBreadcrumb(
+            clock: null,
+            message,
+            category,
+            type: null,
+            data,
+            level ?? default,
+            hint: exception is null ? null : new SentryHint(HintTypes.Exception, exception));
         return;
     }
 

--- a/src/Sentry.Log4Net/SentryAppender.cs
+++ b/src/Sentry.Log4Net/SentryAppender.cs
@@ -96,7 +96,7 @@ public partial class SentryAppender : AppenderSkeleton
 
         if (MinimumEventLevel is not null && loggingEvent.Level < MinimumEventLevel)
         {
-            AddBreadcrumbFromLoggingEvent(loggingEvent);
+            AddBreadcrumbFromLoggingEvent(loggingEvent, exception);
             return;
         }
 
@@ -163,7 +163,7 @@ public partial class SentryAppender : AppenderSkeleton
         _hub.CaptureEvent(evt);
     }
 
-    private void AddBreadcrumbFromLoggingEvent(LoggingEvent loggingEvent)
+    private void AddBreadcrumbFromLoggingEvent(LoggingEvent loggingEvent, Exception? exception)
     {
         var message = !string.IsNullOrWhiteSpace(loggingEvent.RenderedMessage) ? loggingEvent.RenderedMessage : string.Empty;
         var category = loggingEvent.LoggerName;
@@ -179,7 +179,7 @@ public partial class SentryAppender : AppenderSkeleton
             type: null,
             data,
             level ?? default,
-            hint: loggingEvent.ExceptionObject.ToHint());
+            hint: exception.ToHint());
         return;
     }
 

--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -425,8 +425,10 @@ public sealed partial class SentryTarget : TargetWithContext
             _clock,
             message,
             breadcrumbCategory,
+            type: null,
             data: data,
-            level: logEvent.Level.ToBreadcrumbLevel());
+            level: logEvent.Level.ToBreadcrumbLevel(),
+            hint: exception is null ? null : new SentryHint(HintTypes.Exception, exception));
     }
 
     private void CreateSentryEvent(LogEventInfo logEvent, Exception? exception, bool shouldIncludeProperties, IHub hub)

--- a/src/Sentry.NLog/SentryTarget.cs
+++ b/src/Sentry.NLog/SentryTarget.cs
@@ -428,7 +428,7 @@ public sealed partial class SentryTarget : TargetWithContext
             type: null,
             data: data,
             level: logEvent.Level.ToBreadcrumbLevel(),
-            hint: exception is null ? null : new SentryHint(HintTypes.Exception, exception));
+            hint: exception.ToHint());
     }
 
     private void CreateSentryEvent(LogEventInfo logEvent, Exception? exception, bool shouldIncludeProperties, IHub hub)

--- a/src/Sentry.Serilog/SentrySink.cs
+++ b/src/Sentry.Serilog/SentrySink.cs
@@ -161,8 +161,10 @@ internal sealed partial class SentrySink : ILogEventSink, IDisposable
                     ? exception?.Message ?? ""
                     : formatted,
                 context,
+                type: null,
                 data: data,
-                level: logEvent.Level.ToBreadcrumbLevel());
+                level: logEvent.Level.ToBreadcrumbLevel(),
+                hint: exception is null ? null : new SentryHint(HintTypes.Exception, exception));
         }
 
         // Read the options from the Hub, rather than the Sink's Serilog-Options, because 'EnableLogs' is declared in the base 'SentryOptions', rather than the derived 'SentrySerilogOptions'.

--- a/src/Sentry.Serilog/SentrySink.cs
+++ b/src/Sentry.Serilog/SentrySink.cs
@@ -164,7 +164,7 @@ internal sealed partial class SentrySink : ILogEventSink, IDisposable
                 type: null,
                 data: data,
                 level: logEvent.Level.ToBreadcrumbLevel(),
-                hint: exception is null ? null : new SentryHint(HintTypes.Exception, exception));
+                hint: exception.ToHint());
         }
 
         // Read the options from the Hub, rather than the Sink's Serilog-Options, because 'EnableLogs' is declared in the base 'SentryOptions', rather than the derived 'SentrySerilogOptions'.

--- a/src/Sentry/HintTypes.cs
+++ b/src/Sentry/HintTypes.cs
@@ -9,4 +9,9 @@ public static class HintTypes
     /// Used for HttpResponseMessage hints
     /// </summary>
     public const string HttpResponseMessage = "http-response-message";
+
+    /// <summary>
+    /// Used for the <see cref="System.Exception"/> that a breadcrumb was created from
+    /// </summary>
+    public const string Exception = "exception";
 }

--- a/src/Sentry/HubExtensions.cs
+++ b/src/Sentry/HubExtensions.cs
@@ -191,6 +191,32 @@ public static class HubExtensions
         string? type = null,
         IDictionary<string, string>? data = null,
         BreadcrumbLevel level = default)
+        => hub.AddBreadcrumb(clock, message, category, type, data, level, hint: null);
+
+    /// <summary>
+    /// Adds a breadcrumb using a custom <see cref="ISystemClock"/> which allows better testability.
+    /// </summary>
+    /// <param name="hub">The Hub which holds the scope stack.</param>
+    /// <param name="clock">The system clock.</param>
+    /// <param name="message">The message.</param>
+    /// <param name="category">Category.</param>
+    /// <param name="type">Breadcrumb type.</param>
+    /// <param name="data">Additional data.</param>
+    /// <param name="level">Breadcrumb level.</param>
+    /// <param name="hint">A hint provided with the breadcrumb in the BeforeBreadcrumb callback.</param>
+    /// <remarks>
+    /// This method is to be used by integrations to allow testing.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static void AddBreadcrumb(
+        this IHub hub,
+        ISystemClock? clock,
+        string message,
+        string? category,
+        string? type,
+        IDictionary<string, string>? data,
+        BreadcrumbLevel level,
+        SentryHint? hint)
     {
         // Not to throw on code that ignores nullability warnings.
         if (hub.IsNull())
@@ -207,9 +233,7 @@ public static class HubExtensions
             level
         );
 
-        hub.AddBreadcrumb(
-            breadcrumb
-            );
+        hub.AddBreadcrumb(breadcrumb, hint);
     }
 
     /// <summary>

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -587,7 +587,19 @@ internal class Hub : IHub, IDisposable
                     {"exception_message", exceptionMessage}
                 };
             }
-            scope.AddBreadcrumb(breadcrumbMessage, "Exception", data: data, level: BreadcrumbLevel.Fatal);
+
+            // Provide the original exception in a Hint, so that the BeforeBreadcrumb callback can filter or modify
+            // the breadcrumb based on the exception itself (e.g. by type) rather than by matching on its message.
+            var hint = new SentryHint(_options);
+            hint.Items[HintTypes.Exception] = exception;
+
+            var breadcrumb = new Breadcrumb(
+                message: breadcrumbMessage,
+                data: data,
+                category: "Exception",
+                level: BreadcrumbLevel.Fatal);
+
+            scope.AddBreadcrumb(breadcrumb, hint);
         }
         catch (Exception e)
         {

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -588,8 +588,6 @@ internal class Hub : IHub, IDisposable
                 };
             }
 
-            // Provide the original exception in a Hint, so that the BeforeBreadcrumb callback can filter or modify
-            // the breadcrumb based on the exception itself (e.g. by type) rather than by matching on its message.
             var hint = new SentryHint(_options);
             hint.Items[HintTypes.Exception] = exception;
 

--- a/src/Sentry/SentryExceptionExtensions.cs
+++ b/src/Sentry/SentryExceptionExtensions.cs
@@ -1,3 +1,4 @@
+using Sentry;
 using Sentry.Internal;
 using Sentry.Protocol;
 
@@ -7,6 +8,14 @@ using Sentry.Protocol;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class SentryExceptionExtensions
 {
+    /// <summary>
+    /// Creates a <see cref="SentryHint"/> carrying the exception that a breadcrumb was created from, or
+    /// <see langword="null"/> if there is no exception.
+    /// </summary>
+    internal static SentryHint? ToHint(this Exception? exception) => exception is null
+        ? null
+        : new SentryHint(HintTypes.Exception, exception);
+
     /// <summary>
     /// Set a tag that will be added to the event when the exception is captured.
     /// </summary>

--- a/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
+++ b/test/Sentry.Extensions.Logging.Tests/SentryLoggerTests.cs
@@ -59,6 +59,26 @@ public class SentryLoggerTests
     }
 
     [Fact]
+    public void Log_BreadcrumbWithException_ProvidesExceptionInHint()
+    {
+        SentryHint hint = null;
+        _fixture.Scope.Options.SetBeforeBreadcrumb((breadcrumb, h) =>
+        {
+            hint = h;
+            return breadcrumb;
+        });
+        var expectedException = new Exception("expected message");
+
+        var sut = _fixture.GetSut();
+
+        // LogLevel.Warning is below the default MinimumEventLevel, so only a breadcrumb is added
+        sut.Log<object>(LogLevel.Warning, default, null, expectedException, null);
+
+        hint.Should().NotBeNull();
+        hint.Items[HintTypes.Exception].Should().BeSameAs(expectedException);
+    }
+
+    [Fact]
     public void Log_WithEventId_EventIdAsTagOnEvent()
     {
         var expectedEventId = new EventId(10, "EventId-!@#$%^&*(");

--- a/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
+++ b/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
@@ -345,8 +345,10 @@ public partial class SentryAppenderTests : IDisposable
         Assert.Equal(expectedBreadcrumbMsg, breadcrumb.Message);
     }
 
-    [Fact]
-    public void DoAppend_BreadcrumbWithException_ProvidesExceptionInHint()
+    [Theory]
+    [InlineData(false)] // logger.Warn("message", ex) -> ExceptionObject
+    [InlineData(true)]  // logger.Warn(ex)            -> MessageObject
+    public void DoAppend_BreadcrumbWithException_ProvidesExceptionInHint(bool exceptionAsMessage)
     {
         SentryHint hint = null;
         _fixture.Scope.Options.SetBeforeBreadcrumb((breadcrumb, h) =>
@@ -355,13 +357,16 @@ public partial class SentryAppenderTests : IDisposable
             return breadcrumb;
         });
         var expectedException = new Exception("expected");
+        var evt = exceptionAsMessage
+            ? new LoggingEvent(null, null, "logger", Level.Warn, expectedException, null)
+            : new LoggingEvent(null, null, "logger", Level.Warn, "log4net breadcrumb", expectedException);
 
         var sut = _fixture.GetSut();
         sut.Threshold = Level.Debug;
         sut.MinimumEventLevel = Level.Error;
 
         // Level.Warn is below the MinimumEventLevel, so only a breadcrumb is added
-        sut.DoAppend(new LoggingEvent(null, null, "logger", Level.Warn, "log4net breadcrumb", expectedException));
+        sut.DoAppend(evt);
 
         hint.Should().NotBeNull();
         hint.Items[HintTypes.Exception].Should().BeSameAs(expectedException);

--- a/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
+++ b/test/Sentry.Log4Net.Tests/SentryAppenderTests.cs
@@ -346,6 +346,28 @@ public partial class SentryAppenderTests : IDisposable
     }
 
     [Fact]
+    public void DoAppend_BreadcrumbWithException_ProvidesExceptionInHint()
+    {
+        SentryHint hint = null;
+        _fixture.Scope.Options.SetBeforeBreadcrumb((breadcrumb, h) =>
+        {
+            hint = h;
+            return breadcrumb;
+        });
+        var expectedException = new Exception("expected");
+
+        var sut = _fixture.GetSut();
+        sut.Threshold = Level.Debug;
+        sut.MinimumEventLevel = Level.Error;
+
+        // Level.Warn is below the MinimumEventLevel, so only a breadcrumb is added
+        sut.DoAppend(new LoggingEvent(null, null, "logger", Level.Warn, "log4net breadcrumb", expectedException));
+
+        hint.Should().NotBeNull();
+        hint.Items[HintTypes.Exception].Should().BeSameAs(expectedException);
+    }
+
+    [Fact]
     public void DoAppend_NullMinimumEventLevel_AddsEvent()
     {
         var sut = _fixture.GetSut();

--- a/test/Sentry.NLog.Tests/SentryTargetTests.cs
+++ b/test/Sentry.NLog.Tests/SentryTargetTests.cs
@@ -192,6 +192,27 @@ public partial class SentryTargetTests
     }
 
     [Fact]
+    public void Log_BreadcrumbWithException_ProvidesExceptionInHint()
+    {
+        SentryHint hint = null;
+        _fixture.Scope.Options.SetBeforeBreadcrumb((breadcrumb, h) =>
+        {
+            hint = h;
+            return breadcrumb;
+        });
+        var expectedException = new Exception("expected");
+
+        _fixture.Options.MinimumEventLevel = LogLevel.Fatal;
+        var logger = _fixture.GetLogger();
+
+        // LogLevel.Error is below the MinimumEventLevel, so only a breadcrumb is added
+        logger.Error(expectedException, DefaultMessage);
+
+        hint.Should().NotBeNull();
+        hint.Items[HintTypes.Exception].Should().BeSameAs(expectedException);
+    }
+
+    [Fact]
     public void Log_WithException_CreatesEventWithException()
     {
         var expected = new Exception("expected");

--- a/test/Sentry.Serilog.Tests/SentrySinkTests.cs
+++ b/test/Sentry.Serilog.Tests/SentrySinkTests.cs
@@ -77,6 +77,29 @@ public partial class SentrySinkTests
     }
 
     [Fact]
+    public void EmitBreadcrumb_WithException_ProvidesExceptionInHint()
+    {
+        SentryHint hint = null;
+        _fixture.Scope.Options.SetBeforeBreadcrumb((breadcrumb, h) =>
+        {
+            hint = h;
+            return breadcrumb;
+        });
+        var expectedException = new Exception("expected message");
+
+        var sut = _fixture.GetSut();
+
+        // LogEventLevel.Warning is below the default MinimumEventLevel, so only a breadcrumb is added
+        var evt = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Warning, expectedException,
+            MessageTemplate.Empty, Enumerable.Empty<LogEventProperty>());
+
+        sut.Emit(evt);
+
+        hint.Should().NotBeNull();
+        hint.Items[HintTypes.Exception].Should().BeSameAs(expectedException);
+    }
+
+    [Fact]
     public void Emit_SerilogSdk_Name()
     {
         var sut = _fixture.GetSut();

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -125,6 +125,7 @@ namespace Sentry
     public delegate bool HeapDumpTrigger(long usedMemory, long totalMemory);
     public static class HintTypes
     {
+        public const string Exception = "exception";
         public const string HttpResponseMessage = "http-response-message";
     }
     public readonly struct HttpStatusCodeRange : System.IEquatable<Sentry.HttpStatusCodeRange>
@@ -149,6 +150,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
+        public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category, string? type, System.Collections.Generic.IDictionary<string, string>? data, Sentry.BreadcrumbLevel level, Sentry.SentryHint? hint) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, bool terminal, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -125,6 +125,7 @@ namespace Sentry
     public delegate bool HeapDumpTrigger(long usedMemory, long totalMemory);
     public static class HintTypes
     {
+        public const string Exception = "exception";
         public const string HttpResponseMessage = "http-response-message";
     }
     public readonly struct HttpStatusCodeRange : System.IEquatable<Sentry.HttpStatusCodeRange>
@@ -149,6 +150,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
+        public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category, string? type, System.Collections.Generic.IDictionary<string, string>? data, Sentry.BreadcrumbLevel level, Sentry.SentryHint? hint) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, bool terminal, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -125,6 +125,7 @@ namespace Sentry
     public delegate bool HeapDumpTrigger(long usedMemory, long totalMemory);
     public static class HintTypes
     {
+        public const string Exception = "exception";
         public const string HttpResponseMessage = "http-response-message";
     }
     public readonly struct HttpStatusCodeRange : System.IEquatable<Sentry.HttpStatusCodeRange>
@@ -149,6 +150,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
+        public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category, string? type, System.Collections.Generic.IDictionary<string, string>? data, Sentry.BreadcrumbLevel level, Sentry.SentryHint? hint) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, bool terminal, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -113,6 +113,7 @@ namespace Sentry
     }
     public static class HintTypes
     {
+        public const string Exception = "exception";
         public const string HttpResponseMessage = "http-response-message";
     }
     public readonly struct HttpStatusCodeRange : System.IEquatable<Sentry.HttpStatusCodeRange>
@@ -137,6 +138,7 @@ namespace Sentry
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Breadcrumb breadcrumb, Sentry.SentryHint? hint = null) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
         public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category = null, string? type = null, System.Collections.Generic.IDictionary<string, string>? data = null, Sentry.BreadcrumbLevel level = 0) { }
+        public static void AddBreadcrumb(this Sentry.IHub hub, Sentry.Infrastructure.ISystemClock? clock, string message, string? category, string? type, System.Collections.Generic.IDictionary<string, string>? data, Sentry.BreadcrumbLevel level, Sentry.SentryHint? hint) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureException(this Sentry.IHub hub, System.Exception ex, bool handled, bool terminal, System.Action<Sentry.Scope> configureScope) { }
         public static Sentry.SentryId CaptureFeedback(this Sentry.IHub hub, Sentry.SentryFeedback feedback, System.Action<Sentry.Scope> configureScope, Sentry.SentryHint? hint = null) { }

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -314,6 +314,47 @@ public partial class HubTests : IDisposable
     }
 
     [Fact]
+    public void CaptureEvent_Exception_BreadcrumbHintContainsException()
+    {
+        // Arrange
+        SentryHint hint = null;
+        _fixture.Options.SetBeforeBreadcrumb((breadcrumb, h) =>
+        {
+            hint = h;
+            return breadcrumb;
+        });
+        using var hub = _fixture.GetSut();
+        var exception = new Exception("original");
+
+        // Act
+        hub.CaptureEvent(new SentryEvent(exception));
+
+        // Assert
+        hint.Should().NotBeNull();
+        hint.Items[HintTypes.Exception].Should().BeSameAs(exception);
+    }
+
+    [Fact]
+    public void CaptureEvent_Exception_BeforeBreadcrumbCanFilterOnExceptionType()
+    {
+        // Arrange
+        _fixture.Options.SetBeforeBreadcrumb((breadcrumb, hint) =>
+            hint.Items.TryGetValue(HintTypes.Exception, out var exception) && exception is InvalidOperationException
+                ? null
+                : breadcrumb);
+        using var hub = _fixture.GetSut();
+        var scope = hub.ScopeManager.GetCurrent().Key;
+
+        // Act
+        hub.CaptureEvent(new SentryEvent(new InvalidOperationException("filtered")));
+        hub.CaptureEvent(new SentryEvent(new Exception("kept")));
+
+        // Assert
+        scope.Breadcrumbs.Should().ContainSingle(b => b.Category == "Exception")
+            .Which.Message.Should().Be("kept");
+    }
+
+    [Fact]
     public void CaptureEvent_WithMessageAndException_StoresExceptionMessageAsData()
     {
         // Arrange


### PR DESCRIPTION
Closes #5514 

## Summary

When a breadcrumb is created from an exception, the exception itself is now provided in the `SentryHint` passed to the `SetBeforeBreadcrumb` callback, under a new `HintTypes.Exception` key.

This mirrors the Java SDK, which puts the originating logging event into the `Hint` it passes to `beforeBreadcrumb` (see [`TypeCheckHint`](https://github.com/getsentry/sentry-java/blob/main/sentry/src/main/java/io/sentry/TypeCheckHint.java), e.g. `logback:loggingEvent`). Until now .NET only ever passed an empty hint for these, so a `BeforeBreadcrumb` callback could only filter exception breadcrumbs by string-matching the message.

```csharp
options.SetBeforeBreadcrumb((breadcrumb, hint) =>
    hint.Items.TryGetValue(HintTypes.Exception, out var exception) && exception is MyException
        ? null       // drop it
        : breadcrumb);
```

Covered sites:

- `Hub.AddBreadcrumbForException` — the automatic `Exception` breadcrumb left on the scope for every captured exception event.
- `Sentry.Extensions.Logging`, `Sentry.Serilog`, `Sentry.NLog` and `Sentry.Log4Net` — breadcrumbs those integrations create for log entries that carry an exception (i.e. below `MinimumEventLevel`, where they don't defer to the Hub's breadcrumb).

## Notes for review

- `HubExtensions` gains a hint-carrying overload of the `[EditorBrowsable(Never)]` `AddBreadcrumb(clock, …)` method that the logging integrations use. It's a new overload rather than an added optional parameter, to avoid a binary-breaking change and overload ambiguity at existing call sites.
- The `Net4_8` API approval snapshot was hand-edited, since that TFM can't be built on macOS. The other three regenerated normally.

Relates to #5514. It does **not** close that issue: this gives users a way to filter exception breadcrumbs by type, but the SDK still leaves a breadcrumb for an exception that its own `IExceptionFilter` just dropped. That needs a separate change to `AddBreadcrumbForException` so it respects `SentryOptions.ExceptionFilters`.
