### PR TITLE
chore: bump vulnerable dependencies in samples and tests

### DIFF
--- a/samples/Sentry.Samples.AspNetCore.Blazor.Server/Sentry.Samples.AspNetCore.Blazor.Server.csproj
+++ b/samples/Sentry.Samples.AspNetCore.Blazor.Server/Sentry.Samples.AspNetCore.Blazor.Server.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/Sentry.Samples.GraphQL.Server/Sentry.Samples.GraphQL.Server.csproj
+++ b/samples/Sentry.Samples.GraphQL.Server/Sentry.Samples.GraphQL.Server.csproj
@@ -14,9 +14,9 @@
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="7.6.0" />
     <PackageReference Include="GraphQL.Server.Ui.Altair" Version="7.6.0" />
     <PackageReference Include="GraphQL.SystemTextJson" Version="7.6.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
   </ItemGroup>
 

--- a/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Sentry.Samples.OpenTelemetry.AspNetCore.csproj
+++ b/samples/Sentry.Samples.OpenTelemetry.AspNetCore/Sentry.Samples.OpenTelemetry.AspNetCore.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/samples/Sentry.Samples.OpenTelemetry.AzureFunctions/Sentry.Samples.OpenTelemetry.AzureFunctions.csproj
+++ b/samples/Sentry.Samples.OpenTelemetry.AzureFunctions/Sentry.Samples.OpenTelemetry.AzureFunctions.csproj
@@ -10,9 +10,10 @@
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
-        <PackageReference Include="OpenTelemetry" Version="1.15.0" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+        <PackageReference Include="OpenTelemetry" Version="1.18.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/Sentry.Samples.OpenTelemetry.Console/Sentry.Samples.OpenTelemetry.Console.csproj
+++ b/samples/Sentry.Samples.OpenTelemetry.Console/Sentry.Samples.OpenTelemetry.Console.csproj
@@ -8,8 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/samples/Sentry.Samples.OpenTelemetry.MongoDB/Sentry.Samples.OpenTelemetry.MongoDB.csproj
+++ b/samples/Sentry.Samples.OpenTelemetry.MongoDB/Sentry.Samples.OpenTelemetry.MongoDB.csproj
@@ -10,7 +10,8 @@
   <ItemGroup>
     <!-- MongoDB.Driver 3.7.0 and later has built-in OpenTelemetry instrumentation -->
     <PackageReference Include="MongoDB.Driver" Version="3.9.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
+++ b/test/Sentry.DiagnosticSource.Tests/Sentry.DiagnosticSource.Tests.csproj
@@ -26,6 +26,14 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
   </ItemGroup>
 
+  <!-- EF Core's Sqlite provider floors SQLitePCLRaw at a vulnerable version on every .NET
+       target we test (2.1.6 / 2.1.10 / 2.1.11). Pin it forward rather than bumping EF Core,
+       so each TFM still tests against the baseline EF Core release above.
+       https://github.com/advisories/GHSA-2m69-gcr7-jv3q -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.13" />
+  </ItemGroup>
+
   <!-- Test .NET Framework -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <ProjectReference Include="..\..\src\Sentry.DiagnosticSource\Sentry.DiagnosticSource.csproj" />

--- a/test/Sentry.OpenTelemetry.Exporter.Tests/Sentry.OpenTelemetry.Exporter.Tests.csproj
+++ b/test/Sentry.OpenTelemetry.Exporter.Tests/Sentry.OpenTelemetry.Exporter.Tests.csproj
@@ -7,8 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.18.0" />
+    <!-- Keep the OTLP exporter in lockstep with the rest of the OpenTelemetry family. Left at the
+         floor Sentry.OpenTelemetry.Exporter declares (1.10.0), mixing it with a newer OpenTelemetry
+         makes the public OtlpExporterOptions constructor throw TypeLoadException. -->
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Bumps the vulnerable dependencies that **don't reach a consumer's dependency graph** — samples and test projects. These cost our users nothing to move, unlike the floors our shipped packages declare, which stay put deliberately so consumers keep the freedom to resolve higher.

Takes the nightly scan from 18 affected projects down to 12 findings, every one of which now traces to either a shipped-package floor or the perfview submodule.

### Bumped

| What | Change | Clears |
|---|---|---|
| All OTel samples + `Sentry.OpenTelemetry.Exporter.Tests` | OpenTelemetry family → **1.18.0** (latest clear) | GHSA-g94r-2vxg-569j, GHSA-4625-4j76-fww9, GHSA-q834-8qmm-v933, GHSA-mr8r-92fq-pj8p |
| `Sentry.DiagnosticSource.Tests` | pin `SQLitePCLRaw.bundle_e_sqlite3` → 2.1.13 | GHSA-2m69-gcr7-jv3q |

The SQLitePCLRaw fix is a forward pin rather than an EF Core bump, so each TFM still tests against the baseline EF Core release the comments say it should. This follows the `Microsoft.Extensions.Caching.Memory` precedent already in that file.

Three OTel samples and the exporter tests now reference `OpenTelemetry.Exporter.OpenTelemetryProtocol` explicitly, matching what `Sentry.Samples.OpenTelemetry.AspNetCore` already did. Without it they inherited the 1.10.0 floor from `Sentry.OpenTelemetry.Exporter`, and **1.10.0 mixed with a newer `OpenTelemetry` makes the public `OtlpExporterOptions` constructor throw `TypeLoadException`** — that combination broke 4 exporter tests until the exporter was raised in lockstep. Worth flagging in review: the normal `AddSentryOtlpExporter(...).Build()` path is unaffected, but a consumer who raises `OpenTelemetry` without also raising the OTLP exporter can land in that same mismatch.

### Left alone on purpose

- **`Sentry.Log4Net.Tests`** stays on log4net 2.0.15. The advisory is only fixed in log4net **3.3.0**, and on 3.4.0 three `SentryAppender` structured-logging tests fail — log4net 3.x is not a drop-in for the appender. That is now evidence, not just caution, against raising the shipped `Sentry.Log4Net` floor.
- **`Sentry.OpenTelemetry.Tests`** stays on OpenTelemetry 1.6.0, mirroring the floor `Sentry.OpenTelemetry` declares, so we keep testing that minimum actually works.
- **`Sentry.TrimTest`** has no OTel reference of its own; its finding is inherited from `Sentry.OpenTelemetry`.
- **`FastSerialization` / `TraceEvent`** pull a vulnerable SourceLink (`Microsoft.Build.Tasks.Git` 8.0.0, GHSA-23fw-v26w-5fgq) from the perfview submodule — needs a change in `getsentry/perfview` first. It is `PrivateAssets="all"`, so build-time only.

### Verification

- All six affected samples build clean, including `Sentry.Samples.GraphQL.Server` jumping from 1.8.x to 1.18.0.
- `Sentry.OpenTelemetry.Exporter.Tests` 59/59 on net8.0, net9.0, net10.0.
- `Sentry.DiagnosticSource.Tests` 82/82 on net8.0, net9.0, net10.0.
- Re-ran `dotnet package list --project Sentry.slnx --vulnerable --include-transitive` locally to confirm which findings actually clear.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)
