### PR TITLE
feat: Expose StringOrRegex discriminator

### DIFF
--- a/src/Sentry/StringOrRegex.cs
+++ b/src/Sentry/StringOrRegex.cs
@@ -3,6 +3,22 @@ using Sentry.Internal;
 namespace Sentry;
 
 /// <summary>
+/// The type of value stored by <see cref="StringOrRegex"/>.
+/// </summary>
+public enum StringOrRegexType
+{
+    /// <summary>
+    /// A plain string.
+    /// </summary>
+    String,
+
+    /// <summary>
+    /// A regular expression.
+    /// </summary>
+    Regex,
+}
+
+/// <summary>
 /// Stores either a plain string or a Regular Expression, typically to match against filters in the SentryOptions
 /// </summary>
 [TypeConverter(typeof(StringOrRegexTypeConverter))]
@@ -12,12 +28,18 @@ public class StringOrRegex
     internal readonly string? _string;
 
     /// <summary>
+    /// Gets the type of value stored by this instance.
+    /// </summary>
+    public StringOrRegexType Type { get; }
+
+    /// <summary>
     /// Constructs a <see cref="StringOrRegex"/> instance.
     /// </summary>
     /// <param name="stringOrRegex">The prefix or regular expression pattern to match on.</param>
     public StringOrRegex(string stringOrRegex)
     {
         _string = stringOrRegex;
+        Type = StringOrRegexType.String;
     }
 
     /// <summary>
@@ -27,7 +49,11 @@ public class StringOrRegex
     /// <remarks>
     /// Use this constructor when you want the match to be performed using a regular expression.
     /// </remarks>
-    public StringOrRegex(Regex regex) => _regex = regex;
+    public StringOrRegex(Regex regex)
+    {
+        _regex = regex;
+        Type = StringOrRegexType.Regex;
+    }
 
     /// <summary>
     /// Implicitly converts a <see cref="string"/> to a <see cref="StringOrRegex"/>.

--- a/src/Sentry/StringOrRegex.cs
+++ b/src/Sentry/StringOrRegex.cs
@@ -3,22 +3,6 @@ using Sentry.Internal;
 namespace Sentry;
 
 /// <summary>
-/// The type of value stored by <see cref="StringOrRegex"/>.
-/// </summary>
-public enum StringOrRegexType
-{
-    /// <summary>
-    /// A plain string.
-    /// </summary>
-    String,
-
-    /// <summary>
-    /// A regular expression.
-    /// </summary>
-    Regex,
-}
-
-/// <summary>
 /// Stores either a plain string or a Regular Expression, typically to match against filters in the SentryOptions
 /// </summary>
 [TypeConverter(typeof(StringOrRegexTypeConverter))]
@@ -28,9 +12,9 @@ public class StringOrRegex
     internal readonly string? _string;
 
     /// <summary>
-    /// Gets the type of value stored by this instance.
+    /// Whether this instance contains a regular expression.
     /// </summary>
-    public StringOrRegexType Type { get; }
+    public bool IsRegex => _regex is Regex;
 
     /// <summary>
     /// Constructs a <see cref="StringOrRegex"/> instance.
@@ -39,7 +23,6 @@ public class StringOrRegex
     public StringOrRegex(string stringOrRegex)
     {
         _string = stringOrRegex;
-        Type = StringOrRegexType.String;
     }
 
     /// <summary>
@@ -49,11 +32,7 @@ public class StringOrRegex
     /// <remarks>
     /// Use this constructor when you want the match to be performed using a regular expression.
     /// </remarks>
