### PR TITLE
docs(otel): configure MongoDB sample sampling

### DIFF
--- a/samples/Sentry.Samples.OpenTelemetry.MongoDB/Program.cs
+++ b/samples/Sentry.Samples.OpenTelemetry.MongoDB/Program.cs
@@ -30,11 +30,11 @@ SentrySdk.Init(options =>
 {
     options.Dsn = dsn;
     options.Debug = true;
-    options.TracesSampleRate = 1.0;
     options.UseOtlp(); // <-- Configure Sentry to use OpenTelemetry trace information
 });
 
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .SetSampler(new AlwaysOnSampler()) // <-- Configure trace sampling through OpenTelemetry
     .AddSource(activitySource.Name)
     .AddSource(MongoTelemetry.ActivitySourceName) // <-- Subscribe to the MongoDB driver's built-in instrumentation
     .AddProcessor(new Sentry.Samples.OpenTelemetry.MongoDB.RedactSensitiveMongoData()) // <-- Redact PII from query text BEFORE it's exported (see below)


### PR DESCRIPTION
## Summary

Configure trace sampling through the OpenTelemetry sampler in the MongoDB sample instead of setting `SentryOptions.TracesSampleRate`.

Closes #5407

## Testing

- Source contract check
- `git diff --check`

The sample build was not run because this repository pins .NET SDK 10.0.400, while the available SDK is 8.0.424.