### PR TITLE
fix: isolate TracesSampler callback failures

### DIFF
--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -205,20 +205,31 @@ internal class Hub : IHub, IDisposable
                 context,
                 customSamplingContext);
 
-            if (tracesSampler(samplingContext) is { } samplerSampleRate)
+            double? samplerSampleRate;
+            try
+            {
+                samplerSampleRate = tracesSampler(samplingContext);
+            }
+            catch (Exception ex)
+            {
+                _options.LogError(ex, "TracesSampler callback failed.");
+                samplerSampleRate = null;
+            }
+
+            if (samplerSampleRate is { } samplerRate)
             {
                 // The TracesSampler trumps all other sampling decisions (even the trace header)
-                sampleRate = samplerSampleRate * _backpressureMonitor.GetDownsampleFactor();
+                sampleRate = samplerRate * _backpressureMonitor.GetDownsampleFactor();
                 isSampled = SampleRandHelper.IsSampled(sampleRand, sampleRate.Value);
                 if (isSampled is false)
                 {
                     // If sampling out is only a result of the downsampling then we specify the reason as backpressure
                     // management... otherwise the event would have been sampled out anyway, so it's just regular sampling.
-                    discardReason = sampleRand < samplerSampleRate ? DiscardReason.Backpressure : DiscardReason.SampleRate;
+                    discardReason = sampleRand < samplerRate ? DiscardReason.Backpressure : DiscardReason.SampleRate;
                 }
 
                 // Ensure the actual sampleRate is set on the provided DSC (if any) when the TracesSampler reached a sampling decision
-                dynamicSamplingContext?.SetSampleRate(samplerSampleRate);
+                dynamicSamplingContext?.SetSampleRate(samplerRate);
             }
         }
 

--- a/src/Sentry/Platforms/Android/Callbacks/TracesSamplerCallback.cs
+++ b/src/Sentry/Platforms/Android/Callbacks/TracesSamplerCallback.cs
@@ -1,19 +1,32 @@
 using Sentry.Android.Extensions;
+using Sentry.Extensibility;
 
 namespace Sentry.Android.Callbacks;
 
 internal class TracesSamplerCallback : JavaObject, JavaSdk.SentryOptions.ITracesSamplerCallback
 {
     private readonly Func<TransactionSamplingContext, double?> _tracesSampler;
+    private readonly SentryOptions _options;
 
-    public TracesSamplerCallback(Func<TransactionSamplingContext, double?> tracesSampler)
+    public TracesSamplerCallback(
+        Func<TransactionSamplingContext, double?> tracesSampler,
+        SentryOptions options)
     {
         _tracesSampler = tracesSampler;
+        _options = options;
     }
 
     public JavaDouble? Sample(JavaSdk.SamplingContext c)
     {
         var context = c.ToTransactionSamplingContext();
-        return (JavaDouble?)_tracesSampler.Invoke(context);
+        try
+        {
+            return (JavaDouble?)_tracesSampler.Invoke(context);
+        }
+        catch (Exception exception)
+        {
+            _options.LogError(exception, "TracesSampler callback failed.");
+            return null;
+        }
     }
 }

--- a/src/Sentry/Platforms/Android/Callbacks/TracesSamplerCallback.cs
+++ b/src/Sentry/Platforms/Android/Callbacks/TracesSamplerCallback.cs
@@ -18,9 +18,9 @@ internal class TracesSamplerCallback : JavaObject, JavaSdk.SentryOptions.ITraces
 
     public JavaDouble? Sample(JavaSdk.SamplingContext c)
     {
-        var context = c.ToTransactionSamplingContext();
         try
         {
+            var context = c.ToTransactionSamplingContext();
             return (JavaDouble?)_tracesSampler.Invoke(context);
         }
         catch (Exception exception)

--- a/src/Sentry/Platforms/Android/SentrySdk.cs
+++ b/src/Sentry/Platforms/Android/SentrySdk.cs
@@ -123,7 +123,7 @@ public static partial class SentrySdk
 
                 if (options.TracesSampler is { } tracesSampler)
                 {
-                    o.TracesSampler = new TracesSamplerCallback(tracesSampler);
+                    o.TracesSampler = new TracesSamplerCallback(tracesSampler, options);
                 }
             }
 

--- a/src/Sentry/Platforms/Cocoa/SentrySdk.cs
+++ b/src/Sentry/Platforms/Cocoa/SentrySdk.cs
@@ -80,7 +80,16 @@ public static partial class SentrySdk
                 nativeOptions.TracesSampler = cocoaContext =>
                 {
                     var context = cocoaContext.ToTransactionSamplingContext();
-                    var result = tracesSampler(context);
+                    double? result;
+                    try
+                    {
+                        result = tracesSampler(context);
+                    }
+                    catch (Exception ex)
+                    {
+                        options.LogError(ex, "TracesSampler callback failed.");
+                        result = null;
+                    }
 
                     // Note: Nullable result is allowed but delegate is generated incorrectly
                     // See https://github.com/xamarin/xamarin-macios/issues/15299#issuecomment-1201863294

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1471,6 +1471,82 @@ public partial class HubTests : IDisposable
     }
 
     [Fact]