-    public StringOrRegex(Regex regex)
-    {
-        _regex = regex;
-        Type = StringOrRegexType.Regex;
-    }
+    public StringOrRegex(Regex regex) => _regex = regex;
 
     /// <summary>
     /// Implicitly converts a <see cref="string"/> to a <see cref="StringOrRegex"/>.

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -1358,11 +1358,17 @@ namespace Sentry
     {
         public StringOrRegex(System.Text.RegularExpressions.Regex regex) { }
         public StringOrRegex(string stringOrRegex) { }
+        public Sentry.StringOrRegexType Type { get; }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
         public static Sentry.StringOrRegex op_Implicit(System.Text.RegularExpressions.Regex regex) { }
         public static Sentry.StringOrRegex op_Implicit(string stringOrRegex) { }
+    }
+    public enum StringOrRegexType
+    {
+        String = 0,
+        Regex = 1,
     }
     public class TransactionContext : Sentry.SpanContext, Sentry.ITransactionContext, Sentry.Protocol.ITraceContext
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet10_0.verified.txt
@@ -1358,17 +1358,12 @@ namespace Sentry
     {
         public StringOrRegex(System.Text.RegularExpressions.Regex regex) { }
         public StringOrRegex(string stringOrRegex) { }
-        public Sentry.StringOrRegexType Type { get; }
+        public bool IsRegex { get; }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
         public static Sentry.StringOrRegex op_Implicit(System.Text.RegularExpressions.Regex regex) { }
         public static Sentry.StringOrRegex op_Implicit(string stringOrRegex) { }
-    }
-    public enum StringOrRegexType
-    {
-        String = 0,
-        Regex = 1,
     }
     public class TransactionContext : Sentry.SpanContext, Sentry.ITransactionContext, Sentry.Protocol.ITraceContext
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -1358,11 +1358,17 @@ namespace Sentry
     {
         public StringOrRegex(System.Text.RegularExpressions.Regex regex) { }
         public StringOrRegex(string stringOrRegex) { }
+        public Sentry.StringOrRegexType Type { get; }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
         public static Sentry.StringOrRegex op_Implicit(System.Text.RegularExpressions.Regex regex) { }
         public static Sentry.StringOrRegex op_Implicit(string stringOrRegex) { }
+    }
+    public enum StringOrRegexType
+    {
+        String = 0,
+        Regex = 1,
     }
     public class TransactionContext : Sentry.SpanContext, Sentry.ITransactionContext, Sentry.Protocol.ITraceContext
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet8_0.verified.txt
@@ -1358,17 +1358,12 @@ namespace Sentry
     {
         public StringOrRegex(System.Text.RegularExpressions.Regex regex) { }
         public StringOrRegex(string stringOrRegex) { }
-        public Sentry.StringOrRegexType Type { get; }
+        public bool IsRegex { get; }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
         public static Sentry.StringOrRegex op_Implicit(System.Text.RegularExpressions.Regex regex) { }
         public static Sentry.StringOrRegex op_Implicit(string stringOrRegex) { }
-    }
-    public enum StringOrRegexType
-    {
-        String = 0,
-        Regex = 1,
     }
     public class TransactionContext : Sentry.SpanContext, Sentry.ITransactionContext, Sentry.Protocol.ITraceContext
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -1358,11 +1358,17 @@ namespace Sentry
     {
         public StringOrRegex(System.Text.RegularExpressions.Regex regex) { }
         public StringOrRegex(string stringOrRegex) { }
+        public Sentry.StringOrRegexType Type { get; }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
         public static Sentry.StringOrRegex op_Implicit(System.Text.RegularExpressions.Regex regex) { }
         public static Sentry.StringOrRegex op_Implicit(string stringOrRegex) { }
+    }
+    public enum StringOrRegexType
+    {
+        String = 0,
+        Regex = 1,
     }
     public class TransactionContext : Sentry.SpanContext, Sentry.ITransactionContext, Sentry.Protocol.ITraceContext
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.DotNet9_0.verified.txt
@@ -1358,17 +1358,12 @@ namespace Sentry
     {
         public StringOrRegex(System.Text.RegularExpressions.Regex regex) { }
         public StringOrRegex(string stringOrRegex) { }
-        public Sentry.StringOrRegexType Type { get; }
+        public bool IsRegex { get; }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
         public static Sentry.StringOrRegex op_Implicit(System.Text.RegularExpressions.Regex regex) { }
         public static Sentry.StringOrRegex op_Implicit(string stringOrRegex) { }
-    }
-    public enum StringOrRegexType
-    {
-        String = 0,
-        Regex = 1,
     }
     public class TransactionContext : Sentry.SpanContext, Sentry.ITransactionContext, Sentry.Protocol.ITraceContext
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -1339,11 +1339,17 @@ namespace Sentry
     {
         public StringOrRegex(System.Text.RegularExpressions.Regex regex) { }
         public StringOrRegex(string stringOrRegex) { }
+        public Sentry.StringOrRegexType Type { get; }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
         public static Sentry.StringOrRegex op_Implicit(System.Text.RegularExpressions.Regex regex) { }
         public static Sentry.StringOrRegex op_Implicit(string stringOrRegex) { }
+    }
+    public enum StringOrRegexType
+    {
+        String = 0,
+        Regex = 1,
     }
     public class TransactionContext : Sentry.SpanContext, Sentry.ITransactionContext, Sentry.Protocol.ITraceContext
     {

--- a/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
+++ b/test/Sentry.Tests/ApiApprovalTests.Run.Net4_8.verified.txt
@@ -1339,17 +1339,12 @@ namespace Sentry
     {
         public StringOrRegex(System.Text.RegularExpressions.Regex regex) { }
         public StringOrRegex(string stringOrRegex) { }
-        public Sentry.StringOrRegexType Type { get; }
+        public bool IsRegex { get; }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
         public static Sentry.StringOrRegex op_Implicit(System.Text.RegularExpressions.Regex regex) { }
         public static Sentry.StringOrRegex op_Implicit(string stringOrRegex) { }
-    }
-    public enum StringOrRegexType
-    {
-        String = 0,
-        Regex = 1,
     }
     public class TransactionContext : Sentry.SpanContext, Sentry.ITransactionContext, Sentry.Protocol.ITraceContext
     {

--- a/test/Sentry.Tests/StringOrRegexTests.cs
+++ b/test/Sentry.Tests/StringOrRegexTests.cs
@@ -3,17 +3,33 @@ namespace Sentry.Tests;
 public class StringOrRegexTests
 {
     [Fact]
-    public void StringOrRegex_ImplicitlyConvertsFromString()
+    public void Constructor_String_TypeIsString()
+    {
+        var target = new StringOrRegex("abc");
+        target.Type.Should().Be(StringOrRegexType.String);
+    }
+
+    [Fact]
+    public void Constructor_Regex_TypeIsRegex()
+    {
+        var target = new StringOrRegex(new Regex("^abc.*ghi$"));
+        target.Type.Should().Be(StringOrRegexType.Regex);
+    }
+
+    [Fact]
+    public void ImplicitConversion_String_PreservesValueAndType()
     {
         StringOrRegex target = "abc";
+        target.Type.Should().Be(StringOrRegexType.String);
         target._string.Should().Be("abc");
         target._regex.Should().BeNull();
     }
 
     [Fact]
-    public void StringOrRegex_ImplicitlyConvertsFromRegex()
+    public void ImplicitConversion_Regex_PreservesValueAndType()
     {
         StringOrRegex target = new Regex("^abc.*ghi$");
+        target.Type.Should().Be(StringOrRegexType.Regex);
         target._string.Should().BeNull();
         target._regex.Should().NotBeNull();
         target._regex?.ToString().Should().Be("^abc.*ghi$");

--- a/test/Sentry.Tests/StringOrRegexTests.cs
+++ b/test/Sentry.Tests/StringOrRegexTests.cs
@@ -3,24 +3,32 @@ namespace Sentry.Tests;
 public class StringOrRegexTests
 {
     [Fact]
-    public void Constructor_String_TypeIsString()
+    public void Constructor_String_IsRegexFalse()
     {
         var target = new StringOrRegex("abc");
-        target.Type.Should().Be(StringOrRegexType.String);
+        target.IsRegex.Should().BeFalse();
     }
 
     [Fact]
-    public void Constructor_Regex_TypeIsRegex()
+    public void Constructor_Regex_IsRegexTrue()
     {
         var target = new StringOrRegex(new Regex("^abc.*ghi$"));
-        target.Type.Should().Be(StringOrRegexType.Regex);
+        target.IsRegex.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Constructor_NullRegex_IsRegexFalse()
+    {
+        var target = new StringOrRegex((Regex)null!);
+        target.IsRegex.Should().BeFalse();
+        target.ToString().Should().BeEmpty();
     }
 
     [Fact]
     public void ImplicitConversion_String_PreservesValueAndType()
     {
         StringOrRegex target = "abc";
-        target.Type.Should().Be(StringOrRegexType.String);
+        target.IsRegex.Should().BeFalse();
         target._string.Should().Be("abc");
         target._regex.Should().BeNull();
     }
@@ -29,7 +37,7 @@ public class StringOrRegexTests
     public void ImplicitConversion_Regex_PreservesValueAndType()
     {
         StringOrRegex target = new Regex("^abc.*ghi$");
-        target.Type.Should().Be(StringOrRegexType.Regex);
+        target.IsRegex.Should().BeTrue();
         target._string.Should().BeNull();
         target._regex.Should().NotBeNull();
         target._regex?.ToString().Should().Be("^abc.*ghi$");


### PR DESCRIPTION
Exposes whether a `StringOrRegex` contains a literal string or a regular expression through a new public discriminator. This allows SDK integrations to preserve trace propagation target semantics across interop boundaries without reflection or treating regex patterns as literal strings.

- Refs https://github.com/getsentry/sentry-godot/pull/916

The Godot SDK reads these targets from the .NET SDK and passes them to its native layer. Without this discriminator, it cannot tell a plain string from a regex. Reflection is not an option because Godot supports AOT on iOS, while treating regex patterns as strings would be incorrect.