### PR TITLE
fix(log4net): send event properties as log attributes on log4net 3.x

### DIFF
--- a/.generated.NoMobile.slnx
+++ b/.generated.NoMobile.slnx
@@ -193,6 +193,7 @@
     <Project Path="test/Sentry.Google.Cloud.Functions.Tests/Sentry.Google.Cloud.Functions.Tests.csproj" />
     <Project Path="test/Sentry.Hangfire.Tests/Sentry.Hangfire.Tests.csproj" />
     <Project Path="test/Sentry.Log4Net.Tests/Sentry.Log4Net.Tests.csproj" />
+    <Project Path="test/Sentry.Log4Net.V3.Tests/Sentry.Log4Net.V3.Tests.csproj" />
     <Project Path="test/Sentry.Maui.CommunityToolkit.Mvvm.Tests/Sentry.Maui.CommunityToolkit.Mvvm.Tests.csproj" />
     <Project Path="test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj" />
     <Project Path="test/Sentry.Maui.Tests/Sentry.Maui.Tests.csproj" />

--- a/Sentry-CI-Build-Linux-NoMobile.slnf
+++ b/Sentry-CI-Build-Linux-NoMobile.slnf
@@ -65,6 +65,7 @@
       "test\\Sentry.Google.Cloud.Functions.Tests\\Sentry.Google.Cloud.Functions.Tests.csproj",
       "test\\Sentry.Hangfire.Tests\\Sentry.Hangfire.Tests.csproj",
       "test\\Sentry.Log4Net.Tests\\Sentry.Log4Net.Tests.csproj",
+      "test\\Sentry.Log4Net.V3.Tests\\Sentry.Log4Net.V3.Tests.csproj",
       "test\\Sentry.NLog.Tests\\Sentry.NLog.Tests.csproj",
       "test\\Sentry.OpenTelemetry.Exporter.Tests\\Sentry.OpenTelemetry.Exporter.Tests.csproj",
       "test\\Sentry.OpenTelemetry.Tests\\Sentry.OpenTelemetry.Tests.csproj",

--- a/Sentry-CI-Build-Linux.slnf
+++ b/Sentry-CI-Build-Linux.slnf
@@ -72,6 +72,7 @@
       "test\\Sentry.Google.Cloud.Functions.Tests\\Sentry.Google.Cloud.Functions.Tests.csproj",
       "test\\Sentry.Hangfire.Tests\\Sentry.Hangfire.Tests.csproj",
       "test\\Sentry.Log4Net.Tests\\Sentry.Log4Net.Tests.csproj",
+      "test\\Sentry.Log4Net.V3.Tests\\Sentry.Log4Net.V3.Tests.csproj",
       "test\\Sentry.Maui.CommunityToolkit.Mvvm.Tests\\Sentry.Maui.CommunityToolkit.Mvvm.Tests.csproj",
       "test\\Sentry.Maui.Tests\\Sentry.Maui.Tests.csproj",
       "test\\Sentry.NLog.Tests\\Sentry.NLog.Tests.csproj",

--- a/Sentry-CI-Build-Windows-arm64.slnf
+++ b/Sentry-CI-Build-Windows-arm64.slnf
@@ -71,6 +71,7 @@
       "test\\Sentry.Google.Cloud.Functions.Tests\\Sentry.Google.Cloud.Functions.Tests.csproj",
       "test\\Sentry.Hangfire.Tests\\Sentry.Hangfire.Tests.csproj",
       "test\\Sentry.Log4Net.Tests\\Sentry.Log4Net.Tests.csproj",
+      "test\\Sentry.Log4Net.V3.Tests\\Sentry.Log4Net.V3.Tests.csproj",
       "test\\Sentry.Maui.CommunityToolkit.Mvvm.Tests\\Sentry.Maui.CommunityToolkit.Mvvm.Tests.csproj",
       "test\\Sentry.Maui.Tests\\Sentry.Maui.Tests.csproj",
       "test\\Sentry.NLog.Tests\\Sentry.NLog.Tests.csproj",