+    public void StartTransaction_TracesSamplerThrows_FallsBackToStaticAndLogsError()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("sampler failed");
+        _fixture.Options.TracesSampler = _ => throw exception;
+        _fixture.Options.TracesSampleRate = 1.0;
+        _fixture.Options.AddDiagnosticLoggerSubstitute();
+        var hub = _fixture.GetSut();
+
+        // Act
+        var transaction = hub.StartTransaction("foo", "bar");
+
+        // Assert
+        transaction.IsSampled.Should().BeTrue();
+        _fixture.Options.ReceivedLogError(exception, "TracesSampler callback failed.");
+    }
+
+    [Fact]
+    public void StartTransaction_TracesSamplerThrows_PreservesInheritedDecision()
+    {
+        // Arrange
+        _fixture.Options.TracesSampler = _ => throw new InvalidOperationException("sampler failed");
+        _fixture.Options.TracesSampleRate = 0.0;
+        var hub = _fixture.GetSut();
+        var traceHeader = new SentryTraceHeader(
+            SentryId.Parse("75302ac48a024bde9a3b3734a82e36c8"),
+            SpanId.Parse("2000000000000000"),
+            true);
+
+        // Act
+        var transaction = hub.StartTransaction("foo", "bar", traceHeader);
+
+        // Assert
+        transaction.IsSampled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void StartTransaction_TracesSamplerThrows_PreservesInheritedSampledOutDecision()
+    {
+        // Arrange
+        _fixture.Options.TracesSampler = _ => throw new InvalidOperationException("sampler failed");
+        _fixture.Options.TracesSampleRate = 1.0;
+        var hub = _fixture.GetSut();
+        var traceHeader = new SentryTraceHeader(
+            SentryId.Parse("75302ac48a024bde9a3b3734a82e36c8"),
+            SpanId.Parse("2000000000000000"),
+            false);
+
+        // Act
+        var transaction = hub.StartTransaction("foo", "bar", traceHeader);
+
+        // Assert
+        transaction.IsSampled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void StartTransaction_TracesSamplerThrows_StaticSampleOut_RecordsSampleRateDiscard()
+    {
+        // Arrange
+        var recorder = Substitute.For<IClientReportRecorder>();
+        _fixture.Options.ClientReportRecorder = recorder;
+        _fixture.Options.TracesSampler = _ => throw new InvalidOperationException("sampler failed");
+        _fixture.Options.TracesSampleRate = 0.0;
+        var hub = _fixture.GetSut();
+
+        // Act
+        var transaction = hub.StartTransaction("foo", "bar");
+        transaction.Finish();
+
+        // Assert
+        transaction.IsSampled.Should().BeFalse();
+        recorder.Received(1).RecordDiscardedEvent(DiscardReason.SampleRate, DataCategory.Transaction);
+        recorder.Received(1).RecordDiscardedEvent(DiscardReason.SampleRate, DataCategory.Span, 1);
+    }
+
+    [Fact]
     public void StartTransaction_DisableSentryTracing_DropsTransactionAndLogsWarning()
     {
         // Arrange


### PR DESCRIPTION
Addresses the `TracesSampler` portion of #5535.

## What changed

- isolate managed `TracesSampler` failures at the user-callback boundary and log `TracesSampler callback failed.` at error level
- return to the existing unconfigured-sampler fallback path, preserving inherited decisions before `TracesSampleRate`
- keep SDK-owned backpressure, random sampling, discard-reason, and DSC logic outside the recovery boundary
- apply the same callback isolation to the Android JNI and Cocoa native bridges, returning `null` on callback failure so the native SDK can use its normal fallback
- add managed regressions for static sample-in/sample-out, inherited sampled-in/sampled-out, exact error logging, and normal `sample_rate` client-report accounting

## Validation

- `dotnet test test/Sentry.Tests/Sentry.Tests.csproj -c Release -f net10.0 --filter "FullyQualifiedName~StartTransaction_TracesSampler" --no-restore` — 10/10 passed
- `dotnet build src/Sentry/Sentry.csproj -c Release -f net10.0 --no-restore` — passed, 0 warnings/errors
- `dotnet build src/Sentry/Sentry.csproj -c Release -f net10.0-android36.0 --no-restore` — passed, 0 warnings/errors
- scoped `dotnet format whitespace --folder --verify-no-changes` for the five changed files — passed
- `git diff --check` — passed

Cocoa compilation requires macOS; the Cocoa change is limited to the same user-delegate recovery boundary and will be exercised by the repository's macOS CI.