### PR TITLE
ci: query only nuget.org in the vulnerable-packages scan

### DIFF
--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -34,12 +34,8 @@ jobs:
       # The dotnet package list command doesn't change its exit code on detection, so tee to a file and scan it
       # See https://github.com/NuGet/Home/issues/11315#issuecomment-1243055173
       #
-      # --source pins the query to nuget.org, which is the only feed in nuget.config that publishes a
-      # VulnerabilityInfo resource - the four Azure DevOps feeds have none, so they can only ever
-      # contribute zero advisories. Pinning is also what keeps the step running at all: unlike restore,
-      # `dotnet package list` ignores packageSourceMapping and queries every configured source for
-      # every package, and `perfview-build` answers 401 - not 404 - for anything it hasn't cached,
-      # which NuGet treats as fatal. That is the same feed, and the same failure, as #5528.
+      # --source pins the query to nuget.org - the only feed that publishes a
+      # VulnerabilityInfo resource. The other feeds can error out with 401s
       - name: List vulnerable packages
         shell: bash
         run: |

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -33,10 +33,18 @@ jobs:
 
       # The dotnet package list command doesn't change its exit code on detection, so tee to a file and scan it
       # See https://github.com/NuGet/Home/issues/11315#issuecomment-1243055173
+      #
+      # --source pins the query to nuget.org, which is the only feed in nuget.config that publishes a
+      # VulnerabilityInfo resource - the four Azure DevOps feeds have none, so they can only ever
+      # contribute zero advisories. Pinning is also what keeps the step running at all: unlike restore,
+      # `dotnet package list` ignores packageSourceMapping and queries every configured source for
+      # every package, and `perfview-build` answers 401 - not 404 - for anything it hasn't cached,
+      # which NuGet treats as fatal. That is the same feed, and the same failure, as #5528.
       - name: List vulnerable packages
         shell: bash
         run: |
-          dotnet package list --project Sentry.slnx --vulnerable --include-transitive --no-restore | tee vulnerable.txt
+          dotnet package list --project Sentry.slnx --vulnerable --include-transitive --no-restore \
+            --source https://api.nuget.org/v3/index.json | tee vulnerable.txt
 
           if grep -q 'has the following vulnerable packages' vulnerable.txt; then
             echo "::error::Vulnerable packages detected - see the job output above for the affected projects and advisories."


### PR DESCRIPTION
The nightly `List vulnerable packages` job has failed on every run since #5513 enabled the gate:

```
error: Response status code does not indicate success: 401 (Unauthorized - No local versions of
package 'nsubstitute'; please provide authentication to access versions from upstream that have
not yet been saved to your feed.)
```

Same feed, same 401, as #5528 — but a different code path.

#5528 scoped `perfview-build` to the package it provides, which fixed **restore**. But `dotnet package list --vulnerable` **ignores `packageSourceMapping`** and queries every configured source for every package. `perfview-build` proxies an upstream it can't authenticate to, so it answers 401 — not 404 — for anything it hasn't already cached, and NuGet treats a 401 from any source as fatal.

Minimal reproduction, a single `PackageReference` to `NSubstitute` alongside the repo's `nuget.config`:

| | result |
|---|---|
| `dotnet restore` | ✅ succeeds — mapping honoured, `perfview-build` never queried |
| `dotnet package list --vulnerable` | ❌ `401 … No local versions of package 'nsubstitute'` |

Probing the feeds directly confirms `perfview-build` is the only one that fails this way — `dotnet-eng` and `mattleibow` return a clean 404 for an unknown package, and `dotnet-public` returns 200.

## Fix

nuget.org is the **only** configured feed that publishes vulnerability data at all, so `--source https://api.nuget.org/v3/index.json` (i.e. don't check any sources except nuget.org) removes the failure without narrowing coverage.

## Verification

Against the real `Sentry.slnx`, the command in the diff completes with no 401 and produces the full report for all projects. Running the step's rendered script under CI's exact shell flags (`bash --noprofile --norc -e -o pipefail`) exits 1 with the intended annotation:

```
::error::Vulnerable packages detected - see the job output above for the affected projects and advisories.
```

Dispatched against this branch to confirm end-to-end: [run 33705427479](https://github.com/getsentry/sentry-dotnet/actions/runs/33705427479). No 401 anywhere in the log, `The following sources were used:` lists nuget.org alone, the scan runs to completion across all projects, and the step fails with the annotation *"Vulnerable packages detected - see the job output above for the affected projects and advisories."* — 17 projects flagged.

## The job will still be red after this — as designed

The scan reports genuine advisories (Newtonsoft.Json in `Sentry.Hangfire`, log4net in `Sentry.Log4Net`, OpenTelemetry.Api in `Sentry.OpenTelemetry`, …), all minimum-version floors inherited from direct dependencies. Clearing them raises our published minimums and is tracked by #5275 under `Breaking Change` / `Next Major`.

#skip-changelog
