### PR TITLE
fix: Propagate the incoming Dynamic Sampling Context when starting a transaction from ContinueTrace

### DIFF
--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -412,7 +412,16 @@ internal class Hub : IHub, IDisposable
             // Hand the incoming DSC to the transaction that gets started from this context, so it is propagated
             // unchanged (same as the ASP.NET Core middleware does). The transaction gets its own instance rather
             // than the one stored on the scope, because StartTransaction may still adjust it (sample rate, replay id).
-            DynamicSamplingContext = traceHeader is null ? null : baggageHeader?.CreateDynamicSamplingContext(_replaySession)
+            // A sentry-trace header without a baggage header comes from an older SDK without dynamic sampling
+            // support, in which case the DSC is frozen as empty instead of being created from the transaction. See:
+            // https://develop.sentry.dev/sdk/telemetry/traces/dynamic-sampling-context/#freezing-dynamic-sampling-context
+            // https://develop.sentry.dev/sdk/telemetry/traces/dynamic-sampling-context/#unified-propagation-mechanism
+            DynamicSamplingContext = (traceHeader, baggageHeader) switch
+            {
+                (null, _) => null,
+                (_, null) => DynamicSamplingContext.Empty(),
+                _ => propagationContext.DynamicSamplingContext?.Clone()
+            }
         };
     }
 

--- a/src/Sentry/Internal/Hub.cs
+++ b/src/Sentry/Internal/Hub.cs
@@ -171,7 +171,8 @@ internal class Hub : IHub, IDisposable
     public ITransactionTracer StartTransaction(
         ITransactionContext context,
         IReadOnlyDictionary<string, object?> customSamplingContext)
-        => StartTransaction(context, customSamplingContext, null);
+        // A context returned by ContinueTrace carries the Dynamic Sampling Context of the incoming baggage.
+        => StartTransaction(context, customSamplingContext, (context as TransactionContext)?.DynamicSamplingContext);
 
     internal ITransactionTracer StartTransaction(
         ITransactionContext context,
@@ -406,7 +407,13 @@ internal class Hub : IHub, IDisposable
             parentSpanId: propagationContext.ParentSpanId,
             traceId: propagationContext.TraceId,
             isSampled: traceHeader?.IsSampled,
-            isParentSampled: traceHeader?.IsSampled);
+            isParentSampled: traceHeader?.IsSampled)
+        {
+            // Hand the incoming DSC to the transaction that gets started from this context, so it is propagated
+            // unchanged (same as the ASP.NET Core middleware does). The transaction gets its own instance rather
+            // than the one stored on the scope, because StartTransaction may still adjust it (sample rate, replay id).
+            DynamicSamplingContext = traceHeader is null ? null : baggageHeader?.CreateDynamicSamplingContext(_replaySession)
+        };
     }
 
     internal bool ShouldContinueTrace(BaggageHeader? baggageHeader)

--- a/src/Sentry/TransactionContext.cs
+++ b/src/Sentry/TransactionContext.cs
@@ -17,6 +17,15 @@ public class TransactionContext : SpanContext, ITransactionContext
     public bool? IsParentSampled { get; }
 
     /// <summary>
+    /// The Dynamic Sampling Context received from the upstream SDK, when this context was created by
+    /// <see cref="IHub.ContinueTrace(SentryTraceHeader?, BaggageHeader?, string?, string?)"/> from a baggage header.
+    /// A transaction started from this context propagates it unchanged instead of creating a new one, so that
+    /// <c>sample_rand</c> and the other frozen items stay the same across the whole trace.
+    /// </summary>
+    /// <seealso href="https://develop.sentry.dev/sdk/telemetry/traces/dynamic-sampling-context/#unified-propagation-mechanism"/>
+    internal DynamicSamplingContext? DynamicSamplingContext { get; set; }
+
+    /// <summary>
     /// Initializes an instance of <see cref="TransactionContext"/>.
     /// </summary>
     public TransactionContext(

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -2028,7 +2028,7 @@ public partial class HubTests : IDisposable
     }
 
     [Fact]
