### PR TITLE
fix(ios): Prevent managed exceptions from leaking as NSExceptions

### DIFF
--- a/integration-test/ios.Tests.ps1
+++ b/integration-test/ios.Tests.ps1
@@ -25,6 +25,9 @@ Describe 'iOS app (<tfm>, <configuration>, <runtime>)' -ForEach @(
 
         Remove-Item -Path "$PSScriptRoot/mobile-app" -Recurse -Force -ErrorAction SilentlyContinue
         Copy-Item -Path "$PSScriptRoot/net9-maui" -Destination "$PSScriptRoot/mobile-app" -Recurse -Force
+        # clean up potential old copied build outputs that may target a different configuration or runtime
+        Remove-Item -Path "$PSScriptRoot/mobile-app/bin", "$PSScriptRoot/mobile-app/obj" `
+            -Recurse -Force -ErrorAction SilentlyContinue
         Push-Location $PSScriptRoot/mobile-app
 
         $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLower()
@@ -104,6 +107,19 @@ Describe 'iOS app (<tfm>, <configuration>, <runtime>)' -ForEach @(
         $result.HasErrors() | Should -BeFalse
         $result.Envelopes() | Should -AnyElementMatch "`"type`":`"System.ApplicationException`""
         $result.Envelopes() | Should -Not -AnyElementMatch "`"type`":`"(EXC_[A-Z_]+|SIG[A-Z]+)`""
+        $result.Envelopes() | Should -HaveCount 1
+    }
+
+    It 'does not leak managed exception as NSException (<configuration>, <runtime>)' {
+        $result = Invoke-SentryServer {
+            param([string]$url)
+            RunIosApp -Dsn $url -TestArg "OnActivated"
+            RunIosApp -Dsn $url
+        }
+
+        $result.HasErrors() | Should -BeFalse
+        $result.Envelopes() | Should -AnyElementMatch "`"type`":`"System.ApplicationException`""
+        $result.Envelopes() | Should -Not -AnyElementMatch "`"type`":`"nsexception`""
         $result.Envelopes() | Should -HaveCount 1
     }
 

--- a/integration-test/net9-maui/App.xaml.cs
+++ b/integration-test/net9-maui/App.xaml.cs
@@ -61,6 +61,16 @@ public partial class App : Application
         return new Window(new AppShell());
     }
 
+    public static void OnActivated()
+    {
+        testArg = System.Environment.GetEnvironmentVariable("SENTRY_TEST_ARG");
+
+        if (HasTestArg("OnActivated"))
+        {
+            throw new ApplicationException("This exception was thrown deliberately from AppDelegate.OnActivated.");
+        }
+    }
+
     public static void OnAppearing()
     {
         testArg = System.Environment.GetEnvironmentVariable("SENTRY_TEST_ARG");

--- a/integration-test/net9-maui/Platforms/iOS/AppDelegate.cs
+++ b/integration-test/net9-maui/Platforms/iOS/AppDelegate.cs
@@ -1,4 +1,5 @@
 ﻿using Foundation;
+using UIKit;
 
 namespace Sentry.Maui.Device.IntegrationTestApp;
 
@@ -6,4 +7,10 @@ namespace Sentry.Maui.Device.IntegrationTestApp;
 public class AppDelegate : MauiUIApplicationDelegate
 {
     protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+    public override void OnActivated(UIApplication application)
+    {
+        base.OnActivated(application);
+        App.OnActivated();
+    }
 }

--- a/src/Sentry/Platforms/Cocoa/RuntimeMarshalManagedExceptionIntegration.cs
+++ b/src/Sentry/Platforms/Cocoa/RuntimeMarshalManagedExceptionIntegration.cs
@@ -54,9 +54,10 @@ internal class RuntimeMarshalManagedExceptionIntegration : ISdkIntegration
                 return;
             }
 
+            e.ExceptionMode = MarshalManagedExceptionMode.Abort;
+
             // Otherwise the runtime will call abort() after we return — directly via
-            // xamarin_assertion_message, or indirectly via the uncaught-NSException handler for
-            // ThrowObjectiveCException. Tell SentryCrash to ignore that SIGABRT so we don't emit a
+            // xamarin_assertion_message. Tell SentryCrash to ignore that SIGABRT so we don't emit a
             // duplicate native crash for an exception we've already captured. See
             // https://github.com/dotnet/macios/blob/be8a2ca1057242f745ef58011a02ffe21326d180/runtime/runtime.m#L2285
             const int SIGABRT = 6;

--- a/test/Sentry.Tests/Platforms/iOS/RuntimeMarshalManagedExceptionIntegrationTests.cs
+++ b/test/Sentry.Tests/Platforms/iOS/RuntimeMarshalManagedExceptionIntegrationTests.cs
@@ -82,6 +82,18 @@ public class RuntimeMarshalManagedExceptionIntegrationTests
         _fixture.Runtime.Received(1).IgnoreNextSignal(6);
     }
 
+    [Fact]
+    public void Handle_ThrowObjectiveCException_ChangesModeToAbort()
+    {
+        var sut = _fixture.GetSut();
+        sut.Register(_fixture.Hub, SentryOptions);
+        var args = new MarshalManagedExceptionEventArgs { Exception = new Exception(), ExceptionMode = MarshalManagedExceptionMode.ThrowObjectiveCException };
+
+        sut.Handle(this, args);
+
+        Assert.Equal(MarshalManagedExceptionMode.Abort, args.ExceptionMode);
+    }
+
     [Theory]
     [InlineData(MarshalManagedExceptionMode.Disable)]
     [InlineData(MarshalManagedExceptionMode.UnwindNativeCode)]


### PR DESCRIPTION
After Sentry .NET captures an unhandled exception in `Runtime.MarshalManagedException`, the default `ThrowObjectiveCException` mode throws an `NSException`.

The existing managed-crash test throws through `NSAsyncActionDispatcher`, where .NET’s `UIApplicationMain` wrapper catches the `NSException` before Sentry Cocoa observes it. The new test throws from `UIApplicationDelegate.OnActivated`, reproducing the path where the `NSException` reaches Sentry Cocoa’s uncaught-exception handler and creates a duplicate event.

This changes the per-event mode to `Abort` after capture, preventing the `NSException`. The existing one-shot `SIGABRT` suppression ignores the runtime’s resulting unconditional `abort()`.

Close: #5493

### Changelog Entry

fix: Prevent managed exceptions from leaking as NSExceptions, resulting in duplicate exception capture on iOS