### PR TITLE
feat(otel): raise the OpenTelemetry floor to 1.12.0

### DIFF
--- a/src/Sentry.OpenTelemetry.Exporter/Sentry.OpenTelemetry.Exporter.csproj
+++ b/src/Sentry.OpenTelemetry.Exporter/Sentry.OpenTelemetry.Exporter.csproj
@@ -13,7 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+    <!-- 1.12.0 is the lowest floor we can offer: 1.10.0-1.11.1 are delisted from nuget.org over
+         GHSA-8785-wc3w-h8q6, and 1.11.1/1.11.2 pull the deprecated Grpc.Core on net462. 1.12.0 also
+         drops the Google.Protobuf and Grpc.Net.Client dependencies 1.10.0 carried. -->
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sentry.OpenTelemetry/Sentry.OpenTelemetry.csproj
+++ b/src/Sentry.OpenTelemetry/Sentry.OpenTelemetry.csproj
@@ -23,8 +23,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Version 1.6.0 is the minimum version that does not have trim warnings   -->
-    <PackageReference Include="OpenTelemetry" Version="1.6.0" />
+    <!-- 1.6.0 was the lowest version without trim warnings; 1.12.0 is the lowest that also avoids
+         the delisted 1.10.0-1.11.1 range (GHSA-8785-wc3w-h8q6). -->
+    <PackageReference Include="OpenTelemetry" Version="1.12.0" />
+  </ItemGroup>
+
+  <!-- On .NET Framework, we need an assembly reference to System.Net.Http. OpenTelemetry 1.6.0 pulled
+       one in transitively; 1.12.0 dropped those dependencies, so reference it explicitly. -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sentry.OpenTelemetry.Tests/Sentry.OpenTelemetry.Tests.csproj
+++ b/test/Sentry.OpenTelemetry.Tests/Sentry.OpenTelemetry.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.6.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(PreviousTfm)'">


### PR DESCRIPTION
Closes #4931 

## Summary

Raises the OpenTelemetry floors on the two shipped packages, targeting `version7`:

| Project | Package | Before | After |
|---|---|---|---|
| `Sentry.OpenTelemetry` | `OpenTelemetry` | 1.6.0 | 1.12.0 |
| `Sentry.OpenTelemetry.Exporter` | `OpenTelemetry.Exporter.OpenTelemetryProtocol` | 1.10.0 | 1.12.0 |

Closes #4931

### Rationale

Normally we target the oldest dependencies possible so consumers can pick whatever version they want.

However `OpenTelemetry.Api` 1.10.0, 1.11.0 and 1.11.1 are **delisted from nuget.org** (`listed=false`
on the registration feed), pulled deliberately over [GHSA-8785-wc3w-h8q6](https://github.com/advisories/GHSA-8785-wc3w-h8q6). That advisory needs no opt-in — receiving a `traceparent`/`tracestate` header is enough, and it "impacts any application accessible over the web ... Even if an application does not explicitly use trace
context propagation."

`OpenTelemetry.Exporter.OpenTelemetryProtocol` 1.10.0 is itself still listed, so restore emits no warning at all while quietly resolving a dependency the ecosystem has hidden. The do-nothing path lands on the bad version silently, and
nothing tells anyone to override it.

Additionally:
- 1.11.0 and 1.11.1 are delisted for the same advisory.
- 1.11.1 and 1.11.2 pull `Grpc.Core [2.44.0, 3.0.0)` on net462 — the deprecated native gRPC
  library. 1.12.0 drops it again.

1.12.0 is the lowest floor that is both listed and free of `Grpc.Core`. 

### Note on the `System.Net.Http` reference

`OpenTelemetry` 1.12.0 no longer brings `System.Net.Http` in transitively on .NET Framework (1.6.0 did, via `Microsoft.Extensions.Logging.Configuration`). `SentryPropagator` uses `HttpRequestMessage`, so net462 failed with CS0246 until `Sentry.OpenTelemetry` referenced the framework assembly explicitly — the same pattern already in `src/Sentry/Sentry.csproj`. 

`Sentry.OpenTelemetry.Exporter` doesn't need it: the OTLP exporter package declares `System.Net.Http` as a `frameworkAssembly` for net462.

### Verified locally

- Both `src` projects build clean across all TFMs, including net462.
- `Sentry.OpenTelemetry.Tests` (44) and `Sentry.OpenTelemetry.Exporter.Tests` (59) pass on net8.0/net9.0/net10.0.
- `dotnet publish test/Sentry.TrimTest -c Release -r osx-arm64 -p:NO_MOBILE=true` (the Trim analysis
  CI job) succeeds with zero IL warnings — 1.12.0 keeps the trim-clean guarantee the old 1.6.0
  comment was protecting.
- The five OTel-consuming samples build with no NU warnings.
- Resolved graph on both projects is `OpenTelemetry{,.Api,.Api.ProviderBuilderExtensions}/1.12.0`
  plus `OpenTelemetry.Exporter.OpenTelemetryProtocol/1.12.0`, with no `Grpc*` or `Google.Protobuf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
