### PR TITLE
ci: allowlist reviewed vulnerability findings, with reasoning

### DIFF
--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -7,10 +7,15 @@ name: List vulnerable packages
 # halting unrelated work until the dependency is updated, which is routine maintenance
 # rather than a defect in the PR. Running on a schedule keeps the signal without making
 # it a gate on everybody's work.
+#
+# Weekly rather than daily: we deliberately floor our PackageReferences at the oldest
+# version that works, so consumers keep the freedom to resolve higher. Most findings here
+# are therefore informational - a floor we won't raise - rather than something to action,
+# and a daily red run trains people to ignore it.
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *" # once a day
+    - cron: "0 0 * * 4" # once a week, on Thursdays
 
 jobs:
   list-vulnerable-packages:

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -8,10 +8,7 @@ name: List vulnerable packages
 # rather than a defect in the PR. Running on a schedule keeps the signal without making
 # it a gate on everybody's work.
 #
-# Weekly rather than daily: we deliberately floor our PackageReferences at the oldest
-# version that works, so consumers keep the freedom to resolve higher. Most findings here
-# are therefore informational - a floor we won't raise - rather than something to action,
-# and a daily red run trains people to ignore it.
+# Weekly rather than daily - we don't publish nightly builds for sentry-dotnet anyway
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -33,18 +33,15 @@ jobs:
       - name: Restore .NET Dependencies
         run: dotnet restore Sentry.slnx --nologo
 
-      # The dotnet package list command doesn't change its exit code on detection, so tee to a file and scan it
-      # See https://github.com/NuGet/Home/issues/11315#issuecomment-1243055173
+      # `dotnet package list` doesn't change its exit code on detection, so the script reads its
+      # JSON output and decides. See https://github.com/NuGet/Home/issues/11315#issuecomment-1243055173
       #
-      # --source pins the query to nuget.org - the only feed that publishes a
-      # VulnerabilityInfo resource. The other feeds can error out with 401s
+      # Advisories we've reviewed and decided to hold on are recorded, with reasoning, in
+      # scripts/vulnerability-allowlist.json. Anything not listed there fails the run.
+      #
+      # NuGetAuditSuppress - the mechanism you'd normally reach for - is not an option here:
+      # `dotnet package list --vulnerable` ignores it entirely (it only silences restore-time
+      # NU19xx warnings), and restore-time auditing doesn't produce findings in this repo
+      # anyway, because the audit can't use the extra feeds in NuGet.config.
       - name: List vulnerable packages
-        shell: bash
-        run: |
-          dotnet package list --project Sentry.slnx --vulnerable --include-transitive --no-restore \
-            --source https://api.nuget.org/v3/index.json | tee vulnerable.txt
-
-          if grep -q 'has the following vulnerable packages' vulnerable.txt; then
-            echo "::error::Vulnerable packages detected - see the job output above for the affected projects and advisories."
-            exit 1
-          fi
+        run: pwsh scripts/check-vulnerabilities.ps1

