### PR TITLE
test: sentry-cocoa #8921 cancel-crash fix (do not merge)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,10 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>6.10.0</VersionPrefix>
+    <VersionPrefix>6.10.1</VersionPrefix>
+    <!-- TEST BRANCH ONLY: distinct prerelease so this build cannot be confused with,
+         or resolved instead of, the released 6.10.0. Do not merge. -->
+    <VersionSuffix>alpha.8921.1</VersionSuffix>
     <LangVersion>14.0</LangVersion>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
+++ b/src/Sentry.Bindings.Cocoa/ApiDefinitions.cs
@@ -1337,6 +1337,10 @@ interface SentryObjCOptions
     [Export("maxBreadcrumbs")]
     nuint MaxBreadcrumbs { get; set; }
 
+    // @property (nonatomic) NSUInteger maxFeatureFlags;
+    [Export("maxFeatureFlags")]
+    nuint MaxFeatureFlags { get; set; }
+
     // @property (nonatomic) BOOL enableNetworkBreadcrumbs;
     [Export("enableNetworkBreadcrumbs")]
     bool EnableNetworkBreadcrumbs { get; set; }
@@ -1750,6 +1754,18 @@ interface SentryObjCInternalScopeApi
     // -(NSDictionary<NSString *,NSDictionary<NSString *,id> *> * _Nonnull)serializedContexts;
     [Export("serializedContexts")]
     NSDictionary<NSString, NSDictionary<NSString, NSObject>> SerializedContexts { get; }
+
+    // -(void)withCurrentScope:(SentryObjCScope * _Nonnull)scope callback:(void (^ _Nonnull)(void))callback;
+    [Export("withCurrentScope:callback:")]
+    void WithCurrentScope(SentryObjCScope scope, Action callback);
+
+    // -(SentryObjCScope * _Nonnull)createScope;
+    [Export("createScope")]
+    SentryObjCScope CreateScope { get; }
+
+    // -(SentryObjCScope * _Nonnull)cloneScope:(SentryObjCScope * _Nonnull)scope;
+    [Export("cloneScope:")]
+    SentryObjCScope CloneScope(SentryObjCScope scope);
 }
 
 // @interface SentryObjCInternalSdkApi : NSObject


### PR DESCRIPTION
## Do not merge

`modules/sentry-cocoa` points at an **unmerged branch** — getsentry/sentry-cocoa#8921. This branch
exists only so CI produces a `Sentry.Maui` package containing that proposed fix, for the reporter of
#5519 to test against his own reproduction.

## Context

#5519 is an `EXC_BAD_ACCESS` in `-[NSURLSessionTask cancel]` on iOS when native swizzling is enabled
and a retry policy disposes a 5xx response while the body is still streaming. I reduced it to a
minimal reproduction and filed it upstream as getsentry/sentry-cocoa#8917; #8921 is the proposed fix
(skip the private `setCurrentRequest:` when the task is already canceling or completed).

We could not verify the fix locally: the reproduction stopped firing on my machine, and the *unfixed*
control also came back 0/10, so the experiment has no discriminating power. The reporter reproduces
reliably on his own hardware, so the practical route is to hand him a build.

Building it here rather than using a prebuilt sentry-cocoa artefact, since our bindings build passes
its own parameters.

#skip-changelog
