### PR TITLE
docs(android): note that ReportHistoricalTombstones requires TombstoneEnabled

### DIFF
--- a/src/Sentry/Platforms/Android/NativeOptions.cs
+++ b/src/Sentry/Platforms/Android/NativeOptions.cs
@@ -165,6 +165,7 @@ public partial class SentryOptions
 
         /// <summary>
         /// Gets or sets a value that indicates if historical tombstones should be reported.
+        /// Requires <see cref="TombstoneEnabled"/> set <c>true</c>.
         /// The default value is <c>false</c> (disabled).
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
Mirrors the wording added in getsentry/sentry-docs#18560 ("This option only takes effect when `Native.TombstoneEnabled` is also enabled") in the XML doc comment, so the constraint is visible from IntelliSense too.

The dependency is real in the pinned Android SDK (8.55.0): `TombstoneIntegration.register` returns early unless `options.isTombstoneEnabled()`, and `isReportHistoricalTombstones()` is only read by the `TombstonePolicy` created inside that branch — so `ReportHistoricalTombstones` has no effect on its own.

Phrasing follows the existing pairing in the same file (`EnableActivityLifecycleTracingAutoFinish` → `Requires <see cref="EnableAutoActivityLifecycleTracing"/> set <c>true</c>.`).

#skip-changelog

Fixes #5362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