--- a/scripts/check-vulnerabilities.ps1
+++ b/scripts/check-vulnerabilities.ps1
@@ -1,0 +1,181 @@
+<#
+.SYNOPSIS
+    Reports vulnerable packages, failing only on advisories that are not allowlisted.
+
+.DESCRIPTION
+    Wraps `dotnet package list --vulnerable` and filters its machine-readable output
+    through scripts/vulnerability-allowlist.json.
+
+    We deliberately floor our PackageReferences at the oldest version that works, so most
+    findings are floors we have decided not to raise rather than something to action. The
+    allowlist records those decisions and the reasoning; anything not listed fails.
+
+    Fails closed: any error running or parsing the scan is a failure, never a pass.
+
+.PARAMETER Project
+    Solution or project to scan. Defaults to Sentry.slnx.
+
+.PARAMETER InputJson
+    Use an existing `--format json` report instead of invoking dotnet. For testing.
+
+.PARAMETER AllowlistPath
+    Defaults to scripts/vulnerability-allowlist.json next to this script.
+#>
+[CmdletBinding()]
+param(
+    [string] $Project = 'Sentry.slnx',
+    [string] $InputJson,
+    [string] $AllowlistPath = (Join-Path $PSScriptRoot 'vulnerability-allowlist.json')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Read-Allowlist([string] $path) {
+    if (-not (Test-Path -LiteralPath $path)) {
+        throw "Allowlist not found: $path"
+    }
+    $parsed = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+    $entries = @($parsed.allowed)
+    foreach ($entry in $entries) {
+        foreach ($field in 'advisory', 'package', 'reason') {
+            if ([string]::IsNullOrWhiteSpace($entry.$field)) {
+                throw "Allowlist entry is missing '$field': $($entry | ConvertTo-Json -Compress)"
+            }
+        }
+    }
+    # Comma operator: stop PowerShell unrolling the array, so an empty allowlist stays an
+    # empty array instead of collapsing to $null.
+    return , $entries
+}
+
+function Get-ScanReport([string] $project, [string] $inputJson) {
+    if ($inputJson) {
+        if (-not (Test-Path -LiteralPath $inputJson)) {
+            throw "Input JSON not found: $inputJson"
+        }
+        return Get-Content -LiteralPath $inputJson -Raw
+    }
+
+    # --source pins the query to nuget.org - the only feed that publishes a
+    # VulnerabilityInfo resource. The other feeds can error out with 401s.
+    $output = dotnet package list --project $project --vulnerable --include-transitive `
+        --no-restore --format json --source https://api.nuget.org/v3/index.json 2>&1 | Out-String
+
+    # A non-zero exit still yields a valid report when the cause is per-project problems, which
+    # Assert-NoProblems explains far better than the raw JSON would. Only treat output we can't
+    # parse at all as a hard failure here.
+    try {
+        $null = $output | ConvertFrom-Json
+    }
+    catch {
+        throw "dotnet package list exited with $LASTEXITCODE and produced no readable report:`n$output"
+    }
+    return $output
+}
+
+# A project that failed to report wasn't scanned, so we can't say it's clean. Usually it just
+# wasn't restored - `dotnet restore Sentry.slnx` covers projects the .slnf filters leave out.
+function Assert-NoProblems($report) {
+    if ($report.PSObject.Properties.Name -notcontains 'problems') { return }
+    $problems = @($report.problems)
+    if ($problems.Count -eq 0) { return }
+
+    Write-Host ''
+    Write-Host "$($problems.Count) project(s) could not be scanned:"
+    foreach ($problem in $problems) {
+        $name = if ($problem.PSObject.Properties.Name -contains 'project') { Split-Path -Leaf $problem.project } else { '?' }
+        Write-Host "  [$($problem.level)] $name - $($problem.text)"
+    }
+    throw 'Cannot report on vulnerabilities while projects are missing from the scan. Run `dotnet restore Sentry.slnx` first.'
+}
+
+# `dotnet package list` reports a vulnerability once per project/framework/package, so the
+# same advisory shows up many times. Flatten to one row each so we can group and count.
+function Get-Findings($report) {
+    $rows = [System.Collections.Generic.List[object]]::new()
+    foreach ($project in @($report.projects)) {
+        $name = [System.IO.Path]::GetFileNameWithoutExtension($project.path)
+        # A project with nothing to report has no 'frameworks' member at all.
+        $frameworks = if ($project.PSObject.Properties.Name -contains 'frameworks') { @($project.frameworks) } else { @() }
+        foreach ($framework in $frameworks) {
+            foreach ($kind in 'topLevelPackages', 'transitivePackages') {
+                if ($framework.PSObject.Properties.Name -notcontains $kind) { continue }
+                foreach ($package in @($framework.$kind)) {
+                    if ($package.PSObject.Properties.Name -notcontains 'vulnerabilities') { continue }
+                    foreach ($vulnerability in @($package.vulnerabilities)) {
+                        $rows.Add([pscustomobject]@{
+                            Project   = $name
+                            Framework = $framework.framework
+                            Package   = $package.id
+                            Version   = $package.resolvedVersion
+                            Severity  = $vulnerability.severity
+                            Advisory  = $vulnerability.advisoryurl
+                        })
+                    }
+                }
+            }
+        }
+    }
+    # As above: a clean scan must return an empty collection, not $null.
+    return , $rows
+}
+
+function Write-Findings([string] $heading, $findings) {
+    Write-Host ''
+    Write-Host $heading
+    $findings |
+        Sort-Object Package, Version, Project, Framework |
+        Select-Object Package, Version, Severity, Project, Framework, Advisory |
+        Format-Table -AutoSize |
+        Out-String -Width 200 |
+        Write-Host
+}
+
+$allowlist = Read-Allowlist $AllowlistPath
+$report = Get-ScanReport $Project $InputJson | ConvertFrom-Json
+Assert-NoProblems $report
+$findings = Get-Findings $report
+
+# Match on advisory + package, so a new advisory against an already-listed package still fails.
+$matched = @{}
+$allowed = [System.Collections.Generic.List[object]]::new()
+$blocking = [System.Collections.Generic.List[object]]::new()
+foreach ($finding in $findings) {
+    $entry = $allowlist | Where-Object { $_.advisory -eq $finding.Advisory -and $_.package -eq $finding.Package } | Select-Object -First 1
+    if ($entry) {
+        $matched["$($entry.advisory)|$($entry.package)"] = $true
+        $allowed.Add($finding)
+    }
+    else {
+        $blocking.Add($finding)
+    }
+}
+
+Write-Host "Scanned $(@($report.projects).Count) projects; $($findings.Count) vulnerability findings."
+
+if ($allowed.Count -gt 0) {
+    Write-Findings "Allowlisted ($($allowed.Count) findings) - see $(Split-Path -Leaf $AllowlistPath) for the reasoning:" $allowed
+}
+
+# An entry that matches nothing is stale - the finding it covered is gone. Report it so the
+# allowlist does not rot, but do not fail on it: fixing a vulnerability must never break CI.
+$stale = $allowlist | Where-Object { -not $matched.ContainsKey("$($_.advisory)|$($_.package)") }
+if ($stale) {
+    Write-Host ''
+    Write-Host '::warning::Stale allowlist entries - these no longer match any finding and should be removed:'
+    foreach ($entry in $stale) {
+        Write-Host "  $($entry.package) $($entry.advisory)"
+    }
+}
+
+if ($blocking.Count -eq 0) {
+    Write-Host ''
+    Write-Host 'No vulnerable packages outside the allowlist.'
+    exit 0
+}
+
+Write-Findings "Not allowlisted ($($blocking.Count) findings):" $blocking
+$packages = ($blocking | Select-Object -ExpandProperty Package -Unique | Sort-Object) -join ', '
+Write-Host "::error::Vulnerable packages detected outside the allowlist: $packages. Either update the dependency, or add an entry to $(Split-Path -Leaf $AllowlistPath) explaining why the floor stays."
+exit 1