-    public void StartTransaction_ContextFromContinueTraceWithoutBaggage_CreatesDynamicSamplingContextFromTransaction()
+    public void StartTransaction_ContextFromContinueTraceWithoutBaggage_FreezesEmptyDynamicSamplingContext()
     {
         // Arrange
         var hub = _fixture.GetSut();
@@ -2040,9 +2040,51 @@ public partial class HubTests : IDisposable
         var transaction = hub.StartTransaction(transactionContext);
 
         // Assert
+        // A sentry-trace header without baggage comes from an SDK without dynamic sampling support, so the DSC
+        // is frozen as empty rather than created from this transaction (same as the ASP.NET Core middleware).
+        var tracer = transaction.Should().BeOfType<TransactionTracer>().Subject;
+        tracer.DynamicSamplingContext.Should().NotBeNull();
+        tracer.DynamicSamplingContext!.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void StartTransaction_ContextFromContinueTraceWithInvalidBaggage_CreatesDynamicSamplingContextFromTransaction()
+    {
+        // Arrange
+        var hub = _fixture.GetSut();
+        var traceHeader = new SentryTraceHeader(SentryId.Parse("5bd5f6d346b442dd9177dce9302fd737"),
+            SpanId.Parse("2000000000000000"), true);
+        // Missing the required public_key and sample_rate members, so no DSC can be created from it.
+        var baggageHeader = BaggageHeader.Create(new List<KeyValuePair<string, string>>
+        {
+            {"sentry-trace_id", "5bd5f6d346b442dd9177dce9302fd737"}
+        });
+        var transactionContext = hub.ContinueTrace(traceHeader, baggageHeader, "test-name", "test-operation");
+
+        // Act
+        var transaction = hub.StartTransaction(transactionContext);
+
+        // Assert
         var tracer = transaction.Should().BeOfType<TransactionTracer>().Subject;
         tracer.DynamicSamplingContext.Should().NotBeNull();
         tracer.DynamicSamplingContext!.Items["trace_id"].Should().Be("5bd5f6d346b442dd9177dce9302fd737");
+        tracer.DynamicSamplingContext.Items["public_key"].Should().Be(_fixture.Options.ParsedDsn.PublicKey);
+    }
+
+    [Fact]
+    public void StartTransaction_ContextFromContinueTraceWithoutTraceHeader_CreatesDynamicSamplingContextFromTransaction()
+    {
+        // Arrange
+        var hub = _fixture.GetSut();
+        var transactionContext = hub.ContinueTrace((SentryTraceHeader)null, (BaggageHeader)null, "test-name", "test-operation");
+
+        // Act
+        var transaction = hub.StartTransaction(transactionContext);
+
+        // Assert
+        var tracer = transaction.Should().BeOfType<TransactionTracer>().Subject;
+        tracer.DynamicSamplingContext.Should().NotBeNull();
+        tracer.DynamicSamplingContext!.IsEmpty.Should().BeFalse();
         tracer.DynamicSamplingContext.Items["public_key"].Should().Be(_fixture.Options.ParsedDsn.PublicKey);
     }
 

--- a/test/Sentry.Tests/HubTests.cs
+++ b/test/Sentry.Tests/HubTests.cs
@@ -1947,6 +1947,106 @@ public partial class HubTests : IDisposable
     }
 
     [Fact]
