### PR TITLE
test: serialize profiling test classes

### DIFF
--- a/test/Sentry.Profiling.Tests/ProfilingSentryOptionsExtensionsTests.cs
+++ b/test/Sentry.Profiling.Tests/ProfilingSentryOptionsExtensionsTests.cs
@@ -2,6 +2,7 @@ namespace Sentry.Profiling.Tests;
 
 #nullable enable
 
+[Collection(nameof(ProfilingTestCollection))]
 public class ProfilingSentryOptionsExtensionsTests
 {
     private readonly InMemoryDiagnosticLogger _logger = new();

--- a/test/Sentry.Profiling.Tests/ProfilingTestCollection.cs
+++ b/test/Sentry.Profiling.Tests/ProfilingTestCollection.cs
@@ -1,0 +1,6 @@
+namespace Sentry.Profiling.Tests;
+
+[CollectionDefinition(nameof(ProfilingTestCollection), DisableParallelization = true)]
+public sealed class ProfilingTestCollection
+{
+}

--- a/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs
+++ b/test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs
@@ -6,7 +6,7 @@ namespace Sentry.Profiling.Tests;
 
 // Note: we must not run tests in parallel because we only support profiling one transaction at a time.
 // That means setting up a test-collection with parallelization disabled and NOT using any async test functions.
-[CollectionDefinition(nameof(SamplingTransactionProfilerTests), DisableParallelization = true)]
+[Collection(nameof(ProfilingTestCollection))]
 public class SamplingTransactionProfilerTests
 {
     private readonly TestOutputDiagnosticLogger _testOutputLogger;


### PR DESCRIPTION
## Summary

- replace the unused collection definition on `SamplingTransactionProfilerTests` with a dedicated profiling test collection
- make both test classes that create real profiler factories join that non-parallel collection

Fixes #5524.

## Testing

- `dotnet test test/Sentry.Profiling.Tests/Sentry.Profiling.Tests.csproj --framework net10.0 -p:NO_ANDROID=true` (27 passed, 3 intentionally skipped)
- `dotnet format test/Sentry.Profiling.Tests/Sentry.Profiling.Tests.csproj --no-restore --verify-no-changes --include test/Sentry.Profiling.Tests/SamplingTransactionProfilerTests.cs test/Sentry.Profiling.Tests/ProfilingSentryOptionsExtensionsTests.cs test/Sentry.Profiling.Tests/ProfilingTestCollection.cs -p:NO_ANDROID=true`
- `git diff --check`

#skip-changelog