--- a/scripts/vulnerability-allowlist.json
+++ b/scripts/vulnerability-allowlist.json
@@ -1,0 +1,43 @@
+{
+  "comment": [
+    "Advisories the vulnerable-packages scan is allowed to report without failing.",
+    "",
+    "We deliberately floor our PackageReferences at the oldest version that works, so",
+    "consumers keep the freedom to resolve higher. Raising a floor forces every consumer",
+    "up with us and risks a diamond dependency, so an advisory against a floor is not by",
+    "itself a reason to move. Entries here record the ones we have looked at and decided",
+    "to hold, and why.",
+    "",
+    "An entry matches on advisory + package, so a NEW advisory against an already-listed",
+    "package still fails the scan. Entries that match nothing are reported as stale.",
+    "",
+    "Only add an entry once someone has actually read the advisory. 'reason' should say",
+    "why the floor stays, not merely that it is inconvenient to move."
+  ],
+  "allowed": [
+    {
+      "advisory": "https://github.com/advisories/GHSA-5crp-9r3c-p9vr",
+      "package": "Newtonsoft.Json",
+      "reviewed": "2026-09-10",
+      "reason": "Sentry.Hangfire does not reference Newtonsoft.Json at all - it arrives via Hangfire.Core, whose own floors are >= 5.0.1 (net462) and >= 11.0.1 (netstandard2.0). The latest Hangfire.Core keeps those same floors and mitigates the advisory in-product ('Use safe default serializer settings for Newtonsoft.Json 12.X and below', i.e. MaxDepth - exactly what the advisory prescribes). Our only lever would be adding an explicit Newtonsoft.Json reference to a package that does not use it, purely to override a floor Hangfire chose on purpose."
+    },
+    {
+      "advisory": "https://github.com/advisories/GHSA-4f7c-pmjv-c25w",
+      "package": "log4net",
+      "reviewed": "2026-09-10",
+      "reason": "Fixed only in log4net 3.3.0, a major version with no 2.x backport (2.0.17 ends the line). The defect is scoped to XmlLayout/XmlLayoutSchemaLog4J - forbidden XML characters cause a serialization exception and the silent loss of that one log event. SentryAppender does not use those layouts; layout choice is the user's own log4net config. Moving to 3.x is also not currently possible: on log4net 3.4.0 three SentryAppender structured-logging tests fail because event properties stop being surfaced as Sentry log attributes."
+    },
+    {
+      "advisory": "https://github.com/advisories/GHSA-23fw-v26w-5fgq",
+      "package": "Microsoft.Build.Tasks.Git",
+      "reviewed": "2026-09-10",
+      "reason": "SourceLink inside the perfview submodule, referenced with PrivateAssets=\"all\", so it never enters a consumer's dependency graph - it is build-time only. Fixing it means patching getsentry/perfview, which currently tracks microsoft/perfview via sync branches rather than carrying local patches; that divergence would have to be maintained through every future upstream sync, for a build-time PDB metadata disclosure."
+    },
+    {
+      "advisory": "https://github.com/advisories/GHSA-g94r-2vxg-569j",
+      "package": "OpenTelemetry.Api",
+      "reviewed": "2026-09-10",
+      "reason": "Sentry.OpenTelemetry floors the OpenTelemetry package at 1.6.0, the minimum version without trim warnings. The advisory is fixed only in 1.15.3, so clearing it means forcing every consumer up nine minor versions. The impact is excessive allocation while parsing oversized baggage/B3/Jaeger headers, and the advisory's own mitigation - HTTP request header size limits - is applied by default by IIS (16KB) and nginx (8KB)."
+    }
+  ]
+}