+    public void StartTransaction_ContextFromContinueTraceWithBaggage_PropagatesIncomingDynamicSamplingContext()
+    {
+        // Arrange
+        var hub = _fixture.GetSut();
+        var traceHeader = new SentryTraceHeader(SentryId.Parse("5bd5f6d346b442dd9177dce9302fd737"),
+            SpanId.Parse("2000000000000000"), true);
+        var baggageHeader = BaggageHeader.Create(new List<KeyValuePair<string, string>>
+        {
+            {"sentry-trace_id", "5bd5f6d346b442dd9177dce9302fd737"},
+            {"sentry-public_key", "49d0f7386ad645858ae85020e393bef3"},
+            {"sentry-sample_rate", "0.5"},
+            {"sentry-sample_rand", "0.1234"},
+            {"sentry-sampled", "true"}
+        });
+        var transactionContext = hub.ContinueTrace(traceHeader, baggageHeader, "test-name", "test-operation");
+
+        // Act
+        var transaction = hub.StartTransaction(transactionContext);
+
+        // Assert
+        var tracer = transaction.Should().BeOfType<TransactionTracer>().Subject;
+        tracer.IsSampled.Should().BeTrue();
+        tracer.SampleRand.Should().Be(0.1234);
+        tracer.DynamicSamplingContext.Should().NotBeNull();
+        tracer.DynamicSamplingContext!.Items.Should().Contain(baggageHeader.GetSentryMembers());
+    }
+
+    [Fact]
+    public void StartTransaction_ContextFromContinueTraceWithBaggage_SampledOut_PropagatesIncomingDynamicSamplingContext()
+    {
+        // Arrange
+        var hub = _fixture.GetSut();
+        var traceHeader = new SentryTraceHeader(SentryId.Parse("5bd5f6d346b442dd9177dce9302fd737"),
+            SpanId.Parse("2000000000000000"), false);
+        var baggageHeader = BaggageHeader.Create(new List<KeyValuePair<string, string>>
+        {
+            {"sentry-trace_id", "5bd5f6d346b442dd9177dce9302fd737"},
+            {"sentry-public_key", "49d0f7386ad645858ae85020e393bef3"},
+            {"sentry-sample_rate", "0.5"},
+            {"sentry-sample_rand", "0.9876"},
+            {"sentry-sampled", "false"}
+        });
+        var transactionContext = hub.ContinueTrace(traceHeader, baggageHeader, "test-name", "test-operation");
+
+        // Act
+        var transaction = hub.StartTransaction(transactionContext);
+
+        // Assert
+        var unsampled = transaction.Should().BeOfType<UnsampledTransaction>().Subject;
+        unsampled.SampleRand.Should().Be(0.9876);
+        unsampled.DynamicSamplingContext.Should().NotBeNull();
+        unsampled.DynamicSamplingContext!.Items.Should().Contain(baggageHeader.GetSentryMembers());
+    }
+
+    [Fact]
+    public void StartTransaction_ContextFromContinueTraceWithHeadersAsStrings_PropagatesIncomingDynamicSamplingContext()
+    {
+        // Arrange
+        var hub = _fixture.GetSut();
+        var traceHeader = "5bd5f6d346b442dd9177dce9302fd737-2000000000000000-1";
+        var baggageHeader = "sentry-trace_id=5bd5f6d346b442dd9177dce9302fd737,sentry-public_key=49d0f7386ad645858ae85020e393bef3,sentry-sample_rate=0.5,sentry-sample_rand=0.1234,sentry-sampled=true";
+        var transactionContext = hub.ContinueTrace(traceHeader, baggageHeader, "test-name", "test-operation");
+
+        // Act
+        var transaction = hub.StartTransaction(transactionContext);
+
+        // Assert
+        var tracer = transaction.Should().BeOfType<TransactionTracer>().Subject;
+        tracer.SampleRand.Should().Be(0.1234);
+        tracer.DynamicSamplingContext.Should().NotBeNull();
+        tracer.DynamicSamplingContext!.Items.Should().Contain(new Dictionary<string, string>
+        {
+            ["trace_id"] = "5bd5f6d346b442dd9177dce9302fd737",
+            ["public_key"] = "49d0f7386ad645858ae85020e393bef3",
+            ["sample_rate"] = "0.5",
+            ["sample_rand"] = "0.1234",
+            ["sampled"] = "true"
+        });
+    }
+
+    [Fact]
+    public void StartTransaction_ContextFromContinueTraceWithoutBaggage_CreatesDynamicSamplingContextFromTransaction()
+    {
+        // Arrange
+        var hub = _fixture.GetSut();
+        var traceHeader = new SentryTraceHeader(SentryId.Parse("5bd5f6d346b442dd9177dce9302fd737"),
+            SpanId.Parse("2000000000000000"), true);
+        var transactionContext = hub.ContinueTrace(traceHeader, (BaggageHeader)null, "test-name", "test-operation");
+
+        // Act
+        var transaction = hub.StartTransaction(transactionContext);
+
+        // Assert
+        var tracer = transaction.Should().BeOfType<TransactionTracer>().Subject;
+        tracer.DynamicSamplingContext.Should().NotBeNull();
+        tracer.DynamicSamplingContext!.Items["trace_id"].Should().Be("5bd5f6d346b442dd9177dce9302fd737");
+        tracer.DynamicSamplingContext.Items["public_key"].Should().Be(_fixture.Options.ParsedDsn.PublicKey);
+    }
+
+    [Fact]
     public void CaptureTransaction_AfterTransactionFinishes_ResetsTransactionOnScope()
     {
         // Arrange


### PR DESCRIPTION
## Description

`SentrySdk.ContinueTrace(traceHeader, baggageHeader)` followed by `SentrySdk.StartTransaction(context)` is the documented way to continue a distributed trace from a non-HTTP boundary (#2646). The baggage is parsed into a `DynamicSamplingContext` and stored on the scope's propagation context, but `Hub.StartTransaction(ITransactionContext, customSamplingContext)` always passes `null` as the DSC to the internal overload, so the transaction creates a fresh DSC from itself: a locally generated `sample_rand`, the local `public_key`, the local `sample_rate`, and so on. The incoming DSC is only honoured by `Sentry.AspNetCore`, which reaches the internal `StartTransaction(context, customSamplingContext, dynamicSamplingContext)` overload through `InternalsVisibleTo`.

This change lets `ContinueTrace` attach the DSC parsed from the baggage to the `TransactionContext` it returns (as an internal property), and makes the public `StartTransaction(context, customSamplingContext)` overload pass that DSC to the internal overload. A transaction started from a continued trace now propagates the incoming DSC unchanged, and `sample_rand` follows from it, exactly like the ASP.NET Core middleware already does. No public API is added or changed.

When `ContinueTrace` receives a `sentry-trace` header without a `baggage` header, the request comes from an SDK without dynamic sampling support and the DSC is frozen as empty, again matching the ASP.NET Core middleware and the [spec](https://develop.sentry.dev/sdk/telemetry/traces/dynamic-sampling-context/#freezing-dynamic-sampling-context). When the baggage does not yield a valid DSC, or when there is no trace header to continue, the behaviour is unchanged and the transaction creates its own DSC.

## Motivation and Context

The [dynamic sampling context spec](https://develop.sentry.dev/sdk/telemetry/traces/dynamic-sampling-context/#unified-propagation-mechanism) says a received DSC MUST be treated as frozen and propagated unchanged, and the [propagated random value](https://develop.sentry.dev/sdk/telemetry/traces/#propagated-random-value) section requires `sample_rand` to stay the same across a trace so that Relay reaches one consistent keep-or-drop decision. Today a .NET transaction that continues a trace from headers reports its own `sample_rand` and `public_key`, so Relay can sample it independently of the rest of the trace.

Our use case is a desktop app where a web view (JavaScript SDK) starts the trace and the .NET host continues it for the requests it handles, the same situation as #4021. The only workaround is reflection into the internal overload, since `DynamicSamplingContext`, `BaggageHeader.TryParse` and the DSC-taking `StartTransaction` overload are all internal.

Related: #2646, #4021, #3838.

## How did you test it?

- Added six tests to `HubTests`: sampled and sampled-out continued traces propagate the incoming DSC and `sample_rand`, the string-header overload does the same, a trace header without baggage freezes an empty DSC, and invalid baggage or no trace header still create a DSC from the transaction. The three baggage tests and the empty-freeze test fail on `main` and pass with this change.
- `dotnet test test/Sentry.Tests -f net10.0` passes, including the public API approval tests (no public API change).

### Changelog Entry

- fix: Propagate the incoming Dynamic Sampling Context when starting a transaction from a `TransactionContext` returned by `ContinueTrace`, so `sample_rand` and the other frozen DSC items stay consistent across the trace