--- a/Sentry-CI-Build-Windows.slnf
+++ b/Sentry-CI-Build-Windows.slnf
@@ -74,6 +74,7 @@
       "test\\Sentry.Google.Cloud.Functions.Tests\\Sentry.Google.Cloud.Functions.Tests.csproj",
       "test\\Sentry.Hangfire.Tests\\Sentry.Hangfire.Tests.csproj",
       "test\\Sentry.Log4Net.Tests\\Sentry.Log4Net.Tests.csproj",
+      "test\\Sentry.Log4Net.V3.Tests\\Sentry.Log4Net.V3.Tests.csproj",
       "test\\Sentry.Maui.CommunityToolkit.Mvvm.Tests\\Sentry.Maui.CommunityToolkit.Mvvm.Tests.csproj",
       "test\\Sentry.Maui.Tests\\Sentry.Maui.Tests.csproj",
       "test\\Sentry.NLog.Tests\\Sentry.NLog.Tests.csproj",

--- a/Sentry-CI-Build-macOS.slnf
+++ b/Sentry-CI-Build-macOS.slnf
@@ -79,6 +79,7 @@
       "test\\Sentry.Google.Cloud.Functions.Tests\\Sentry.Google.Cloud.Functions.Tests.csproj",
       "test\\Sentry.Hangfire.Tests\\Sentry.Hangfire.Tests.csproj",
       "test\\Sentry.Log4Net.Tests\\Sentry.Log4Net.Tests.csproj",
+      "test\\Sentry.Log4Net.V3.Tests\\Sentry.Log4Net.V3.Tests.csproj",
       "test\\Sentry.Maui.CommunityToolkit.Mvvm.Tests\\Sentry.Maui.CommunityToolkit.Mvvm.Tests.csproj",
       "test\\Sentry.Maui.Device.TestApp\\Sentry.Maui.Device.TestApp.csproj",
       "test\\Sentry.Maui.Tests\\Sentry.Maui.Tests.csproj",

--- a/Sentry.slnx
+++ b/Sentry.slnx
@@ -193,6 +193,7 @@
     <Project Path="test/Sentry.Google.Cloud.Functions.Tests/Sentry.Google.Cloud.Functions.Tests.csproj" />
     <Project Path="test/Sentry.Hangfire.Tests/Sentry.Hangfire.Tests.csproj" />
     <Project Path="test/Sentry.Log4Net.Tests/Sentry.Log4Net.Tests.csproj" />
+    <Project Path="test/Sentry.Log4Net.V3.Tests/Sentry.Log4Net.V3.Tests.csproj" />
     <Project Path="test/Sentry.Maui.CommunityToolkit.Mvvm.Tests/Sentry.Maui.CommunityToolkit.Mvvm.Tests.csproj" />
     <Project Path="test/Sentry.Maui.Device.TestApp/Sentry.Maui.Device.TestApp.csproj" />
     <Project Path="test/Sentry.Maui.Tests/Sentry.Maui.Tests.csproj" />

--- a/SentryNoMobile.slnf
+++ b/SentryNoMobile.slnf
@@ -70,6 +70,7 @@
       "test\\Sentry.Google.Cloud.Functions.Tests\\Sentry.Google.Cloud.Functions.Tests.csproj",
       "test\\Sentry.Hangfire.Tests\\Sentry.Hangfire.Tests.csproj",
       "test\\Sentry.Log4Net.Tests\\Sentry.Log4Net.Tests.csproj",
+      "test\\Sentry.Log4Net.V3.Tests\\Sentry.Log4Net.V3.Tests.csproj",
       "test\\Sentry.NLog.Tests\\Sentry.NLog.Tests.csproj",
       "test\\Sentry.OpenTelemetry.Exporter.Tests\\Sentry.OpenTelemetry.Exporter.Tests.csproj",
       "test\\Sentry.OpenTelemetry.Tests\\Sentry.OpenTelemetry.Tests.csproj",