### PR DESCRIPTION
> [!NOTE]
> Stacked on #5554 — **base that PR first**, then this one retargets to `main`. The diff shown here is only this PR's own changes.

## Summary

Gives us somewhere to record advisories we've reviewed and decided *not* to act on, so the scan stops being permanently red.

The scan reports on the versions we **floor** our `PackageReference`s at, and we floor low on purpose so consumers keep the freedom to resolve higher. Raising a floor forces every consumer up with us and risks a diamond dependency, so an advisory against a floor isn't by itself a reason to move. Until now there was nowhere to write that reasoning down, so the run stayed red and the signal got ignored.

- **`scripts/vulnerability-allowlist.json`** — one entry per advisory + package, each carrying the reasoning and the date it was reviewed.
- **`scripts/check-vulnerabilities.ps1`** — reads the scan's `--format json` output, prints allowlisted findings separately from blocking ones, and fails only on the latter.

This is the part worth discussing — hence draft, and split out from the mundane cadence change.

## Seeded entries

| Package | Advisory | Why it stays |
|---|---|---|
| `Newtonsoft.Json` | GHSA-5crp-9r3c-p9vr | Arrives via Hangfire.Core, whose latest release keeps the same floors (`>= 5.0.1` / `>= 11.0.1`) and mitigates it in-product — their notes say "Use safe default serializer settings for Newtonsoft.Json 12.X and below", i.e. `MaxDepth`, exactly what the advisory prescribes. Our only lever would be adding an explicit reference to a package we don't use. |
| `log4net` | GHSA-4f7c-pmjv-c25w | Fixed only in 3.3.0 (major, no 2.x backport). Scoped to `XmlLayout`/`XmlLayoutSchemaLog4J`, which `SentryAppender` doesn't use. And 3.x isn't reachable yet regardless — on log4net 3.4.0 three `SentryAppender` structured-logging tests fail. |
| `Microsoft.Build.Tasks.Git` | GHSA-23fw-v26w-5fgq | SourceLink inside the perfview submodule, `PrivateAssets="all"` — build-time only, never in a consumer's graph. Fixing it means carrying a getsentry-local divergence from `microsoft/perfview` through every future sync. |
| `OpenTelemetry.Api` 1.6.0 | GHSA-g94r-2vxg-569j | Fixed only in 1.15.3 — nine minor versions forced on every consumer, against a floor chosen deliberately (minimum without trim warnings), for allocation pressure that IIS (16KB) and nginx (8KB) default header limits already bound. |

### Deliberately *not* allowlisted

`Sentry.OpenTelemetry.Exporter`'s findings. That floor resolves `OpenTelemetry.Api` **1.10.0**, which nuget.org has **delisted** over GHSA-8785-wc3w-h8q6 — high CPU merely from *receiving* a `traceparent`/`tracestate` header, no opt-in required. That decision is still open, so the scan should keep failing on it until it's made. After this PR the run fails for that one reason and nothing else.

## Design notes

- Matching on **advisory + package** means a *new* advisory against an already-listed package still fails.
- Entries matching nothing are reported as **stale** but don't fail the run — fixing a vulnerability must never break CI.
- **Fails closed** throughout: an unparseable report, a missing allowlist, or any project missing from the scan is a failure, never a pass. That last one is not hypothetical — six projects the `.slnf` filters skip were absent from a local scan, and the script refuses to report on a partial scan rather than calling it clean.

### Why not `NuGetAuditSuppress`?

Worth recording before someone suggests it. It's the purpose-built mechanism, but it doesn't work here:

1. `dotnet package list --vulnerable` **ignores it entirely** — verified: it silences the restore-time `NU1903` warning and the package still appears in the scan.
2. Switching the gate to restore-time auditing isn't a way out either. `NuGetAudit=true` / `NuGetAuditMode=direct` are already in effect, yet a full restore produces **zero** `NU19xx` warnings, because the audit can't use the extra Azure DevOps feeds in `NuGet.config`. That's the same reason the existing step pins `--source` to nuget.org.

## Verification

Ran against a full `dotnet restore Sentry.slnx` locally, plus the edge cases: clean scan → exit 0 with stale warnings; empty allowlist → all 38 findings block; malformed JSON / missing input / missing allowlist → exit 1; unrestored projects → refuses to report.

# Related / References

- https://github.com/getsentry/sentry-dotnet/pull/5556
- https://github.com/getsentry/sentry-dotnet/pull/5560 (for version 7)

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)
