### PR TITLE
build: scope the perfview-build feed to the package it provides

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -23,8 +23,18 @@
     <packageSource key="dotnet-public">
       <package pattern="*" />
     </packageSource>
+    <!--
+      Scoped to the one package this feed uniquely provides: nuget.org only publishes
+      Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles up to 1.0.23, and perfview
+      needs 1.0.30. Every other perfview dependency resolves from nuget.org.
+
+      It must not be a "*" source. This feed proxies upstream, and answers 401 - not 404 -
+      for any package version it has not already cached. NuGet treats a 401 from any mapped
+      source as fatal, so a "*" mapping makes every new package version in the repo depend
+      on that proxy succeeding.
+    -->
     <packageSource key="perfview-build">
-      <package pattern="*" />
+      <package pattern="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" />
     </packageSource>
     <packageSource key="dotnet-eng">
       <package pattern="Microsoft.DotNet.XHarness.*" />


### PR DESCRIPTION
`nuget.config` maps the `perfview-build` feed to the `*` package pattern, so NuGet queries that single-purpose feed for **every** package in the repo. It proxies upstream and answers **401** — not 404 — for any package version it has not already cached, and NuGet treats a 401 from any mapped source as fatal.

That was harmless for years while the feed served everything, and started failing today when its anonymous upstream fetches began returning 401. It takes out restore on `main`:

```
Workload update failed: 401 (Unauthorized - No local versions of package
'microsoft.net.workloads.10.0.400.msi.x64'; please provide authentication to
access versions from upstream that have not yet been saved to your feed.)
```

This is an external outage, not a code change — `main` was green as recently as the run for #5503 (`2026-08-31T11:14`), and the only change before the first red run (`2026-09-01T01:21`) was #5513, a workflow file. The feed still 401s on those packages as of writing.

## Why the feed is still needed

For exactly one package. The `perfview` submodule references `Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles`, and nuget.org only publishes up to **1.0.23**:

| SupportFiles | nuget.org | perfview-build |
|---|---|---|
| 1.0.29 (before #5502) | ❌ | ✅ |
| 1.0.30 (current) | ❌ | ✅ |

So this predates the recent submodule bump — the bump moved 1.0.29 → 1.0.30, both of which are perfview-build-only.

The other eleven packages the perfview projects reference (`MicroBuild.Core`, `Microsoft.Bcl.HashCode`, `Microsoft.Diagnostics.NETCore.Client`, `Microsoft.Win32.Registry`, `System.Collections.Immutable`, `System.IO.Hashing`, `System.Reflection.Metadata`, `System.Reflection.TypeExtensions`, `System.Runtime.CompilerServices.Unsafe`, `System.Text.Json`, `Microsoft.SourceLink.GitHub`) are all on nuget.org at their exact required versions.

Scoping the mapping to that one package keeps it resolvable while removing the repo's dependency on the feed for everything else, so a future dnceng hiccup can't take out CI again.

## Verification

Cold restore of `Sentry-CI-Build-macOS.slnf` into an empty packages folder (not the warm local cache): **6.1 GB fetched, no errors**, and `SupportFiles 1.0.30` confirmed resolved from `perfview-build`.

`dotnet-public` is healthy and stays mapped to `*`.

#skip-changelog