--- a/SentryNoSamples.slnf
+++ b/SentryNoSamples.slnf
@@ -43,6 +43,7 @@
       "test\\Sentry.Google.Cloud.Functions.Tests\\Sentry.Google.Cloud.Functions.Tests.csproj",
       "test\\Sentry.Hangfire.Tests\\Sentry.Hangfire.Tests.csproj",
       "test\\Sentry.Log4Net.Tests\\Sentry.Log4Net.Tests.csproj",
+      "test\\Sentry.Log4Net.V3.Tests\\Sentry.Log4Net.V3.Tests.csproj",
       "test\\Sentry.Maui.CommunityToolkit.Mvvm.Tests\\Sentry.Maui.CommunityToolkit.Mvvm.Tests.csproj",
       "test\\Sentry.Maui.Tests\\Sentry.Maui.Tests.csproj",
       "test\\Sentry.NLog.Tests\\Sentry.NLog.Tests.csproj",

--- a/src/Sentry.Log4Net/Sentry.Log4Net.csproj
+++ b/src/Sentry.Log4Net/Sentry.Log4Net.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Sentry.Log4Net.Tests" PublicKey="$(SentryPublicKey)" />
+    <InternalsVisibleTo Include="Sentry.Log4Net.V3.Tests" PublicKey="$(SentryPublicKey)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sentry.Log4Net/SentryAppender.Structured.cs
+++ b/src/Sentry.Log4Net/SentryAppender.Structured.cs
@@ -40,10 +40,9 @@ public partial class SentryAppender
         // against null, so we do too rather than rely on log4net's internals.
         if (loggingEvent.GetProperties() is { } properties)
         {
-            // Read through GetKeys()/the indexer rather than enumerating the dictionary. log4net 3.x added
-            // IDictionary<string, object?> to PropertiesDictionary, which changed what its non-generic
-            // IEnumerable yields (KeyValuePair<string, object?> instead of DictionaryEntry), so enumerating
-            // silently matched nothing there. GetKeys() behaves the same on both majors.
+            // Read via GetKeys()/the indexer rather than enumerating: PropertiesDictionary's non-generic
+            // IEnumerable yields DictionaryEntry on log4net 2.x but KeyValuePair on 3.x. GetKeys() is the
+            // same on both.
             foreach (var key in properties.GetKeys())
             {
                 if (string.IsNullOrEmpty(key) || key.StartsWith("log4net:", StringComparison.OrdinalIgnoreCase) || Guid.TryParse(key, out _))

--- a/src/Sentry.Log4Net/SentryAppender.Structured.cs
+++ b/src/Sentry.Log4Net/SentryAppender.Structured.cs
@@ -40,14 +40,20 @@ public partial class SentryAppender
         // against null, so we do too rather than rely on log4net's internals.
         if (loggingEvent.GetProperties() is { } properties)
         {
-            foreach (var property in properties)
+            // Read through GetKeys()/the indexer rather than enumerating the dictionary. log4net 3.x added
+            // IDictionary<string, object?> to PropertiesDictionary, which changed what its non-generic
+            // IEnumerable yields (KeyValuePair<string, object?> instead of DictionaryEntry), so enumerating
+            // silently matched nothing there. GetKeys() behaves the same on both majors.
+            foreach (var key in properties.GetKeys())
             {
-                if (property is DictionaryEntry { Key: string key, Value: { } value })
+                if (string.IsNullOrEmpty(key) || key.StartsWith("log4net:", StringComparison.OrdinalIgnoreCase) || Guid.TryParse(key, out _))
                 {
-                    if (key.Length != 0 && !key.StartsWith("log4net:", StringComparison.OrdinalIgnoreCase) && !Guid.TryParse(key, out _))
-                    {
-                        log.SetAttribute($"property.{key}", value);
-                    }
+                    continue;
+                }
+
+                if (properties[key] is { } value)
+                {
+                    log.SetAttribute($"property.{key}", value);
                 }
             }
         }

--- a/src/Sentry.Log4Net/SentryAppender.Structured.cs
+++ b/src/Sentry.Log4Net/SentryAppender.Structured.cs
@@ -40,9 +40,6 @@ public partial class SentryAppender
         // against null, so we do too rather than rely on log4net's internals.
         if (loggingEvent.GetProperties() is { } properties)
         {
-            // Read via GetKeys()/the indexer rather than enumerating: PropertiesDictionary's non-generic
-            // IEnumerable yields DictionaryEntry on log4net 2.x but KeyValuePair on 3.x. GetKeys() is the
-            // same on both.
             foreach (var key in properties.GetKeys())
             {
                 if (string.IsNullOrEmpty(key) || key.StartsWith("log4net:", StringComparison.OrdinalIgnoreCase) || Guid.TryParse(key, out _))

--- a/src/Sentry/Sentry.csproj
+++ b/src/Sentry/Sentry.csproj
@@ -161,6 +161,7 @@
     <InternalsVisibleTo Include="Sentry.Hangfire.Tests" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.Log4Net" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.Log4Net.Tests" PublicKey="$(SentryPublicKey)" />
+    <InternalsVisibleTo Include="Sentry.Log4Net.V3.Tests" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.Maui" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.Maui.CommunityToolkit.Mvvm" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.Maui.CommunityToolkit.Mvvm.Tests" PublicKey="$(SentryPublicKey)" />

--- a/test/Sentry.Log4Net.V3.Tests/Sentry.Log4Net.V3.Tests.csproj
+++ b/test/Sentry.Log4Net.V3.Tests/Sentry.Log4Net.V3.Tests.csproj
@@ -1,0 +1,41 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(LatestTfm)</TargetFrameworks>
+    <!-- These tests fail on Mono -->
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net48</TargetFrameworks>
+  </PropertyGroup>
+
+  <!--
+    The appender tests from Sentry.Log4Net.Tests, run against log4net 3.x instead of 2.x.
+
+    Sentry.Log4Net keeps its 2.0.12 floor, so this covers what users on log4net 3.x actually get: the
+    2.x-compiled appender loaded against the 3.x assembly. log4net 3.x added IDictionary<string, object?>
+    to PropertiesDictionary, which changes what its non-generic IEnumerable yields - a runtime-only
+    difference that no amount of building against 2.x can catch. See #5557.
+
+    Source is linked rather than duplicated so the two majors can never drift apart. The Verify-based
+    tests are deliberately not linked: their snapshots are keyed off the original file paths, and running
+    them from two projects would have both writing the same files.
+  -->
+  <ItemGroup>
+    <Compile Include="..\Sentry.Log4Net.Tests\SentryAppenderTests.cs" Link="SentryAppenderTests.cs" />
+    <Compile Include="..\Sentry.Log4Net.Tests\SentryAppenderTests.Structured.cs" Link="SentryAppenderTests.Structured.cs">
+      <DependentUpon>SentryAppenderTests.cs</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="3.4.0" />
+    <ProjectReference Include="..\..\src\Sentry.Log4Net\Sentry.Log4Net.csproj" />
+    <ProjectReference Include="..\Sentry.Testing\Sentry.Testing.csproj" />
+
+    <Using Include="log4net" />
+    <Using Include="log4net.Core" />
+    <Using Include="log4net.Appender" />
+    <Using Include="log4net.Layout" />
+    <Using Include="log4net.Repository.Hierarchy" />
+    <Using Include="Sentry.Log4Net" />
+  </ItemGroup>
+
+</Project>

--- a/test/Sentry.Log4Net.V3.Tests/Sentry.Log4Net.V3.Tests.csproj
+++ b/test/Sentry.Log4Net.V3.Tests/Sentry.Log4Net.V3.Tests.csproj
@@ -6,18 +6,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net48</TargetFrameworks>
   </PropertyGroup>
 
-  <!--
-    The appender tests from Sentry.Log4Net.Tests, run against log4net 3.x instead of 2.x.
-
-    Sentry.Log4Net keeps its 2.0.12 floor, so this covers what users on log4net 3.x actually get: the
-    2.x-compiled appender loaded against the 3.x assembly. log4net 3.x added IDictionary<string, object?>
-    to PropertiesDictionary, which changes what its non-generic IEnumerable yields - a runtime-only
-    difference that no amount of building against 2.x can catch. See #5557.
-
-    Source is linked rather than duplicated so the two majors can never drift apart. The Verify-based
-    tests are deliberately not linked: their snapshots are keyed off the original file paths, and running
-    them from two projects would have both writing the same files.
-  -->
   <ItemGroup>
     <Compile Include="..\Sentry.Log4Net.Tests\SentryAppenderTests.cs" Link="SentryAppenderTests.cs" />
     <Compile Include="..\Sentry.Log4Net.Tests\SentryAppenderTests.Structured.cs" Link="SentryAppenderTests.Structured.cs">

--- a/test/Sentry.Testing/Sentry.Testing.csproj
+++ b/test/Sentry.Testing/Sentry.Testing.csproj
@@ -17,6 +17,7 @@
     <InternalsVisibleTo Include="Sentry.Google.Cloud.Functions.Tests" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.GraphQL.Client.Tests" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.Log4Net.Tests" PublicKey="$(SentryPublicKey)" />
+    <InternalsVisibleTo Include="Sentry.Log4Net.V3.Tests" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.Maui.Tests" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.NLog.Tests" PublicKey="$(SentryPublicKey)" />
     <InternalsVisibleTo Include="Sentry.Profiling.Tests" PublicKey="$(SentryPublicKey)" />


### PR DESCRIPTION
Closes #5557

## Summary

On log4net 3.x, `SentryAppender` silently dropped every event property from structured logs — no `property.*` attribute was ever attached to a `SentryLog`, with no exception and no warning.

`log4net.Util.PropertiesDictionary` gained `IDictionary<string, object?>` in 3.x, and that changed what its **non-generic** `IEnumerable` yields: `KeyValuePair<string, object?>` instead of `DictionaryEntry`. `Sentry.Log4Net` is compiled against its 2.0.12 floor and walks exactly that non-generic enumerator, so `property is DictionaryEntry` matched nothing and the loop body never ran.

The fix reads through `GetKeys()` + the indexer, the way the sibling `SentryEvent` path in `GetLoggingEventProperties` already does. That API behaves identically on both majors, so the appender is version-agnostic and **the package floor stays at 2.0.12** — no new minimum for consumers still on log4net 2.x.

## Notes for review

- **New test project, `Sentry.Log4Net.V3.Tests`.** This is a runtime-only difference — nothing that builds against 2.x can catch it — so covering it needs the appender actually loaded against a 3.x assembly. The new project links the same two appender test files (`Compile Include`, not copies, so the two majors can't drift) and references log4net 3.4.0, while `Sentry.Log4Net.Tests` stays on 2.0.15. Both majors now run in CI. I confirmed the new project has teeth: reverting just the appender change reproduces exactly the three failures from the issue (52 passed / 3 failed), and both suites are green with it.

- The two Verify-based tests are deliberately *not* linked into the new project — their snapshots are keyed off the original file paths, so running them from two projects would have both writing the same files.

- Three `InternalsVisibleTo` entries were needed for the new assembly (`Sentry`, `Sentry.Log4Net`, `Sentry.Testing`), following the pattern every other test project uses. These don't appear in the API approval snapshots, and `ApiApprovalTests` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
